### PR TITLE
Add unit tests for compiler pipeline

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -1,0 +1,23 @@
+name: Unit tests
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v5
+    - uses: actions/setup-python@v6
+      with:
+        python-version: "3.11"
+    - name: Install pytest
+      run: pip install pytest
+    - name: Run unit tests
+      run: python -m pytest tests/ -v

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,9 @@
 """Shared fixtures and pipeline helpers for Casa compiler tests."""
 
+import sys
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 import pytest
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,22 +27,28 @@ from casa.typechecker import type_check_ops
 TEST_FILE = Path("test.casa")
 
 
+def _clear_globals():
+    """Reset all module-level mutable state to a clean slate."""
+    GLOBAL_FUNCTIONS.clear()
+    GLOBAL_STRUCTS.clear()
+    GLOBAL_VARIABLES.clear()
+    INCLUDED_FILES.clear()
+    reset_labels()
+    _op_label_map.clear()
+
+
 @pytest.fixture(autouse=True)
 def clear_global_state():
-    """Clear all global mutable state before and after every test."""
-    GLOBAL_FUNCTIONS.clear()
-    GLOBAL_STRUCTS.clear()
-    GLOBAL_VARIABLES.clear()
-    INCLUDED_FILES.clear()
-    reset_labels()
-    _op_label_map.clear()
+    """
+    Clear all global mutable state before and after every test.
+
+    The pre-yield clear ensures a clean slate even if a previous test's
+    teardown was skipped (e.g. due to a crash). The post-yield clear is
+    the normal teardown so the current test doesn't leak state.
+    """
+    _clear_globals()
     yield
-    GLOBAL_FUNCTIONS.clear()
-    GLOBAL_STRUCTS.clear()
-    GLOBAL_VARIABLES.clear()
-    INCLUDED_FILES.clear()
-    reset_labels()
-    _op_label_map.clear()
+    _clear_globals()
 
 
 def lex_string(code: str) -> list[Token]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,79 @@
+"""Shared fixtures and pipeline helpers for Casa compiler tests."""
+
+from pathlib import Path
+
+import pytest
+
+from casa.common import (
+    GLOBAL_FUNCTIONS,
+    GLOBAL_STRUCTS,
+    GLOBAL_VARIABLES,
+    INCLUDED_FILES,
+    Cursor,
+    Op,
+    Program,
+    Signature,
+    Token,
+)
+from casa.bytecode import _op_label_map, compile_bytecode, reset_labels
+from casa.emitter import emit_program
+from casa.lexer import Lexer
+from casa.parser import parse_ops, resolve_identifiers
+from casa.typechecker import type_check_ops
+
+TEST_FILE = Path("test.casa")
+
+
+@pytest.fixture(autouse=True)
+def clear_global_state():
+    """Clear all global mutable state before and after every test."""
+    GLOBAL_FUNCTIONS.clear()
+    GLOBAL_STRUCTS.clear()
+    GLOBAL_VARIABLES.clear()
+    INCLUDED_FILES.clear()
+    reset_labels()
+    _op_label_map.clear()
+    yield
+    GLOBAL_FUNCTIONS.clear()
+    GLOBAL_STRUCTS.clear()
+    GLOBAL_VARIABLES.clear()
+    INCLUDED_FILES.clear()
+    reset_labels()
+    _op_label_map.clear()
+
+
+def lex_string(code: str) -> list[Token]:
+    """Lex a source string into tokens."""
+    lexer = Lexer(cursor=Cursor(sequence=code), file=TEST_FILE)
+    return lexer.lex()
+
+
+def parse_string(code: str) -> list[Op]:
+    """Lex and parse a source string into ops."""
+    tokens = lex_string(code)
+    return parse_ops(tokens)
+
+
+def resolve_string(code: str) -> list[Op]:
+    """Lex, parse, and resolve identifiers in a source string."""
+    ops = parse_string(code)
+    return resolve_identifiers(ops)
+
+
+def typecheck_string(code: str) -> Signature:
+    """Full pipeline through type checking. Returns inferred signature."""
+    ops = resolve_string(code)
+    return type_check_ops(ops)
+
+
+def compile_string(code: str) -> Program:
+    """Full pipeline through bytecode compilation."""
+    ops = resolve_string(code)
+    type_check_ops(ops)
+    return compile_bytecode(ops)
+
+
+def emit_string(code: str) -> str:
+    """Full pipeline to assembly string."""
+    program = compile_string(code)
+    return emit_program(program)

