### PR TITLE
feat: add option[T] type

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ source → lex → parse → resolve → type check → bytecode → emit asm �
 | [Control Flow](docs/control-flow.md) | Conditionals (`if`/`elif`/`else`/`fi`), loops (`while`/`do`/`done`) |
 | [Functions and Lambdas](docs/functions-and-lambdas.md) | Functions, lambdas, closures, variables, stack intrinsics, IO, memory |
 | [Structs and Methods](docs/structs-and-methods.md) | Struct definition, accessors, `impl` blocks, dot/arrow syntax |
-| [Standard Library](docs/standard-library.md) | `include`, `memcpy`, arrays (`map`, `filter`, `reduce`), `List`, type conversions |
+| [Standard Library](docs/standard-library.md) | `include`, `memcpy`, arrays (`map`, `filter`, `reduce`), `option[T]`, `List`, type conversions |
 | [Errors](docs/errors.md) | Error kinds, diagnostics format, multi-error collection |
 
 ## Examples

--- a/casa/common.py
+++ b/casa/common.py
@@ -617,7 +617,7 @@ class Program:
 
 
 ANY_TYPE = "any"
-BUILTIN_TYPES: set[str] = {"int", "bool", "str", "ptr", "array", "any"}
+BUILTIN_TYPES: set[str] = {"int", "bool", "str", "ptr", "array", "any", "option"}
 
 
 def is_array_type(typ: str) -> bool:

--- a/casa/common.py
+++ b/casa/common.py
@@ -237,7 +237,9 @@ class OpKind(Enum):
     PUSH_ARRAY = auto()
     PUSH_BOOL = auto()
     PUSH_INT = auto()
+    PUSH_NONE = auto()
     PUSH_STR = auto()
+    SOME = auto()
 
     # Arithmetic
     ADD = auto()
@@ -314,9 +316,13 @@ class Op:
     location: Location
 
     def __post_init__(self):
-        assert len(OpKind) == 63, "Exhaustive handling for `OpKind`"
+        assert len(OpKind) == 65, "Exhaustive handling for `OpKind`"
 
         match self.kind:
+            # Requires Python `None`
+            case OpKind.PUSH_NONE | OpKind.SOME:
+                if self.value is not None:
+                    raise TypeError(f"`{self.kind}` requires value of type `NoneType`")
             # Requires `bool`
             case OpKind.PUSH_BOOL:
                 if not isinstance(self.value, bool):
@@ -630,6 +636,22 @@ def extract_array_element_type(typ: str) -> str | None:
     return typ[len(array_prefix) : -1]
 
 
+def is_option_type(typ: str) -> bool:
+    """Check if a type is an option type (bare or parameterized)."""
+    return typ == "option" or typ.startswith("option[")
+
+
+def extract_option_element_type(typ: str) -> str | None:
+    """Extract the element type from a parameterized option type.
+
+    Returns None for bare 'option' or non-option types.
+    """
+    option_prefix = "option["
+    if not typ.startswith(option_prefix) or not typ.endswith("]"):
+        return None
+    return typ[len(option_prefix) : -1]
+
+
 def is_fn_type(typ: str) -> bool:
     """Check if a type is a function type (bare or parameterized)."""
     return typ == "fn" or typ.startswith("fn[")
@@ -721,6 +743,8 @@ class Signature:
                 if not (
                     (a.typ == "array" and is_array_type(b.typ))
                     or (b.typ == "array" and is_array_type(a.typ))
+                    or (a.typ == "option" and is_option_type(b.typ))
+                    or (b.typ == "option" and is_option_type(a.typ))
                 ):
                     return False
 
@@ -729,6 +753,8 @@ class Signature:
                 if not (
                     (ra == "array" and is_array_type(rb))
                     or (rb == "array" and is_array_type(ra))
+                    or (ra == "option" and is_option_type(rb))
+                    or (rb == "option" and is_option_type(ra))
                 ):
                     return False
 

--- a/casa/lexer.py
+++ b/casa/lexer.py
@@ -255,6 +255,8 @@ class Lexer:
             return Token(value, TokenKind.LITERAL, location)
         if value in ("true", "false"):
             return Token(value, TokenKind.LITERAL, location)
+        if value in ("none", "some"):
+            return Token(value, TokenKind.LITERAL, location)
         if Delimiter.from_str(value):
             return Token(value, TokenKind.DELIMITER, location)
         if Intrinsic.from_lowercase(value):

