### PR TITLE
feat: add statically typed array literals

### DIFF
--- a/docs/standard-library.md
+++ b/docs/standard-library.md
@@ -57,11 +57,11 @@ arr.length print    # 3
 
 ### `array::nth`
 
-Returns the nth element of an array (zero-indexed).
+Returns the nth element of an array (zero-indexed). This is a generic function that returns the element type of the array.
 
-**Signature:** `array::nth array:array n:int -> any`
+**Signature:** `array::nth[T] array:array[T] n:int -> T`
 
-**Stack effect:** `array n -> any`
+**Stack effect:** `array[T] n -> T`
 
 ```casa
 [10, 20, 30] = arr
@@ -70,7 +70,7 @@ Returns the nth element of an array (zero-indexed).
 1 arr.nth print           # 20
 ```
 
-> **Note:** The return type is `any`. Use a [type cast](types-and-literals.md#type-casting) if you need a specific type.
+The return type matches the array's element type. For example, calling `nth` on an `array[int]` returns `int`, not `any`.
 
 ## `List`
 

--- a/docs/types-and-literals.md
+++ b/docs/types-and-literals.md
@@ -128,13 +128,42 @@ buffer 3 + load print  # 99
 
 See [Functions and Lambdas — Memory Intrinsics](functions-and-lambdas.md#memory-intrinsics) for details.
 
-### `array`
+### `array[T]`
 
-Fixed-size array literal. Items must be literal values (integers, booleans, or strings).
+Fixed-size, statically typed array literal. The element type `T` is inferred from the items in the array.
 
 ```casa
-[1, 2, 3]
+[1, 2, 3]          # type: array[int]
+["a", "b", "c"]    # type: array[str]
+[true, false]       # type: array[bool]
 ```
+
+Array items can be literals or variables:
+
+```casa
+42 = x
+[x, 2, 3]          # type: array[int]
+```
+
+All items must have the same type. Heterogeneous arrays are compile-time errors:
+
+```casa
+[1, "hello"]        # TYPE_MISMATCH error
+```
+
+An empty array has type `array[any]`:
+
+```casa
+[]                  # type: array[any]
+```
+
+Arrays can be nested. The element type is inferred recursively:
+
+```casa
+[[1, 2], [3, 4]]   # type: array[array[int]]
+```
+
+The bare type name `array` matches any `array[T]` for backward compatibility (e.g. in function signatures).
 
 The array's length is stored in the first heap slot. Elements are stored starting at offset 1.
 

--- a/lib/std.casa
+++ b/lib/std.casa
@@ -13,7 +13,7 @@ impl array {
         load
     }
 
-    fn nth array:array n:int -> any {
+    fn nth[T] array:array[T] n:int -> T {
         # The first item of an array is its length
         array n + 1 + load
     }

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -737,11 +737,25 @@ def test_delimiter_from_str_consistent_with_enum():
 def test_operator_from_str_consistent_with_enum():
     """Every Operator enum member has a from_str mapping."""
     all_strings = [
-        "+", "-", "*", "/", "%",
-        "<<", ">>",
-        "&&", "||", "!",
-        "==", ">=", ">", "<=", "<", "!=",
-        "=", "-=", "+=",
+        "+",
+        "-",
+        "*",
+        "/",
+        "%",
+        "<<",
+        ">>",
+        "&&",
+        "||",
+        "!",
+        "==",
+        ">=",
+        ">",
+        "<=",
+        "<",
+        "!=",
+        "=",
+        "-=",
+        "+=",
     ]
     assert len(all_strings) == len(Operator)
     for s in all_strings:


### PR DESCRIPTION
## Summary

- Array literals are now parameterized types (`array[int]`, `array[str]`, `array[array[int]]`) instead of bare `array`
- Empty arrays `[]` get type `array[any]`
- Mixed-type arrays like `[1, "hello"]` are compile-time `TYPE_MISMATCH` errors
- Array literals now accept identifiers (`[x, y, z]`), not just literal values
- `array::nth` is now generic and returns the element type instead of `any`
- Bare `array` still matches any `array[T]` for backward compatibility
- Parser supports parameterized types in function signatures, struct members, type casts, and impl blocks

## Test plan

- [x] All 440 existing + new tests pass
- [x] Typed array literals: `array[int]`, `array[str]`, `array[bool]`
- [x] Empty array types as `array[any]`
- [x] Nested arrays type as `array[array[int]]`
- [x] Heterogeneous arrays raise TYPE_MISMATCH
- [x] Backward compat: bare `array` matches `array[T]`
- [x] Generic `array::nth` returns element type
- [x] Identifier support in array items
- [x] Parameterized types in function signatures
- [x] `black`, `mypy` checks pass (pre-existing mypy issue in parser.py unchanged)