### PR TITLE
feat: remove trailing newline from print intrinsic

### DIFF
--- a/casa/emitter.py
+++ b/casa/emitter.py
@@ -81,8 +81,6 @@ class Emitter:
         for s in self.program.strings:
             self._line(f"    .quad {len(s)}")
 
-        # Characters for print helpers
-        self._line("newline: .byte 10")
         self._line("")
 
     def _emit_text(self) -> None:
@@ -95,8 +93,7 @@ class Emitter:
         # print_int: value in %rdi, returns via r14
         self._line("print_int:")
         self._indent("movq %rdi, %rax")
-        self._indent("leaq print_buf+31(%rip), %rsi")
-        self._indent("movb $10, (%rsi)")
+        self._indent("leaq print_buf+32(%rip), %rsi")
         # Zero check
         self._indent("testq %rax, %rax")
         self._indent("jnz .Lpi_nonzero")
@@ -141,12 +138,6 @@ class Emitter:
         self._indent("movq (%rax, %rdi, 8), %rsi")
         self._indent("leaq str_len_table(%rip), %rax")
         self._indent("movq (%rax, %rdi, 8), %rdx")
-        self._indent("movq $1, %rax")
-        self._indent("movq $1, %rdi")
-        self._indent("syscall")
-        # Print newline
-        self._indent("leaq newline(%rip), %rsi")
-        self._indent("movq $1, %rdx")
         self._indent("movq $1, %rax")
         self._indent("movq $1, %rdi")
         self._indent("syscall")

--- a/docs/functions-and-lambdas.md
+++ b/docs/functions-and-lambdas.md
@@ -274,16 +274,17 @@ See [`examples/stack_operations.casa`](../examples/stack_operations.casa).
 
 ### `print`
 
-Prints the top of the stack to stdout, followed by a newline.
+Prints the top of the stack to stdout.
 
 **Stack effect:** `a -> None`
 
 Integers and booleans are printed as decimal numbers. Strings are printed as text.
 
 ```casa
-42 print           # 42
-true print         # 1
-"Hello" print      # Hello
+42 print                    # 42
+true print                  # 1
+"Hello" print               # Hello
+"Hello" print "\n" print    # Hello followed by a newline
 ```
 
 ## Memory Intrinsics

--- a/examples/arithmetic.casa
+++ b/examples/arithmetic.casa
@@ -1,5 +1,5 @@
-34 35 + print
-1357 20 - print
-7 6 * print
-14 3 / print
-14 3 % print
+34 35 + print "\n" print
+1357 20 - print "\n" print
+7 6 * print "\n" print
+14 3 / print "\n" print
+14 3 % print "\n" print

--- a/examples/boolean.casa
+++ b/examples/boolean.casa
@@ -1,10 +1,10 @@
-true true && print
-true false && print
-false true && print
-false false && print
-true true || print
-true false || print
-false true || print
-false false || print
-true ! print
-false ! print
+true true && print "\n" print
+true false && print "\n" print
+false true && print "\n" print
+false false && print "\n" print
+true true || print "\n" print
+true false || print "\n" print
+false true || print "\n" print
+false false || print "\n" print
+true ! print "\n" print
+false ! print "\n" print

--- a/examples/comparison.casa
+++ b/examples/comparison.casa
@@ -1,16 +1,16 @@
-1 1 == print
-1 0 == print
-1 1 != print
-1 0 != print
-1 1 >  print
-1 0 >  print
-0 1 >  print
-1 1 >= print
-1 0 >= print
-0 1 >= print
-1 1 <  print
-1 0 <  print
-0 1 <  print
-1 1 <= print
-1 0 <= print
-0 1 <= print
+1 1 == print "\n" print
+1 0 == print "\n" print
+1 1 != print "\n" print
+1 0 != print "\n" print
+1 1 >  print "\n" print
+1 0 >  print "\n" print
+0 1 >  print "\n" print
+1 1 >= print "\n" print
+1 0 >= print "\n" print
+0 1 >= print "\n" print
+1 1 <  print "\n" print
+1 0 <  print "\n" print
+0 1 <  print "\n" print
+1 1 <= print "\n" print
+1 0 <= print "\n" print
+0 1 <= print "\n" print

--- a/examples/conditional.casa
+++ b/examples/conditional.casa
@@ -9,4 +9,4 @@ else
     "Correct!"
 fi
 
-print
+print "\n" print

