### PR TITLE
feat: improve STACK_MISMATCH error messages with per-branch signatures

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -22,7 +22,7 @@ Each error includes:
 Some errors include additional context:
 
 - **Expected** and **Got** (or **Inferred**) lines showing what was expected versus what was found
-- **Note** with a secondary source annotation pointing to a related location (e.g. where a mismatched value was originally pushed)
+- **Notes** with secondary source annotations pointing to related locations (e.g. where a mismatched value was originally pushed, or which branches have incompatible stack effects)
 
 When multiple errors are found, they are all printed before the compiler stops, followed by a summary line:
 
@@ -129,16 +129,34 @@ error[TYPE_MISMATCH]: Type variable `T` bound to `str` but got `int`
 
 ### `STACK_MISMATCH`
 
-Branches of a conditional or loop leave the stack in inconsistent states.
+Branches of a conditional or loop leave the stack in inconsistent states. The error shows each branch's stack signature so you can see which branch diverges.
 
 ```casa
-if true then 1 else "two" fi
+fn branchy bool -> int {
+    if dup then
+        1 2
+    else
+        3
+    fi
+}
 ```
 
 ```
-error[STACK_MISMATCH]: Stack state changed across branch
-  Expected: [int]
-  Got: [str]
+error[STACK_MISMATCH]: Branches have incompatible stack effects
+  --> examples/multi_error.casa:27:5
+   |
+27 |     fi
+   |     ^^
+  Note: `if` branch has signature `any -> any int int`
+  --> examples/multi_error.casa:23:5
+   |
+23 |     if dup then
+   |     ^^
+  Note: `else` branch has signature `any -> any int`
+  --> examples/multi_error.casa:25:5
+   |
+25 |     else
+   |     ^^^^
 ```
 
 ### `SIGNATURE_MISMATCH`

--- a/examples/outputs/multi_error.err
+++ b/examples/outputs/multi_error.err
@@ -25,12 +25,20 @@ error[INVALID_VARIABLE]: Cannot override local variable `count` of type `int` wi
 18 |     "oops" = count
    |              ^^^^^
 
-error[STACK_MISMATCH]: Stack state changed across branch
+error[STACK_MISMATCH]: Branches have incompatible stack effects
   --> examples/multi_error.casa:27:5
    |
 27 |     fi
    |     ^^
-  Expected: ['any']
-  Got: ['any', 'int']
+  Note: `if` branch has signature `any -> any int int`
+  --> examples/multi_error.casa:23:5
+   |
+23 |     if dup then
+   |     ^^
+  Note: `else` branch has signature `any -> any int`
+  --> examples/multi_error.casa:25:5
+   |
+25 |     else
+   |     ^^^^
 
 Found 4 error(s).


### PR DESCRIPTION
## Summary

- Replace the generic `Expected`/`Got` format in branch mismatch errors with per-branch `Note:` annotations showing each branch's stack signature and source location
- Generalize `CasaError.note` (single optional tuple) to `CasaError.notes` (list) to support multiple secondary source annotations
- Update documentation and expected test output to reflect the new format

**Before:**
```
error[STACK_MISMATCH]: Stack state changed across branch
  Expected: ['any']
  Got: ['any', 'int']
```

**After:**
```
error[STACK_MISMATCH]: Branches have incompatible stack effects
  --> examples/multi_error.casa:27:5
   |
27 |     fi
   |     ^^
  Note: `if` branch has signature `any -> any int int`
  --> examples/multi_error.casa:23:5
   |
23 |     if dup then
   |     ^^
  Note: `else` branch has signature `any -> any int`
  --> examples/multi_error.casa:25:5
   |
25 |     else
   |     ^^^^
```

## Test plan

- [x] All 304 unit tests pass
- [x] All 17 integration tests pass (`test_examples.sh`)
- [x] New tests for: multiple notes formatting, note without source cache, if/else mismatch notes, if/elif mismatch notes, if-without-else mismatch, `_format_branch_signature` helper
- [x] `black` and `pylint` clean (no new warnings)