### PR TITLE
Add Arena allocator to standard library

### DIFF
--- a/examples/arena.casa
+++ b/examples/arena.casa
@@ -1,0 +1,60 @@
+include "../lib/std.casa"
+
+# === Create an arena with 10 slots ===
+"=== Create an arena with 10 slots ===" print "\n" print
+10 Arena::new = arena
+
+"Used: " print arena.used print "\n" print
+"Available: " print arena.available print "\n" print
+
+# === Allocate and use memory ===
+"=== Allocate and use memory ===" print "\n" print
+3 arena.alloc = ptr1
+42 ptr1 store
+99 ptr1 1 + store
+7 ptr1 2 + store
+
+"Values: " print
+ptr1 load print " " print
+ptr1 1 + load print " " print
+ptr1 2 + load print "\n" print
+
+"Used: " print arena.used print "\n" print
+"Available: " print arena.available print "\n" print
+
+# === Allocate more memory ===
+"=== Allocate more memory ===" print "\n" print
+2 arena.alloc = ptr2
+100 ptr2 store
+200 ptr2 1 + store
+
+"Values: " print
+ptr2 load print " " print
+ptr2 1 + load print "\n" print
+
+"Used: " print arena.used print "\n" print
+"Available: " print arena.available print "\n" print
+
+# === Reset the arena ===
+"=== Reset the arena ===" print "\n" print
+arena.reset
+
+"Used: " print arena.used print "\n" print
+"Available: " print arena.available print "\n" print
+
+# === Reuse after reset ===
+"=== Reuse after reset ===" print "\n" print
+4 arena.alloc = ptr3
+1 ptr3 store
+2 ptr3 1 + store
+3 ptr3 2 + store
+4 ptr3 3 + store
+
+"Values: " print
+ptr3 load print " " print
+ptr3 1 + load print " " print
+ptr3 2 + load print " " print
+ptr3 3 + load print "\n" print
+
+"Used: " print arena.used print "\n" print
+"Available: " print arena.available print "\n" print

--- a/examples/outputs/arena.out
+++ b/examples/outputs/arena.out
@@ -1,0 +1,18 @@
+=== Create an arena with 10 slots ===
+Used: 0
+Available: 10
+=== Allocate and use memory ===
+Values: 42 99 7
+Used: 3
+Available: 7
+=== Allocate more memory ===
+Values: 100 200
+Used: 5
+Available: 5
+=== Reset the arena ===
+Used: 0
+Available: 10
+=== Reuse after reset ===
+Values: 1 2 3 4
+Used: 4
+Available: 6

--- a/lib/std.casa
+++ b/lib/std.casa
@@ -88,6 +88,36 @@ impl List {
     }
 }
 
+struct Arena {
+    buffer: ptr
+    size: int
+    offset: int
+}
+
+impl Arena {
+    fn new _arena_size:int -> Arena {
+        0 _arena_size dup alloc Arena
+    }
+
+    fn alloc self:Arena n:int -> ptr {
+        self.buffer self.offset + = _arena_ptr
+        self.offset n + self->offset
+        _arena_ptr
+    }
+
+    fn reset self:Arena {
+        0 self->offset
+    }
+
+    fn used self:Arena -> int {
+        self.offset
+    }
+
+    fn available self:Arena -> int {
+        self.size self.offset -
+    }
+}
+
 # ---------------------------------------------------------------------------
 # Type conversions
 # ---------------------------------------------------------------------------

