### PR TITLE
refactor: clean up lexer for efficiency and simplicity

### DIFF
--- a/casa/common.py
+++ b/casa/common.py
@@ -95,21 +95,23 @@ class Delimiter(Enum):
 
     @classmethod
     def from_str(cls, value: str) -> Self | None:
-        mapping = {
-            "->": cls.ARROW,
-            ",": cls.COMMA,
-            ":": cls.COLON,
-            ".": cls.DOT,
-            "#": cls.HASHTAG,
-            "{": cls.OPEN_BRACE,
-            "}": cls.CLOSE_BRACE,
-            "[": cls.OPEN_BRACKET,
-            "]": cls.CLOSE_BRACKET,
-            "(": cls.OPEN_PAREN,
-            ")": cls.CLOSE_PAREN,
-        }
-        assert len(mapping) == len(Delimiter), "Exhaustive handling for `Delimiter`"
-        return mapping.get(value)  # type: ignore
+        return cls._MAPPING.get(value)  # type: ignore
+
+
+Delimiter._MAPPING = {  # type: ignore
+    "->": Delimiter.ARROW,
+    ",": Delimiter.COMMA,
+    ":": Delimiter.COLON,
+    ".": Delimiter.DOT,
+    "#": Delimiter.HASHTAG,
+    "{": Delimiter.OPEN_BRACE,
+    "}": Delimiter.CLOSE_BRACE,
+    "[": Delimiter.OPEN_BRACKET,
+    "]": Delimiter.CLOSE_BRACKET,
+    "(": Delimiter.OPEN_PAREN,
+    ")": Delimiter.CLOSE_PAREN,
+}
+assert len(Delimiter._MAPPING) == len(Delimiter), "Exhaustive handling for `Delimiter`"  # type: ignore
 
 
 class Operator(Enum):
@@ -144,34 +146,36 @@ class Operator(Enum):
 
     @classmethod
     def from_str(cls, value: str) -> Self | None:
-        mapping = {
-            # Arithmetic
-            "+": cls.PLUS,
-            "-": cls.MINUS,
-            "*": cls.MULTIPLICATION,
-            "/": cls.DIVISION,
-            "%": cls.MODULO,
-            # Bitshift
-            "<<": cls.SHL,
-            ">>": cls.SHR,
-            # Boolean
-            "&&": cls.AND,
-            "||": cls.OR,
-            "!": cls.NOT,
-            # Comparison
-            "==": cls.EQ,
-            ">=": cls.GE,
-            ">": cls.GT,
-            "<=": cls.LE,
-            "<": cls.LT,
-            "!=": cls.NE,
-            # Assignment
-            "=": cls.ASSIGN,
-            "-=": cls.ASSIGN_DECREMENT,
-            "+=": cls.ASSIGN_INCREMENT,
-        }
-        assert len(mapping) == len(Operator), "Exhaustive handling for `Operator`"
-        return mapping.get(value)  # type: ignore
+        return cls._MAPPING.get(value)  # type: ignore
+
+
+Operator._MAPPING = {  # type: ignore
+    # Arithmetic
+    "+": Operator.PLUS,
+    "-": Operator.MINUS,
+    "*": Operator.MULTIPLICATION,
+    "/": Operator.DIVISION,
+    "%": Operator.MODULO,
+    # Bitshift
+    "<<": Operator.SHL,
+    ">>": Operator.SHR,
+    # Boolean
+    "&&": Operator.AND,
+    "||": Operator.OR,
+    "!": Operator.NOT,
+    # Comparison
+    "==": Operator.EQ,
+    ">=": Operator.GE,
+    ">": Operator.GT,
+    "<=": Operator.LE,
+    "<": Operator.LT,
+    "!=": Operator.NE,
+    # Assignment
+    "=": Operator.ASSIGN,
+    "-=": Operator.ASSIGN_DECREMENT,
+    "+=": Operator.ASSIGN_INCREMENT,
+}
+assert len(Operator._MAPPING) == len(Operator), "Exhaustive handling for `Operator`"  # type: ignore
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- Cache `Delimiter.from_str` and `Operator.from_str` mapping dicts as class-level constants instead of recreating them on every call
- Remove dead code (`is_whitespace()`, `rest()`, `expect_char()`, `expect_startswith()`) and unused `itertools` import
- Deduplicate FSTRING_TEXT flush logic in `parse_fstring()` via a `flush_text()` helper
- Eliminate O(n^2) string building in `peek_word()` and `parse_string_literal()` by using list accumulation
- Replace string slicing with index-based iteration in `startswith()`, `skip_whitespace()`, `skip_line()`, and `lex_integer_literal()`
- Remove redundant `skip_whitespace()` call in `parse_token()`
- Fix pylint `unspecified-encoding` warning and add missing return type annotation
- Add 48 new lexer edge case tests (arrow handling, namespaces, whitespace, long inputs, from_str correctness)

## Test plan
- [x] All 421 existing + new tests pass
- [x] `black` formatting verified
- [x] `pylint` score improved (8.97 -> 9.21)
- [x] `mypy --check-untyped-defs` clean (no new errors)
- [x] Pure refactor with no behavioral changes