### PR TITLE
feat: add escape sequence support to string literals

### DIFF
--- a/casa/emitter.py
+++ b/casa/emitter.py
@@ -42,6 +42,8 @@ class Emitter:
                 result.append("\\t")
             elif c == "\0":
                 result.append("\\0")
+            elif c == "\r":
+                result.append("\\r")
             else:
                 result.append(c)
         return "".join(result)

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -44,6 +44,16 @@ Malformed tokens or structural problems in the source code.
 error[SYNTAX]: Unclosed string literal
 ```
 
+Invalid escape sequences in strings are also reported as `SYNTAX` errors:
+
+```casa
+"bad\q"
+```
+
+```
+error[SYNTAX]: Invalid escape sequence `\q`
+```
+
 ### `UNEXPECTED_TOKEN`
 
 The parser expected one token but found another.

--- a/docs/types-and-literals.md
+++ b/docs/types-and-literals.md
@@ -32,7 +32,24 @@ String type. String literals are enclosed in double quotes.
 "Hello world!" print
 ```
 
-Strings do not support escape sequences. Characters between quotes are read literally.
+Strings support the following escape sequences:
+
+| Sequence | Meaning |
+|----------|---------|
+| `\n` | Newline |
+| `\t` | Tab |
+| `\\` | Literal backslash |
+| `\"` | Double quote |
+| `\0` | Null byte |
+| `\r` | Carriage return |
+
+```casa
+"hello\nworld" print    # prints on two lines
+"say \"hi\"" print      # say "hi"
+"col1\tcol2" print      # tab-separated
+```
+
+Invalid escape sequences (e.g. `\q`) produce a compile-time `SYNTAX` error.
 
 ## Composite Types
 

--- a/tests/test_emitter.py
+++ b/tests/test_emitter.py
@@ -46,6 +46,36 @@ def test_emit_push_str():
     assert 'str_0: .asciz "hello"' in asm
 
 
+def test_emit_escaped_newline_str():
+    asm = emit_string(r'"hello\nworld"')
+    assert 'str_0: .asciz "hello\\nworld"' in asm
+
+
+def test_emit_escaped_tab_str():
+    asm = emit_string(r'"col1\tcol2"')
+    assert 'str_0: .asciz "col1\\tcol2"' in asm
+
+
+def test_emit_escaped_backslash_str():
+    asm = emit_string(r'"path\\file"')
+    assert 'str_0: .asciz "path\\\\file"' in asm
+
+
+def test_emit_escaped_carriage_return_str():
+    asm = emit_string(r'"line\r"')
+    assert 'str_0: .asciz "line\\r"' in asm
+
+
+def test_emit_escaped_quote_str():
+    asm = emit_string(r'"say \"hi\""')
+    assert r'str_0: .asciz "say \"hi\""' in asm
+
+
+def test_emit_escaped_null_str():
+    asm = emit_string(r'"hello\0world"')
+    assert 'str_0: .asciz "hello\\0world"' in asm
+
+
 # ---------------------------------------------------------------------------
 # Stack operations
 # ---------------------------------------------------------------------------

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -49,6 +49,12 @@ def test_parse_push_str():
     assert ops[0].value == "hello"
 
 
+def test_parse_push_str_with_escapes():
+    ops = parse_string(r'"hello\nworld"')
+    assert ops[0].kind == OpKind.PUSH_STR
+    assert ops[0].value == "hello\nworld"
+
+
 def test_parse_negative_int():
     ops = parse_string("-42")
     assert len(ops) == 1


### PR DESCRIPTION
## Summary

- Add escape sequence processing (`\n`, `\t`, `\\`, `\"`, `\0`, `\r`) to the lexer's string literal parser
- Invalid escape sequences produce a `SYNTAX` error pointing at the two-character sequence
- Fix token span length to reflect source length rather than processed length
- Add `\r` handling to the emitter's assembly string escaping
- Add 20 new tests covering all escape sequences, error cases, and assembly output
- Update documentation in `docs/types-and-literals.md` and `docs/errors.md`

## Test plan

- [x] All 328 tests pass (20 new, 308 existing unchanged)
- [x] `pylint` clean (no new warnings, 9.37/10)
- [x] `black` formatting clean
- [x] Manual test: `"hello\nworld" print` prints on two lines
- [x] Manual test: `"say \"hi\"" print` prints `say "hi"`
- [x] Manual test: `"bad\q"` produces a SYNTAX error pointing at `\q`