--- a/tests/test_arena.py
+++ b/tests/test_arena.py
@@ -1,0 +1,279 @@
+"""End-to-end tests for Arena allocator.
+
+These tests verify that programs using the Arena struct compile through
+the full pipeline (lex -> parse -> resolve -> typecheck -> bytecode -> emit).
+"""
+
+from tests.conftest import emit_string, typecheck_string
+
+STD_INCLUDE = 'include "lib/std.casa"\n'
+
+
+# ---------------------------------------------------------------------------
+# Construction (Arena::new)
+# ---------------------------------------------------------------------------
+def test_arena_new_compiles():
+    """Arena::new compiles through the full pipeline."""
+    code = STD_INCLUDE + """
+    1024 Arena::new = arena
+    arena.size print
+    """
+    emit_string(code)
+
+
+def test_arena_new_returns_arena_type():
+    """Arena::new returns Arena type on the stack."""
+    code = STD_INCLUDE + """
+    1024 Arena::new
+    """
+    sig = typecheck_string(code)
+    assert sig.return_types == ["Arena"]
+
+
+# ---------------------------------------------------------------------------
+# Allocation (Arena::alloc)
+# ---------------------------------------------------------------------------
+def test_arena_alloc_compiles():
+    """Arena::alloc compiles through the full pipeline."""
+    code = STD_INCLUDE + """
+    1024 Arena::new = arena
+    4 arena Arena::alloc = p
+    p print
+    """
+    emit_string(code)
+
+
+def test_arena_alloc_returns_ptr_type():
+    """Arena::alloc returns ptr type on the stack."""
+    code = STD_INCLUDE + """
+    1024 Arena::new = arena
+    4 arena Arena::alloc
+    """
+    sig = typecheck_string(code)
+    assert sig.return_types == ["ptr"]
+
+
+def test_arena_alloc_dot_syntax():
+    """Arena::alloc works with dot syntax."""
+    code = STD_INCLUDE + """
+    1024 Arena::new = arena
+    4 arena.alloc = p
+    p print
+    """
+    emit_string(code)
+
+
+def test_arena_alloc_multiple():
+    """Multiple arena allocations compile correctly."""
+    code = STD_INCLUDE + """
+    1024 Arena::new = arena
+    4 arena.alloc = p1
+    8 arena.alloc = p2
+    2 arena.alloc = p3
+    p1 print
+    p2 print
+    p3 print
+    """
+    emit_string(code)
+
+
+# ---------------------------------------------------------------------------
+# Store / Load (arena-allocated memory)
+# ---------------------------------------------------------------------------
+def test_arena_store_load():
+    """Arena-allocated memory can be written to and read from."""
+    code = STD_INCLUDE + """
+    1024 Arena::new = arena
+    1 arena.alloc = p
+    42 p store
+    p load print
+    """
+    emit_string(code)
+
+
+def test_arena_store_load_multiple_slots():
+    """Multiple slots in arena-allocated memory work correctly."""
+    code = STD_INCLUDE + """
+    1024 Arena::new = arena
+    4 arena.alloc = p
+    10 p store
+    20 p 1 + store
+    30 p 2 + store
+    40 p 3 + store
+    p load print
+    p 1 + load print
+    p 2 + load print
+    p 3 + load print
+    """
+    emit_string(code)
+
+
+def test_arena_separate_allocations_independent():
+    """Separate arena allocations hold independent values."""
+    code = STD_INCLUDE + """
+    1024 Arena::new = arena
+    1 arena.alloc = p1
+    1 arena.alloc = p2
+    100 p1 store
+    200 p2 store
+    p1 load print
+    p2 load print
+    """
+    emit_string(code)
+
+
+# ---------------------------------------------------------------------------
+# Reset (Arena::reset)
+# ---------------------------------------------------------------------------
+def test_arena_reset_compiles():
+    """Arena::reset compiles through the full pipeline."""
+    code = STD_INCLUDE + """
+    1024 Arena::new = arena
+    4 arena.alloc drop
+    arena Arena::reset
+    """
+    emit_string(code)
+
+
+def test_arena_reset_dot_syntax():
+    """Arena::reset works with dot syntax."""
+    code = STD_INCLUDE + """
+    1024 Arena::new = arena
+    4 arena.alloc drop
+    arena.reset
+    """
+    emit_string(code)
+
+
+def test_arena_reuse_after_reset():
+    """Arena can allocate again after reset."""
+    code = STD_INCLUDE + """
+    1024 Arena::new = arena
+    4 arena.alloc = p1
+    42 p1 store
+    arena.reset
+    4 arena.alloc = p2
+    99 p2 store
+    p2 load print
+    """
+    emit_string(code)
+
+
+# ---------------------------------------------------------------------------
+# used / available
+# ---------------------------------------------------------------------------
+def test_arena_used_compiles():
+    """Arena::used compiles through the full pipeline."""
+    code = STD_INCLUDE + """
+    1024 Arena::new = arena
+    4 arena.alloc drop
+    arena Arena::used print
+    """
+    emit_string(code)
+
+
+def test_arena_used_returns_int_type():
+    """Arena::used returns int type on the stack."""
+    code = STD_INCLUDE + """
+    1024 Arena::new = arena
+    4 arena.alloc drop
+    arena Arena::used
+    """
+    sig = typecheck_string(code)
+    assert sig.return_types == ["int"]
+
+
+def test_arena_used_dot_syntax():
+    """Arena::used works with dot syntax."""
+    code = STD_INCLUDE + """
+    1024 Arena::new = arena
+    4 arena.alloc drop
+    arena.used print
+    """
+    emit_string(code)
+
+
+def test_arena_available_compiles():
+    """Arena::available compiles through the full pipeline."""
+    code = STD_INCLUDE + """
+    1024 Arena::new = arena
+    4 arena.alloc drop
+    arena Arena::available print
+    """
+    emit_string(code)
+
+
+def test_arena_available_returns_int_type():
+    """Arena::available returns int type on the stack."""
+    code = STD_INCLUDE + """
+    1024 Arena::new = arena
+    4 arena.alloc drop
+    arena Arena::available
+    """
+    sig = typecheck_string(code)
+    assert sig.return_types == ["int"]
+
+
+def test_arena_available_dot_syntax():
+    """Arena::available works with dot syntax."""
+    code = STD_INCLUDE + """
+    1024 Arena::new = arena
+    4 arena.alloc drop
+    arena.available print
+    """
+    emit_string(code)
+
+
+# ---------------------------------------------------------------------------
+# Integration (full lifecycle)
+# ---------------------------------------------------------------------------
+def test_arena_full_lifecycle():
+    """Full arena lifecycle: create, alloc, store, load, reset, reuse."""
+    code = STD_INCLUDE + """
+    256 Arena::new = arena
+
+    # First allocation phase
+    2 arena.alloc = p1
+    42 p1 store
+    99 p1 1 + store
+    p1 load print
+    p1 1 + load print
+    arena.used print
+
+    # Reset and reuse
+    arena.reset
+    arena.used print
+
+    # Second allocation phase
+    1 arena.alloc = p2
+    77 p2 store
+    p2 load print
+    arena.available print
+    """
+    emit_string(code)
+
+
+def test_arena_multiple_alloc_and_query():
+    """Multiple allocations with used/available queries compile correctly."""
+    code = STD_INCLUDE + """
+    100 Arena::new = arena
+    10 arena.alloc drop
+    arena.used print
+    arena.available print
+    20 arena.alloc drop
+    arena.used print
+    arena.available print
+    """
+    emit_string(code)
+
+
+def test_arena_reset_restores_capacity():
+    """After reset, the full arena capacity is available again."""
+    code = STD_INCLUDE + """
+    64 Arena::new = arena
+    32 arena.alloc drop
+    arena.reset
+    arena.used print
+    arena.available print
+    """
+    emit_string(code)


### PR DESCRIPTION
## Summary
- Add `expect_name_token` parser helper to allow intrinsic names (like `alloc`) as method/function names
- Add `Arena` struct with `new`, `alloc`, `reset`, `used`, and `available` methods to `lib/std.casa`
- Add 21 tests covering construction, allocation, store/load, reset, usage queries, and full lifecycle
- Add `examples/arena.casa` example program with expected output
- Add Arena documentation to `docs/standard-library.md`

## Test plan
- [x] `python3 -m pytest tests/test_arena.py -v` (21 passed)
- [x] `python3 -m pytest tests/ -v` (491 passed)
- [x] `bash tests/test_examples.sh` (19 passed, 0 failed)
- [x] `black --check` passes
- [x] `pylint` passes
- [x] `mypy --check-untyped-defs` (pre-existing error only)