### PR TITLE
feat: add generics (type variables) to functions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,13 +71,14 @@ print  # any -> None     print top of stack
 
 ### Functions
 ```
-fn name param:type -> return_type {
+fn name[T1 T2] param:type -> return_type {
     body
 }
 ```
 - Parameters popped from stack in declaration order (first param = top)
 - Return types describe what remains on the stack after the call
 - Signatures can be explicit or inferred by the type checker
+- Optional `[T1 T2]` declares generic type variables, resolved at each call site
 - Must be defined at global scope
 
 ### Variables
@@ -181,3 +182,7 @@ include "relative/path/to/file.casa"   # included at most once
 ## Documentation
 
 When any language feature, intrinsic, operator, or standard library function is changed or added, the corresponding documentation in `docs/` and `README.md` must be updated to reflect the change.
+
+## Coding style
+
+- **Keep code flat.** Prefer early returns, `continue`, and guard clauses over deeply nested `if`/`else` blocks. Extract helpers when nesting exceeds 2–3 levels inside a loop or function.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Casa compiles to x86-64 Linux executables via GNU assembly. It features static t
 ## Features
 
 - **Stack-based** — values live on the stack; operators consume and produce stack entries
-- **Statically typed** — types are checked at compile time with automatic inference
+- **Statically typed** — types are checked at compile time with automatic inference and generics
 - **First-class functions** — lambdas are values on the stack like any other (TODO: function pointers)
 - **Structs and methods** — user-defined types with auto-generated accessors and `impl` blocks
 - **Compiles to native code** — generates x86-64 assembly with `ld` and `as`

--- a/casa/common.py
+++ b/casa/common.py
@@ -571,6 +571,7 @@ class Parameter:
 class Signature:
     parameters: list[Parameter]
     return_types: list[Type]
+    type_vars: set[str] = field(default_factory=set)
 
     @classmethod
     def from_str(cls, repr: str) -> Self:

--- a/casa/parser.py
+++ b/casa/parser.py
@@ -435,9 +435,13 @@ def parse_type_vars(cursor: Cursor[Token]) -> set[str]:
     type_vars: set[str] = set()
     while token := cursor.pop():
         if token.value == "]":
+            if not type_vars:
+                raise SyntaxError("Empty type parameter list `[]` is not allowed")
             return type_vars
         if token.kind == TokenKind.IDENTIFIER:
             type_vars.add(token.value)
+        elif token.value != ",":
+            raise SyntaxError(f"Expected type variable name but got `{token.value}`")
     raise SyntaxError("Expected `]` to close type parameters")
 
 

--- a/casa/parser.py
+++ b/casa/parser.py
@@ -430,10 +430,29 @@ def parse_struct(cursor: Cursor[Token]) -> Struct:
     return Struct(struct_name.value, members, struct_name.location)
 
 
+def parse_type_vars(cursor: Cursor[Token]) -> set[str]:
+    expect_token(cursor, value="[")
+    type_vars: set[str] = set()
+    while token := cursor.pop():
+        if token.value == "]":
+            return type_vars
+        if token.kind == TokenKind.IDENTIFIER:
+            type_vars.add(token.value)
+    raise SyntaxError("Expected `]` to close type parameters")
+
+
 def parse_function(cursor: Cursor[Token]) -> Function:
     expect_token(cursor, value="fn")
     name = expect_token(cursor, kind=TokenKind.IDENTIFIER)
+
+    # Parse optional type parameters: fn name[T1 T2] ...
+    type_vars: set[str] = set()
+    next_token = cursor.peek()
+    if next_token and next_token.value == "[":
+        type_vars = parse_type_vars(cursor)
+
     signature = parse_signature(cursor)
+    signature.type_vars = type_vars
 
     ops: list[Op] = []
     variables: list[Variable] = []

--- a/casa/typechecker.py
+++ b/casa/typechecker.py
@@ -530,8 +530,9 @@ Stack:    {tc.stack}
             if r in function.signature.type_vars and r not in param_tvs
         }
         if ret_only:
+            names = ", ".join(sorted(ret_only))
             raise TypeError(
-                f"Type variable(s) {ret_only} appear in return types "
+                f"Type variable(s) `{names}` appear in return types "
                 f"but not in parameters of `{function.name}`"
             )
 

--- a/docs/functions-and-lambdas.md
+++ b/docs/functions-and-lambdas.md
@@ -7,10 +7,12 @@ Functions are defined with `fn` at global scope. They can be called before their
 ### Syntax
 
 ```
-fn name param:type ... -> return_type ... {
+fn name[TypeVar ...] param:type ... -> return_type ... {
     body
 }
 ```
