### PR TITLE
feat: add map, filter, reduce array methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ source → lex → parse → resolve → type check → bytecode → emit asm �
 | [Control Flow](docs/control-flow.md) | Conditionals (`if`/`elif`/`else`/`fi`), loops (`while`/`do`/`done`) |
 | [Functions and Lambdas](docs/functions-and-lambdas.md) | Functions, lambdas, closures, variables, stack intrinsics, IO, memory |
 | [Structs and Methods](docs/structs-and-methods.md) | Struct definition, accessors, `impl` blocks, dot/arrow syntax |
-| [Standard Library](docs/standard-library.md) | `include`, `memcpy`, arrays, `List`, type conversions |
+| [Standard Library](docs/standard-library.md) | `include`, `memcpy`, arrays (`map`, `filter`, `reduce`), `List`, type conversions |
 | [Errors](docs/errors.md) | Error kinds, diagnostics format, multi-error collection |
 
 ## Examples

--- a/casa/parser.py
+++ b/casa/parser.py
@@ -543,7 +543,12 @@ def get_op_keyword(
 
 def parse_type(cursor: Cursor[Token]) -> Type:
     """Parse a type, potentially parameterized like array[int] or fn[int -> int]."""
-    base = expect_token(cursor, kind=TokenKind.IDENTIFIER)
+    next_token = cursor.peek()
+    if next_token and next_token.value == "fn":
+        base = cursor.pop()
+        assert base is not None
+    else:
+        base = expect_token(cursor, kind=TokenKind.IDENTIFIER)
     next_tok = cursor.peek()
     if not next_tok or next_tok.value != "[":
         return base.value

--- a/casa/typechecker.py
+++ b/casa/typechecker.py
@@ -112,16 +112,16 @@ class TypeChecker:
         origin = self.stack_origins.pop()
         typ = self.stack.pop()
         self.last_pop_origin = origin
-        if expected == ANY_TYPE or (
-            expected == "array" and is_array_type(typ)
-        ) or (
-            expected == "fn" and is_fn_type(typ)
+        if (
+            expected == ANY_TYPE
+            or (expected == "array" and is_array_type(typ))
+            or (expected == "fn" and is_fn_type(typ))
         ):
             return typ
-        if typ == ANY_TYPE or (
-            typ == "array" and is_array_type(expected)
-        ) or (
-            typ == "fn" and is_fn_type(expected)
+        if (
+            typ == ANY_TYPE
+            or (typ == "array" and is_array_type(expected))
+            or (typ == "fn" and is_fn_type(expected))
         ):
             return expected
         if typ == expected:
@@ -228,15 +228,13 @@ class TypeChecker:
                 if is_fn_type(actual):
                     actual_sig_str = extract_fn_signature_str(actual)
                     if actual_sig_str:
-                        expected_inner = Signature.from_str(fn_sig_str)
-                        actual_inner = Signature.from_str(actual_sig_str)
-                        for ep, ap in zip(
-                            expected_inner.parameters, actual_inner.parameters
-                        ):
+                        exp_fn_sig = Signature.from_str(fn_sig_str)
+                        act_fn_sig = Signature.from_str(actual_sig_str)
+                        for ep, ap in zip(exp_fn_sig.parameters, act_fn_sig.parameters):
                             if ep.typ in signature.type_vars:
                                 self._bind_type_var(bindings, ep.typ, ap.typ)
                         for er, ar in zip(
-                            expected_inner.return_types, actual_inner.return_types
+                            exp_fn_sig.return_types, act_fn_sig.return_types
                         ):
                             if er in signature.type_vars:
                                 self._bind_type_var(bindings, er, ar)

--- a/docs/standard-library.md
+++ b/docs/standard-library.md
@@ -72,6 +72,50 @@ Returns the nth element of an array (zero-indexed). This is a generic function t
 
 The return type matches the array's element type. For example, calling `nth` on an `array[int]` returns `int`, not `any`.
 
+### `array::map`
+
+Applies a function to each element, returning a new array with the results.
+
+**Signature:** `array::map[T1 T2] arr:array[T1] f:fn[T1 -> T2] -> array[T2]`
+
+**Stack effect:** `array[T1] fn[T1 -> T2] -> array[T2]`
+
+```casa
+{ 2 * } [1, 2, 3].map
+# result: [2, 4, 6]
+```
+
+The return type is determined by the function's return type. For example, mapping `fn[int -> str]` over an `array[int]` produces `array[str]`.
+
+### `array::filter`
+
+Returns a new array containing only elements for which the function returns `true`.
+
+**Signature:** `array::filter[T] arr:array[T] f:fn[T -> bool] -> array[T]`
+
+**Stack effect:** `array[T] fn[T -> bool] -> array[T]`
+
+```casa
+{ 2 % 0 == } [1, 2, 3, 4].filter
+# result: [2, 4]
+```
+
+### `array::reduce`
+
+Reduces an array to a single value by applying a function to an accumulator and each element.
+
+**Signature:** `array::reduce[T1 T2] arr:array[T1] acc:T2 f:fn[T2 T1 -> T2] -> T2`
+
+**Stack effect:** `array[T1] T2 fn[T2 T1 -> T2] -> T2`
+
+The accumulator is the initial value. The function receives the current accumulator and the current element, and returns the new accumulator.
+
+```casa
+{ + } 0 [1, 2, 3].reduce print    # 6
+```
+
+The accumulator type and the array element type can differ.
+
 ## `List`
 
 A dynamic list that grows automatically when items are pushed.

--- a/docs/types-and-literals.md
+++ b/docs/types-and-literals.md
@@ -186,6 +186,16 @@ Call a function value with `exec`:
 21 double exec print   # 42
 ```
 
+`fn[sig]` can be used as a parameter type in function declarations, allowing functions to accept callbacks:
+
+```casa
+fn apply f:fn[int -> int] x:int -> int {
+    x f exec
+}
+
+40 { 2 + } apply print   # 42
+```
+
 See [Functions and Lambdas](functions-and-lambdas.md#lambdas) for details.
 
 ### User-Defined Structs

--- a/lib/std.casa
+++ b/lib/std.casa
@@ -17,6 +17,45 @@ impl array {
         # The first item of an array is its length
         array n + 1 + load
     }
+    fn map[T1 T2] arr:array[T1] f:fn[T1 -> T2] -> array[T2] {
+        arr.length = len
+        len 1 + alloc = result
+        len result store
+        0 = i
+        while i len > do
+            i arr.nth f exec
+            result i 1 + + store
+            1 += i
+        done
+        result (array)
+    }
+
+    fn filter[T] arr:array[T] f:fn[T -> bool] -> array[T] {
+        arr.length = len
+        len 1 + alloc = result
+        0 = count
+        0 = i
+        while i len > do
+            i arr.nth = elem
+            if elem f exec then
+                elem result count 1 + + store
+                1 += count
+            fi
+            1 += i
+        done
+        count result store
+        result (array)
+    }
+
+    fn reduce[T1 T2] arr:array[T1] init:T2 f:fn[T2 T1 -> T2] -> T2 {
+        arr.length = len
+        0 = i
+        while i len > do
+            i arr.nth init f exec = init
+            1 += i
+        done
+        init
+    }
 }
 
 struct List {

--- a/lib/std.casa
+++ b/lib/std.casa
@@ -18,43 +18,43 @@ impl array {
         array n + 1 + load
     }
     fn map[T1 T2] arr:array[T1] f:fn[T1 -> T2] -> array[T2] {
-        arr.length = len
-        len 1 + alloc = result
-        len result store
-        0 = i
-        while i len > do
-            i arr.nth f exec
-            result i 1 + + store
-            1 += i
+        arr.length = _map_len
+        _map_len 1 + alloc = _map_buf
+        _map_len _map_buf store
+        0 = _map_i
+        while _map_i _map_len > do
+            _map_i arr.nth f exec
+            _map_buf _map_i 1 + + store
+            1 += _map_i
         done
-        result (array)
+        _map_buf (array)
     }
 
     fn filter[T] arr:array[T] f:fn[T -> bool] -> array[T] {
-        arr.length = len
-        len 1 + alloc = result
-        0 = count
-        0 = i
-        while i len > do
-            i arr.nth = elem
-            if elem f exec then
-                elem result count 1 + + store
-                1 += count
+        arr.length = _flt_len
+        _flt_len 1 + alloc = _flt_buf
+        0 = _flt_count
+        0 = _flt_i
+        while _flt_i _flt_len > do
+            _flt_i arr.nth = _flt_elem
+            if _flt_elem f exec then
+                _flt_elem _flt_buf _flt_count 1 + + store
+                1 += _flt_count
             fi
-            1 += i
+            1 += _flt_i
         done
-        count result store
-        result (array)
+        _flt_count _flt_buf store
+        _flt_buf (array)
     }
 
-    fn reduce[T1 T2] arr:array[T1] init:T2 f:fn[T2 T1 -> T2] -> T2 {
-        arr.length = len
-        0 = i
-        while i len > do
-            i arr.nth init f exec = init
-            1 += i
+    fn reduce[T1 T2] arr:array[T1] acc:T2 f:fn[T2 T1 -> T2] -> T2 {
+        arr.length = _red_len
+        0 = _red_i
+        while _red_i _red_len > do
+            _red_i arr.nth acc f exec = acc
+            1 += _red_i
         done
-        init
+        acc
     }
 }
 

--- a/tests/test_array_methods.py
+++ b/tests/test_array_methods.py
@@ -1,0 +1,110 @@
+"""End-to-end tests for array map, filter, reduce methods.
+
+These tests verify that programs using map/filter/reduce compile through
+the full pipeline (lex -> parse -> resolve -> typecheck -> bytecode -> emit).
+"""
+
+from tests.conftest import compile_string, emit_string, typecheck_string
+
+STD_INCLUDE = 'include "lib/std.casa"\n'
+
+
+# ---------------------------------------------------------------------------
+# map
+# ---------------------------------------------------------------------------
+def test_e2e_map_double():
+    """map that doubles each element compiles through the full pipeline."""
+    code = STD_INCLUDE + """
+    { 2 * } [1, 2, 3] .map = result
+    0 result array::nth print
+    """
+    emit_string(code)
+
+
+def test_e2e_map_negate():
+    """map that negates each element compiles through the full pipeline."""
+    code = STD_INCLUDE + """
+    { 0 swap - } [1, 2, 3] .map = result
+    0 result array::nth print
+    """
+    emit_string(code)
+
+
+def test_e2e_map_to_bool():
+    """map that transforms int to bool compiles correctly."""
+    code = STD_INCLUDE + """
+    { 0 > } [1, -2, 3] .map = result
+    result array::length print
+    """
+    emit_string(code)
+
+
+# ---------------------------------------------------------------------------
+# filter
+# ---------------------------------------------------------------------------
+def test_e2e_filter_positive():
+    """filter that keeps positive numbers compiles through the full pipeline."""
+    code = STD_INCLUDE + """
+    { 0 > } [1, -2, 3, -4, 5] .filter = result
+    result array::length print
+    """
+    emit_string(code)
+
+
+def test_e2e_filter_even():
+    """filter that keeps even numbers compiles through the full pipeline."""
+    code = STD_INCLUDE + """
+    { 2 % 0 == } [1, 2, 3, 4, 5, 6] .filter = result
+    result array::length print
+    """
+    emit_string(code)
+
+
+# ---------------------------------------------------------------------------
+# reduce
+# ---------------------------------------------------------------------------
+def test_e2e_reduce_sum():
+    """reduce that sums an array compiles through the full pipeline."""
+    code = STD_INCLUDE + """
+    { + } 0 [1, 2, 3, 4, 5] .reduce print
+    """
+    emit_string(code)
+
+
+def test_e2e_reduce_product():
+    """reduce that computes product compiles through the full pipeline."""
+    code = STD_INCLUDE + """
+    { * } 1 [1, 2, 3, 4, 5] .reduce print
+    """
+    emit_string(code)
+
+
+# ---------------------------------------------------------------------------
+# Chaining
+# ---------------------------------------------------------------------------
+def test_e2e_map_then_filter():
+    """map followed by filter compiles through the full pipeline."""
+    code = STD_INCLUDE + """
+    { 2 * } [1, 2, 3, 4, 5] .map = doubled
+    { 6 > } doubled .filter = big
+    big array::length print
+    """
+    emit_string(code)
+
+
+def test_e2e_map_then_reduce():
+    """map followed by reduce compiles through the full pipeline."""
+    code = STD_INCLUDE + """
+    { 2 * } [1, 2, 3] .map = doubled
+    { + } 0 doubled .reduce print
+    """
+    emit_string(code)
+
+
+def test_e2e_filter_then_reduce():
+    """filter followed by reduce compiles through the full pipeline."""
+    code = STD_INCLUDE + """
+    { 0 > } [1, -2, 3, -4, 5] .filter = positive
+    { + } 0 positive .reduce print
+    """
+    emit_string(code)


### PR DESCRIPTION
## Summary

- Add `fn[sig]` as a valid parameter type in function declarations, enabling higher-order functions with typed callbacks
- Add bracket-aware parsing in `Signature.from_str` to handle nested types like `fn[array[int] -> int]`
- Add generic type variable binding from `fn[sig]` types in the type checker
- Add `map`, `filter`, `reduce` as `impl array` methods in the standard library
- Add 30 new tests covering parser, type checker, and end-to-end compilation

## Test plan

- [x] All 470 tests pass (440 existing + 30 new)
- [x] black formatting clean
- [x] mypy clean (only pre-existing parser.py:352 error)
- [x] End-to-end: `{ 2 * } [1, 2, 3].map` produces `[2, 4, 6]`
- [x] End-to-end: `{ 2 % 0 == } [1, 2, 3, 4].filter` produces `[2, 4]`
- [x] End-to-end: `{ + } 0 [1, 2, 3].reduce` produces `6`