### PR TITLE
feat: add function reference syntax with & prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Casa compiles to x86-64 Linux executables via GNU assembly. It features static t
 
 - **Stack-based** — values live on the stack; operators consume and produce stack entries
 - **Statically typed** — types are checked at compile time with automatic inference and generics
-- **First-class functions** — lambdas are values on the stack like any other (TODO: function pointers)
+- **First-class functions** — lambdas and function references (`&name`) are values on the stack
 - **Structs and methods** — user-defined types with auto-generated accessors and `impl` blocks
 - **String interpolation** — f-strings with embedded expressions (`f"hello {name}"`)
 - **Compiles to native code** — generates x86-64 assembly with `ld` and `as`

--- a/casa/bytecode.py
+++ b/casa/bytecode.py
@@ -234,14 +234,15 @@ class Compiler:
                             op.location,
                         )
 
-                    # Compile the lambda function
-                    fn_compiler = Compiler(
-                        lambda_function.ops,
-                        lambda_function,
-                        string_table=self.string_table,
-                        constants_table=self.constants_table,
-                    )
-                    lambda_function.bytecode = fn_compiler.compile()
+                    # Compile the function only if not already compiled
+                    if lambda_function.bytecode is None:
+                        fn_compiler = Compiler(
+                            lambda_function.ops,
+                            lambda_function,
+                            string_table=self.string_table,
+                            constants_table=self.constants_table,
+                        )
+                        lambda_function.bytecode = fn_compiler.compile()
 
                     # Setup captures (local variables shadow globals)
                     for index, capture in enumerate(lambda_function.captures):

--- a/casa/bytecode.py
+++ b/casa/bytecode.py
@@ -21,7 +21,6 @@ from casa.common import (
 )
 from casa.error import ErrorKind, raise_error
 
-
 _label_counter = 0
 
 

--- a/casa/bytecode.py
+++ b/casa/bytecode.py
@@ -100,6 +100,32 @@ class Compiler:
         """Create an Inst with the current source location."""
         return Inst(kind, args=args or [], location=self._current_loc)
 
+    def _compile_function(self, function: Function, op: Op) -> None:
+        """Compile a function if not already compiled."""
+        if function.bytecode is not None:
+            return
+        # Check if the function assigns a non-parameter
+        # variable that shadows a global variable
+        param_names = set()
+        if function.signature:
+            param_names = {p.name for p in function.signature.parameters if p.name}
+        for var in function.variables:
+            if var in GLOBAL_VARIABLES and var.name not in param_names:
+                raise_error(
+                    ErrorKind.UNDEFINED_NAME,
+                    f"Function `{function.name}` assigns a global variable `{var.name}` before it is initialized within the global scope",
+                    op.location,
+                )
+        if self.function != function:
+            function.bytecode = []
+            fn_compiler = Compiler(
+                function.ops,
+                function,
+                string_table=self.string_table,
+                constants_table=self.constants_table,
+            )
+            function.bytecode = fn_compiler.compile()
+
     def compile(self) -> Bytecode:
         assert len(InstKind) == 45, "Exhaustive handling for `InstructionKind"
         assert len(OpKind) == 56, "Exhaustive handling for `OpKind`"
@@ -192,33 +218,7 @@ class Compiler:
                     function = GLOBAL_FUNCTIONS.get(function_name)
                     assert isinstance(function, Function), "Expected function"
 
-                    # Compile the function if it is not compiled already
-                    if function.bytecode is None:
-                        # Check if the function assigns a non-parameter
-                        # variable that shadows a global variable
-                        param_names = set()
-                        if function.signature:
-                            param_names = {
-                                p.name for p in function.signature.parameters if p.name
-                            }
-                        for var in function.variables:
-                            if var in GLOBAL_VARIABLES and var.name not in param_names:
-                                raise_error(
-                                    ErrorKind.UNDEFINED_NAME,
-                                    f"Function `{function.name}` assigns a global variable `{var.name}` before it is initialized within the global scope",
-                                    op.location,
-                                )
-
-                        if self.function != function:
-                            # Mark as being compiled to prevent recursion
-                            function.bytecode = []
-                            fn_compiler = Compiler(
-                                function.ops,
-                                function,
-                                string_table=self.string_table,
-                                constants_table=self.constants_table,
-                            )
-                            function.bytecode = fn_compiler.compile()
+                    self._compile_function(function, op)
 
                     bytecode.append(self.inst(InstKind.FN_CALL, args=[function_name]))
                 case OpKind.FN_EXEC:
