### PR TITLE
feat: add syscall0-syscall6 intrinsics

### DIFF
--- a/casa/bytecode.py
+++ b/casa/bytecode.py
@@ -127,8 +127,8 @@ class Compiler:
             function.bytecode = fn_compiler.compile()
 
     def compile(self) -> Bytecode:
-        assert len(InstKind) == 45, "Exhaustive handling for `InstructionKind"
-        assert len(OpKind) == 56, "Exhaustive handling for `OpKind`"
+        assert len(InstKind) == 52, "Exhaustive handling for `InstructionKind"
+        assert len(OpKind) == 63, "Exhaustive handling for `OpKind`"
 
         cursor = Cursor(sequence=self.ops)
         bytecode: list[Inst] = []
@@ -647,6 +647,20 @@ class Compiler:
                 case OpKind.WHILE_START:
                     label = op_to_label(op)
                     bytecode.append(self.inst(InstKind.LABEL, args=[label]))
+                case OpKind.SYSCALL0:
+                    bytecode.append(self.inst(InstKind.SYSCALL0))
+                case OpKind.SYSCALL1:
+                    bytecode.append(self.inst(InstKind.SYSCALL1))
+                case OpKind.SYSCALL2:
+                    bytecode.append(self.inst(InstKind.SYSCALL2))
+                case OpKind.SYSCALL3:
+                    bytecode.append(self.inst(InstKind.SYSCALL3))
+                case OpKind.SYSCALL4:
+                    bytecode.append(self.inst(InstKind.SYSCALL4))
+                case OpKind.SYSCALL5:
+                    bytecode.append(self.inst(InstKind.SYSCALL5))
+                case OpKind.SYSCALL6:
+                    bytecode.append(self.inst(InstKind.SYSCALL6))
                 case _:
                     assert_never(op.kind)
 

--- a/casa/common.py
+++ b/casa/common.py
@@ -40,6 +40,15 @@ class Intrinsic(Enum):
     # Functions
     EXEC = auto()
 
+    # Syscalls
+    SYSCALL0 = auto()
+    SYSCALL1 = auto()
+    SYSCALL2 = auto()
+    SYSCALL3 = auto()
+    SYSCALL4 = auto()
+    SYSCALL5 = auto()
+    SYSCALL6 = auto()
+
     @classmethod
     def from_lowercase(cls, value: str) -> Self | None:
         if not value.islower():
@@ -215,6 +224,15 @@ class OpKind(Enum):
     LOAD = auto()
     STORE = auto()
 
+    # Syscalls
+    SYSCALL0 = auto()
+    SYSCALL1 = auto()
+    SYSCALL2 = auto()
+    SYSCALL3 = auto()
+    SYSCALL4 = auto()
+    SYSCALL5 = auto()
+    SYSCALL6 = auto()
+
     # Literals
     PUSH_ARRAY = auto()
     PUSH_BOOL = auto()
@@ -296,7 +314,7 @@ class Op:
     location: Location
 
     def __post_init__(self):
-        assert len(OpKind) == 56, "Exhaustive handling for `OpKind`"
+        assert len(OpKind) == 63, "Exhaustive handling for `OpKind`"
 
         match self.kind:
             # Requires `bool`
@@ -341,6 +359,13 @@ class Op:
                 | OpKind.ROT
                 | OpKind.STORE
                 | OpKind.SWAP
+                | OpKind.SYSCALL0
+                | OpKind.SYSCALL1
+                | OpKind.SYSCALL2
+                | OpKind.SYSCALL3
+                | OpKind.SYSCALL4
+                | OpKind.SYSCALL5
+                | OpKind.SYSCALL6
             ):
                 if not isinstance(self.value, Intrinsic):
                     raise TypeError(f"`{self.kind}` requires value of type `Intrinsic`")
@@ -465,6 +490,15 @@ class InstKind(Enum):
     # F-strings
     FSTRING_CONCAT = auto()
 
+    # Syscalls
+    SYSCALL0 = auto()
+    SYSCALL1 = auto()
+    SYSCALL2 = auto()
+    SYSCALL3 = auto()
+    SYSCALL4 = auto()
+    SYSCALL5 = auto()
+    SYSCALL6 = auto()
+
 
 @dataclass
 class Inst:
