### PR TITLE
docs: add language documentation and rewrite README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,23 +50,23 @@ true false  # bool
 
 ### Stack intrinsics
 ```
-drop   # ( a -- )        discard top
-dup    # ( a -- a a )    duplicate top
-swap   # ( a b -- b a )  swap top two
-over   # ( a b -- a b a) copy second to top
-rot    # ( a b c -- b c a ) rotate top three
+drop   # a -> None         discard top
+dup    # a -> a a          duplicate top
+swap   # a b -> b a        swap top two
+over   # a b -> a b a      copy second to top
+rot    # a b c -> b c a    rotate top three
 ```
 
 ### Memory intrinsics
 ```
-alloc  # ( int -- ptr )  heap-allocate N slots
-load   # ( ptr -- any )  read heap at address
-store  # ( any ptr -- )  write heap at address
+alloc  # int -> ptr          heap-allocate N slots
+load   # ptr -> any          read heap at address
+store  # any ptr -> None     write heap at address
 ```
 
 ### IO
 ```
-print  # ( any -- )  print top of stack
+print  # any -> None     print top of stack
 ```
 
 ### Functions
@@ -130,8 +130,8 @@ impl TypeName {
 
 ### Lambdas / closures
 ```
-{ body }   # ( -- fn[sig] )  create lambda, captures enclosing variables
-exec       # ( fn[sig] -- )  call lambda on top of stack
+{ body }   # -> fn[sig]           create lambda, captures enclosing variables
+exec       # fn[sig] -> None      call lambda on top of stack
 ```
 Example: `{ 2 * }` has type `fn[int -> int]`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,183 @@
+# Casa
+
+**casa** is a statically typed, stack-based programming language with functional programming influences.
+
+- **Pipeline**: source → lex → parse → type check → bytecode → emit asm → compile asm → run
+
+## Key files
+
+| File | Purpose |
+|------|---------|
+| `casa/lexer.py` | Tokenizer |
+| `casa/parser.py` | Op tree builder, identifier resolution |
+| `casa/typechecker.py` | Stack-based type inference and checking |
+| `casa/bytecode.py` | Op → Inst lowering |
+| `casa/emitter.py` | GNU assembly emitter |
+| `casa/compiler.py` | Compiles GNU assembly code to x86_64 executable |
+| `casa/common.py` | All shared types: `OpKind`, `InstKind`, `Keyword`, `Intrinsic`, `Operator`, `Signature`, `Function`, `Struct`, … |
+| `lib/std.casa` | Standard library (`memcpy`, `array`, `List`) |
+| `examples/` | Example programs |
+| `.claude/commands/` | Slash command agents: `designer`, `documenter`, `programmer`, `reviewer`, `tester` |
+
+## Language features
+
+### Types
+| Type | Description |
+|------|-------------|
+| `int` | Integer |
+| `bool` | Boolean (`true` / `false`) |
+| `str` | String |
+| `ptr` | Heap pointer (from `alloc`) |
+| `array` | Fixed-size array literal |
+| `fn[sig]` | Function/lambda type, e.g. `fn[int int -> int]` |
+| `any` | Escape hatch, matches anything |
+| `SomeStruct` | User-defined struct type |
+
+### Literals
+```
+42          # int
+true false  # bool
+"hello"     # str
+[1, 2, 3]   # array (literal items only)
+```
+
+### Operators
+- Arithmetic: `+` `-` `*` `/` `%`
+- Bitshift: `<<` `>>`
+- Comparison: `==` `!=` `<` `<=` `>` `>=`
+- Boolean: `&&` `||` `!`
+- Assignment: `= name`  `+= name`  `-= name`
+
+### Stack intrinsics
+```
+drop   # ( a -- )        discard top
+dup    # ( a -- a a )    duplicate top
+swap   # ( a b -- b a )  swap top two
+over   # ( a b -- a b a) copy second to top
+rot    # ( a b c -- b c a ) rotate top three
+```
+
+### Memory intrinsics
+```
+alloc  # ( int -- ptr )  heap-allocate N slots
+load   # ( ptr -- any )  read heap at address
+store  # ( any ptr -- )  write heap at address
+```
+
+### IO
+```
+print  # ( any -- )  print top of stack
+```
+
+### Functions
+```
+fn name param:type -> return_type {
+    body
+}
+```
+- Parameters popped from stack in declaration order (first param = top)
+- Return types describe what remains on the stack after the call
+- Signatures can be explicit or inferred by the type checker
+- Must be defined at global scope
+
+### Variables
+```
+42 = count    # global or local assignment
+1 += count    # increment
+1 -= count    # decrement
+```
+- Global: declared at top level, visible everywhere
+- Local: declared inside a function, scoped to that function
+
+### Control flow
+```
+if condition then
+    ...
+elif other_condition then
+    ...
+else
+    ...
+fi
+
+while condition do
+    ...
+    break
+    continue
+done
+```
+The type checker enforces stack consistency across all branches and after loops.
+
+### Structs
+```
+struct Person {
+    name: str
+    age:  int
+}
+```
+- Instantiation: push fields bottom-to-top, then call struct name: `18 "John" Person`
+- Auto-generated getter `Type::field` and setter `Type::set_field`
+- Dot / arrow shorthand: `person.name` → `person Person::name`, `"Jane" person->name` → `"Jane" person Person::set_name`
+
+### impl blocks
+```
+impl TypeName {
+    fn method self:TypeName -> RetType { body }
+}
+```
+- Namespaced as `TypeName::method`
+- Dot sugar: `instance.method` → `instance TypeName::method`
+- Can span multiple `impl` blocks and files
+
+### Lambdas / closures
+```
+{ body }   # ( -- fn[sig] )  create lambda, captures enclosing variables
+exec       # ( fn[sig] -- )  call lambda on top of stack
+```
+Example: `{ 2 * }` has type `fn[int -> int]`
+
+### Type cast
+```
+(TypeName)   # pops top, pushes as TypeName (no runtime check)
+```
+
+### Include
+```
+include "relative/path/to/file.casa"   # included at most once
+```
+
+## Standard library (`lib/std.casa`)
+- `memcpy dst:ptr src:ptr n:int` — copy n heap slots
+- `array::length array -> int` — length of array (stored in first slot)
+- `array::nth array:array n:int -> any` — nth element
+- `List` struct — dynamic list with `from_array`, `nth`, `push`
+
+## Architecture notes
+
+### Type checker (`typechecker.py`)
+- Simulates the stack symbolically with types instead of values
+- Infers function signatures by replaying ops
+- Compares inferred signature against declared one when both exist
+- `BranchedStack` tracks stack state before/after conditionals and loops
+- `ANY_TYPE = "any"` acts as a wildcard that matches any type
+
+### Parser / identifier resolution (`parser.py`)
+- `resolve_identifiers` converts `IDENTIFIER` ops to `FN_CALL`, `PUSH_VARIABLE`, `STRUCT_NEW`, etc.
+- Lambda functions are registered globally as `lambda__<scope>_o<offset>`
+- Method calls (`.foo` / `->foo`) are resolved to `FN_CALL` during type checking using the receiver type
+
+### Bytecode (`bytecode.py`)
+- Ops lower to `Inst` objects with `InstKind`
+- VM has: `data_stack`, `call_stack` (doubles as locals frame), `globals`, `heap`, `strings`
+- `CONSTANT_LOAD/STORE` used for string interning
+
+### Assembly emitter (`emitter.py`)
+- Target: x86-64 Linux (System V ABI), uses hardware stack as data stack
+
+### Compilation
+- Link assembly code with `ld`
+- Compile with `as`
+- The result is a statically linked x86_64 executable
+
+## Documentation
+
+When any language feature, intrinsic, operator, or standard library function is changed or added, the corresponding documentation in `docs/` and `README.md` must be updated to reflect the change.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,89 @@
-# casa
-Stack-based functional programming language
+# Casa
+
+**A statically typed, stack-based programming language with functional influences.**
+
+Casa compiles to x86-64 Linux executables via GNU assembly. It features static type inference, first-class functions, closures, structs with methods, and a stack-based execution model.
+
+`"Hello, world!" print`
+
+## Features
+
+- **Stack-based** — values live on the stack; operators consume and produce stack entries
+- **Statically typed** — types are checked at compile time with automatic inference
+- **First-class functions** — lambdas are values on the stack like any other (TODO: function pointers)
+- **Structs and methods** — user-defined types with auto-generated accessors and `impl` blocks
+- **Compiles to native code** — generates x86-64 assembly with `ld` and `as`
+- **Standard library** — dynamic `List`, arrays, and memory utilities
+
+## Requirements
+
+- **Linux x86-64**
+- **Python 3.11+**
+- **GNU assembler** (`as`) and **linker** (`ld`)
+
+## Getting Started
+
+Compile and run a program:
+
+```sh
+python3 casa.py examples/hello_world.casa -r
+# Hello world!
+```
+
+Compile with a custom output name:
+
+```sh
+python3 casa.py examples/fibonacci.casa -o fib
+./fib
+# 6765
+```
+
+## CLI Usage
+
+```
+python3 casa.py <file> [-o name] [--keep-asm] [-r] [-v]
+```
+
+| Flag | Description |
+|------|-------------|
+| `-o`, `--output` | Output binary name (default: input file stem) |
+| `--keep-asm` | Keep the generated `.s` assembly file |
+| `-r`, `--run` | Execute the binary after compilation |
+| `-v`, `--verbose` | Enable verbose logging |
+
+## Compilation Pipeline
+
+```
+source → lex → parse → resolve → type check → bytecode → emit asm → assemble → link → executable
+```
+
+## Documentation
+
+| Document | Topics |
+|----------|--------|
+| [Types and Literals](docs/types-and-literals.md) | Primitive types, composite types, literals, type casting, comments |
+| [Operators](docs/operators.md) | Arithmetic, comparison, boolean, bitshift, assignment |
+| [Control Flow](docs/control-flow.md) | Conditionals (`if`/`elif`/`else`/`fi`), loops (`while`/`do`/`done`) |
+| [Functions and Lambdas](docs/functions-and-lambdas.md) | Functions, lambdas, closures, variables, stack intrinsics, IO, memory |
+| [Structs and Methods](docs/structs-and-methods.md) | Struct definition, accessors, `impl` blocks, dot/arrow syntax |
+| [Standard Library](docs/standard-library.md) | `include`, `memcpy`, arrays, `List` |
+
+## Examples
+
+| File | Description |
+|------|-------------|
+| [hello_world.casa](examples/hello_world.casa) | Print a string |
+| [fibonacci.casa](examples/fibonacci.casa) | Recursive Fibonacci function |
+| [fizzbuzz.casa](examples/fizzbuzz.casa) | FizzBuzz with functions, variables, and conditionals |
+| [struct.casa](examples/struct.casa) | Structs, getters, setters, and methods |
+| [euler01.casa](examples/euler01.casa) | Project Euler problem 1 — sum of multiples |
+
+More examples: [examples](./examples/)
+
+## Testing
+
+Run the following command from the root folder of the repository:
+
+```sh
+pytest tests
+```

--- a/docs/control-flow.md
+++ b/docs/control-flow.md
@@ -1,0 +1,169 @@
+# Control Flow
+
+## Conditionals
+
+Casa uses `if`/`elif`/`else`/`fi` for branching. Each condition must be followed by `then`.
+
+### Syntax
+
+```
+if <condition> then
+    <body>
+elif <condition> then
+    <body>
+else
+    <body>
+fi
+```
+
+The condition must leave a `bool` on top of the stack (it is consumed by `then`).
+
+### Basic Example
+
+```casa
+42 = guess
+42 = number
+
+if guess number > then
+    "Too low" print
+elif guess number < then
+    "Too high" print
+else
+    "Correct!" print
+fi
+```
+
+### Stack Interaction
+
+Conditionals can leave values on the stack, but all branches must leave the stack in the same state. This is enforced by the type checker.
+
+```casa
+42 = guess
+42 = number
+
+if guess number > then
+    "Too low"
+elif guess number < then
+    "Too high"
+else
+    "Correct!"
+fi
+
+print    # prints whatever the branch pushed
+```
+
+### Stack Consistency
+
+All branches of a conditional must produce the same stack effect. The following is a type error:
+
+```casa
+# ERROR: branches leave different stack states
+if true then
+    1
+else
+    "hello"
+fi
+```
+
+The first branch pushes an `int`, the second pushes a `str` — the type checker rejects this.
+
+If there is no `else` branch, the `if`/`elif` branches must not change the stack at all (since the "no match" path leaves the stack unchanged).
+
+## Loops
+
+Casa has `while`/`do`/`done` loops with `break` and `continue`.
+
+### Syntax
+
+```
+while <condition> do
+    <body>
+done
+```
+
+The condition must leave a `bool` on top of the stack (consumed by `do`).
+
+### Basic Example
+
+```casa
+0 = i
+while i 10 > do
+    i print
+    1 += i
+done
+```
+
+### Infinite Loops
+
+Use `true` as the condition with `break` to exit:
+
+```casa
+0 = i
+while true do
+    i print
+    1 += i
+    if i 5 <= then
+        break
+    fi
+done
+```
+
+### `break` and `continue`
+
+- `break` — exit the innermost loop immediately
+- `continue` — skip the rest of the loop body and jump to the condition
+
+```casa
+0 = index
+while true do
+    index print
+
+    if index 15 <= then
+        break
+    fi
+
+    if index 2 % 0 == then
+        3 += index
+        continue
+    fi
+
+    1 += index
+done
+```
+
+### Stack Consistency in Loops
+
+The stack state must be identical:
+1. Before the loop starts and after the loop ends
+2. At the start of each iteration (before the condition)
+3. At every `break` and `continue` point
+
+The type checker enforces that loops do not accumulate or consume stack values across iterations.
+
+## Nested Control Flow
+
+Conditionals and loops can be freely nested:
+
+```casa
+1 = index
+30 = last
+
+while index last >= do
+    index 3 % 0 == = fizz
+    index 5 % 0 == = buzz
+
+    if fizz buzz && then
+        "FizzBuzz" print
+    elif fizz then
+        "Fizz" print
+    elif buzz then
+        "Buzz" print
+    else
+        index print
+    fi
+
+    1 += index
+done
+```
+
+See [`examples/fizzbuzz.casa`](../examples/fizzbuzz.casa) for the full program.

--- a/docs/functions-and-lambdas.md
+++ b/docs/functions-and-lambdas.md
@@ -122,9 +122,9 @@ fn fizzbuzz number:int {
 
 | Operator | Stack Effect | Description |
 |----------|-------------|-------------|
-| `= name` | `( a -- )` | Assign top of stack to `name` |
-| `+= name` | `( int -- )` | Add to `name` |
-| `-= name` | `( int -- )` | Subtract from `name` |
+| `= name` | `a -> None` | Assign top of stack to `name` |
+| `+= name` | `int -> None` | Add to `name` |
+| `-= name` | `int -> None` | Subtract from `name` |
 
 A variable's type is set on first assignment and cannot change:
 
@@ -137,7 +137,7 @@ A variable's type is set on first assignment and cannot change:
 
 Lambdas are anonymous functions created with braces `{ body }`. They push a function value onto the stack.
 
-**Stack effect:** `( -- fn[sig] )`
+**Stack effect:** `-> fn[sig]`
 
 ### Basic Example
 
@@ -181,7 +181,7 @@ fn apply_twice f:fn[int -> int] x:int -> int {
 
 Calls the function value on top of the stack.
 
-**Stack effect:** `( args... fn[sig] -- results... )`
+**Stack effect:** `args... fn[sig] -> results...`
 
 The function value must be on top of the stack, with its arguments below. For `fn[int -> int]`, exec pops the function and one `int`, then pushes one `int`.
 
@@ -191,11 +191,11 @@ Built-in operations for manipulating the stack directly.
 
 | Intrinsic | Stack Effect | Description |
 |-----------|-------------|-------------|
-| `drop` | `( a -- )` | Discard top of stack |
-| `dup` | `( a -- a a )` | Duplicate top of stack |
-| `swap` | `( a b -- b a )` | Swap top two values |
-| `over` | `( a b -- a b a )` | Copy second value to top |
-| `rot` | `( a b c -- b c a )` | Rotate top three values |
+| `drop` | `a -> None` | Discard top of stack |
+| `dup` | `a -> a a` | Duplicate top of stack |
+| `swap` | `a b -> b a` | Swap top two values |
+| `over` | `a b -> a b a` | Copy second value to top |
+| `rot` | `a b c -> b c a` | Rotate top three values |
 
 ### Examples
 
@@ -222,7 +222,7 @@ See [`examples/stack_operations.casa`](../examples/stack_operations.casa).
 
 Prints the top of the stack to stdout, followed by a newline.
 
-**Stack effect:** `( a -- )`
+**Stack effect:** `a -> None`
 
 Integers and booleans are printed as decimal numbers. Strings are printed as text.
 
@@ -238,9 +238,9 @@ Low-level heap access for building data structures.
 
 | Intrinsic | Stack Effect | Description |
 |-----------|-------------|-------------|
-| `alloc` | `( int -- ptr )` | Allocate N heap slots, return pointer |
-| `load` | `( ptr -- any )` | Read value at heap address |
-| `store` | `( any ptr -- )` | Write value to heap address |
+| `alloc` | `int -> ptr` | Allocate N heap slots, return pointer |
+| `load` | `ptr -> any` | Read value at heap address |
+| `store` | `any ptr -> None` | Write value to heap address |
 
 ### Example
 

--- a/docs/functions-and-lambdas.md
+++ b/docs/functions-and-lambdas.md
@@ -1,0 +1,260 @@
+# Functions and Lambdas
+
+## Functions
+
+Functions are defined with `fn` at global scope. They can be called before their definition (forward references are allowed).
+
+### Syntax
+
+```
+fn name param:type ... -> return_type ... {
+    body
+}
+```
+
+Parameters are consumed from the top of the stack in declaration order: the first parameter is on top, and the last parameter is deepest. Return types describe what the function leaves on the stack after it returns.
+
+### Basic Example
+
+```casa
+fn local_add a:int b:int -> int {
+    a b +
+}
+
+34 35 local_add print   # 69
+```
+
+When `34 35 local_add` is called, `35` is assigned to `a` (first param, popped from top) and `34` is assigned to `b` (second param, popped next). The result is the same since addition is commutative.
+
+### No Parameters
+
+Functions can have no explicit parameters. They can still consume values from the stack if the body does so, and the type checker will infer the signature.
+
+```casa
+fn global_add -> int {
+    global_a global_b +
+}
+```
+
+### No Return Type
+
+If a function returns nothing, omit the `-> type` part:
+
+```casa
+fn greet name:str {
+    name print
+}
+```
+
+### Signature Inference
+
+Type annotations are optional. The type checker can infer the full signature by replaying the function's operations on a symbolic stack.
+
+```casa
+fn double {
+    2 *
+}
+# Inferred signature: int -> int
+```
+
+When both an explicit signature and inference are available, the type checker verifies that they match.
+
+### Calling Functions
+
+Push the arguments onto the stack, then write the function name:
+
+```casa
+20 fib print
+```
+
+### Early Return
+
+Use `return` to exit a function early. The stack at the `return` point must match the function's return type.
+
+```casa
+fn fib number:int -> int {
+    if number 1 >= then
+        number return
+    elif number 0 == then
+        number return
+    fi
+
+    number 1 - fib
+    number 2 - fib +
+}
+```
+
+See [`examples/fibonacci.casa`](../examples/fibonacci.casa).
+
+### Restrictions
+
+- Functions must be defined at **global scope** — no nested function definitions (use lambdas instead).
+- A function's signature mismatch is detected when the function is **called**, not at its definition.
+
+## Variables
+
+### Global Variables
+
+Declared at the top level, visible everywhere (including inside functions):
+
+```casa
+1 = global_a
+2 = global_b
+
+fn global_add -> int {
+    global_a global_b +
+}
+```
+
+### Local Variables
+
+Declared inside a function, scoped to that function:
+
+```casa
+fn fizzbuzz number:int {
+    number 3 % 0 == = fizz    # fizz is local
+    number 5 % 0 == = buzz    # buzz is local
+    # ...
+}
+```
+
+### Assignment Operators
+
+| Operator | Stack Effect | Description |
+|----------|-------------|-------------|
+| `= name` | `( a -- )` | Assign top of stack to `name` |
+| `+= name` | `( int -- )` | Add to `name` |
+| `-= name` | `( int -- )` | Subtract from `name` |
+
+A variable's type is set on first assignment and cannot change:
+
+```casa
+42 = x       # x is int
+"hi" = x     # ERROR: cannot assign str to int variable
+```
+
+## Lambdas
+
+Lambdas are anonymous functions created with braces `{ body }`. They push a function value onto the stack.
+
+**Stack effect:** `( -- fn[sig] )`
+
+### Basic Example
+
+```casa
+{ 2 * }              # type: fn[int -> int]
+21 swap exec print   # 42
+```
+
+### Storing and Calling
+
+```casa
+{ 1 + } = increment
+41 increment exec print   # 42
+```
+
+### Closures
+
+Lambdas capture variables from their enclosing scope:
+
+```casa
+10 = offset
+{ offset + } = add_offset
+32 add_offset exec print   # 42
+```
+
+Captured variables are copied at the time the lambda is created.
+
+### Passing Lambdas
+
+Lambdas are first-class values and can be passed to functions:
+
+```casa
+fn apply_twice f:fn[int -> int] x:int -> int {
+    x f exec f exec
+}
+
+40 { 1 + } apply_twice print   # 42
+```
+
+### `exec`
+
+Calls the function value on top of the stack.
+
+**Stack effect:** `( args... fn[sig] -- results... )`
+
+The function value must be on top of the stack, with its arguments below. For `fn[int -> int]`, exec pops the function and one `int`, then pushes one `int`.
+
+## Stack Intrinsics
+
+Built-in operations for manipulating the stack directly.
+
+| Intrinsic | Stack Effect | Description |
+|-----------|-------------|-------------|
+| `drop` | `( a -- )` | Discard top of stack |
+| `dup` | `( a -- a a )` | Duplicate top of stack |
+| `swap` | `( a b -- b a )` | Swap top two values |
+| `over` | `( a b -- a b a )` | Copy second value to top |
+| `rot` | `( a b c -- b c a )` | Rotate top three values |
+
+### Examples
+
+```casa
+1 2 drop print       # 1
+
+3 dup print print    # 3 3
+
+9 10 swap
+print print          # 9 10
+
+4 5 over
+print print print    # 4 5 4
+
+6 7 8 rot
+print print print    # 7 8 6
+```
+
+See [`examples/stack_operations.casa`](../examples/stack_operations.casa).
+
+## IO
+
+### `print`
+
+Prints the top of the stack to stdout, followed by a newline.
+
+**Stack effect:** `( a -- )`
+
+Integers and booleans are printed as decimal numbers. Strings are printed as text.
+
+```casa
+42 print           # 42
+true print         # 1
+"Hello" print      # Hello
+```
+
+## Memory Intrinsics
+
+Low-level heap access for building data structures.
+
+| Intrinsic | Stack Effect | Description |
+|-----------|-------------|-------------|
+| `alloc` | `( int -- ptr )` | Allocate N heap slots, return pointer |
+| `load` | `( ptr -- any )` | Read value at heap address |
+| `store` | `( any ptr -- )` | Write value to heap address |
+
+### Example
+
+```casa
+3 alloc = buf         # allocate 3 slots
+10 buf store          # buf[0] = 10
+20 buf 1 + store      # buf[1] = 20
+30 buf 2 + store      # buf[2] = 30
+
+buf load print        # 10
+buf 1 + load print    # 20
+buf 2 + load print    # 30
+```
+
+Values read with `load` have type `any`. Use a [type cast](types-and-literals.md#type-casting) `(TypeName)` to restore a specific type.
+
+See [Standard Library](standard-library.md) for higher-level abstractions built on these primitives.

--- a/docs/operators.md
+++ b/docs/operators.md
@@ -1,0 +1,104 @@
+# Operators
+
+Casa uses postfix (reverse Polish) notation. Operands are pushed onto the stack first, then the operator consumes them and pushes the result.
+
+```casa
+3 4 +     # push 3, push 4, add → 7
+```
+
+There is no operator precedence — evaluation order is determined entirely by the order values appear on the stack.
+
+## Arithmetic
+
+All arithmetic operators consume two values and produce one.
+
+| Operator | Stack Effect | Description |
+|----------|-------------|-------------|
+| `+` | `( a int -- a )` | Addition. The second operand must be `int`; result type matches the first operand. Works on `ptr` for pointer arithmetic. |
+| `-` | `( a int -- a )` | Subtraction. Same typing rules as `+`. |
+| `*` | `( int int -- int )` | Multiplication |
+| `/` | `( int int -- int )` | Integer division (truncates toward zero) |
+| `%` | `( int int -- int )` | Modulo (remainder) |
+
+```casa
+34 35 + print    # 69
+1357 20 - print  # 1337
+7 6 * print      # 42
+14 3 / print     # 4
+14 3 % print     # 2
+```
+
+### Pointer Arithmetic
+
+`+` and `-` support `ptr` as the first operand, allowing offset-based heap access:
+
+```casa
+10 alloc = buf
+42 buf 3 + store    # store 42 at buf+3
+buf 3 + load print  # 42
+```
+
+## Bitshift
+
+| Operator | Stack Effect | Description |
+|----------|-------------|-------------|
+| `<<` | `( a int -- a )` | Left shift. Result type matches the first operand. |
+| `>>` | `( a int -- a )` | Right shift. Result type matches the first operand. |
+
+```casa
+1 4 << print    # 16
+16 4 >> print   # 1
+```
+
+## Comparison
+
+All comparison operators consume two values and push a `bool`.
+
+| Operator | Stack Effect | Description |
+|----------|-------------|-------------|
+| `==` | `( any any -- bool )` | Equal |
+| `!=` | `( any any -- bool )` | Not equal |
+| `<`  | `( any any -- bool )` | Less than |
+| `<=` | `( any any -- bool )` | Less than or equal |
+| `>`  | `( any any -- bool )` | Greater than |
+| `>=` | `( any any -- bool )` | Greater than or equal |
+
+```casa
+1 1 == print    # 1 (true)
+1 0 != print    # 1 (true)
+1 0 > print     # 0 (false: top=0 is not greater than second=1)
+```
+
+> **Note on stack order:** In `1 0 >`, the value `0` is on top of the stack and `1` is below. The comparison checks whether the top (`0`) is greater than the second (`1`), which is false. To check if 1 > 0, write `0 1 >` or equivalently `1 0 <`.
+
+## Boolean
+
+| Operator | Stack Effect | Description |
+|----------|-------------|-------------|
+| `&&` | `( any any -- bool )` | Logical AND |
+| `\|\|` | `( any any -- bool )` | Logical OR |
+| `!`  | `( any -- bool )` | Logical NOT |
+
+```casa
+true true && print    # 1
+true false || print   # 1
+true ! print          # 0
+```
+
+## Assignment
+
+Assignment operators pop a value from the stack and store it in a named variable.
+
+| Operator | Stack Effect | Description |
+|----------|-------------|-------------|
+| `= name` | `( a -- )` | Assign top of stack to variable `name` |
+| `+= name` | `( int -- )` | Add top of stack to variable `name` |
+| `-= name` | `( int -- )` | Subtract top of stack from variable `name` |
+
+```casa
+42 = count        # count is now 42
+1 += count        # count is now 43
+10 -= count       # count is now 33
+```
+
+Variables are created on first assignment. See [Functions and Lambdas — Variables](functions-and-lambdas.md#variables) for scoping rules.

--- a/docs/operators.md
+++ b/docs/operators.md
@@ -14,11 +14,11 @@ All arithmetic operators consume two values and produce one.
 
 | Operator | Stack Effect | Description |
 |----------|-------------|-------------|
-| `+` | `( a int -- a )` | Addition. The second operand must be `int`; result type matches the first operand. Works on `ptr` for pointer arithmetic. |
-| `-` | `( a int -- a )` | Subtraction. Same typing rules as `+`. |
-| `*` | `( int int -- int )` | Multiplication |
-| `/` | `( int int -- int )` | Integer division (truncates toward zero) |
-| `%` | `( int int -- int )` | Modulo (remainder) |
+| `+` | `a int -> a` | Addition. The second operand must be `int`; result type matches the first operand. Works on `ptr` for pointer arithmetic. |
+| `-` | `a int -> a` | Subtraction. Same typing rules as `+`. |
+| `*` | `int int -> int` | Multiplication |
+| `/` | `int int -> int` | Integer division (truncates toward zero) |
+| `%` | `int int -> int` | Modulo (remainder) |
 
 ```casa
 34 35 + print    # 69
@@ -42,8 +42,8 @@ buf 3 + load print  # 42
 
 | Operator | Stack Effect | Description |
 |----------|-------------|-------------|
-| `<<` | `( a int -- a )` | Left shift. Result type matches the first operand. |
-| `>>` | `( a int -- a )` | Right shift. Result type matches the first operand. |
+| `<<` | `a int -> a` | Left shift. Result type matches the first operand. |
+| `>>` | `a int -> a` | Right shift. Result type matches the first operand. |
 
 ```casa
 1 4 << print    # 16
@@ -56,12 +56,12 @@ All comparison operators consume two values and push a `bool`.
 
 | Operator | Stack Effect | Description |
 |----------|-------------|-------------|
-| `==` | `( any any -- bool )` | Equal |
-| `!=` | `( any any -- bool )` | Not equal |
-| `<`  | `( any any -- bool )` | Less than |
-| `<=` | `( any any -- bool )` | Less than or equal |
-| `>`  | `( any any -- bool )` | Greater than |
-| `>=` | `( any any -- bool )` | Greater than or equal |
+| `==` | `any any -> bool` | Equal |
+| `!=` | `any any -> bool` | Not equal |
+| `<`  | `any any -> bool` | Less than |
+| `<=` | `any any -> bool` | Less than or equal |
+| `>`  | `any any -> bool` | Greater than |
+| `>=` | `any any -> bool` | Greater than or equal |
 
 ```casa
 1 1 == print    # 1 (true)
@@ -75,9 +75,9 @@ All comparison operators consume two values and push a `bool`.
 
 | Operator | Stack Effect | Description |
 |----------|-------------|-------------|
-| `&&` | `( any any -- bool )` | Logical AND |
-| `\|\|` | `( any any -- bool )` | Logical OR |
-| `!`  | `( any -- bool )` | Logical NOT |
+| `&&` | `any any -> bool` | Logical AND |
+| `\|\|` | `any any -> bool` | Logical OR |
+| `!`  | `any -> bool` | Logical NOT |
 
 ```casa
 true true && print    # 1
@@ -91,9 +91,9 @@ Assignment operators pop a value from the stack and store it in a named variable
 
 | Operator | Stack Effect | Description |
 |----------|-------------|-------------|
-| `= name` | `( a -- )` | Assign top of stack to variable `name` |
-| `+= name` | `( int -- )` | Add top of stack to variable `name` |
-| `-= name` | `( int -- )` | Subtract top of stack from variable `name` |
+| `= name` | `a -> None` | Assign top of stack to variable `name` |
+| `+= name` | `int -> None` | Add top of stack to variable `name` |
+| `-= name` | `int -> None` | Subtract top of stack from variable `name` |
 
 ```casa
 42 = count        # count is now 42

--- a/docs/standard-library.md
+++ b/docs/standard-library.md
@@ -1,0 +1,145 @@
+# Standard Library
+
+The standard library is in `lib/std.casa`. Include it with:
+
+```casa
+include "../lib/std.casa"
+```
+
+## `include` Directive
+
+`include` loads another Casa source file. Each file is included at most once, regardless of how many times it appears.
+
+```casa
+include "relative/path/to/file.casa"
+```
+
+Paths are resolved relative to the file containing the `include` directive. All functions, structs, and global variables defined in the included file become available.
+
+## `memcpy`
+
+Copies heap slots from one pointer to another.
+
+**Signature:** `memcpy dst:ptr src:ptr n:int`
+
+**Stack effect:** `( dst src n -- )`
+
+```casa
+3 alloc = src
+10 src store
+20 src 1 + store
+30 src 2 + store
+
+3 alloc = dst
+3 src dst memcpy
+
+dst load print        # 10
+dst 1 + load print    # 20
+dst 2 + load print    # 30
+```
+
+## Arrays
+
+Arrays are fixed-size heap-allocated sequences created with bracket syntax. The length is stored in the first heap slot, and elements start at offset 1.
+
+### `array::length`
+
+Returns the length of an array.
+
+**Signature:** `array::length array -> int`
+
+**Stack effect:** `( array -- int )`
+
+```casa
+[1, 2, 3] = arr
+arr.length print    # 3
+```
+
+### `array::nth`
+
+Returns the nth element of an array (zero-indexed).
+
+**Signature:** `array::nth array:array n:int -> any`
+
+**Stack effect:** `( array n -- any )`
+
+```casa
+[10, 20, 30] = arr
+1 arr array::nth print    # 20
+# or with dot syntax:
+1 arr.nth print           # 20
+```
+
+> **Note:** The return type is `any`. Use a [type cast](types-and-literals.md#type-casting) if you need a specific type.
+
+## `List`
+
+A dynamic list that grows automatically when items are pushed.
+
+### Definition
+
+```casa
+struct List {
+    size:     int
+    capacity: int
+    array:    array
+}
+```
+
+### `List::from_array`
+
+Creates a `List` from a fixed-size array. The list's size and capacity are both set to the array's length.
+
+**Signature:** `List::from_array array:array -> List`
+
+**Stack effect:** `( array -- List )`
+
+```casa
+[1, 2, 3] List::from_array = list
+```
+
+### `List::nth`
+
+Returns the nth element (zero-indexed).
+
+**Signature:** `List::nth List int -> any`
+
+**Stack effect:** `( List int -- any )`
+
+```casa
+0 list.nth print    # 1
+2 list.nth print    # 3
+```
+
+### `List::push`
+
+Appends an item to the list. If the list is at capacity, it allocates a new array with double the capacity and copies the existing elements.
+
+**Signature:** `List::push self:List item:any`
+
+**Stack effect:** `( List any -- )`
+
+```casa
+4 list.push
+list.size print       # 4
+3 list.nth print      # 4
+```
+
+### Complete Example
+
+```casa
+include "../lib/std.casa"
+
+[1, 2, 3] List::from_array = list
+list.size print         # 3
+list.capacity print     # 3
+
+4 list.push
+list.size print         # 4
+list.capacity print     # 6
+
+0 list.nth print        # 1
+3 list.nth print        # 4
+```
+
+See [`examples/dynamic_list.casa`](../examples/dynamic_list.casa) for a full program using the List.

--- a/docs/standard-library.md
+++ b/docs/standard-library.md
@@ -22,7 +22,7 @@ Copies heap slots from one pointer to another.
 
 **Signature:** `memcpy dst:ptr src:ptr n:int`
 
-**Stack effect:** `( dst src n -- )`
+**Stack effect:** `dst src n -> None`
 
 ```casa
 3 alloc = src
@@ -48,7 +48,7 @@ Returns the length of an array.
 
 **Signature:** `array::length array -> int`
 
-**Stack effect:** `( array -- int )`
+**Stack effect:** `array -> int`
 
 ```casa
 [1, 2, 3] = arr
@@ -61,7 +61,7 @@ Returns the nth element of an array (zero-indexed).
 
 **Signature:** `array::nth array:array n:int -> any`
 
-**Stack effect:** `( array n -- any )`
+**Stack effect:** `array n -> any`
 
 ```casa
 [10, 20, 30] = arr
@@ -92,7 +92,7 @@ Creates a `List` from a fixed-size array. The list's size and capacity are both 
 
 **Signature:** `List::from_array array:array -> List`
 
-**Stack effect:** `( array -- List )`
+**Stack effect:** `array -> List`
 
 ```casa
 [1, 2, 3] List::from_array = list
@@ -104,7 +104,7 @@ Returns the nth element (zero-indexed).
 
 **Signature:** `List::nth List int -> any`
 
-**Stack effect:** `( List int -- any )`
+**Stack effect:** `List int -> any`
 
 ```casa
 0 list.nth print    # 1
@@ -117,7 +117,7 @@ Appends an item to the list. If the list is at capacity, it allocates a new arra
 
 **Signature:** `List::push self:List item:any`
 
-**Stack effect:** `( List any -- )`
+**Stack effect:** `List any -> None`
 
 ```casa
 4 list.push

--- a/docs/structs-and-methods.md
+++ b/docs/structs-and-methods.md
@@ -15,7 +15,7 @@ struct Person {
 
 Push fields onto the stack in reverse declaration order (last declared field deepest, first declared field on top), then call the struct name. Fields are popped from the top in declaration order.
 
-**Stack effect:** `( fieldN ... field2 field1 -- StructName )`
+**Stack effect:** `fieldN ... field2 field1 -> StructName`
 
 ```casa
 18 "John Doe" Person = person
@@ -31,7 +31,7 @@ Every struct automatically gets getter and setter functions for each field.
 
 `Type::field` — pops a struct instance, pushes the field value.
 
-**Stack effect:** `( StructName -- field_type )`
+**Stack effect:** `StructName -> field_type`
 
 ```casa
 person Person::name print    # John Doe
@@ -42,7 +42,7 @@ person Person::age print     # 18
 
 `Type::set_field` — pops a new value and a struct instance, updates the field in place.
 
-**Stack effect:** `( value StructName -- )`
+**Stack effect:** `value StructName -> None`
 
 ```casa
 "Jane Doe" person Person::set_name

--- a/docs/structs-and-methods.md
+++ b/docs/structs-and-methods.md
@@ -1,0 +1,173 @@
+# Structs and Methods
+
+## Defining a Struct
+
+Structs group named, typed fields into a single type.
+
+```casa
+struct Person {
+    name: str
+    age:  int
+}
+```
+
+## Instantiation
+
+Push fields onto the stack in reverse declaration order (last declared field deepest, first declared field on top), then call the struct name. Fields are popped from the top in declaration order.
+
+**Stack effect:** `( fieldN ... field2 field1 -- StructName )`
+
+```casa
+18 "John Doe" Person = person
+```
+
+Here `18` (`age`, last declared) is pushed first and sits deepest. `"John Doe"` (`name`, first declared) is pushed second and sits on top. The struct constructor pops fields in declaration order: `name` first (from top), then `age`.
+
+## Auto-Generated Accessors
+
+Every struct automatically gets getter and setter functions for each field.
+
+### Getters
+
+`Type::field` — pops a struct instance, pushes the field value.
+
+**Stack effect:** `( StructName -- field_type )`
+
+```casa
+person Person::name print    # John Doe
+person Person::age print     # 18
+```
+
+### Setters
+
+`Type::set_field` — pops a new value and a struct instance, updates the field in place.
+
+**Stack effect:** `( value StructName -- )`
+
+```casa
+"Jane Doe" person Person::set_name
+person Person::name print    # Jane Doe
+```
+
+## Dot and Arrow Syntax
+
+Shorthand syntax makes struct access more readable.
+
+### Dot Syntax (Getter)
+
+`instance.field` is equivalent to `instance Type::field`.
+
+```casa
+person.name print    # same as: person Person::name print
+person.age print     # same as: person Person::age print
+```
+
+The type checker resolves the receiver type automatically — you do not need to write the struct name.
+
+### Arrow Syntax (Setter)
+
+`value instance->field` is equivalent to `value instance Type::set_field`.
+
+```casa
+"Jane Doe" person->name    # same as: "Jane Doe" person Person::set_name
+```
+
+## `impl` Blocks
+
+Add methods to a type with `impl`:
+
+```casa
+impl Person {
+    fn celebrate_birthday self:Person {
+        self.age 1 + self->age
+    }
+}
+```
+
+Methods are namespaced as `TypeName::method`. The first parameter is typically the instance (named `self` by convention, but any name works).
+
+### Calling Methods
+
+Full syntax:
+
+```casa
+person Person::celebrate_birthday
+```
+
+Dot syntax (preferred):
+
+```casa
+person.celebrate_birthday
+```
+
+### Example
+
+```casa
+person.celebrate_birthday
+person.age print    # 19
+```
+
+### Multiple `impl` Blocks
+
+A type can have multiple `impl` blocks, even across different files:
+
+```casa
+impl Person {
+    fn greet self:Person {
+        self.name print
+    }
+}
+
+impl Person {
+    fn is_adult self:Person -> bool {
+        self.age 18 <= !
+    }
+}
+```
+
+## `impl` on Built-In Types
+
+`impl` blocks work on any type, including built-in types like `int`, `str`, `bool`, and `ptr`:
+
+```casa
+impl int {
+    fn double  int -> int { 2 * }
+    fn add_one int -> int { 1 + }
+}
+
+20.add_one.double print    # 42
+```
+
+See [`examples/method_chain.casa`](../examples/method_chain.casa).
+
+## Complete Example
+
+```casa
+struct Person {
+    name: str
+    age:  int
+}
+
+impl Person {
+    fn celebrate_birthday self:Person {
+        self.age 1 + self->age
+    }
+}
+
+# Instantiate
+18 "John Doe" Person = person
+
+# Getters
+person.name print       # John Doe
+person.age print        # 18
+
+# Setters
+"Jane Doe" person->name
+person.name print       # Jane Doe
+
+# Methods
+person.celebrate_birthday
+person.age print        # 19
+```
+
+See [`examples/struct.casa`](../examples/struct.casa).

--- a/docs/types-and-literals.md
+++ b/docs/types-and-literals.md
@@ -1,0 +1,142 @@
+# Types and Literals
+
+Casa is a statically typed language. Types are checked at compile time and most can be inferred automatically — you rarely need to write type annotations outside of function signatures.
+
+## Primitive Types
+
+### `int`
+
+Integer type. All integers are 64-bit signed values.
+
+```casa
+42 print       # 42
+0 print        # 0
+```
+
+There are no negative integer literals. To get a negative number, subtract from zero:
+
+```casa
+0 1 - print    # -1
+```
+
+### `bool`
+
+Boolean type with two values: `true` and `false`.
+
+```casa
+true print     # 1
+false print    # 0
+```
+
+Booleans are printed as integers (`1` for true, `0` for false).
+
+### `str`
+
+String type. String literals are enclosed in double quotes.
+
+```casa
+"Hello world!" print
+```
+
+Strings support the following escape sequences: `\n` (newline), `\t` (tab), `\\` (backslash), `\"` (quote), `\0` (null).
+
+## Composite Types
+
+### `ptr`
+
+Heap pointer returned by `alloc`. Used with `load` and `store` for heap memory access.
+
+```casa
+10 alloc = buffer    # allocate 10 heap slots
+42 buffer store      # store 42 at buffer
+buffer load print    # 42
+```
+
+Pointer arithmetic is supported with `+` and `-`:
+
+```casa
+10 alloc = buffer
+99 buffer 3 + store   # store 99 at offset 3
+buffer 3 + load print  # 99
+```
+
+See [Functions and Lambdas — Memory Intrinsics](functions-and-lambdas.md#memory-intrinsics) for details.
+
+### `array`
+
+Fixed-size array literal. Items must be literal values (integers, booleans, or strings).
+
+```casa
+[1, 2, 3]
+```
+
+The array's length is stored in the first heap slot. Elements are stored starting at offset 1.
+
+See [Standard Library — Arrays](standard-library.md#arrays) for `array::length` and `array::nth`.
+
+### `fn[sig]`
+
+Function type representing a lambda or function reference. The signature inside the brackets describes the parameter and return types.
+
+```casa
+{ 2 * }           # type: fn[int -> int]
+{ 1 + }           # type: fn[int -> int]
+{ drop "hi" }     # type: fn[any -> str]
+```
+
+Call a function value with `exec`:
+
+```casa
+{ 2 * } = double
+21 double exec print   # 42
+```
+
+See [Functions and Lambdas](functions-and-lambdas.md#lambdas) for details.
+
+### User-Defined Structs
+
+Struct names are types. After defining a struct, its name can be used as a type.
+
+```casa
+struct Point {
+    x: int
+    y: int
+}
+
+10 20 Point = p    # p has type Point
+```
+
+See [Structs and Methods](structs-and-methods.md) for details.
+
+## The `any` Type
+
+`any` is a special wildcard type that matches any other type. It is used as an escape hatch when the type system cannot determine a precise type — for example, values read from the heap with `load` have type `any`.
+
+```casa
+10 alloc = buffer
+42 buffer store
+buffer load         # type: any
+```
+
+## Type Casting
+
+The `(TypeName)` syntax casts the top of the stack to the given type. This is a compile-time annotation only — no runtime check is performed.
+
+**Stack effect:** `( a -- TypeName )`
+
+```casa
+buffer load (int)    # cast any -> int
+```
+
+This is useful after `load` or when working with generic data structures that return `any`.
+
+## Comments
+
+Line comments start with `#` and extend to the end of the line.
+
+```casa
+# This is a comment
+42 print  # This is also a comment
+```
+
+There are no block comments.

--- a/docs/types-and-literals.md
+++ b/docs/types-and-literals.md
@@ -11,12 +11,15 @@ Integer type. All integers are 64-bit signed values.
 ```casa
 42 print       # 42
 0 print        # 0
+-42 print      # -42
 ```
 
-There are no negative integer literals. To get a negative number, subtract from zero:
+Negative literals are written with a `-` prefix directly attached to the digits (no space). Note that `- 42` (with a space) is the subtraction operator followed by `42`, not a negative literal.
 
 ```casa
-0 1 - print    # -1
+-42            # negative integer literal
+- 42           # subtraction operator, then 42
+10 -3 + print  # 7 (push 10, push -3, add)
 ```
 
 ### `bool`
@@ -68,6 +71,7 @@ Fixed-size array literal. Items must be literal values (integers, booleans, or s
 
 ```casa
 [1, 2, 3]
+[-1, -2, -3]    # negative literals work in arrays
 ```
 
 The array's length is stored in the first heap slot. Elements are stored starting at offset 1.

--- a/docs/types-and-literals.md
+++ b/docs/types-and-literals.md
@@ -116,7 +116,7 @@ buffer load         # type: any
 
 The `(TypeName)` syntax casts the top of the stack to the given type. This is a compile-time annotation only — no runtime check is performed.
 
-**Stack effect:** `( a -- TypeName )`
+**Stack effect:** `a -> TypeName`
 
 ```casa
 buffer load (int)    # cast any -> int

--- a/docs/types-and-literals.md
+++ b/docs/types-and-literals.md
@@ -10,16 +10,7 @@ Integer type. All integers are 64-bit signed values.
 
 ```casa
 42 print       # 42
-0 print        # 0
 -42 print      # -42
-```
-
-Negative literals are written with a `-` prefix directly attached to the digits (no space). Note that `- 42` (with a space) is the subtraction operator followed by `42`, not a negative literal.
-
-```casa
--42            # negative integer literal
-- 42           # subtraction operator, then 42
-10 -3 + print  # 7 (push 10, push -3, add)
 ```
 
 ### `bool`
@@ -71,7 +62,6 @@ Fixed-size array literal. Items must be literal values (integers, booleans, or s
 
 ```casa
 [1, 2, 3]
-[-1, -2, -3]    # negative literals work in arrays
 ```
 
 The array's length is stored in the first heap slot. Elements are stored starting at offset 1.


### PR DESCRIPTION
## Summary

- Replace the 2-line README with a full project landing page (features, getting started, CLI usage, compilation pipeline, example listings)
- Add six documentation files under `docs/`:
  - **types-and-literals.md** — primitive types, composite types, `any`, type casting, comments
  - **operators.md** — arithmetic, bitshift, comparison, boolean, assignment with stack effects
  - **control-flow.md** — `if`/`elif`/`else`/`fi`, `while`/`do`/`done`, stack consistency rules
  - **functions-and-lambdas.md** — functions, signature inference, variables, lambdas, closures, stack/memory/IO intrinsics
  - **structs-and-methods.md** — struct definition, auto-generated accessors, `impl` blocks, dot/arrow syntax
  - **standard-library.md** — `include` directive, `memcpy`, arrays, `List`
- Update CLAUDE.md with documentation maintenance policy and fix parameter ordering note (first param = top, not deepest)

## Test plan

- [x] Verify all Casa code examples in docs are syntactically correct
- [x] Verify cross-reference links between docs files resolve correctly
- [x] Verify README example listings match actual files in `examples/`
- [x] Verify CLI flags match `casa/cli.py`
- [x] Verify stack effects match `typechecker.py` implementation