--- a/tests/test_bytecode.py
+++ b/tests/test_bytecode.py
@@ -1,0 +1,216 @@
+"""Tests for casa/bytecode.py — verifies Program structure, instruction kinds, string table."""
+
+import pytest
+
+from casa.common import InstKind, Program
+from tests.conftest import compile_string
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def find_insts(program: Program, kind: InstKind, in_functions: bool = False):
+    """Find instructions of a given kind in main bytecode or all function bytecodes."""
+    results = [i for i in program.bytecode if i.kind == kind]
+    if in_functions:
+        for fn_bc in program.functions.values():
+            results += [i for i in fn_bc if i.kind == kind]
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Simple ops (1:1 mapping from OpKind to InstKind)
+# ---------------------------------------------------------------------------
+SIMPLE_OP_CASES = [
+    ("1 2 +", InstKind.ADD),
+    ("1 2 -", InstKind.SUB),
+    ("1 2 *", InstKind.MUL),
+    ("1 2 /", InstKind.DIV),
+    ("1 2 %", InstKind.MOD),
+    ("1 2 <<", InstKind.SHL),
+    ("1 2 >>", InstKind.SHR),
+    ("true false &&", InstKind.AND),
+    ("true false ||", InstKind.OR),
+    ("true !", InstKind.NOT),
+    ("1 2 ==", InstKind.EQ),
+    ("1 2 !=", InstKind.NE),
+    ("1 2 >", InstKind.GT),
+    ("1 2 >=", InstKind.GE),
+    ("1 2 <", InstKind.LT),
+    ("1 2 <=", InstKind.LE),
+    ("1 drop", InstKind.DROP),
+    ("1 dup", InstKind.DUP),
+    ("1 2 swap", InstKind.SWAP),
+    ("1 2 over", InstKind.OVER),
+    ("1 2 3 rot", InstKind.ROT),
+]
+
+
+@pytest.mark.parametrize("code,expected_kind", SIMPLE_OP_CASES)
+def test_bytecode_simple_ops(code, expected_kind):
+    program = compile_string(code)
+    insts = find_insts(program, expected_kind)
+    assert len(insts) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Push instructions
+# ---------------------------------------------------------------------------
+def test_bytecode_push_int():
+    program = compile_string("42")
+    pushes = find_insts(program, InstKind.PUSH)
+    assert any(i.args == [42] for i in pushes)
+
+
+def test_bytecode_push_bool_true():
+    program = compile_string("true")
+    pushes = find_insts(program, InstKind.PUSH)
+    assert any(i.args == [1] for i in pushes)
+
+
+def test_bytecode_push_bool_false():
+    program = compile_string("false")
+    pushes = find_insts(program, InstKind.PUSH)
+    assert any(i.args == [0] for i in pushes)
+
+
+def test_bytecode_push_str():
+    program = compile_string('"hello"')
+    pushes = find_insts(program, InstKind.PUSH_STR)
+    assert len(pushes) >= 1
+    assert "hello" in program.strings
+
+
+# ---------------------------------------------------------------------------
+# Print
+# ---------------------------------------------------------------------------
+def test_bytecode_print_int():
+    program = compile_string("42 print")
+    assert len(find_insts(program, InstKind.PRINT_INT)) >= 1
+
+
+def test_bytecode_print_str():
+    program = compile_string('"hello" print')
+    assert len(find_insts(program, InstKind.PRINT_STR)) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Heap
+# ---------------------------------------------------------------------------
+def test_bytecode_heap_alloc():
+    program = compile_string("10 alloc")
+    assert len(find_insts(program, InstKind.HEAP_ALLOC)) >= 1
+
+
+def test_bytecode_load_store():
+    program = compile_string("42 10 alloc store 10 alloc load")
+    assert len(find_insts(program, InstKind.STORE)) >= 1
+    assert len(find_insts(program, InstKind.LOAD)) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Globals
+# ---------------------------------------------------------------------------
+def test_bytecode_globals():
+    program = compile_string("42 = x x")
+    assert program.globals_count >= 1
+    assert len(find_insts(program, InstKind.GLOBALS_INIT)) >= 1
+    assert len(find_insts(program, InstKind.GLOBAL_SET)) >= 1
+    assert len(find_insts(program, InstKind.GLOBAL_GET)) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Locals
+# ---------------------------------------------------------------------------
+def test_bytecode_locals():
+    code = "fn foo a:int -> int { a }\n5 foo"
+    program = compile_string(code)
+    all_insts = find_insts(program, InstKind.LOCALS_INIT, in_functions=True)
+    assert len(all_insts) >= 1
+    all_insts = find_insts(program, InstKind.LOCALS_UNINIT, in_functions=True)
+    assert len(all_insts) >= 1
+    all_insts = find_insts(program, InstKind.LOCAL_SET, in_functions=True)
+    assert len(all_insts) >= 1
+    all_insts = find_insts(program, InstKind.LOCAL_GET, in_functions=True)
+    assert len(all_insts) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Function call / return
+# ---------------------------------------------------------------------------
+def test_bytecode_fn_call():
+    code = "fn greet { } greet"
+    program = compile_string(code)
+    calls = find_insts(program, InstKind.FN_CALL)
+    assert len(calls) >= 1
+    assert calls[0].args == ["greet"]
+    assert "greet" in program.functions
+
+
+def test_bytecode_fn_return():
+    code = "fn noop { } noop"
+    program = compile_string(code)
+    returns = find_insts(program, InstKind.FN_RETURN, in_functions=True)
+    assert len(returns) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Lambda: FN_PUSH / FN_EXEC
+# ---------------------------------------------------------------------------
+def test_bytecode_fn_push_exec():
+    code = "42 { 1 + } exec"
+    program = compile_string(code)
+    pushes = find_insts(program, InstKind.FN_PUSH)
+    assert len(pushes) >= 1
+    execs = find_insts(program, InstKind.FN_EXEC)
+    assert len(execs) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Constants (captures)
+# ---------------------------------------------------------------------------
+def test_bytecode_constants():
+    code = "42 = x { x } exec"
+    program = compile_string(code)
+    assert program.constants_count >= 1
+    stores = find_insts(program, InstKind.CONSTANT_STORE)
+    assert len(stores) >= 1
+    loads = find_insts(program, InstKind.CONSTANT_LOAD, in_functions=True)
+    assert len(loads) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Control flow: if
+# ---------------------------------------------------------------------------
+def test_bytecode_if_control_flow():
+    code = "if true then 1 drop fi"
+    program = compile_string(code)
+    labels = find_insts(program, InstKind.LABEL)
+    assert len(labels) >= 1
+    jumps_ne = find_insts(program, InstKind.JUMP_NE)
+    assert len(jumps_ne) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Control flow: while
+# ---------------------------------------------------------------------------
+def test_bytecode_while_control_flow():
+    code = "while false do done"
+    program = compile_string(code)
+    labels = find_insts(program, InstKind.LABEL)
+    assert len(labels) >= 2  # loop start + loop end
+    jumps = find_insts(program, InstKind.JUMP)
+    assert len(jumps) >= 1
+    jumps_ne = find_insts(program, InstKind.JUMP_NE)
+    assert len(jumps_ne) >= 1
+
+
+# ---------------------------------------------------------------------------
+# String interning
+# ---------------------------------------------------------------------------
+def test_bytecode_string_interning():
+    code = '"hello" print "hello" print "world" print'
+    program = compile_string(code)
+    assert program.strings.count("hello") == 1
+    assert "world" in program.strings
+    assert len(program.strings) == 2