@@ -233,15 +233,7 @@ class Compiler:
                             op.location,
                         )
 
-                    # Compile the function only if not already compiled
-                    if lambda_function.bytecode is None:
-                        fn_compiler = Compiler(
-                            lambda_function.ops,
-                            lambda_function,
-                            string_table=self.string_table,
-                            constants_table=self.constants_table,
-                        )
-                        lambda_function.bytecode = fn_compiler.compile()
+                    self._compile_function(lambda_function, op)
 
                     # Setup captures (local variables shadow globals)
                     for index, capture in enumerate(lambda_function.captures):

--- a/casa/parser.py
+++ b/casa/parser.py
@@ -91,6 +91,14 @@ def parse_ops(tokens: list[Token]) -> list[Op]:
     return ops
 
 
+def _mark_used_and_resolve(global_function: Function) -> None:
+    """Mark a function as used and resolve its identifiers if not already done."""
+    if global_function.is_used:
+        return
+    global_function.is_used = True
+    global_function.ops = resolve_identifiers(global_function.ops, global_function)
+
+
 def resolve_identifiers(
     ops: list[Op],
     function: Function | None = None,
@@ -181,11 +189,7 @@ def resolve_identifiers(
                         continue
                     op.kind = OpKind.FN_PUSH
                     op.value = function_name
-                    if not global_function.is_used:
-                        global_function.is_used = True
-                        global_function.ops = resolve_identifiers(
-                            global_function.ops, global_function
-                        )
+                    _mark_used_and_resolve(global_function)
                     continue
 
                 # Check different identifiers
@@ -195,11 +199,7 @@ def resolve_identifiers(
                     continue
                 if global_function := GLOBAL_FUNCTIONS.get(identifier):
                     op.kind = OpKind.FN_CALL
-                    if not global_function.is_used:
-                        global_function.is_used = True
-                        global_function.ops = resolve_identifiers(
-                            global_function.ops, global_function
-                        )
+                    _mark_used_and_resolve(global_function)
                     continue
                 if function and identifier in function.captures:
                     op.kind = OpKind.PUSH_CAPTURE

--- a/casa/parser.py
+++ b/casa/parser.py
@@ -160,6 +160,15 @@ def resolve_identifiers(
                 # Function reference: &name pushes a function as a value
                 if identifier.startswith("&"):
                     function_name = identifier[1:]
+                    if not function_name:
+                        errors.append(
+                            CasaError(
+                                ErrorKind.SYNTAX,
+                                "Expected function name after `&`",
+                                op.location,
+                            )
+                        )
+                        continue
                     global_function = GLOBAL_FUNCTIONS.get(function_name)
                     if not global_function:
                         errors.append(

--- a/casa/typechecker.py
+++ b/casa/typechecker.py
@@ -431,9 +431,7 @@ def type_check_ops(ops: list[Op], function: Function | None = None) -> Signature
 
                 if not global_function.is_typechecked:
                     global_function.is_typechecked = True
-                    signature = type_check_ops(
-                        global_function.ops, global_function
-                    )
+                    signature = type_check_ops(global_function.ops, global_function)
                     if not global_function.signature:
                         global_function.signature = signature
                 tc.stack_push(f"fn[{global_function.signature}]")

--- a/casa/typechecker.py
+++ b/casa/typechecker.py
@@ -430,10 +430,12 @@ def type_check_ops(ops: list[Op], function: Function | None = None) -> Signature
                 assert isinstance(global_function, Function), "Expected function"
 
                 if not global_function.is_typechecked:
-                    global_function.signature = type_check_ops(
+                    global_function.is_typechecked = True
+                    signature = type_check_ops(
                         global_function.ops, global_function
                     )
-                    global_function.is_typechecked = True
+                    if not global_function.signature:
+                        global_function.signature = signature
                 tc.stack_push(f"fn[{global_function.signature}]")
             case OpKind.GE:
                 tc.stack_pop()

--- a/docs/functions-and-lambdas.md
+++ b/docs/functions-and-lambdas.md
@@ -69,6 +69,37 @@ Push the arguments onto the stack, then write the function name:
 20 fib print
 ```
 
+### Function References
+
+The `&name` syntax pushes a named function onto the stack as a value instead of calling it.
+
+**Stack effect:** `-> fn[sig]`
+
+```casa
+fn add a:int b:int -> int { a b + }
+
+&add                # pushes fn[int int -> int]
+3 5 &add exec       # calls add, result: 8
+&add = my_fn        # store in variable
+3 5 my_fn exec      # call via variable, result: 8
+```
+
+This works for struct accessors and methods too:
+
+```casa
+struct Point { x: int y: int }
+
+&Point::x           # pushes fn[Point -> int]
+
+impl Point {
+    fn sum self:Point -> int { self.x self.y + }
+}
+
+&Point::sum          # pushes fn[Point -> int]
+```
+
+Use `exec` to call the function reference, just like with lambdas. See [`exec`](#exec) for details.
+
 ### Early Return
 
 Use `return` to exit a function early. The stack at the `return` point must match the function's return type.

--- a/tests/test_bytecode.py
+++ b/tests/test_bytecode.py
@@ -199,6 +199,34 @@ def test_bytecode_fn_push_exec():
 
 
 # ---------------------------------------------------------------------------
+# Function references
+# ---------------------------------------------------------------------------
+def test_bytecode_fn_ref():
+    code = "fn add a:int b:int -> int { a b + } &add"
+    program = compile_string(code)
+    pushes = find_insts(program, InstKind.FN_PUSH)
+    assert len(pushes) >= 1
+    assert any(i.args == ["add"] for i in pushes)
+
+
+def test_bytecode_fn_ref_no_captures():
+    code = "fn add a:int b:int -> int { a b + } &add"
+    program = compile_string(code)
+    constant_stores = find_insts(program, InstKind.CONSTANT_STORE)
+    assert len(constant_stores) == 0
+
+
+def test_bytecode_fn_ref_no_double_compile():
+    code = "fn foo a:int -> int { a } 5 foo &foo"
+    program = compile_string(code)
+    # Both call and reference should work without error
+    calls = find_insts(program, InstKind.FN_CALL)
+    pushes = find_insts(program, InstKind.FN_PUSH)
+    assert len(calls) >= 1
+    assert len(pushes) >= 1
+
+
+# ---------------------------------------------------------------------------
 # Constants (captures)
 # ---------------------------------------------------------------------------
 def test_bytecode_constants():

--- a/tests/test_emitter.py
+++ b/tests/test_emitter.py
@@ -210,6 +210,26 @@ def test_emit_fn_push():
 
 
 # ---------------------------------------------------------------------------
+# Function references
+# ---------------------------------------------------------------------------
+def test_emit_fn_ref():
+    asm = emit_string("fn add a:int b:int -> int { a b + } &add")
+    assert "leaq fn_add" in asm
+
+
+def test_emit_fn_ref_method():
+    code = """
+    struct Foo { val: int }
+    impl Foo {
+        fn double self:Foo -> int { self Foo::val 2 * }
+    }
+    &Foo::double
+    """
+    asm = emit_string(code)
+    assert "leaq fn_Foo__double" in asm
+
+
+# ---------------------------------------------------------------------------
 # Globals
 # ---------------------------------------------------------------------------
 def test_emit_global_get_set():

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -6,7 +6,6 @@ from casa.common import Delimiter, Intrinsic, Keyword, Operator, TokenKind
 from casa.error import CasaErrorCollection, ErrorKind
 from tests.conftest import lex_string
 
-
 # ---------------------------------------------------------------------------
 # Keywords
 # ---------------------------------------------------------------------------

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -374,6 +374,12 @@ def test_resolve_fn_ref_marks_used():
     assert GLOBAL_FUNCTIONS["greet"].is_used is True
 
 
+def test_resolve_fn_ref_bare_ampersand_raises():
+    with pytest.raises(CasaErrorCollection) as exc_info:
+        resolve_string("&")
+    assert exc_info.value.errors[0].kind == ErrorKind.SYNTAX
+
+
 # ---------------------------------------------------------------------------
 # Generic type parameters (parsing)
 # ---------------------------------------------------------------------------

--- a/tests/test_typechecker.py
+++ b/tests/test_typechecker.py
@@ -275,6 +275,42 @@ def test_typecheck_lambda_exec():
 
 
 # ---------------------------------------------------------------------------
+# Function references
+# ---------------------------------------------------------------------------
+def test_typecheck_fn_ref_pushes_signature():
+    code = "fn add a:int b:int -> int { a b + } &add"
+    sig = typecheck_string(code)
+    assert sig.return_types == ["fn[int int -> int]"]
+
+
+def test_typecheck_fn_ref_exec():
+    code = "fn inc a:int -> int { a 1 + } 5 &inc exec"
+    sig = typecheck_string(code)
+    assert sig.return_types == ["int"]
+
+
+def test_typecheck_fn_ref_method():
+    code = """
+    struct Point { x: int y: int }
+    impl Point {
+        fn sum self:Point -> int { self Point::x self Point::y + }
+    }
+    &Point::sum
+    """
+    sig = typecheck_string(code)
+    assert sig.return_types == ["fn[Point -> int]"]
+
+
+def test_typecheck_fn_ref_accessor():
+    code = """
+    struct Point { x: int y: int }
+    &Point::x
+    """
+    sig = typecheck_string(code)
+    assert sig.return_types == ["fn[Point -> int]"]
+
+
+# ---------------------------------------------------------------------------
 # ANY_TYPE matching
 # ---------------------------------------------------------------------------
 def test_typecheck_any_type_matches():

--- a/tests/test_typechecker.py
+++ b/tests/test_typechecker.py
@@ -310,6 +310,16 @@ def test_typecheck_fn_ref_accessor():
     assert sig.return_types == ["fn[Point -> int]"]
 
 
+def test_typecheck_fn_ref_inside_function():
+    code = """
+    fn inc a:int -> int { a 1 + }
+    fn apply_inc x:int -> int { x &inc exec }
+    5 apply_inc
+    """
+    sig = typecheck_string(code)
+    assert sig.return_types == ["int"]
+
+
 # ---------------------------------------------------------------------------
 # ANY_TYPE matching
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add `&name` syntax to push named functions as values (`fn[sig]`) instead of calling them
- Works for free functions (`&add`), methods (`&Type::method`), and struct accessors (`&Type::field`)
- Fix typechecker FN_PUSH handler to preserve declared signatures instead of overwriting with inferred ones
- Add guard against double-compilation in bytecode when a function is both called and referenced

## Test plan

- [x] Parser: `&name` resolves to FN_PUSH, `&Type::method` resolves, `&undefined` errors, bare `&` errors, marks function as used
- [x] Typechecker: `&name` pushes correct `fn[sig]`, `&name exec` works, struct accessors and methods work, works inside function bodies
- [x] Bytecode: `&name` produces FN_PUSH instruction, no captures, no double-compilation issues
- [x] Emitter: `&name` emits `leaq fn_name`, method reference emits sanitized label
- [x] All 389 tests pass
- [x] black, pylint, mypy checks pass (no new issues)