--- a/casa/parser.py
+++ b/casa/parser.py
@@ -829,6 +829,10 @@ def get_op_literal(token: Token) -> Op:
         return Op(True, OpKind.PUSH_BOOL, token.location)
     if value == "false":
         return Op(False, OpKind.PUSH_BOOL, token.location)
+    if value == "none":
+        return Op(None, OpKind.PUSH_NONE, token.location)
+    if value == "some":
+        return Op(None, OpKind.SOME, token.location)
     if value.isdigit() or is_negative_integer_literal(value):
         return Op(int(value), OpKind.PUSH_INT, token.location)
     if value.startswith('"') and value.endswith('"'):

--- a/docs/control-flow.md
+++ b/docs/control-flow.md
@@ -67,6 +67,19 @@ fi
 
 The first branch pushes an `int`, the second pushes a `str` — the type checker rejects this.
 
+Compatible types are allowed across branches. For example, `none` (bare `option`) and `some` (`option[T]`) can appear in different branches. The type checker unifies them to the more specific type:
+
+```casa
+if condition then
+    none           # option
+else
+    42 some        # option[int]
+fi
+# result type: option[int]
+```
+
+The same applies to bare `array` and `array[T]`, and to `any` with any concrete type.
+
 If there is no `else` branch, the `if`/`elif` branches must not change the stack at all (since the "no match" path leaves the stack unchanged).
 
 ## Loops

--- a/docs/standard-library.md
+++ b/docs/standard-library.md
@@ -116,6 +116,62 @@ The accumulator is the initial value. The function receives the current accumula
 
 The accumulator type and the array element type can differ.
 
+## Option
+
+Methods for working with `option[T]` values. Method calls on any `option[T]` receiver are resolved to `option::method`.
+
+### `option::is_some`
+
+Returns `true` if the option contains a value.
+
+**Signature:** `option::is_some self:option -> bool`
+
+**Stack effect:** `option -> bool`
+
+```casa
+42 some .is_some print    # 1
+none .is_some print       # 0
+```
+
+### `option::is_none`
+
+Returns `true` if the option is empty.
+
+**Signature:** `option::is_none self:option -> bool`
+
+**Stack effect:** `option -> bool`
+
+```casa
+42 some .is_none print    # 0
+none .is_none print       # 1
+```
+
+### `option::unwrap`
+
+Extracts the contained value. Prints an error and exits with code 60 if called on `none`.
+
+**Signature:** `option::unwrap[T] self:option[T] -> T`
+
+**Stack effect:** `option[T] -> T`
+
+```casa
+42 some .unwrap print     # 42
+none .unwrap              # error: called unwrap on None
+```
+
+### `option::unwrap_or`
+
+Returns the contained value, or a default if the option is empty.
+
+**Signature:** `option::unwrap_or[T] self:option[T] default:T -> T`
+
+**Stack effect:** `option[T] T -> T`
+
+```casa
+0 42 some .unwrap_or print    # 42
+0 none .unwrap_or print       # 0
+```
+
 ## `List`
 
 A dynamic list that grows automatically when items are pushed.

--- a/docs/types-and-literals.md
+++ b/docs/types-and-literals.md
@@ -232,6 +232,18 @@ fn check opt:option -> bool { true }
 42 some check    # works: option[int] matches bare option
 ```
 
+`none` and `some` can appear in different branches of a conditional. The type checker unifies them to the more specific `option[T]`:
+
+```casa
+fn safe_head arr:array[int] -> option[int] {
+    if 0 arr .length < then
+        0 arr array::nth some
+    else
+        none
+    fi
+}
+```
+
 See [Standard Library -- Option](standard-library.md#option) for `is_some`, `is_none`, `unwrap`, and `unwrap_or`.
 
 ### User-Defined Structs

--- a/docs/types-and-literals.md
+++ b/docs/types-and-literals.md
@@ -61,7 +61,7 @@ Invalid escape sequences (e.g. `\q`) produce a compile-time `SYNTAX` error.
 
 F-strings let you embed expressions inside a string literal. Prefix a string with `f` and wrap expressions in `{}`.
 
-**Stack effect:** `( -- str )`
+**Stack effect:** `-> str`
 
 ```casa
 "world" = name
@@ -204,11 +204,11 @@ Optional type representing a value that may or may not be present. Built with th
 
 `none` pushes an empty option with bare type `option`. It is compatible with any `option[T]`.
 
-**Stack effect:** `( -- option )`
+**Stack effect:** `-> option`
 
 `some` wraps the top-of-stack value into an option. The resulting type is `option[T]` where `T` is the type of the wrapped value.
 