--- a/tests/test_emitter.py
+++ b/tests/test_emitter.py
@@ -1,0 +1,243 @@
+"""Tests for casa/emitter.py — verifies assembly output contains expected patterns."""
+
+import pytest
+
+from tests.conftest import emit_string
+
+
+# ---------------------------------------------------------------------------
+# Sections
+# ---------------------------------------------------------------------------
+def test_emit_sections():
+    asm = emit_string("42")
+    assert ".section .bss" in asm
+    assert ".section .data" in asm
+    assert ".section .text" in asm
+    assert ".globl _start" in asm
+
+
+# ---------------------------------------------------------------------------
+# Push
+# ---------------------------------------------------------------------------
+def test_emit_push_int():
+    asm = emit_string("42")
+    assert "pushq $42" in asm
+
+
+def test_emit_push_large_int():
+    large = 2**32
+    asm = emit_string(str(large))
+    assert "movabsq" in asm
+
+
+def test_emit_push_str():
+    asm = emit_string('"hello"')
+    assert 'str_0: .asciz "hello"' in asm
+
+
+# ---------------------------------------------------------------------------
+# Stack operations
+# ---------------------------------------------------------------------------
+def test_emit_drop():
+    asm = emit_string("42 drop")
+    assert "addq $8, %rsp" in asm
+
+
+def test_emit_dup():
+    asm = emit_string("42 dup")
+    assert "pushq (%rsp)" in asm
+
+
+def test_emit_swap():
+    asm = emit_string("1 2 swap")
+    assert "popq %rax" in asm
+    assert "popq %rbx" in asm
+    assert "pushq %rax" in asm
+    assert "pushq %rbx" in asm
+
+
+def test_emit_over():
+    asm = emit_string("1 2 over")
+    assert "pushq 8(%rsp)" in asm
+
+
+# ---------------------------------------------------------------------------
+# Arithmetic
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "code,expected_asm",
+    [
+        ("1 2 +", "addq"),
+        ("1 2 -", "subq"),
+        ("1 2 *", "imulq"),
+        ("1 2 /", "idivq"),
+    ],
+)
+def test_emit_arithmetic(code, expected_asm):
+    asm = emit_string(code)
+    assert expected_asm in asm
+
+
+# ---------------------------------------------------------------------------
+# Bitshift
+# ---------------------------------------------------------------------------
+def test_emit_shl():
+    asm = emit_string("8 2 <<")
+    assert "shlq %cl" in asm
+
+
+def test_emit_shr():
+    asm = emit_string("8 2 >>")
+    assert "sarq %cl" in asm
+
+
+# ---------------------------------------------------------------------------
+# Boolean
+# ---------------------------------------------------------------------------
+def test_emit_and():
+    asm = emit_string("true false &&")
+    assert "andb" in asm
+
+
+def test_emit_or():
+    asm = emit_string("true false ||")
+    assert "orq" in asm
+
+
+def test_emit_not():
+    asm = emit_string("true !")
+    assert "sete" in asm
+
+
+# ---------------------------------------------------------------------------
+# Comparison
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "code,expected_setcc",
+    [
+        ("1 2 ==", "sete"),
+        ("1 2 !=", "setne"),
+        ("1 2 <", "setl"),
+        ("1 2 <=", "setle"),
+        ("1 2 >", "setg"),
+        ("1 2 >=", "setge"),
+    ],
+)
+def test_emit_comparison(code, expected_setcc):
+    asm = emit_string(code)
+    assert expected_setcc in asm
+
+
+# ---------------------------------------------------------------------------
+# Labels and jumps
+# ---------------------------------------------------------------------------
+def test_emit_label_jump():
+    asm = emit_string("if true then 1 drop fi")
+    assert ".L" in asm
+    assert "jz" in asm
+
+
+def test_emit_while_jump():
+    asm = emit_string("while false do done")
+    assert "jmp .L" in asm
+    assert "jz .L" in asm
+
+
+# ---------------------------------------------------------------------------
+# Functions
+# ---------------------------------------------------------------------------
+def test_emit_fn_call():
+    asm = emit_string("fn greet { } greet")
+    assert "jmp fn_greet" in asm
+    assert ".Lret_" in asm
+
+
+def test_emit_fn_return():
+    asm = emit_string("fn noop { } noop")
+    assert "jmpq *(%r14)" in asm
+
+
+def test_emit_fn_exec():
+    asm = emit_string("42 { 1 + } exec")
+    assert "jmpq *%rax" in asm
+
+
+def test_emit_fn_push():
+    asm = emit_string("{ 1 + }")
+    assert "leaq fn_lambda__" in asm
+
+
+# ---------------------------------------------------------------------------
+# Globals
+# ---------------------------------------------------------------------------
+def test_emit_global_get_set():
+    asm = emit_string("42 = x x")
+    assert "globals+" in asm
+
+
+# ---------------------------------------------------------------------------
+# Locals
+# ---------------------------------------------------------------------------
+def test_emit_local_get_set():
+    asm = emit_string("fn foo a:int -> int { a }\n5 foo")
+    assert "(%r14)" in asm
+
+
+def test_emit_locals_init_uninit():
+    asm = emit_string("fn foo a:int -> int { a }\n5 foo")
+    assert "rep stosq" in asm
+
+
+# ---------------------------------------------------------------------------
+# Constants (captures)
+# ---------------------------------------------------------------------------
+def test_emit_constant_load_store():
+    asm = emit_string("42 = x { x } exec")
+    assert "constants+" in asm
+
+
+# ---------------------------------------------------------------------------
+# Heap
+# ---------------------------------------------------------------------------
+def test_emit_heap_alloc():
+    asm = emit_string("10 alloc")
+    assert "heap_ptr" in asm
+
+
+def test_emit_load_store():
+    asm = emit_string("42 10 alloc store")
+    assert "leaq heap(%rip)" in asm
+
+
+# ---------------------------------------------------------------------------
+# Print
+# ---------------------------------------------------------------------------
+def test_emit_print_int():
+    asm = emit_string("42 print")
+    assert "jmp print_int" in asm
+
+
+def test_emit_print_str():
+    asm = emit_string('"hello" print')
+    assert "jmp print_str" in asm
+
+
+# ---------------------------------------------------------------------------
+# Exit syscall
+# ---------------------------------------------------------------------------
+def test_emit_exit_syscall():
+    asm = emit_string("42")
+    assert "movq $60, %rax" in asm
+    assert "syscall" in asm
+
+
+# ---------------------------------------------------------------------------
+# Name sanitization
+# ---------------------------------------------------------------------------
+def test_emit_sanitized_names():
+    code = """
+    struct Foo { x: int }
+    42 Foo .x
+    """
+    asm = emit_string(code)
+    assert "fn_Foo__x" in asm

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -1,0 +1,193 @@
+"""Tests for casa/lexer.py — covers all TokenKind, Keyword, Intrinsic, Operator, Delimiter values."""
+
+import pytest
+
+from casa.common import Delimiter, Intrinsic, Keyword, Operator, TokenKind
+from tests.conftest import lex_string
+
+
+# ---------------------------------------------------------------------------
+# Keywords
+# ---------------------------------------------------------------------------
+ALL_KEYWORDS = [
+    "fn", "impl", "return", "while", "do", "break", "continue", "done",
+    "if", "then", "elif", "else", "fi", "struct", "include",
+]
+assert len(ALL_KEYWORDS) == len(Keyword)
+
+
+@pytest.mark.parametrize("word", ALL_KEYWORDS)
+def test_lex_all_keywords(word):
+    tokens = lex_string(word)
+    # Last token is EOF
+    assert tokens[0].kind == TokenKind.KEYWORD
+    assert tokens[0].value == word
+
+
+# ---------------------------------------------------------------------------
+# Intrinsics
+# ---------------------------------------------------------------------------
+ALL_INTRINSICS = [
+    "drop", "dup", "over", "rot", "swap",
+    "alloc", "load", "store",
+    "print", "exec",
+]
+assert len(ALL_INTRINSICS) == len(Intrinsic)
+
+
+@pytest.mark.parametrize("word", ALL_INTRINSICS)
+def test_lex_all_intrinsics(word):
+    tokens = lex_string(word)
+    assert tokens[0].kind == TokenKind.INTRINSIC
+    assert tokens[0].value == word
+
+
+# ---------------------------------------------------------------------------
+# Operators
+# ---------------------------------------------------------------------------
+ALL_OPERATORS = [
+    "+", "-", "*", "/", "%",
+    "<<", ">>",
+    "&&", "||", "!",
+    "==", ">=", ">", "<=", "<", "!=",
+    "=", "-=", "+=",
+]
+assert len(ALL_OPERATORS) == len(Operator)
+
+
+@pytest.mark.parametrize("op", ALL_OPERATORS)
+def test_lex_all_operators(op):
+    # Operators like = need an identifier after them to not cause parse issues,
+    # but the lexer itself should still produce an OPERATOR token.
+    tokens = lex_string(op)
+    assert tokens[0].kind == TokenKind.OPERATOR
+    assert tokens[0].value == op
+
+
+# ---------------------------------------------------------------------------
+# Delimiters
+# ---------------------------------------------------------------------------
+# # (HASHTAG) is a comment — the lexer skips it, so we test it separately.
+DELIMITER_PAIRS = [
+    ("->", "->"),
+    (",", ","),
+    (":", ":"),
+    (".", "."),
+    ("{", "{"),
+    ("}", "}"),
+    ("[", "["),
+    ("]", "]"),
+    ("(", "("),
+    (")", ")"),
+]
+
+
+@pytest.mark.parametrize("text,expected_value", DELIMITER_PAIRS)
+def test_lex_all_delimiters(text, expected_value):
+    tokens = lex_string(text)
+    assert tokens[0].kind == TokenKind.DELIMITER
+    assert tokens[0].value == expected_value
+
+
+def test_lex_hashtag_comment_skips():
+    """HASHTAG delimiter causes the rest of the line to be skipped."""
+    tokens = lex_string("# this is a comment")
+    assert len(tokens) == 1
+    assert tokens[0].kind == TokenKind.EOF
+
+
+# ---------------------------------------------------------------------------
+# Literals
+# ---------------------------------------------------------------------------
+def test_lex_integer_literal():
+    tokens = lex_string("42")
+    assert tokens[0].kind == TokenKind.LITERAL
+    assert tokens[0].value == "42"
+
+
+@pytest.mark.parametrize("word", ["true", "false"])
+def test_lex_boolean_literals(word):
+    tokens = lex_string(word)
+    assert tokens[0].kind == TokenKind.LITERAL
+    assert tokens[0].value == word
+
+
+def test_lex_string_literal():
+    tokens = lex_string('"hello"')
+    assert tokens[0].kind == TokenKind.LITERAL
+    assert tokens[0].value == '"hello"'
+
+
+def test_lex_empty_string_literal():
+    tokens = lex_string('""')
+    assert tokens[0].kind == TokenKind.LITERAL
+    assert tokens[0].value == '""'
+
+
+# ---------------------------------------------------------------------------
+# Identifiers
+# ---------------------------------------------------------------------------
+def test_lex_identifier():
+    tokens = lex_string("my_var")
+    assert tokens[0].kind == TokenKind.IDENTIFIER
+    assert tokens[0].value == "my_var"
+
+
+def test_lex_identifier_capitalized():
+    tokens = lex_string("Person")
+    assert tokens[0].kind == TokenKind.IDENTIFIER
+    assert tokens[0].value == "Person"
+
+
+def test_lex_identifier_namespaced():
+    tokens = lex_string("A::b")
+    assert tokens[0].kind == TokenKind.IDENTIFIER
+    assert tokens[0].value == "A::b"
+
+
+# ---------------------------------------------------------------------------
+# EOF
+# ---------------------------------------------------------------------------
+def test_lex_eof():
+    tokens = lex_string("")
+    assert len(tokens) == 1
+    assert tokens[0].kind == TokenKind.EOF
+
+
+# ---------------------------------------------------------------------------
+# Comments
+# ---------------------------------------------------------------------------
+def test_lex_comment_skipping():
+    tokens = lex_string("42 # comment\n43")
+    non_eof = [t for t in tokens if t.kind != TokenKind.EOF]
+    assert len(non_eof) == 2
+    assert non_eof[0].value == "42"
+    assert non_eof[1].value == "43"
+
+
+# ---------------------------------------------------------------------------
+# Location tracking
+# ---------------------------------------------------------------------------
+def test_lex_location_tracking():
+    tokens = lex_string("42 hello")
+    assert tokens[0].location.span.offset == 0
+    assert tokens[0].location.span.length == 2
+    assert tokens[1].location.span.offset == 3
+    assert tokens[1].location.span.length == 5
+
+
+# ---------------------------------------------------------------------------
+# Full expression
+# ---------------------------------------------------------------------------
+def test_lex_full_expression():
+    tokens = lex_string("34 35 + print")
+    kinds = [t.kind for t in tokens]
+    assert kinds == [
+        TokenKind.LITERAL,
+        TokenKind.LITERAL,
+        TokenKind.OPERATOR,
+        TokenKind.INTRINSIC,
+        TokenKind.EOF,
+    ]
+    values = [t.value for t in tokens[:-1]]
+    assert values == ["34", "35", "+", "print"]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,315 @@
+"""Tests for casa/parser.py — covers OpKind values via parse_ops and resolve_identifiers."""
+
+import pytest
+
+from casa.common import (
+    GLOBAL_FUNCTIONS,
+    GLOBAL_STRUCTS,
+    GLOBAL_VARIABLES,
+    Function,
+    Intrinsic,
+    Keyword,
+    Op,
+    OpKind,
+    Operator,
+    Struct,
+    Variable,
+)
+from tests.conftest import lex_string, parse_string, resolve_string
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def find_ops(ops: list[Op], kind: OpKind) -> list[Op]:
+    return [op for op in ops if op.kind == kind]
+
+
+# ---------------------------------------------------------------------------
+# Literals
+# ---------------------------------------------------------------------------
+def test_parse_push_int():
+    ops = parse_string("42")
+    assert len(ops) == 1
+    assert ops[0].kind == OpKind.PUSH_INT
+    assert ops[0].value == 42
+
+
+@pytest.mark.parametrize("text,expected", [("true", True), ("false", False)])
+def test_parse_push_bool(text, expected):
+    ops = parse_string(text)
+    assert ops[0].kind == OpKind.PUSH_BOOL
+    assert ops[0].value is expected
+
+
+def test_parse_push_str():
+    ops = parse_string('"hello"')
+    assert ops[0].kind == OpKind.PUSH_STR
+    assert ops[0].value == "hello"
+
+
+def test_parse_push_array():
+    ops = parse_string("[1, 2, 3]")
+    assert ops[0].kind == OpKind.PUSH_ARRAY
+    assert len(ops[0].value) == 3
+
+
+# ---------------------------------------------------------------------------
+# Operators
+# ---------------------------------------------------------------------------
+OPERATOR_CASES = [
+    ("+", OpKind.ADD, Operator.PLUS),
+    ("-", OpKind.SUB, Operator.MINUS),
+    ("*", OpKind.MUL, Operator.MULTIPLICATION),
+    ("/", OpKind.DIV, Operator.DIVISION),
+    ("%", OpKind.MOD, Operator.MODULO),
+    ("<<", OpKind.SHL, Operator.SHL),
+    (">>", OpKind.SHR, Operator.SHR),
+    ("&&", OpKind.AND, Operator.AND),
+    ("||", OpKind.OR, Operator.OR),
+    ("!", OpKind.NOT, Operator.NOT),
+    ("==", OpKind.EQ, Operator.EQ),
+    (">=", OpKind.GE, Operator.GE),
+    (">", OpKind.GT, Operator.GT),
+    ("<=", OpKind.LE, Operator.LE),
+    ("<", OpKind.LT, Operator.LT),
+    ("!=", OpKind.NE, Operator.NE),
+]
+
+
+@pytest.mark.parametrize("text,expected_kind,expected_value", OPERATOR_CASES)
+def test_parse_all_operators(text, expected_kind, expected_value):
+    ops = parse_string(f"1 2 {text}")
+    op = [o for o in ops if o.kind == expected_kind][0]
+    assert op.value == expected_value
+
+
+# ---------------------------------------------------------------------------
+# Intrinsics
+# ---------------------------------------------------------------------------
+INTRINSIC_CASES = [
+    ("drop", OpKind.DROP, Intrinsic.DROP),
+    ("dup", OpKind.DUP, Intrinsic.DUP),
+    ("over", OpKind.OVER, Intrinsic.OVER),
+    ("rot", OpKind.ROT, Intrinsic.ROT),
+    ("swap", OpKind.SWAP, Intrinsic.SWAP),
+    ("alloc", OpKind.HEAP_ALLOC, Intrinsic.ALLOC),
+    ("load", OpKind.LOAD, Intrinsic.LOAD),
+    ("store", OpKind.STORE, Intrinsic.STORE),
+    ("print", OpKind.PRINT, Intrinsic.PRINT),
+    ("exec", OpKind.FN_EXEC, Intrinsic.EXEC),
+]
+
+
+@pytest.mark.parametrize("text,expected_kind,expected_value", INTRINSIC_CASES)
+def test_parse_all_intrinsics(text, expected_kind, expected_value):
+    ops = parse_string(text)
+    assert ops[0].kind == expected_kind
+    assert ops[0].value == expected_value
+
+
+# ---------------------------------------------------------------------------
+# Control flow: if/elif/else/fi
+# ---------------------------------------------------------------------------
+def test_parse_if_then_fi():
+    ops = parse_string("if true then 1 fi")
+    kinds = [op.kind for op in ops]
+    assert OpKind.IF_START in kinds
+    assert OpKind.IF_CONDITION in kinds
+    assert OpKind.IF_END in kinds
+
+
+def test_parse_if_elif_else():
+    ops = parse_string("if true then 1 elif false then 2 else 3 fi")
+    kinds = [op.kind for op in ops]
+    assert OpKind.IF_ELIF in kinds
+    assert OpKind.IF_ELSE in kinds
+
+
+# ---------------------------------------------------------------------------
+# Control flow: while/do/done
+# ---------------------------------------------------------------------------
+def test_parse_while_do_done():
+    ops = parse_string("while true do 1 drop done")
+    kinds = [op.kind for op in ops]
+    assert OpKind.WHILE_START in kinds
+    assert OpKind.WHILE_CONDITION in kinds
+    assert OpKind.WHILE_END in kinds
+
+
+def test_parse_while_break_continue():
+    ops = parse_string("while true do break continue done")
+    kinds = [op.kind for op in ops]
+    assert OpKind.WHILE_BREAK in kinds
+    assert OpKind.WHILE_CONTINUE in kinds
+
+
+# ---------------------------------------------------------------------------
+# Variables
+# ---------------------------------------------------------------------------
+def test_parse_assign_variable():
+    ops = parse_string("42 = x")
+    assign_ops = find_ops(ops, OpKind.ASSIGN_VARIABLE)
+    assert len(assign_ops) == 1
+    assert assign_ops[0].value == "x"
+
+
+def test_parse_assign_increment():
+    ops = parse_string("1 += x")
+    inc_ops = find_ops(ops, OpKind.ASSIGN_INCREMENT)
+    assert len(inc_ops) == 1
+    assert inc_ops[0].value == "x"
+
+
+def test_parse_assign_decrement():
+    ops = parse_string("1 -= x")
+    dec_ops = find_ops(ops, OpKind.ASSIGN_DECREMENT)
+    assert len(dec_ops) == 1
+    assert dec_ops[0].value == "x"
+
+
+# ---------------------------------------------------------------------------
+# Functions
+# ---------------------------------------------------------------------------
+def test_parse_function():
+    parse_string("fn add a:int b:int -> int { a b + }")
+    assert "add" in GLOBAL_FUNCTIONS
+    fn = GLOBAL_FUNCTIONS["add"]
+    assert isinstance(fn, Function)
+    assert fn.signature is not None
+    assert fn.signature.return_types == ["int"]
+    # Function body has ops for assigning params + body
+    fn_return_ops = find_ops(fn.ops, OpKind.ASSIGN_VARIABLE)
+    assert len(fn_return_ops) == 2  # a and b are assigned
+
+
+def test_parse_function_registers_globally():
+    parse_string("fn greet { }")
+    assert "greet" in GLOBAL_FUNCTIONS
+
+
+# ---------------------------------------------------------------------------
+# Structs
+# ---------------------------------------------------------------------------
+def test_parse_struct():
+    parse_string("struct Person { name: str age: int }")
+    assert "Person" in GLOBAL_STRUCTS
+    struct = GLOBAL_STRUCTS["Person"]
+    assert isinstance(struct, Struct)
+    assert len(struct.members) == 2
+    assert struct.members[0].name == "name"
+    assert struct.members[1].name == "age"
+
+
+def test_parse_struct_generates_getters_setters():
+    parse_string("struct Point { x: int y: int }")
+    assert "Point::x" in GLOBAL_FUNCTIONS
+    assert "Point::y" in GLOBAL_FUNCTIONS
+    assert "Point::set_x" in GLOBAL_FUNCTIONS
+    assert "Point::set_y" in GLOBAL_FUNCTIONS
+
+
+# ---------------------------------------------------------------------------
+# Impl blocks
+# ---------------------------------------------------------------------------
+def test_parse_impl_block():
+    code = """
+    struct Foo { val: int }
+    impl Foo {
+        fn double self:Foo -> int { self Foo::val 2 * }
+    }
+    """
+    parse_string(code)
+    assert "Foo::double" in GLOBAL_FUNCTIONS
+
+
+# ---------------------------------------------------------------------------
+# Lambdas
+# ---------------------------------------------------------------------------
+def test_parse_lambda():
+    ops = parse_string("{ 1 + }")
+    fn_push_ops = find_ops(ops, OpKind.FN_PUSH)
+    assert len(fn_push_ops) == 1
+    lambda_name = fn_push_ops[0].value
+    assert lambda_name.startswith("lambda__")
+    assert lambda_name in GLOBAL_FUNCTIONS
+
+
+# ---------------------------------------------------------------------------
+# Type cast
+# ---------------------------------------------------------------------------
+def test_parse_type_cast():
+    ops = parse_string("42 (str)")
+    cast_ops = find_ops(ops, OpKind.TYPE_CAST)
+    assert len(cast_ops) == 1
+    assert cast_ops[0].value == "str"
+
+
+# ---------------------------------------------------------------------------
+# Dot / Arrow method calls
+# ---------------------------------------------------------------------------
+def test_parse_dot_method_call():
+    # .name produces a METHOD_CALL op
+    ops = parse_string("x .name")
+    method_ops = find_ops(ops, OpKind.METHOD_CALL)
+    assert len(method_ops) == 1
+    assert method_ops[0].value == "name"
+
+
+def test_parse_arrow_setter():
+    # ->name produces a METHOD_CALL with set_ prefix
+    ops = parse_string("42 x ->name")
+    method_ops = find_ops(ops, OpKind.METHOD_CALL)
+    assert len(method_ops) == 1
+    assert method_ops[0].value == "set_name"
+
+
+# ---------------------------------------------------------------------------
+# Include
+# ---------------------------------------------------------------------------
+def test_parse_include():
+    ops = parse_string('include "some/file.casa"')
+    include_ops = find_ops(ops, OpKind.INCLUDE_FILE)
+    assert len(include_ops) == 1
+
+
+# ---------------------------------------------------------------------------
+# Identifier resolution
+# ---------------------------------------------------------------------------
+def test_resolve_fn_call():
+    ops = resolve_string("fn greet { } greet")
+    fn_call_ops = find_ops(ops, OpKind.FN_CALL)
+    assert len(fn_call_ops) == 1
+    assert fn_call_ops[0].value == "greet"
+
+
+def test_resolve_push_variable():
+    ops = resolve_string("42 = x x")
+    push_var_ops = find_ops(ops, OpKind.PUSH_VARIABLE)
+    assert len(push_var_ops) == 1
+    assert push_var_ops[0].value == "x"
+
+
+def test_resolve_struct_new():
+    ops = resolve_string('struct Foo { val: int } 42 Foo')
+    struct_new_ops = find_ops(ops, OpKind.STRUCT_NEW)
+    assert len(struct_new_ops) == 1
+    assert isinstance(struct_new_ops[0].value, Struct)
+
+
+def test_resolve_push_capture():
+    code = "42 = x { x }"
+    ops = resolve_string(code)
+    # The lambda body should have a PUSH_CAPTURE
+    fn_push = find_ops(ops, OpKind.FN_PUSH)
+    assert len(fn_push) == 1
+    lambda_name = fn_push[0].value
+    lambda_fn = GLOBAL_FUNCTIONS[lambda_name]
+    capture_ops = find_ops(lambda_fn.ops, OpKind.PUSH_CAPTURE)
+    assert len(capture_ops) == 1
+    assert capture_ops[0].value == "x"
+
+
+def test_resolve_undefined_raises():
+    with pytest.raises(NameError, match="not defined"):
+        resolve_string("undefined_thing")