@@ -487,7 +521,7 @@ class Inst:
         return self.args[0]
 
     def __post_init__(self):
-        assert len(InstKind) == 45, "Exhaustive handling for `InstructionKind`"
+        assert len(InstKind) == 52, "Exhaustive handling for `InstructionKind`"
 
         match self.kind:
             # Should not have a parameter
@@ -520,6 +554,13 @@ class Inst:
                 | InstKind.STORE
                 | InstKind.SUB
                 | InstKind.SWAP
+                | InstKind.SYSCALL0
+                | InstKind.SYSCALL1
+                | InstKind.SYSCALL2
+                | InstKind.SYSCALL3
+                | InstKind.SYSCALL4
+                | InstKind.SYSCALL5
+                | InstKind.SYSCALL6
             ):
                 if self.args:
                     raise TypeError(

--- a/casa/emitter.py
+++ b/casa/emitter.py
@@ -220,7 +220,7 @@ class Emitter:
         self._indent("movq %rax, (%rsp)")
 
     def _emit_inst(self, inst: Inst, is_global: bool) -> None:
-        assert len(InstKind) == 45, "Exhaustive handling for `InstKind`"
+        assert len(InstKind) == 52, "Exhaustive handling for `InstKind`"
         kind = inst.kind
         match kind:
             # === Stack ===
@@ -456,8 +456,32 @@ class Emitter:
                 self._indent("jmp str_concat")
                 self._line(f".Lconcat_done_{uid}:")
 
+            # === Syscalls ===
+            case InstKind.SYSCALL0:
+                self._emit_syscall(0)
+            case InstKind.SYSCALL1:
+                self._emit_syscall(1)
+            case InstKind.SYSCALL2:
+                self._emit_syscall(2)
+            case InstKind.SYSCALL3:
+                self._emit_syscall(3)
+            case InstKind.SYSCALL4:
+                self._emit_syscall(4)
+            case InstKind.SYSCALL5:
+                self._emit_syscall(5)
+            case InstKind.SYSCALL6:
+                self._emit_syscall(6)
+
             case _:
                 assert_never(kind)
+
+    def _emit_syscall(self, arg_count: int) -> None:
+        regs = ["%rdi", "%rsi", "%rdx", "%r10", "%r8", "%r9"]
+        self._indent("popq %rax")
+        for i in range(arg_count):
+            self._indent(f"popq {regs[i]}")
+        self._indent("syscall")
+        self._indent("pushq %rax")
 
 
 def emit_program(program: Program) -> str:

--- a/casa/parser.py
+++ b/casa/parser.py
@@ -41,6 +41,13 @@ INTRINSIC_TO_OPKIND = {
     Intrinsic.ROT: OpKind.ROT,
     Intrinsic.STORE: OpKind.STORE,
     Intrinsic.SWAP: OpKind.SWAP,
+    Intrinsic.SYSCALL0: OpKind.SYSCALL0,
+    Intrinsic.SYSCALL1: OpKind.SYSCALL1,
+    Intrinsic.SYSCALL2: OpKind.SYSCALL2,
+    Intrinsic.SYSCALL3: OpKind.SYSCALL3,
+    Intrinsic.SYSCALL4: OpKind.SYSCALL4,
+    Intrinsic.SYSCALL5: OpKind.SYSCALL5,
+    Intrinsic.SYSCALL6: OpKind.SYSCALL6,
 }
 
 

--- a/casa/typechecker.py
+++ b/casa/typechecker.py
@@ -330,6 +330,13 @@ OP_STACK_EFFECTS: dict[OpKind, tuple[str, str]] = {
     OpKind.HEAP_ALLOC: ("alloc", "int -> ptr"),
     OpKind.IF_CONDITION: ("if condition", "bool -> None"),
     OpKind.WHILE_CONDITION: ("while condition", "bool -> None"),
+    OpKind.SYSCALL0: ("syscall0", "int -> int"),
+    OpKind.SYSCALL1: ("syscall1", "any int -> int"),
+    OpKind.SYSCALL2: ("syscall2", "any any int -> int"),
+    OpKind.SYSCALL3: ("syscall3", "any any any int -> int"),
+    OpKind.SYSCALL4: ("syscall4", "any any any any int -> int"),
+    OpKind.SYSCALL5: ("syscall5", "any any any any any int -> int"),
+    OpKind.SYSCALL6: ("syscall6", "any any any any any any int -> int"),
 }
 
 
@@ -399,7 +406,7 @@ def _ensure_typechecked(global_function: Function) -> None:
 
 
 def type_check_ops(ops: list[Op], function: Function | None = None) -> Signature:
-    assert len(OpKind) == 56, "Exhaustive handling for `OpKind`"
+    assert len(OpKind) == 63, "Exhaustive handling for `OpKind`"
 
     tc = TypeChecker(ops=ops)
     for op in ops:
@@ -923,6 +930,20 @@ def type_check_ops(ops: list[Op], function: Function | None = None) -> Signature
                     )
             case OpKind.WHILE_START:
                 tc.branched_stacks.append(BranchedStack(tc.stack, tc.stack_origins))
