### PR TITLE
Redesign bytecode IR for multi-architecture assembly emission

### DIFF
--- a/casa.py
+++ b/casa.py
@@ -5,7 +5,7 @@ import pathlib
 
 from casa.bytecode import compile_bytecode
 from casa.cli import parse_args
-from casa.interpreter import interpret_bytecode
+from casa.interpreter import interpret_program
 from casa.lexer import lex_file
 from casa.parser import parse_ops, resolve_identifiers
 from casa.typechecker import type_check_ops
@@ -33,10 +33,10 @@ def main():
     type_check_ops(ops)
 
     logger.info("Compiling bytecode")
-    bytecode = compile_bytecode(ops)
+    program = compile_bytecode(ops)
 
     logger.info("Interpreting bytecode")
-    interpret_bytecode(bytecode)
+    interpret_program(program)
 
 
 if __name__ == "__main__":

--- a/casa/bytecode.py
+++ b/casa/bytecode.py
@@ -1,7 +1,5 @@
 from collections.abc import Iterable
 from dataclasses import dataclass
-import random
-import sys
 from typing import assert_never
 
 from casa.common import (
@@ -14,14 +12,44 @@ from casa.common import (
     Inst,
     InstKind,
     LabelId,
+    Location,
     Op,
     OpKind,
+    Program,
     Struct,
     Variable,
 )
 
 
-def compile_bytecode(ops: list[Op]) -> Bytecode:
+_label_counter = 0
+
+
+def new_label() -> LabelId:
+    global _label_counter
+    _label_counter += 1
+    return _label_counter
+
+
+def reset_labels():
+    global _label_counter
+    _label_counter = 0
+
+
+# Stable mapping from Op identity to label, assigned on first access
+_op_label_map: dict[int, LabelId] = {}
+
+
+def op_to_label(op: Op) -> LabelId:
+    op_id = id(op)
+    if op_id not in _op_label_map:
+        _op_label_map[op_id] = new_label()
+    return _op_label_map[op_id]
+
+
+def compile_bytecode(ops: list[Op]) -> Program:
+    reset_labels()
+    _op_label_map.clear()
+
     bytecode: Bytecode = []
     compiler = Compiler(ops)
 
@@ -29,15 +57,17 @@ def compile_bytecode(ops: list[Op]) -> Bytecode:
         bytecode.append(Inst(InstKind.GLOBALS_INIT, args=[len(GLOBAL_VARIABLES)]))
 
     bytecode += compiler.compile()
-    return bytecode
 
-
-def new_label() -> LabelId:
-    return random.randint(0, sys.maxsize)
-
-
-def op_to_label(op: Op) -> LabelId:
-    return id(op)
+    return Program(
+        bytecode=bytecode,
+        functions={
+            name: fn.bytecode
+            for name, fn in GLOBAL_FUNCTIONS.items()
+            if fn.bytecode is not None
+        },
+        strings=compiler.string_table,
+        globals_count=len(GLOBAL_VARIABLES),
+    )
 
 
 @dataclass
@@ -45,6 +75,23 @@ class Compiler:
     ops: list[Op]
     function: Function | None = None
     locals_count: int = 0
+    string_table: list[str] | None = None
+
+    def __post_init__(self):
+        if self.string_table is None:
+            self.string_table = []
+        self._current_loc: Location | None = None
+
+    def intern_string(self, s: str) -> int:
+        """Add a string to the string table and return its index."""
+        if s in self.string_table:
+            return self.string_table.index(s)
+        self.string_table.append(s)
+        return len(self.string_table) - 1
+
+    def inst(self, kind: InstKind, args: list | None = None) -> Inst:
+        """Create an Inst with the current source location."""
+        return Inst(kind, args=args or [], location=self._current_loc)
 
     def compile(self) -> Bytecode:
         assert len(InstKind) == 42, "Exhaustive handling for `InstructionKind"
@@ -56,31 +103,32 @@ class Compiler:
             self.locals_count = len(self.function.variables)
 
         # Function label
-        fn_label = id(self.ops)
+        fn_label = new_label()
         bytecode.append(Inst(InstKind.LABEL, args=[fn_label]))
 
         while op := cursor.pop():
+            self._current_loc = op.location
             match op.kind:
                 case OpKind.ADD:
-                    bytecode.append(Inst(InstKind.ADD))
+                    bytecode.append(self.inst(InstKind.ADD))
                 case OpKind.AND:
-                    bytecode.append(Inst(InstKind.AND))
+                    bytecode.append(self.inst(InstKind.AND))
                 case OpKind.ASSIGN_DECREMENT:
                     variable_name = op.value
                     assert isinstance(variable_name, str), "Valid variable name"
 
                     if variable_name in GLOBAL_VARIABLES:
                         index = list(GLOBAL_VARIABLES.keys()).index(variable_name)
-                        bytecode.append(Inst(InstKind.GLOBAL_GET, args=[index]))
-                        bytecode.append(Inst(InstKind.SWAP))
-                        bytecode.append(Inst(InstKind.ADD))
-                        bytecode.append(Inst(InstKind.GLOBAL_SET, args=[index]))
+                        bytecode.append(self.inst(InstKind.GLOBAL_GET, args=[index]))
+                        bytecode.append(self.inst(InstKind.SWAP))
+                        bytecode.append(self.inst(InstKind.ADD))
+                        bytecode.append(self.inst(InstKind.GLOBAL_SET, args=[index]))
                     elif self.function and variable_name in self.function.variables:
                         index = self.function.variables.index(Variable(variable_name))
-                        bytecode.append(Inst(InstKind.LOCAL_GET, args=[index]))
-                        bytecode.append(Inst(InstKind.SWAP))
-                        bytecode.append(Inst(InstKind.ADD))
-                        bytecode.append(Inst(InstKind.LOCAL_SET, args=[index]))
+                        bytecode.append(self.inst(InstKind.LOCAL_GET, args=[index]))
+                        bytecode.append(self.inst(InstKind.SWAP))
+                        bytecode.append(self.inst(InstKind.ADD))
+                        bytecode.append(self.inst(InstKind.LOCAL_SET, args=[index]))
                     else:
                         raise AssertionError(
                             f"Variable `{variable_name}` is not defined"
@@ -91,14 +139,14 @@ class Compiler:
 
                     if variable_name in GLOBAL_VARIABLES:
                         index = list(GLOBAL_VARIABLES.keys()).index(variable_name)
-                        bytecode.append(Inst(InstKind.GLOBAL_GET, args=[index]))
-                        bytecode.append(Inst(InstKind.ADD))
-                        bytecode.append(Inst(InstKind.GLOBAL_SET, args=[index]))
+                        bytecode.append(self.inst(InstKind.GLOBAL_GET, args=[index]))
+                        bytecode.append(self.inst(InstKind.ADD))
+                        bytecode.append(self.inst(InstKind.GLOBAL_SET, args=[index]))
                     elif self.function and variable_name in self.function.variables:
                         index = self.function.variables.index(Variable(variable_name))
-                        bytecode.append(Inst(InstKind.LOCAL_GET, args=[index]))
-                        bytecode.append(Inst(InstKind.ADD))
-                        bytecode.append(Inst(InstKind.LOCAL_SET, args=[index]))
+                        bytecode.append(self.inst(InstKind.LOCAL_GET, args=[index]))
+                        bytecode.append(self.inst(InstKind.ADD))
+                        bytecode.append(self.inst(InstKind.LOCAL_SET, args=[index]))
                     else:
                         raise AssertionError(
                             f"Variable `{variable_name}` is not defined"
@@ -110,22 +158,22 @@ class Compiler:
                     # Global variable
                     if variable_name in GLOBAL_VARIABLES:
                         index = list(GLOBAL_VARIABLES.keys()).index(variable_name)
-                        bytecode.append(Inst(InstKind.GLOBAL_SET, args=[index]))
+                        bytecode.append(self.inst(InstKind.GLOBAL_SET, args=[index]))
                         continue
 
                     # Local variable
                     assert self.function, "Function exists"
                     assert variable_name in self.function.variables, "Variable exists"
                     index = self.function.variables.index(Variable(variable_name))
-                    bytecode.append(Inst(InstKind.LOCAL_SET, args=[index]))
+                    bytecode.append(self.inst(InstKind.LOCAL_SET, args=[index]))
                 case OpKind.DIV:
-                    bytecode.append(Inst(InstKind.DIV))
+                    bytecode.append(self.inst(InstKind.DIV))
                 case OpKind.DROP:
-                    bytecode.append(Inst(InstKind.DROP))
+                    bytecode.append(self.inst(InstKind.DROP))
                 case OpKind.DUP:
-                    bytecode.append(Inst(InstKind.DUP))
+                    bytecode.append(self.inst(InstKind.DUP))
                 case OpKind.EQ:
-                    bytecode.append(Inst(InstKind.EQ))
+                    bytecode.append(self.inst(InstKind.EQ))
                 case OpKind.FN_CALL:
                     function_name = op.value
                     function = GLOBAL_FUNCTIONS.get(function_name)
@@ -141,12 +189,15 @@ class Compiler:
                                 )
 
                         if self.function != function:
-                            fn_compiler = Compiler(function.ops, function)
+                            fn_compiler = Compiler(
+                                function.ops, function,
+                                string_table=self.string_table,
+                            )
                             function.bytecode = fn_compiler.compile()
 
-                    bytecode.append(Inst(InstKind.FN_CALL, args=[function_name]))
+                    bytecode.append(self.inst(InstKind.FN_CALL, args=[function_name]))
                 case OpKind.FN_EXEC:
-                    bytecode.append(Inst(InstKind.FN_EXEC))
+                    bytecode.append(self.inst(InstKind.FN_EXEC))
                 case OpKind.FN_PUSH:
                     function_name = op.value
                     lambda_function = GLOBAL_FUNCTIONS.get(function_name)
@@ -154,22 +205,25 @@ class Compiler:
                         raise NameError(f"Function `{function_name}` is not defined")
 
                     # Compile the lambda function
-                    fn_compiler = Compiler(lambda_function.ops, lambda_function)
+                    fn_compiler = Compiler(
+                        lambda_function.ops, lambda_function,
+                        string_table=self.string_table,
+                    )
                     lambda_function.bytecode = fn_compiler.compile()
 
                     # Setup captures
                     for index, capture in enumerate(lambda_function.captures):
                         if capture in GLOBAL_VARIABLES:
                             index = list(GLOBAL_VARIABLES.values()).index(capture)
-                            bytecode.append(Inst(InstKind.GLOBAL_GET, args=[index]))
+                            bytecode.append(self.inst(InstKind.GLOBAL_GET, args=[index]))
                         elif self.function and capture in self.function.variables:
                             index = self.function.variables.index(capture)
-                            bytecode.append(Inst(InstKind.LOCAL_GET, args=[index]))
+                            bytecode.append(self.inst(InstKind.LOCAL_GET, args=[index]))
                         else:
                             raise AssertionError("Captured variable should exist")
 
                         bytecode.append(
-                            Inst(
+                            self.inst(
                                 InstKind.CONSTANT_STORE,
                                 args=[f"{lambda_function.name}_{capture.name}"],
                             )
@@ -177,16 +231,16 @@ class Compiler:
 
                     # Push function pointer
                     index = list(GLOBAL_FUNCTIONS).index(function_name)
-                    bytecode.append(Inst(InstKind.PUSH, args=[index]))
+                    bytecode.append(self.inst(InstKind.PUSH, args=[index]))
 
                 case OpKind.FN_RETURN:
-                    bytecode.append(Inst(InstKind.FN_RETURN))
+                    bytecode.append(self.inst(InstKind.FN_RETURN))
                 case OpKind.GE:
-                    bytecode.append(Inst(InstKind.GE))
+                    bytecode.append(self.inst(InstKind.GE))
                 case OpKind.GT:
-                    bytecode.append(Inst(InstKind.GT))
+                    bytecode.append(self.inst(InstKind.GT))
                 case OpKind.HEAP_ALLOC:
-                    bytecode.append(Inst(InstKind.HEAP_ALLOC))
+                    bytecode.append(self.inst(InstKind.HEAP_ALLOC))
                 case OpKind.IDENTIFIER:
                     raise AssertionError(
                         f"Identifier `{op.value}` should be resolved by the parser"
@@ -209,7 +263,7 @@ class Compiler:
                     if not end_label:
                         raise SyntaxError("`then` without matching `fi`")
 
-                    bytecode.append(Inst(InstKind.JUMP_NE, args=[end_label]))
+                    bytecode.append(self.inst(InstKind.JUMP_NE, args=[end_label]))
                 case OpKind.IF_ELIF:
                     # Elif must be inside if block
                     if not self.find_matching_label(
@@ -239,8 +293,8 @@ class Compiler:
                     if not end_label:
                         raise SyntaxError("`elif` without matching `fi`")
 
-                    bytecode.append(Inst(InstKind.JUMP, args=[end_label]))
-                    bytecode.append(Inst(InstKind.LABEL, args=[elif_label]))
+                    bytecode.append(self.inst(InstKind.JUMP, args=[end_label]))
+                    bytecode.append(self.inst(InstKind.LABEL, args=[elif_label]))
                 case OpKind.IF_ELSE:
                     # Else must be inside if block
                     if not self.find_matching_label(
@@ -260,8 +314,8 @@ class Compiler:
                     if not end_label:
                         raise SyntaxError("`else` without matching `fi`")
 
-                    bytecode.append(Inst(InstKind.JUMP, args=[end_label]))
-                    bytecode.append(Inst(InstKind.LABEL, args=[else_label]))
+                    bytecode.append(self.inst(InstKind.JUMP, args=[end_label]))
+                    bytecode.append(self.inst(InstKind.LABEL, args=[else_label]))
                 case OpKind.IF_END:
                     if not self.find_matching_label(
                         op=op,
@@ -271,7 +325,7 @@ class Compiler:
                     ):
                         raise SyntaxError("`fi` without parent `if`")
                     label = op_to_label(op)
-                    bytecode.append(Inst(InstKind.LABEL, args=[label]))
+                    bytecode.append(self.inst(InstKind.LABEL, args=[label]))
                 case OpKind.IF_START:
                     if not self.find_matching_label(
                         op=op,
@@ -282,90 +336,94 @@ class Compiler:
                 case OpKind.INCLUDE_FILE:
                     pass
                 case OpKind.LE:
-                    bytecode.append(Inst(InstKind.LE))
+                    bytecode.append(self.inst(InstKind.LE))
                 case OpKind.LOAD:
-                    bytecode.append(Inst(InstKind.LOAD))
+                    bytecode.append(self.inst(InstKind.LOAD))
                 case OpKind.LT:
-                    bytecode.append(Inst(InstKind.LT))
+                    bytecode.append(self.inst(InstKind.LT))
                 case OpKind.METHOD_CALL:
                     raise AssertionError(
                         "Method call should be transpiled to function call during type checking"
                     )
                 case OpKind.MOD:
-                    bytecode.append(Inst(InstKind.MOD))
+                    bytecode.append(self.inst(InstKind.MOD))
                 case OpKind.MUL:
-                    bytecode.append(Inst(InstKind.MUL))
+                    bytecode.append(self.inst(InstKind.MUL))
                 case OpKind.NE:
-                    bytecode.append(Inst(InstKind.NE))
+                    bytecode.append(self.inst(InstKind.NE))
                 case OpKind.NOT:
-                    bytecode.append(Inst(InstKind.NOT))
+                    bytecode.append(self.inst(InstKind.NOT))
                 case OpKind.OR:
-                    bytecode.append(Inst(InstKind.OR))
+                    bytecode.append(self.inst(InstKind.OR))
                 case OpKind.OVER:
-                    bytecode.append(Inst(InstKind.OVER))
+                    bytecode.append(self.inst(InstKind.OVER))
                 case OpKind.PRINT:
-                    bytecode.append(Inst(InstKind.PRINT))
+                    bytecode.append(self.inst(InstKind.PRINT))
                 case OpKind.PUSH_ARRAY:
                     assert isinstance(op.value, list), "Expected `list`"
                     list_len = len(op.value)
 
                     # Push array items in the reverse order
                     reversed_items: list[Op] = list(reversed(op.value))
-                    list_bytecode = Compiler(reversed_items).compile()
+                    list_compiler = Compiler(
+                        reversed_items,
+                        string_table=self.string_table,
+                    )
+                    list_bytecode = list_compiler.compile()
                     bytecode += list_bytecode
 
                     # Allocate memory for the array
                     local_list = self.locals_count
-                    bytecode.append(Inst(InstKind.PUSH, args=[list_len + 1]))
-                    bytecode.append(Inst(InstKind.HEAP_ALLOC))
-                    bytecode.append(Inst(InstKind.LOCAL_SET, args=[local_list]))
+                    bytecode.append(self.inst(InstKind.PUSH, args=[list_len + 1]))
+                    bytecode.append(self.inst(InstKind.HEAP_ALLOC))
+                    bytecode.append(self.inst(InstKind.LOCAL_SET, args=[local_list]))
                     self.locals_count += 1
 
                     # First item of the array is its length
                     local_len = self.locals_count
-                    bytecode.append(Inst(InstKind.PUSH, args=[list_len]))
-                    bytecode.append(Inst(InstKind.DUP))
-                    bytecode.append(Inst(InstKind.LOCAL_SET, args=[local_len]))
-                    bytecode.append(Inst(InstKind.LOCAL_GET, args=[local_list]))
-                    bytecode.append(Inst(InstKind.STORE))
+                    bytecode.append(self.inst(InstKind.PUSH, args=[list_len]))
+                    bytecode.append(self.inst(InstKind.DUP))
+                    bytecode.append(self.inst(InstKind.LOCAL_SET, args=[local_len]))
+                    bytecode.append(self.inst(InstKind.LOCAL_GET, args=[local_list]))
+                    bytecode.append(self.inst(InstKind.STORE))
                     self.locals_count += 1
 
                     # Create the array
                     local_index = self.locals_count
-                    bytecode.append(Inst(InstKind.PUSH, args=[1]))
-                    bytecode.append(Inst(InstKind.LOCAL_SET, args=[local_index]))
+                    bytecode.append(self.inst(InstKind.PUSH, args=[1]))
+                    bytecode.append(self.inst(InstKind.LOCAL_SET, args=[local_index]))
                     self.locals_count += 1
 
                     start_label = new_label()
                     end_label = new_label()
 
                     # while index len > do
-                    bytecode.append(Inst(InstKind.LABEL, args=[start_label]))
-                    bytecode.append(Inst(InstKind.LOCAL_GET, args=[local_index]))
-                    bytecode.append(Inst(InstKind.LOCAL_GET, args=[local_len]))
-                    bytecode.append(Inst(InstKind.GE))
-                    bytecode.append(Inst(InstKind.JUMP_NE, args=[end_label]))
+                    bytecode.append(self.inst(InstKind.LABEL, args=[start_label]))
+                    bytecode.append(self.inst(InstKind.LOCAL_GET, args=[local_index]))
+                    bytecode.append(self.inst(InstKind.LOCAL_GET, args=[local_len]))
+                    bytecode.append(self.inst(InstKind.GE))
+                    bytecode.append(self.inst(InstKind.JUMP_NE, args=[end_label]))
 
                     # list index + store
-                    bytecode.append(Inst(InstKind.LOCAL_GET, args=[local_list]))
-                    bytecode.append(Inst(InstKind.LOCAL_GET, args=[local_index]))
-                    bytecode.append(Inst(InstKind.ADD))
-                    bytecode.append(Inst(InstKind.STORE))
+                    bytecode.append(self.inst(InstKind.LOCAL_GET, args=[local_list]))
+                    bytecode.append(self.inst(InstKind.LOCAL_GET, args=[local_index]))
+                    bytecode.append(self.inst(InstKind.ADD))
+                    bytecode.append(self.inst(InstKind.STORE))
 
                     # 1 += index
-                    bytecode.append(Inst(InstKind.LOCAL_GET, args=[local_index]))
-                    bytecode.append(Inst(InstKind.PUSH, args=[1]))
-                    bytecode.append(Inst(InstKind.ADD))
-                    bytecode.append(Inst(InstKind.LOCAL_SET, args=[local_index]))
+                    bytecode.append(self.inst(InstKind.LOCAL_GET, args=[local_index]))
+                    bytecode.append(self.inst(InstKind.PUSH, args=[1]))
+                    bytecode.append(self.inst(InstKind.ADD))
+                    bytecode.append(self.inst(InstKind.LOCAL_SET, args=[local_index]))
 
                     # done
-                    bytecode.append(Inst(InstKind.JUMP, args=[start_label]))
-                    bytecode.append(Inst(InstKind.LABEL, args=[end_label]))
+                    bytecode.append(self.inst(InstKind.JUMP, args=[start_label]))
+                    bytecode.append(self.inst(InstKind.LABEL, args=[end_label]))
 
                     # Push array to the stack
-                    bytecode.append(Inst(InstKind.LOCAL_GET, args=[local_list]))
+                    bytecode.append(self.inst(InstKind.LOCAL_GET, args=[local_list]))
                 case OpKind.PUSH_BOOL:
-                    bytecode.append(Inst(InstKind.PUSH, args=[int(op.value)]))
+                    bytecode.append(self.inst(InstKind.PUSH, args=[int(op.value)]))
                 case OpKind.PUSH_CAPTURE:
                     capture_name = op.value
                     assert isinstance(capture_name, str), "Valid capture name"
@@ -374,15 +432,16 @@ class Compiler:
                         self.function.name if self.function else GLOBAL_SCOPE_LABEL
                     )
                     bytecode.append(
-                        Inst(
+                        self.inst(
                             InstKind.CONSTANT_LOAD,
                             args=[f"{function_name}_{capture_name}"],
                         )
                     )
                 case OpKind.PUSH_INT:
-                    bytecode.append(Inst(InstKind.PUSH, args=[op.value]))
+                    bytecode.append(self.inst(InstKind.PUSH, args=[op.value]))
                 case OpKind.PUSH_STR:
-                    bytecode.append(Inst(InstKind.PUSH_STR, args=[op.value]))
+                    string_index = self.intern_string(op.value)
+                    bytecode.append(self.inst(InstKind.PUSH_STR, args=[string_index]))
                 case OpKind.PUSH_VARIABLE:
                     variable_name = op.value
                     assert isinstance(variable_name, str), "Valid variable name"
@@ -390,7 +449,7 @@ class Compiler:
                     # Global variable
                     if variable_name in GLOBAL_VARIABLES:
                         index = list(GLOBAL_VARIABLES.keys()).index(variable_name)
-                        bytecode.append(Inst(InstKind.GLOBAL_GET, args=[index]))
+                        bytecode.append(self.inst(InstKind.GLOBAL_GET, args=[index]))
                         continue
 
                     # Local variable
@@ -401,36 +460,36 @@ class Compiler:
                         )
 
                     index = self.function.variables.index(Variable(variable_name))
-                    bytecode.append(Inst(InstKind.LOCAL_GET, args=[index]))
+                    bytecode.append(self.inst(InstKind.LOCAL_GET, args=[index]))
                 case OpKind.ROT:
-                    bytecode.append(Inst(InstKind.ROT))
+                    bytecode.append(self.inst(InstKind.ROT))
                 case OpKind.SHL:
-                    bytecode.append(Inst(InstKind.SHL))
+                    bytecode.append(self.inst(InstKind.SHL))
                 case OpKind.SHR:
-                    bytecode.append(Inst(InstKind.SHR))
+                    bytecode.append(self.inst(InstKind.SHR))
                 case OpKind.STORE:
-                    bytecode.append(Inst(InstKind.STORE))
+                    bytecode.append(self.inst(InstKind.STORE))
                 case OpKind.STRUCT_NEW:
                     struct = op.value
                     assert isinstance(struct, Struct), "Expected struct"
 
                     # Allocate memory for the struct
                     member_count = len(struct.members)
-                    bytecode.append(Inst(InstKind.PUSH, args=[member_count]))
-                    bytecode.append(Inst(InstKind.HEAP_ALLOC))
+                    bytecode.append(self.inst(InstKind.PUSH, args=[member_count]))
+                    bytecode.append(self.inst(InstKind.HEAP_ALLOC))
 
                     # Create the list
                     for i in range(member_count):
-                        bytecode.append(Inst(InstKind.SWAP))
-                        bytecode.append(Inst(InstKind.OVER))
+                        bytecode.append(self.inst(InstKind.SWAP))
+                        bytecode.append(self.inst(InstKind.OVER))
                         if i > 0:
-                            bytecode.append(Inst(InstKind.PUSH, args=[i]))
-                            bytecode.append(Inst(InstKind.ADD))
-                        bytecode.append(Inst(InstKind.STORE))
+                            bytecode.append(self.inst(InstKind.PUSH, args=[i]))
+                            bytecode.append(self.inst(InstKind.ADD))
+                        bytecode.append(self.inst(InstKind.STORE))
                 case OpKind.SUB:
-                    bytecode.append(Inst(InstKind.SUB))
+                    bytecode.append(self.inst(InstKind.SUB))
                 case OpKind.SWAP:
-                    bytecode.append(Inst(InstKind.SWAP))
+                    bytecode.append(self.inst(InstKind.SWAP))
                 case OpKind.TYPE_CAST:
                     pass
                 case OpKind.WHILE_BREAK:
@@ -450,7 +509,7 @@ class Compiler:
                     if not end_label:
                         raise SyntaxError("`break` without matching `done`")
 
-                    bytecode.append(Inst(InstKind.JUMP, args=[end_label]))
+                    bytecode.append(self.inst(InstKind.JUMP, args=[end_label]))
                 case OpKind.WHILE_CONDITION:
                     if not self.find_matching_label(
                         op=op,
@@ -468,7 +527,7 @@ class Compiler:
                     if not end_label:
                         raise SyntaxError("`do` without matching `done`")
 
-                    bytecode.append(Inst(InstKind.JUMP_NE, args=[end_label]))
+                    bytecode.append(self.inst(InstKind.JUMP_NE, args=[end_label]))
                 case OpKind.WHILE_CONTINUE:
                     start_label = self.find_matching_label(
                         op=op,
@@ -479,7 +538,7 @@ class Compiler:
                     if not start_label:
                         raise SyntaxError("`continue` without parent `while`")
 
-                    bytecode.append(Inst(InstKind.JUMP, args=[start_label]))
+                    bytecode.append(self.inst(InstKind.JUMP, args=[start_label]))
                 case OpKind.WHILE_END:
                     while_label = op_to_label(op)
                     start_label = self.find_matching_label(
@@ -491,11 +550,11 @@ class Compiler:
                     if not start_label:
                         raise SyntaxError("`done` without parent `while`")
 
-                    bytecode.append(Inst(InstKind.JUMP, args=[start_label]))
-                    bytecode.append(Inst(InstKind.LABEL, args=[while_label]))
+                    bytecode.append(self.inst(InstKind.JUMP, args=[start_label]))
+                    bytecode.append(self.inst(InstKind.LABEL, args=[while_label]))
                 case OpKind.WHILE_START:
                     label = op_to_label(op)
-                    bytecode.append(Inst(InstKind.LABEL, args=[label]))
+                    bytecode.append(self.inst(InstKind.LABEL, args=[label]))
                 case _:
                     assert_never(op.kind)
 

--- a/casa/cli.py
+++ b/casa/cli.py
@@ -1,5 +1,6 @@
 import argparse
 
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("input", help="input file")

--- a/casa/common.py
+++ b/casa/common.py
@@ -509,6 +509,8 @@ class Inst:
                 | InstKind.LOCAL_SET
                 | InstKind.PUSH
                 | InstKind.PUSH_STR
+                | InstKind.CONSTANT_LOAD
+                | InstKind.CONSTANT_STORE
             ):
                 if len(self.args) != 1 or not isinstance(self.args[0], int):
                     raise TypeError(
@@ -516,9 +518,7 @@ class Inst:
                     )
             # One parameter of type `str`
             case (
-                InstKind.CONSTANT_LOAD
-                | InstKind.CONSTANT_STORE
-                | InstKind.FN_CALL
+                InstKind.FN_CALL
             ):
                 if len(self.args) != 1 or not isinstance(self.args[0], str):
                     raise TypeError(
@@ -537,6 +537,7 @@ class Program:
     functions: dict[str, Bytecode]            # Function name -> bytecode
     strings: list[str]                        # String table (index = string ID)
     globals_count: int                        # Number of global variables
+    constants_count: int                      # Number of constant/capture slots
 
 ANY_TYPE = "any"
 

--- a/casa/common.py
+++ b/casa/common.py
@@ -383,7 +383,7 @@ class InstKind(Enum):
     DUP = auto()
     OVER = auto()
     PUSH = auto()
-    PUSH_STR = auto()  # TODO: Implement with `PUSH`
+    PUSH_STR = auto()
     ROT = auto()
     SWAP = auto()
 
@@ -449,6 +449,13 @@ class InstKind(Enum):
 class Inst:
     kind: InstKind
     args: list = field(default_factory=list)
+    location: Location | None = None
+
+    @property
+    def arg(self) -> int | str:
+        """Single argument accessor for instructions with exactly one arg."""
+        assert len(self.args) == 1, f"Expected 1 arg, got {len(self.args)}"
+        return self.args[0]
 
     def __post_init__(self):
         assert len(InstKind) == 42, "Exhaustive handling for `InstructionKind`"
@@ -501,6 +508,7 @@ class Inst:
                 | InstKind.LOCAL_GET
                 | InstKind.LOCAL_SET
                 | InstKind.PUSH
+                | InstKind.PUSH_STR
             ):
                 if len(self.args) != 1 or not isinstance(self.args[0], int):
                     raise TypeError(
@@ -511,7 +519,6 @@ class Inst:
                 InstKind.CONSTANT_LOAD
                 | InstKind.CONSTANT_STORE
                 | InstKind.FN_CALL
-                | InstKind.PUSH_STR
             ):
                 if len(self.args) != 1 or not isinstance(self.args[0], str):
                     raise TypeError(
@@ -522,6 +529,14 @@ class Inst:
 Bytecode = list[Inst]
 LabelId = int
 Type = str
+
+
+@dataclass
+class Program:
+    bytecode: Bytecode                        # Global scope instructions
+    functions: dict[str, Bytecode]            # Function name -> bytecode
+    strings: list[str]                        # String table (index = string ID)
+    globals_count: int                        # Number of global variables
 
 ANY_TYPE = "any"
 

--- a/casa/common.py
+++ b/casa/common.py
@@ -517,9 +517,7 @@ class Inst:
                         f"`{self.kind}` requires one parameter of type `int`\nArguments: {self.args}"
                     )
             # One parameter of type `str`
-            case (
-                InstKind.FN_CALL
-            ):
+            case InstKind.FN_CALL:
                 if len(self.args) != 1 or not isinstance(self.args[0], str):
                     raise TypeError(
                         f"`{self.kind}` requires one parameter of type `str`\nArguments: {self.args}"
@@ -533,11 +531,12 @@ Type = str
 
 @dataclass
 class Program:
-    bytecode: Bytecode                        # Global scope instructions
-    functions: dict[str, Bytecode]            # Function name -> bytecode
-    strings: list[str]                        # String table (index = string ID)
-    globals_count: int                        # Number of global variables
-    constants_count: int                      # Number of constant/capture slots
+    bytecode: Bytecode  # Global scope instructions
+    functions: dict[str, Bytecode]  # Function name -> bytecode
+    strings: list[str]  # String table (index = string ID)
+    globals_count: int  # Number of global variables
+    constants_count: int  # Number of constant/capture slots
+
 
 ANY_TYPE = "any"
 

--- a/casa/interpreter.py
+++ b/casa/interpreter.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import assert_never
 
 from casa.common import GLOBAL_FUNCTIONS, Bytecode, Function, InstKind, LabelId, Program
@@ -32,7 +32,9 @@ class VirtualMachine:
 
 
 def interpret_program(program: Program):
-    vm = VirtualMachine(strings=program.strings, constants_count=program.constants_count)
+    vm = VirtualMachine(
+        strings=program.strings, constants_count=program.constants_count
+    )
     interpret_bytecode(program.bytecode, vm)
 
 

--- a/casa/interpreter.py
+++ b/casa/interpreter.py
@@ -33,7 +33,8 @@ class VirtualMachine:
 
 def interpret_program(program: Program):
     vm = VirtualMachine(
-        strings=program.strings, constants_count=program.constants_count
+        strings=program.strings,
+        constants_count=program.constants_count,
     )
     interpret_bytecode(program.bytecode, vm)
 


### PR DESCRIPTION
## Summary
- Redesign `Inst` bytecode with source `location` tracking and `arg` accessor
- Replace non-deterministic label IDs with a monotonic counter for reproducible output
- Build a string table during compilation; `PUSH_STR` now carries a table index
- Add `Program` dataclass bundling bytecode, functions, strings, and metadata
- Convert `CONSTANT_LOAD`/`CONSTANT_STORE` from string keys to indexed slots

## Test plan
- [x] All 13 example programs produce correct output
- [x] Formatted with black
- [x] Linted with pylint (no new warnings)
- [x] Type checked with mypy --check-untyped-defs (no new errors)