### PR TITLE
feat: disallow type variables that shadow existing types

### DIFF
--- a/casa/common.py
+++ b/casa/common.py
@@ -554,6 +554,7 @@ class Program:
 
 
 ANY_TYPE = "any"
+BUILTIN_TYPES: set[str] = {"int", "bool", "str", "ptr", "array", "any"}
 
 
 @dataclass

--- a/casa/parser.py
+++ b/casa/parser.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from typing import assert_never
 
 from casa.common import (
+    BUILTIN_TYPES,
     GLOBAL_FUNCTIONS,
     GLOBAL_SCOPE_LABEL,
     GLOBAL_STRUCTS,
@@ -439,6 +440,14 @@ def parse_type_vars(cursor: Cursor[Token]) -> set[str]:
                 raise SyntaxError("Empty type parameter list `[]` is not allowed")
             return type_vars
         if token.kind == TokenKind.IDENTIFIER:
+            if token.value in BUILTIN_TYPES:
+                raise SyntaxError(
+                    f"Type variable `{token.value}` shadows built-in type `{token.value}`"
+                )
+            if token.value in GLOBAL_STRUCTS:
+                raise SyntaxError(
+                    f"Type variable `{token.value}` shadows struct type `{token.value}`"
+                )
             type_vars.add(token.value)
         elif token.value != ",":
             raise SyntaxError(f"Expected type variable name but got `{token.value}`")

--- a/docs/functions-and-lambdas.md
+++ b/docs/functions-and-lambdas.md
@@ -132,6 +132,14 @@ impl Box {
 
 Every type variable must appear in at least one parameter (return-only type variables are not allowed).
 
+Type variable names must not collide with built-in types (`int`, `bool`, `str`, `ptr`, `array`, `any`, `fn`) or user-defined struct names:
+
+```casa
+fn bad[int] int -> int { }     # ERROR: shadows built-in type
+fn bad[MyStruct] MyStruct -> MyStruct { }   # ERROR: shadows struct type
+fn good[T] T -> T { }         # OK
+```
+
 ### Restrictions
 
 - Functions must be defined at **global scope** — no nested function definitions (use lambdas instead).
@@ -237,7 +245,7 @@ Built-in operations for manipulating the stack directly.
 
 | Intrinsic | Stack Effect | Description |
 |-----------|-------------|-------------|
-| `drop` | `a -> None` | Discard top of stack |
+| `drop` | `a ->` | Discard top of stack |
 | `dup` | `a -> a a` | Duplicate top of stack |
 | `swap` | `a b -> b a` | Swap top two values |
 | `over` | `a b -> a b a` | Copy second value to top |

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -355,3 +355,14 @@ def test_parse_generic_empty_brackets_raises():
 def test_parse_generic_invalid_token_raises():
     with pytest.raises(SyntaxError, match="Expected type variable name"):
         parse_string("fn foo[42] int -> int { }")
+
+
+@pytest.mark.parametrize("builtin", ["int", "bool", "str", "ptr", "array", "any"])
+def test_parse_generic_type_var_shadows_builtin_raises(builtin):
+    with pytest.raises(SyntaxError, match=f"shadows built-in type `{builtin}`"):
+        parse_string(f"fn foo[{builtin}] {builtin} -> {builtin} {{ }}")
+
+
+def test_parse_generic_type_var_shadows_struct_raises():
+    with pytest.raises(SyntaxError, match="shadows struct type `Foo`"):
+        parse_string("struct Foo { val: int } fn id[Foo] Foo -> Foo { }")


### PR DESCRIPTION
## Summary

- Type variable names in generic functions (`fn foo[T]`) now cannot collide with built-in types (`int`, `bool`, `str`, `ptr`, `array`, `any`) or user-defined struct names
- Raises `SyntaxError` at parse time with a clear message
- Fixes `drop` stack effect in docs (`a -> None` to `a ->`)

## Test plan

- [x] Parametrized test for all 6 built-in types shadowing
- [x] Test for struct type shadowing
- [x] All 272 existing tests pass