+            case (
+                OpKind.SYSCALL0
+                | OpKind.SYSCALL1
+                | OpKind.SYSCALL2
+                | OpKind.SYSCALL3
+                | OpKind.SYSCALL4
+                | OpKind.SYSCALL5
+                | OpKind.SYSCALL6
+            ):
+                arg_count = int(op.kind.name[-1])
+                tc.expect_type("int")
+                for _ in range(arg_count):
+                    tc.stack_pop()
+                tc.stack_push("int")
             case _:
                 assert_never(op.kind)
 

--- a/docs/functions-and-lambdas.md
+++ b/docs/functions-and-lambdas.md
@@ -344,3 +344,41 @@ buf 2 + load print    # 30
 Values read with `load` have type `any`. Use a [type cast](types-and-literals.md#type-casting) `(TypeName)` to restore a specific type.
 
 See [Standard Library](standard-library.md) for higher-level abstractions built on these primitives.
+
+## Syscall Intrinsics
+
+Direct Linux system call access. Each intrinsic pops N+1 values from the stack (the syscall number on top, then arguments in order) and pushes the kernel return value as `int`. The syscall number must be `int`. Arguments have no type constraints.
+
+| Intrinsic | Stack Effect | Description |
+|-----------|-------------|-------------|
+| `syscall0` | `nr -> int` | Syscall with 0 args |
+| `syscall1` | `a1 nr -> int` | Syscall with 1 arg |
+| `syscall2` | `a2 a1 nr -> int` | Syscall with 2 args |
+| `syscall3` | `a3 a2 a1 nr -> int` | Syscall with 3 args |
+| `syscall4` | `a4 a3 a2 a1 nr -> int` | Syscall with 4 args |
+| `syscall5` | `a5 a4 a3 a2 a1 nr -> int` | Syscall with 5 args |
+| `syscall6` | `a6 a5 a4 a3 a2 a1 nr -> int` | Syscall with 6 args |
+
+### Register Mapping
+
+Arguments are placed in registers following the Linux x86-64 syscall convention:
+
+| Argument | Register |
+|----------|----------|
+| Syscall number | `%rax` |
+| arg1 | `%rdi` |
+| arg2 | `%rsi` |
+| arg3 | `%rdx` |
+| arg4 | `%r10` |
+| arg5 | `%r8` |
+| arg6 | `%r9` |
+
+### Examples
+
+```casa
+# exit(0)
+0 60 syscall1 drop
+
+# write(1, buf, len) where buf is a string pointer and len is its length
+len buf 1 1 syscall3 drop
+```

--- a/tests/test_bytecode.py
+++ b/tests/test_bytecode.py
@@ -43,6 +43,13 @@ SIMPLE_OP_CASES = [
     ("1 2 swap", InstKind.SWAP),
     ("1 2 over", InstKind.OVER),
     ("1 2 3 rot", InstKind.ROT),
+    ("60 syscall0", InstKind.SYSCALL0),
+    ("0 60 syscall1", InstKind.SYSCALL1),
+    ("0 0 60 syscall2", InstKind.SYSCALL2),
+    ("0 0 0 60 syscall3", InstKind.SYSCALL3),
+    ("0 0 0 0 60 syscall4", InstKind.SYSCALL4),
+    ("0 0 0 0 0 60 syscall5", InstKind.SYSCALL5),
+    ("0 0 0 0 0 0 60 syscall6", InstKind.SYSCALL6),
 ]
 
 

--- a/tests/test_emitter.py
+++ b/tests/test_emitter.py
@@ -313,6 +313,79 @@ def test_emit_print_str_no_newline():
 
 
 # ---------------------------------------------------------------------------
+# Syscall intrinsics
+# ---------------------------------------------------------------------------
+def test_emit_syscall0():
+    asm = emit_string("60 syscall0")
+    assert "popq %rax" in asm
+    assert "syscall" in asm
+    assert "pushq %rax" in asm
+
+
+def test_emit_syscall1():
+    asm = emit_string("0 60 syscall1")
+    assert "popq %rax" in asm
+    assert "popq %rdi" in asm
+    assert "syscall" in asm
+    assert "pushq %rax" in asm
+
+
+def test_emit_syscall2():
+    asm = emit_string("0 0 60 syscall2")
+    assert "popq %rax" in asm
+    assert "popq %rdi" in asm
+    assert "popq %rsi" in asm
+    assert "syscall" in asm
+    assert "pushq %rax" in asm
+
+
+def test_emit_syscall3():
+    asm = emit_string("1 0 1 1 syscall3")
+    assert "popq %rax" in asm
+    assert "popq %rdi" in asm
+    assert "popq %rsi" in asm
+    assert "popq %rdx" in asm
+    assert "syscall" in asm
+    assert "pushq %rax" in asm
+
+
+def test_emit_syscall4():
+    asm = emit_string("0 0 0 0 60 syscall4")
+    assert "popq %rax" in asm
+    assert "popq %rdi" in asm
+    assert "popq %rsi" in asm
+    assert "popq %rdx" in asm
+    assert "popq %r10" in asm
+    assert "syscall" in asm
+    assert "pushq %rax" in asm
+
+
+def test_emit_syscall5():
+    asm = emit_string("0 0 0 0 0 60 syscall5")
+    assert "popq %rax" in asm
+    assert "popq %rdi" in asm
+    assert "popq %rsi" in asm
+    assert "popq %rdx" in asm
+    assert "popq %r10" in asm
+    assert "popq %r8" in asm
+    assert "syscall" in asm
+    assert "pushq %rax" in asm
+
+
+def test_emit_syscall6():
+    asm = emit_string("0 0 0 0 0 0 60 syscall6")
+    assert "popq %rax" in asm
+    assert "popq %rdi" in asm
+    assert "popq %rsi" in asm
+    assert "popq %rdx" in asm
+    assert "popq %r10" in asm
+    assert "popq %r8" in asm
+    assert "popq %r9" in asm
+    assert "syscall" in asm
+    assert "pushq %rax" in asm
+
+
+# ---------------------------------------------------------------------------
 # Exit syscall
 # ---------------------------------------------------------------------------
 def test_emit_exit_syscall():

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -51,6 +51,13 @@ ALL_INTRINSICS = [
     "store",
     "print",
     "exec",
+    "syscall0",
+    "syscall1",
+    "syscall2",
+    "syscall3",
+    "syscall4",
+    "syscall5",
+    "syscall6",
 ]
 assert len(ALL_INTRINSICS) == len(Intrinsic)
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -121,6 +121,13 @@ INTRINSIC_CASES = [
     ("store", OpKind.STORE, Intrinsic.STORE),
     ("print", OpKind.PRINT, Intrinsic.PRINT),
     ("exec", OpKind.FN_EXEC, Intrinsic.EXEC),
+    ("syscall0", OpKind.SYSCALL0, Intrinsic.SYSCALL0),
+    ("syscall1", OpKind.SYSCALL1, Intrinsic.SYSCALL1),
+    ("syscall2", OpKind.SYSCALL2, Intrinsic.SYSCALL2),
+    ("syscall3", OpKind.SYSCALL3, Intrinsic.SYSCALL3),
+    ("syscall4", OpKind.SYSCALL4, Intrinsic.SYSCALL4),
+    ("syscall5", OpKind.SYSCALL5, Intrinsic.SYSCALL5),
+    ("syscall6", OpKind.SYSCALL6, Intrinsic.SYSCALL6),
 ]
 
 

--- a/tests/test_typechecker.py
+++ b/tests/test_typechecker.py
@@ -113,6 +113,69 @@ def test_typecheck_store():
 
 
 # ---------------------------------------------------------------------------
+# Syscall intrinsics
+# ---------------------------------------------------------------------------
+def test_typecheck_syscall0():
+    sig = typecheck_string("60 syscall0")
+    assert sig.return_types == ["int"]
+
+
+def test_typecheck_syscall1():
+    sig = typecheck_string("0 60 syscall1")
+    assert sig.return_types == ["int"]
+
+
+def test_typecheck_syscall2():
+    sig = typecheck_string("0 0 60 syscall2")
+    assert sig.return_types == ["int"]
+
+
+def test_typecheck_syscall3():
+    sig = typecheck_string("1 0 1 1 syscall3")
+    assert sig.return_types == ["int"]
+
+
+def test_typecheck_syscall4():
+    sig = typecheck_string("0 0 0 0 60 syscall4")
+    assert sig.return_types == ["int"]
+
+
+def test_typecheck_syscall5():
+    sig = typecheck_string("0 0 0 0 0 60 syscall5")
+    assert sig.return_types == ["int"]
+
+
+def test_typecheck_syscall6():
+    sig = typecheck_string("1 2 3 4 5 6 100 syscall6")
+    assert sig.return_types == ["int"]
+
+
+def test_typecheck_syscall_accepts_any_type_for_args():
+    """Syscall arguments (not the syscall number) accept any type."""
+    sig = typecheck_string('"hello" 42 syscall1')
+    assert sig.return_types == ["int"]
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        ('"not_a_number" syscall0'),
+        ('0 "not_a_number" syscall1'),
+        ('0 0 "not_a_number" syscall2'),
+        ('0 0 0 "not_a_number" syscall3'),
+        ('0 0 0 0 "not_a_number" syscall4'),
+        ('0 0 0 0 0 "not_a_number" syscall5'),
+        ('0 0 0 0 0 0 "not_a_number" syscall6'),
+    ],
+)
+def test_typecheck_syscall_requires_int_syscall_number(code):
+    """Syscall number (top of stack) must be int for all syscall intrinsics."""
+    with pytest.raises(CasaErrorCollection) as exc_info:
+        typecheck_string(code)
+    assert exc_info.value.errors[0].kind == ErrorKind.TYPE_MISMATCH
+
+
+# ---------------------------------------------------------------------------
 # Print resolves to PRINT_INT / PRINT_STR
 # ---------------------------------------------------------------------------
 def test_typecheck_print_resolves_to_print_int():


### PR DESCRIPTION
## Summary

- Add `syscall0` through `syscall6` intrinsics for direct Linux system call access
- Each `syscallN` pops N+1 values (syscall number on top, then N arguments), executes the `syscall` instruction, and pushes the kernel return value as `int`
- Register mapping follows Linux x86-64 convention: `%rdi`, `%rsi`, `%rdx`, `%r10`, `%r8`, `%r9` for args 1-6

## Changes

- `casa/common.py`: Added SYSCALL0-6 to `Intrinsic`, `OpKind`, and `InstKind` enums with validation
- `casa/parser.py`: Added intrinsic-to-opkind mappings
- `casa/typechecker.py`: Stack effects (pop N+1, push int, no type constraints)
- `casa/bytecode.py`: 1:1 op-to-instruction lowering
- `casa/emitter.py`: x86-64 assembly emission with `_emit_syscall` helper
- Tests across all 5 test files (lexer, parser, typechecker, bytecode, emitter)
- Documentation in `docs/functions-and-lambdas.md` and `CLAUDE.md`

## Test plan

- [x] All 501 tests pass (`pytest tests/ -v`)
- [x] black formatting clean
- [x] mypy clean (pre-existing unrelated error in parser.py)