--- a/tests/test_typechecker.py
+++ b/tests/test_typechecker.py
@@ -1,0 +1,257 @@
+"""Tests for casa/typechecker.py — verifies stack effects and op mutations."""
+
+import pytest
+
+from casa.common import ANY_TYPE, GLOBAL_FUNCTIONS, OpKind, Parameter, Signature
+from tests.conftest import parse_string, resolve_string, typecheck_string
+
+
+# ---------------------------------------------------------------------------
+# Literals
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "code,expected_type",
+    [
+        ("42", "int"),
+        ("true", "bool"),
+        ('"hello"', "str"),
+        ("[1, 2]", "array"),
+    ],
+)
+def test_typecheck_literals(code, expected_type):
+    sig = typecheck_string(code)
+    assert sig.return_types == [expected_type]
+
+
+# ---------------------------------------------------------------------------
+# Arithmetic
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("op", ["+", "-", "*", "/", "%"])
+def test_typecheck_arithmetic(op):
+    sig = typecheck_string(f"1 2 {op}")
+    assert sig.return_types == ["int"]
+
+
+# ---------------------------------------------------------------------------
+# Bitshift
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("op", ["<<", ">>"])
+def test_typecheck_bitshift(op):
+    sig = typecheck_string(f"8 2 {op}")
+    assert sig.return_types == ["int"]
+
+
+# ---------------------------------------------------------------------------
+# Boolean
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("op", ["&&", "||"])
+def test_typecheck_boolean_binary(op):
+    sig = typecheck_string(f"true false {op}")
+    assert sig.return_types == ["bool"]
+
+
+def test_typecheck_boolean_not():
+    sig = typecheck_string("true !")
+    assert sig.return_types == ["bool"]
+
+
+# ---------------------------------------------------------------------------
+# Comparison
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("op", ["==", "!=", "<", "<=", ">", ">="])
+def test_typecheck_comparison(op):
+    sig = typecheck_string(f"1 2 {op}")
+    assert sig.return_types == ["bool"]
+
+
+# ---------------------------------------------------------------------------
+# Stack intrinsics
+# ---------------------------------------------------------------------------
+def test_typecheck_drop():
+    sig = typecheck_string("42 drop")
+    assert sig.return_types == []
+
+
+def test_typecheck_dup():
+    sig = typecheck_string("42 dup")
+    assert sig.return_types == ["int", "int"]
+
+
+def test_typecheck_swap():
+    sig = typecheck_string('42 "hi" swap')
+    assert sig.return_types == ["str", "int"]
+
+
+def test_typecheck_over():
+    sig = typecheck_string('42 "hi" over')
+    assert sig.return_types == ["int", "str", "int"]
+
+
+def test_typecheck_rot():
+    sig = typecheck_string('1 "a" true rot')
+    assert sig.return_types == ["str", "bool", "int"]
+
+
+# ---------------------------------------------------------------------------
+# Memory intrinsics
+# ---------------------------------------------------------------------------
+def test_typecheck_alloc():
+    sig = typecheck_string("10 alloc")
+    assert sig.return_types == ["ptr"]
+
+
+def test_typecheck_load():
+    sig = typecheck_string("10 alloc load")
+    assert sig.return_types == [ANY_TYPE]
+
+
+def test_typecheck_store():
+    sig = typecheck_string("42 10 alloc store")
+    assert sig.return_types == []
+
+
+# ---------------------------------------------------------------------------
+# Print resolves to PRINT_INT / PRINT_STR
+# ---------------------------------------------------------------------------
+def test_typecheck_print_resolves_to_print_int():
+    ops = resolve_string("42 print")
+    from casa.typechecker import type_check_ops
+
+    type_check_ops(ops)
+    print_op = [o for o in ops if o.kind in (OpKind.PRINT_INT, OpKind.PRINT_STR)][0]
+    assert print_op.kind == OpKind.PRINT_INT
+
+
+def test_typecheck_print_resolves_to_print_str():
+    ops = resolve_string('"hello" print')
+    from casa.typechecker import type_check_ops
+
+    type_check_ops(ops)
+    print_op = [o for o in ops if o.kind in (OpKind.PRINT_INT, OpKind.PRINT_STR)][0]
+    assert print_op.kind == OpKind.PRINT_STR
+
+
+# ---------------------------------------------------------------------------
+# Functions
+# ---------------------------------------------------------------------------
+def test_typecheck_fn_signature_inference():
+    code = "fn add a:int b:int -> int { a b + }"
+    typecheck_string(code)
+    fn = GLOBAL_FUNCTIONS["add"]
+    assert fn.signature is not None
+    assert [p.typ for p in fn.signature.parameters] == ["int", "int"]
+    assert fn.signature.return_types == ["int"]
+
+
+def test_typecheck_fn_signature_mismatch():
+    # The mismatch is only detected when the function is called
+    code = "fn bad a:int -> str { a 1 + } bad"
+    with pytest.raises(TypeError, match="Invalid signature"):
+        typecheck_string(code)
+
+
+def test_typecheck_fn_call_stack_effect():
+    code = "fn double a:int -> int { a 2 * } 5 double"
+    sig = typecheck_string(code)
+    assert sig.return_types == ["int"]
+
+
+# ---------------------------------------------------------------------------
+# Method call resolution
+# ---------------------------------------------------------------------------
+def test_typecheck_method_call_resolution():
+    code = """
+    struct Pair { x: int y: int }
+    42 99 Pair .x
+    """
+    ops = resolve_string(code)
+    from casa.typechecker import type_check_ops
+
+    type_check_ops(ops)
+    # METHOD_CALL should be mutated to FN_CALL
+    fn_calls = [o for o in ops if o.kind == OpKind.FN_CALL]
+    method_calls = [o for o in ops if o.kind == OpKind.METHOD_CALL]
+    assert len(fn_calls) >= 1
+    assert any("Pair::x" in str(o.value) for o in fn_calls)
+    assert len(method_calls) == 0
+
+
+# ---------------------------------------------------------------------------
+# Control flow
+# ---------------------------------------------------------------------------
+def test_typecheck_if_else_consistent():
+    code = "if true then 1 else 2 fi"
+    sig = typecheck_string(code)
+    assert sig.return_types == ["int"]
+
+
+def test_typecheck_if_inconsistent_raises():
+    code = 'if true then 1 else "two" fi'
+    with pytest.raises(TypeError):
+        typecheck_string(code)
+
+
+def test_typecheck_while_loop():
+    code = "while false do done"
+    sig = typecheck_string(code)
+    assert sig.return_types == []
+
+
+# ---------------------------------------------------------------------------
+# Variables
+# ---------------------------------------------------------------------------
+def test_typecheck_variable_assign_and_push():
+    code = "42 = x x"
+    sig = typecheck_string(code)
+    assert sig.return_types == ["int"]
+
+
+# ---------------------------------------------------------------------------
+# Type cast
+# ---------------------------------------------------------------------------
+def test_typecheck_type_cast():
+    code = "42 (str)"
+    sig = typecheck_string(code)
+    assert sig.return_types == ["str"]
+
+
+# ---------------------------------------------------------------------------
+# Lambdas
+# ---------------------------------------------------------------------------
+def test_typecheck_lambda_push():
+    code = "{ 1 + }"
+    sig = typecheck_string(code)
+    assert len(sig.return_types) == 1
+    assert sig.return_types[0].startswith("fn[")
+
+
+def test_typecheck_lambda_exec():
+    # Lambda captures from other scopes are typed as `any`
+    code = "42 { 1 + } exec"
+    sig = typecheck_string(code)
+    assert sig.return_types == ["any"]
+
+
+# ---------------------------------------------------------------------------
+# ANY_TYPE matching
+# ---------------------------------------------------------------------------
+def test_typecheck_any_type_matches():
+    sig_a = Signature([Parameter("int")], ["int"])
+    sig_b = Signature([Parameter(ANY_TYPE)], [ANY_TYPE])
+    assert sig_a.matches(sig_b)
+    assert sig_b.matches(sig_a)
+
+
+def test_typecheck_any_type_no_match_different_length():
+    sig_a = Signature([Parameter("int")], ["int"])
+    sig_b = Signature([Parameter("int"), Parameter("int")], ["int"])
+    assert not sig_a.matches(sig_b)
+
+
+# ---------------------------------------------------------------------------
+# FN_EXEC stack effect
+# ---------------------------------------------------------------------------
+def test_typecheck_fn_exec():
+    code = "fn inc a:int -> int { a 1 + } 5 { inc } exec"
+    sig = typecheck_string(code)
+    assert sig.return_types == ["int"]


### PR DESCRIPTION
## Summary
- Add shared test fixtures and pipeline helpers (`conftest.py`) with autouse global state cleanup
- Add unit tests for the lexer covering all token kinds (literals, operators, keywords, intrinsics)
- Add unit tests for the parser covering OpKind values and identifier resolution
- Add unit tests for the type checker verifying stack effects and op mutations
- Add unit tests for the bytecode compiler covering all InstKind values
- Add unit tests for the emitter verifying assembly output patterns

## Test plan
- [x] All tests pass with `pytest tests/ -v`
- [x] Tests cover all five compiler stages: lexer, parser, typechecker, bytecode, emitter
- [x] Global state is properly isolated between tests via `clear_global_state` fixture