+
+The `[TypeVar ...]` part is optional — see [Generic Functions](#generic-functions) below.
 
 Parameters are consumed from the top of the stack in declaration order: the first parameter is on top, and the last parameter is deepest. Return types describe what the function leaves on the stack after it returns.
 
@@ -90,17 +92,19 @@ See [`examples/fibonacci.casa`](../examples/fibonacci.casa).
 
 Functions can declare type variables in square brackets after the name. Type variables are resolved to concrete types at each call site, enabling type-safe polymorphism.
 
+**Stack effect:** `args... -> returns...` (type variables resolve to the actual types at the call site)
+
 ```casa
-fn id[T] T -> T { }
-42 id print         # T=int, prints 42
-"hello" id print    # T=str, prints hello
+fn id[T] T -> T { }       # T -> T
+42 id print                # int -> int, prints 42
+"hello" id print           # str -> str, prints hello
 ```
 
 Multiple type variables:
 
 ```casa
-fn swap_t[T1 T2] T1 T2 -> T1 T2 { swap }
-5 "hi" swap_t       # T1=str, T2=int -> returns str, int
+fn swap_t[T1 T2] T1 T2 -> T1 T2 { swap }   # T1 T2 -> T1 T2
+5 "hi" swap_t              # int str -> str int
 ```
 
 Generic functions can mix type variables with concrete types and named parameters:
@@ -116,6 +120,14 @@ The type checker enforces consistency — if the same type variable appears mult
 fn pair[T] T T -> T T { }
 42 42 pair        # OK: both T=int
 42 "hi" pair      # ERROR: T bound to int and str
+```
+
+Generic type parameters also work in `impl` block methods:
+
+```casa
+impl Box {
+    fn apply[T] self:Box T -> T { }
+}
 ```
 
 Every type variable must appear in at least one parameter (return-only type variables are not allowed).

--- a/docs/functions-and-lambdas.md
+++ b/docs/functions-and-lambdas.md
@@ -86,6 +86,40 @@ fn fib number:int -> int {
 
 See [`examples/fibonacci.casa`](../examples/fibonacci.casa).
 
+### Generic Functions
+
+Functions can declare type variables in square brackets after the name. Type variables are resolved to concrete types at each call site, enabling type-safe polymorphism.
+
+```casa
+fn id[T] T -> T { }
+42 id print         # T=int, prints 42
+"hello" id print    # T=str, prints hello
+```
+
+Multiple type variables:
+
+```casa
+fn swap_t[T1 T2] T1 T2 -> T1 T2 { swap }
+5 "hi" swap_t       # T1=str, T2=int -> returns str, int
+```
+
+Generic functions can mix type variables with concrete types and named parameters:
+
+```casa
+fn first[T1 T2] a:T1 b:T2 -> T1 { a }
+fn wrap[T] T -> T int { 42 }
+```
+
+The type checker enforces consistency — if the same type variable appears multiple times in the parameters, all occurrences must bind to the same type:
+
+```casa
+fn pair[T] T T -> T T { }
+42 42 pair        # OK: both T=int
+42 "hi" pair      # ERROR: T bound to int and str
+```
+
+Every type variable must appear in at least one parameter (return-only type variables are not allowed).
+
 ### Restrictions
 
 - Functions must be defined at **global scope** — no nested function definitions (use lambdas instead).

--- a/docs/structs-and-methods.md
+++ b/docs/structs-and-methods.md
@@ -62,7 +62,12 @@ person.name print    # same as: person Person::name print
 person.age print     # same as: person Person::age print
 ```
 
-The type checker resolves the receiver type automatically — you do not need to write the struct name.
+The type checker resolves the receiver type automatically from whatever value is on top of the stack — you do not need to write the struct name. This means dot syntax works on any expression, not just variables:
+
+```casa
+18 "John Doe" Person .name print   # John Doe (dot on constructor result)
+person.name print                  # John Doe (dot on variable)
+```
 
 ### Arrow Syntax (Setter)
 

--- a/docs/types-and-literals.md
+++ b/docs/types-and-literals.md
@@ -102,6 +102,18 @@ struct Point {
 
 See [Structs and Methods](structs-and-methods.md) for details.
 
+## Type Variables (Generics)
+
+Type variables let functions declare type relationships between inputs and outputs. They are declared in square brackets after the function name and are resolved to concrete types at each call site.
+
+```casa
+fn id[T] T -> T { }
+42 id        # T=int, returns int
+"hi" id      # T=str, returns str
+```
+
+Type variables are purely compile-time — they have no runtime cost. See [Functions and Lambdas — Generic Functions](functions-and-lambdas.md#generic-functions) for details.
+
 ## The `any` Type
 
 `any` is a special wildcard type that matches any other type. It is used as an escape hatch when the type system cannot determine a precise type — for example, values read from the heap with `load` have type `any`.

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -329,3 +329,29 @@ def test_resolve_push_capture():
 def test_resolve_undefined_raises():
     with pytest.raises(NameError, match="not defined"):
         resolve_string("undefined_thing")
+
+
+# ---------------------------------------------------------------------------
+# Generic type parameters (parsing)
+# ---------------------------------------------------------------------------
+def test_parse_generic_function_type_vars():
+    parse_string("fn id[T] T -> T { }")
+    fn = GLOBAL_FUNCTIONS["id"]
+    assert fn.signature is not None
+    assert fn.signature.type_vars == {"T"}
+
+
+def test_parse_generic_multiple_type_vars():
+    parse_string("fn swap_t[T1 T2] T1 T2 -> T1 T2 { swap }")
+    fn = GLOBAL_FUNCTIONS["swap_t"]
+    assert fn.signature.type_vars == {"T1", "T2"}
+
+
+def test_parse_generic_empty_brackets_raises():
+    with pytest.raises(SyntaxError, match="Empty type parameter list"):
+        parse_string("fn foo[] int -> int { }")
+
+
+def test_parse_generic_invalid_token_raises():
+    with pytest.raises(SyntaxError, match="Expected type variable name"):
+        parse_string("fn foo[42] int -> int { }")

--- a/tests/test_typechecker.py
+++ b/tests/test_typechecker.py
@@ -326,3 +326,25 @@ def test_typecheck_generic_called_from_function():
 def test_typecheck_generic_definition_without_call():
     code = "fn id[T] T -> T { }"
     typecheck_string(code)  # Should not raise
+
+
+def test_typecheck_generic_in_impl_block():
+    code = """
+    struct Box { val: int }
+    impl Box {
+        fn apply[T] self:Box T -> T { }
+    }
+    42 99 Box .apply
+    """
+    sig = typecheck_string(code)
+    assert sig.return_types == ["int"]
+
+
+def test_typecheck_generic_lambda_wrapping():
+    code = """
+    fn id[T] T -> T { }
+    42 { id } exec
+    """
+    sig = typecheck_string(code)
+    # Lambda exec produces `any` — generic type info is lost through lambda
+    assert sig.return_types == ["any"]

--- a/tests/test_typechecker.py
+++ b/tests/test_typechecker.py
@@ -334,11 +334,10 @@ def test_typecheck_generic_in_impl_block():
     impl Box {
         fn apply[T] self:Box T -> T { }
     }
-    42 Box = b
-    "hello" b.apply
+    42 99 Box .apply
     """
     sig = typecheck_string(code)
-    assert sig.return_types == ["str"]
+    assert sig.return_types == ["int"]
 
 
 def test_typecheck_generic_lambda_wrapping():

--- a/tests/test_typechecker.py
+++ b/tests/test_typechecker.py
@@ -334,10 +334,11 @@ def test_typecheck_generic_in_impl_block():
     impl Box {
         fn apply[T] self:Box T -> T { }
     }
-    42 99 Box .apply
+    42 Box = b
+    "hello" b.apply
     """
     sig = typecheck_string(code)
-    assert sig.return_types == ["int"]
+    assert sig.return_types == ["str"]
 
 
 def test_typecheck_generic_lambda_wrapping():


### PR DESCRIPTION
## Summary

- Adds generic type parameters to function definitions with `fn name[T1 T2] T1 T2 -> T1 T2 { ... }` syntax
- Type variables are resolved to concrete types at each call site, enabling type-safe polymorphism
- Works with bare params, named params, mixed concrete + generic types, and `impl` block methods
- Purely compile-time — no changes to lexer, bytecode, emitter, or compiler

## Changes

| File | Change |
|------|--------|
| `casa/common.py` | Add `type_vars: set[str]` field to `Signature` |
| `casa/parser.py` | Add `parse_type_vars()`, modify `parse_function()` to parse `[T1 T2]` |
| `casa/typechecker.py` | Generic-aware `apply_signature()`, return-only type var validation |
| `tests/test_parser.py` | 4 parser tests (type vars parsing, empty bracket / invalid token errors) |
| `tests/test_typechecker.py` | 12 type checker tests (identity, swap, named params, consistency, impl, lambda) |
| `docs/` | Type variables section, generic functions docs with stack effects, dot syntax clarification |
| `README.md` | Brief mention of generics in features list |

## Test plan

- [x] All 265 tests pass
- [x] Linted with pylint (no new errors)
- [x] Formatted with black
- [x] Generic identity resolves correctly for int, str, and struct types
- [x] Type consistency enforced (same type var bound to different types raises error)
- [x] Return-only type variables rejected at definition time
- [x] Generics work inside `impl` blocks
- [x] Generic function wrapped in lambda degrades to `any` (consistent with existing lambda semantics)
- [x] Empty `[]` and non-identifier tokens in `[]` produce parse errors