--- a/examples/dynamic_list.casa
+++ b/examples/dynamic_list.casa
@@ -1,14 +1,14 @@
 include "../lib/std.casa"
 
-"=== Create list with items [1, 2, 3] ===" print
+"=== Create list with items [1, 2, 3] ===" print "\n" print
 [1, 2, 3] List::from_array = list
 list.print_metadata
 
-"=== Push 4 to the list ===" print
+"=== Push 4 to the list ===" print "\n" print
 4 list.push
 list.print_metadata
 
-"=== Shrink list size to 1 ===" print
+"=== Shrink list size to 1 ===" print "\n" print
 1 list->size
 list.print_metadata
 
@@ -16,17 +16,17 @@ impl List {
     fn print_items self:List {
         0 = i
         while i self.size > do
-            i self.nth print
+            i self.nth print "\n" print
             1 += i
         done
     }
 
     fn print_metadata self:List {
-        "SIZE" print
-        self.size print
-        "CAPACITY" print
-        self.capacity print
-        "ITEMS" print
+        "SIZE" print "\n" print
+        self.size print "\n" print
+        "CAPACITY" print "\n" print
+        self.capacity print "\n" print
+        "ITEMS" print "\n" print
         self.print_items
     }
 }

--- a/examples/euler01.casa
+++ b/examples/euler01.casa
@@ -9,7 +9,7 @@ LIMIT m1      sum_of_multiples = sum_m1
 LIMIT m2      sum_of_multiples = sum_m2
 LIMIT m1 m2 * sum_of_multiples = sum_lcm
 
-sum_m1 sum_m2 + sum_lcm - print
+sum_m1 sum_m2 + sum_lcm - print "\n" print
 
 # https://www.geeksforgeeks.org/maths/sum-of-n-terms-of-an-ap/
 # n * d(n + 1) / 2

--- a/examples/fibonacci.casa
+++ b/examples/fibonacci.casa
@@ -7,4 +7,4 @@ fn fib n:int -> int {
     n 2 - fib +
 }
 
-20 fib print
+20 fib print "\n" print

--- a/examples/fizzbuzz.casa
+++ b/examples/fizzbuzz.casa
@@ -11,12 +11,12 @@ fn fizzbuzz number:int {
     number 5 % 0 == = buzz
 
     if fizz buzz && then
-        "FizzBuzz" print
+        "FizzBuzz" print "\n" print
     elif fizz then
-        "Fizz" print
+        "Fizz" print "\n" print
     elif buzz then
-        "Buzz" print
+        "Buzz" print "\n" print
     else
-        number print
+        number print "\n" print
     fi
 }

--- a/examples/generics.casa
+++ b/examples/generics.casa
@@ -6,26 +6,26 @@
 # identity: pass any single value through unchanged
 fn id[T] T -> T { }
 
-42 id print         # 42
-"hello" id print    # hello
+42 id print "\n" print         # 42
+"hello" id print "\n" print    # hello
 
 # swap: works on any two types
 fn swap_t[T1 T2] T1 T2 -> T1 T2 { swap }
 
 1 2 swap_t
-print print # 1 2
+print "\n" print print "\n" print # 1 2
 
 # select first / second from a pair
 fn first[T1 T2] a:T1 b:T2 -> T1 { a }
 fn second[T1 T2] a:T1 b:T2 -> T2 { b }
 
-42 "hello" first print  # hello
-42 "hello" second print # 42
+42 "hello" first print "\n" print  # hello
+42 "hello" second print "\n" print # 42
 
 # mixing generic and concrete types
 fn tag[T] T -> T str { "tagged" }
 