-**Stack effect:** `( T -- option[T] )`
+**Stack effect:** `T -> option[T]`
 
 ```casa
 42 some          # type: option[int]

--- a/docs/types-and-literals.md
+++ b/docs/types-and-literals.md
@@ -236,7 +236,7 @@ fn check opt:option -> bool { true }
 
 ```casa
 fn safe_head arr:array[int] -> option[int] {
-    if 0 arr .length < then
+    if 0 arr .length > then
         0 arr array::nth some
     else
         none

--- a/docs/types-and-literals.md
+++ b/docs/types-and-literals.md
@@ -198,6 +198,42 @@ fn apply f:fn[int -> int] x:int -> int {
 
 See [Functions and Lambdas](functions-and-lambdas.md#lambdas) for details.
 
+### `option[T]`
+
+Optional type representing a value that may or may not be present. Built with the `some` and `none` constructors.
+
+`none` pushes an empty option with bare type `option`. It is compatible with any `option[T]`.
+
+**Stack effect:** `( -- option )`
+
+`some` wraps the top-of-stack value into an option. The resulting type is `option[T]` where `T` is the type of the wrapped value.
+
+**Stack effect:** `( T -- option[T] )`
+
+```casa
+42 some          # type: option[int]
+"hello" some     # type: option[str]
+none             # type: option (compatible with any option[T])
+```
+
+At runtime, an option is heap-allocated as 2 slots: `[tag, value]`. The tag is `1` for `Some` and `0` for `None`.
+
+Options stored in variables retain their type:
+
+```casa
+42 some = x      # x has type option[int]
+none = y         # y has type option (bare)
+```
+
+A bare `option` type matches any `option[T]` in function signatures, similar to how bare `array` matches any `array[T]`:
+
+```casa
+fn check opt:option -> bool { true }
+42 some check    # works: option[int] matches bare option
+```
+
+See [Standard Library -- Option](standard-library.md#option) for `is_some`, `is_none`, `unwrap`, and `unwrap_or`.
+
 ### User-Defined Structs
 
 Struct names are types. After defining a struct, its name can be used as a type.

--- a/examples/option.casa
+++ b/examples/option.casa
@@ -31,3 +31,15 @@ maybe_str.unwrap print "\n" print     # hello
 # Using options with generic functions
 fn id[T] T -> T { }
 42 some id .unwrap print "\n" print    # 42
+
+# Branching with option types — none and some in different branches
+fn safe_head arr:array[int] -> option[int] {
+    if 0 arr .length < then
+        0 arr array::nth some
+    else
+        none
+    fi
+}
+
+[1, 2, 3] safe_head .unwrap print "\n" print  # 1
+[] (array[int]) safe_head .is_none print "\n" print  # 1 (true)

--- a/examples/option.casa
+++ b/examples/option.casa
@@ -1,0 +1,33 @@
+# Option type - representing values that may or may not exist
+#
+# some wraps a value into option[T], none creates an empty option.
+# Methods: is_some, is_none, unwrap, unwrap_or
+
+include "../lib/std.casa"
+
+# Creating options
+42 some = maybe_int       # option[int]
+"hello" some = maybe_str  # option[str]
+none = empty              # option (compatible with any option[T])
+
+# Checking presence
+if maybe_int.is_some then
+    "maybe_int has a value\n" print
+fi
+
+if empty.is_none then
+    "empty has no value\n" print
+fi
+
+# Unwrapping values
+maybe_int.unwrap print "\n" print     # 42
+maybe_str.unwrap print "\n" print     # hello
+
+# unwrap_or provides a default when the option is none
+# default value is pushed before the option
+0 empty.unwrap_or print "\n" print     # 0 (fallback for none)
+0 maybe_int.unwrap_or print "\n" print # 42 (has a value, default ignored)
+
+# Using options with generic functions
+fn id[T] T -> T { }
+42 some id .unwrap print "\n" print    # 42

--- a/examples/option.casa
+++ b/examples/option.casa
@@ -34,7 +34,7 @@ fn id[T] T -> T { }
 
 # Branching with option types — none and some in different branches
 fn safe_head arr:array[int] -> option[int] {
-    if 0 arr .length < then
+    if 0 arr .length > then
         0 arr array::nth some
     else
         none

--- a/examples/outputs/option.out
+++ b/examples/outputs/option.out
@@ -1,0 +1,9 @@
+maybe_int has a value
+empty has no value
+42
+hello
+0
+42
+42
+1
+1

--- a/lib/std.casa
+++ b/lib/std.casa
@@ -120,3 +120,26 @@ impl str {
 impl ptr {
     fn to_str p:ptr -> str { p (int) .to_str }
 }
+
+impl option {
+    fn is_some self:option -> bool {
+        self load 1 ==
+    }
+    fn is_none self:option -> bool {
+        self load 0 ==
+    }
+    fn unwrap[T] self:option[T] -> T {
+        if self.is_none then
+            "error: called unwrap on None\n" print
+            60 231 syscall1 drop
+        fi
+        self 1 + load (T)
+    }
+    fn unwrap_or[T] self:option[T] default:T -> T {
+        if self.is_some then
+            self.unwrap
+        else
+            default
+        fi
+    }
+}

--- a/tests/test_bytecode.py
+++ b/tests/test_bytecode.py
@@ -281,3 +281,36 @@ def test_bytecode_string_interning():
     assert program.strings.count("hello") == 1
     assert "world" in program.strings
     assert len(program.strings) == 2
+
+
+# ---------------------------------------------------------------------------
+# Option[T] (none / some)
+# ---------------------------------------------------------------------------
+def test_bytecode_none():
+    """none generates HEAP_ALLOC and STORE instructions (tag 0)."""
+    program = compile_string("none")
+    kinds = [i.kind for i in program.bytecode]
+    assert InstKind.HEAP_ALLOC in kinds
+    assert InstKind.STORE in kinds
+
+
+def test_bytecode_some():
+    """42 some generates HEAP_ALLOC and STORE instructions (tag 1, value)."""
+    program = compile_string("42 some")
+    kinds = [i.kind for i in program.bytecode]
+    assert InstKind.HEAP_ALLOC in kinds
+    assert InstKind.STORE in kinds
+
+
+def test_bytecode_none_push_tag_zero():
+    """none pushes tag 0 for the none variant."""
+    program = compile_string("none")
+    pushes = find_insts(program, InstKind.PUSH)
+    assert any(i.args == [0] for i in pushes)
+
+
+def test_bytecode_some_push_tag_one():
+    """some pushes tag 1 for the some variant."""
+    program = compile_string("42 some")
+    pushes = find_insts(program, InstKind.PUSH)
+    assert any(i.args == [1] for i in pushes)

--- a/tests/test_emitter.py
+++ b/tests/test_emitter.py
@@ -469,3 +469,42 @@ def test_emit_to_str_in_fstring():
     asm = emit_string(STD_INCLUDE + '42 = n f"val: {n.to_str}"')
     assert "fn_int__to_str" in asm
     assert "str_concat" in asm
+
+
+# ---------------------------------------------------------------------------
+# option[T] (none / some)
+# ---------------------------------------------------------------------------
+def test_emit_none():
+    """none generates assembly with heap_ptr reference."""
+    asm = emit_string("none")
+    assert "heap_ptr" in asm
+
+
+def test_emit_some():
+    """42 some generates assembly with heap allocation."""
+    asm = emit_string("42 some")
+    assert "heap_ptr" in asm
+
+
+def test_emit_option_is_some():
+    """option::is_some emits correct function label."""
+    asm = emit_string(STD_INCLUDE + "42 some .is_some")
+    assert "fn_option__is_some" in asm
+
+
+def test_emit_option_is_none():
+    """option::is_none emits correct function label."""
+    asm = emit_string(STD_INCLUDE + "42 some .is_none")
+    assert "fn_option__is_none" in asm
+
+
+def test_emit_option_unwrap():
+    """option::unwrap emits correct function label."""
+    asm = emit_string(STD_INCLUDE + "42 some .unwrap")
+    assert "fn_option__unwrap" in asm
+
+
+def test_emit_option_unwrap_or():
+    """option::unwrap_or emits correct function label."""
+    asm = emit_string(STD_INCLUDE + "0 42 some .unwrap_or")
+    assert "fn_option__unwrap_or" in asm

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -859,3 +859,65 @@ def test_lex_multiple_comment_lines():
     non_eof = [t for t in tokens if t.kind != TokenKind.EOF]
     assert len(non_eof) == 3
     assert [t.value for t in non_eof] == ["1", "2", "3"]
+
+
+# ---------------------------------------------------------------------------
+# Option[T] literals (none / some)
+# ---------------------------------------------------------------------------
+def test_lex_none_literal():
+    """none is recognized as a LITERAL token."""
+    tokens = lex_string("none")
+    assert tokens[0].kind == TokenKind.LITERAL
+    assert tokens[0].value == "none"
+
+
+def test_lex_some_literal():
+    """some is recognized as a LITERAL token."""
+    tokens = lex_string("some")
+    assert tokens[0].kind == TokenKind.LITERAL
+    assert tokens[0].value == "some"
+
+
+def test_lex_none_is_not_keyword():
+    """none should not be lexed as a keyword."""
+    tokens = lex_string("none")
+    assert tokens[0].kind != TokenKind.KEYWORD
+
+
+def test_lex_some_is_not_keyword():
+    """some should not be lexed as a keyword."""
+    tokens = lex_string("some")
+    assert tokens[0].kind != TokenKind.KEYWORD
+
+
+def test_lex_none_is_not_identifier():
+    """none should not be lexed as an identifier."""
+    tokens = lex_string("none")
+    assert tokens[0].kind != TokenKind.IDENTIFIER
+
+
+def test_lex_some_is_not_identifier():
+    """some should not be lexed as an identifier."""
+    tokens = lex_string("some")
+    assert tokens[0].kind != TokenKind.IDENTIFIER
+
+
+def test_lex_none_in_expression():
+    """none in an expression context lexes correctly."""
+    tokens = lex_string("none print")
+    non_eof = [t for t in tokens if t.kind != TokenKind.EOF]
+    assert len(non_eof) == 2
+    assert non_eof[0].kind == TokenKind.LITERAL
+    assert non_eof[0].value == "none"
+    assert non_eof[1].kind == TokenKind.INTRINSIC
+
+
+def test_lex_some_in_expression():
+    """some after a value lexes correctly."""
+    tokens = lex_string("42 some")
+    non_eof = [t for t in tokens if t.kind != TokenKind.EOF]
+    assert len(non_eof) == 2
+    assert non_eof[0].kind == TokenKind.LITERAL
+    assert non_eof[0].value == "42"
+    assert non_eof[1].kind == TokenKind.LITERAL
+    assert non_eof[1].value == "some"

--- a/tests/test_typechecker.py
+++ b/tests/test_typechecker.py
@@ -1170,6 +1170,14 @@ def test_typecheck_option_mixed_elif():
     assert sig.return_types == ["option[int]"]
 
 
+def test_typecheck_option_different_some_types_rejected():
+    """option[int] and option[bool] in different branches are incompatible."""
+    code = "if true then 42 some else true some fi"
+    with pytest.raises(CasaErrorCollection) as exc_info:
+        typecheck_string(code)
+    assert exc_info.value.errors[0].kind == ErrorKind.STACK_MISMATCH
+
+
 def test_typecheck_option_none_if_no_else_no_change():
     """none in if-without-else that doesn't change the stack is fine."""
     code = "none if true then drop none fi"

--- a/tests/test_typechecker.py
+++ b/tests/test_typechecker.py
@@ -1144,3 +1144,34 @@ def test_typecheck_signature_from_str_option_type():
     sig = Signature.from_str("option[int] -> int")
     assert [p.typ for p in sig.parameters] == ["option[int]"]
     assert sig.return_types == ["int"]
+
+
+# ---------------------------------------------------------------------------
+# Option[T] branch compatibility
+# ---------------------------------------------------------------------------
+def test_typecheck_option_none_if_some_else():
+    """none in if branch and some in else branch are compatible."""
+    code = "if true then none else 42 some fi"
+    sig = typecheck_string(code)
+    assert sig.return_types == ["option[int]"]
+
+
+def test_typecheck_option_some_if_none_else():
+    """some in if branch and none in else branch are compatible."""
+    code = "if true then 42 some else none fi"
+    sig = typecheck_string(code)
+    assert sig.return_types == ["option[int]"]
+
+
+def test_typecheck_option_mixed_elif():
+    """Multiple elif branches mixing none and some are compatible."""
+    code = "if true then none elif false then 42 some else 99 some fi"
+    sig = typecheck_string(code)
+    assert sig.return_types == ["option[int]"]
+
+
+def test_typecheck_option_none_if_no_else_no_change():
+    """none in if-without-else that doesn't change the stack is fine."""
+    code = "none if true then drop none fi"
+    sig = typecheck_string(code)
+    assert sig.return_types == ["option"]


### PR DESCRIPTION
## Summary
- Add `option[T]` type with `none` and `some` constructors across all pipeline stages (lexer, parser, typechecker, bytecode, emitter)
- Heap-allocated as 2-slot tagged union (tag + value), with bare `option` compatible with any `option[T]`
- Standard library methods: `is_some`, `is_none`, `unwrap`, `unwrap_or`
- Add `option` to `BUILTIN_TYPES` to prevent type variable shadowing

## Test plan
- [x] 562 tests passing, including new option[T] tests across lexer, parser, typechecker, bytecode, and emitter stages
- [x] Tests cover: none/some construction, type checking, method calls, unwrap behavior, generic function usage