-99 tag print print # tagged 99
+99 tag print "\n" print print "\n" print # tagged 99
 
 # generic method in an impl block
 struct Pair {
@@ -41,4 +41,4 @@ impl Pair {
 }
 
 10 20 Pair = p
-999 p.swap_x print # 10 (the old x value)
+999 p.swap_x print "\n" print # 10 (the old x value)

--- a/examples/hello_world.casa
+++ b/examples/hello_world.casa
@@ -1,1 +1,1 @@
-"Hello world!" print
+"Hello world!" print "\n" print

--- a/examples/loops.casa
+++ b/examples/loops.casa
@@ -1,14 +1,14 @@
 0 = index
 
-"First loop" print
+"First loop" print "\n" print
 while index 3 > do
-    index print
+    index print "\n" print
     1 += index
 done
 
-"Second loop" print
+"Second loop" print "\n" print
 while true do
-    index print
+    index print "\n" print
 
     # Break out of the loop when index >= 15
     if index 15 <= then
@@ -25,5 +25,5 @@ while true do
     1 += index
 done
 
-"After loops" print
-index print
+"After loops" print "\n" print
+index print "\n" print

--- a/examples/method_chain.casa
+++ b/examples/method_chain.casa
@@ -3,4 +3,4 @@ impl int {
     fn add_one int -> int {1 +}
 }
 
-20.add_one.double print
+20.add_one.double print "\n" print

--- a/examples/negative.casa
+++ b/examples/negative.casa
@@ -1,6 +1,6 @@
 # Negative number literals
--42 print
--1 print
-0 print
-1 -1 + print
-10 -3 + print
+-42 print "\n" print
+-1 print "\n" print
+0 print "\n" print
+1 -1 + print "\n" print
+10 -3 + print "\n" print

--- a/examples/stack_operations.casa
+++ b/examples/stack_operations.casa
@@ -1,14 +1,14 @@
 1 2 drop
-print
+print "\n" print
 
 3 dup
-print print
+print "\n" print print "\n" print
 
 4 5 over
-print print print
+print "\n" print print "\n" print print "\n" print
 
 6 7 8 rot
-print print print
+print "\n" print print "\n" print print "\n" print
 
 9 10 swap
-print print
+print "\n" print print "\n" print

--- a/examples/struct.casa
+++ b/examples/struct.casa
@@ -15,17 +15,17 @@ impl Person {
 # Getters:
 #   Person::name
 #   Person::age
-person Person::name print
-person Person::age print
+person Person::name print "\n" print
+person Person::age print "\n" print
 
 # Setters:
 #   Person::set_name
 #   Person::set_age
 "Jane Doe" person Person::set_name
-person Person::name print
+person Person::name print "\n" print
 
 # Shorthand syntax for getters and setters
 #   person.age  <==> person Person::age
 #   person->age <==> person Person::set_age
 person.celebrate_birthday
-person.age print
+person.age print "\n" print

--- a/examples/variables.casa
+++ b/examples/variables.casa
@@ -13,13 +13,13 @@ fn local_add a:int b:int -> int {
 }
 
 # Add `global_a` and `global_b` together
-global_add print
+global_add print "\n" print
 
 # Update the value of `global_a`
 40 = global_a
 
 # Add `global_a` and `global_b` together again
-global_add print
+global_add print "\n" print
 
 # Add two integers together using local variables
-34 35 local_add print
+34 35 local_add print "\n" print

--- a/tests/test_emitter.py
+++ b/tests/test_emitter.py
@@ -258,9 +258,37 @@ def test_emit_print_int():
     assert "jmp print_int" in asm
 
 
+def test_emit_print_int_no_newline():
+    """print_int helper should not append a newline to the output."""
+    asm = emit_string("42 print")
+    lines = asm.split("\n")
+    in_print_int = False
+    for line in lines:
+        if "print_int:" in line:
+            in_print_int = True
+        elif in_print_int and line.strip() and not line.startswith((" ", "\t")):
+            break
+        elif in_print_int:
+            assert "movb $10" not in line, "print_int should not append a newline"
+
+
 def test_emit_print_str():
     asm = emit_string('"hello" print')
     assert "jmp print_str" in asm
+
+
+def test_emit_print_str_no_newline():
+    """print_str helper should not write a newline after the string."""
+    asm = emit_string('"hello" print')
+    lines = asm.split("\n")
+    in_print_str = False
+    for line in lines:
+        if "print_str:" in line:
+            in_print_str = True
+        elif in_print_str and line.strip() and not line.startswith((" ", "\t")):
+            break
+        elif in_print_str:
+            assert "newline" not in line, "print_str should not reference newline"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `print` no longer appends a trailing newline for both integer and string output
- All 16 example files updated to use explicit `"\n" print` for newline output
- Removed dead `newline: .byte 10` data constant from emitter
- Added tests verifying both `print_int` and `print_str` helpers do not emit newlines
- Updated documentation in `docs/functions-and-lambdas.md`

## Test plan
- [x] All 331 tests pass
- [x] `test_emit_print_int_no_newline` verifies no newline byte in `print_int` helper
- [x] `test_emit_print_str_no_newline` verifies no newline reference in `print_str` helper
- [x] Linting and formatting pass
- [x] Compile and run examples to verify correct output