### PR TITLE
feat: add file I/O standard library functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ source → lex → parse → resolve → type check → bytecode → emit asm �
 | [Control Flow](docs/control-flow.md) | Conditionals (`if`/`elif`/`else`/`fi`), loops (`while`/`do`/`done`) |
 | [Functions and Lambdas](docs/functions-and-lambdas.md) | Functions, lambdas, closures, variables, stack intrinsics, IO, memory |
 | [Structs and Methods](docs/structs-and-methods.md) | Struct definition, accessors, `impl` blocks, dot/arrow syntax |
-| [Standard Library](docs/standard-library.md) | `include`, `memcpy`, arrays (`map`, `filter`, `reduce`), `option[T]`, `List`, string methods, C string methods, character classification, type conversions |
+| [Standard Library](docs/standard-library.md) | `include`, `memcpy`, arrays (`map`, `filter`, `reduce`), `option[T]`, `List`, string methods, C string methods, file I/O, character classification, type conversions |
 | [Errors](docs/errors.md) | Error kinds, diagnostics format, multi-error collection |
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ source → lex → parse → resolve → type check → bytecode → emit asm �
 | [euler01.casa](examples/euler01.casa) | Project Euler problem 1 — sum of multiples |
 | [string_operations.casa](examples/string_operations.casa) | String methods, char type, and cstr conversion |
 | [bitwise_operations.casa](examples/bitwise_operations.casa) | Bitwise AND, OR, XOR, and NOT operations |
+| [file_io.casa](examples/file_io.casa) | File I/O operations: read, write, and remove files |
 
 More examples: [examples](./examples/)
 

--- a/docs/standard-library.md
+++ b/docs/standard-library.md
@@ -395,6 +395,115 @@ Converts a null-terminated C string to a `str`. Scans for the null byte to deter
 "hello" .as_cstr .to_str print    # hello
 ```
 
+## File I/O
+
+Functions for reading, writing, and managing files. All file operations use Linux system calls internally.
+
+### File I/O Constants
+
+The standard library provides constants for common file open flags:
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `O_RDONLY` | 0 | Open for reading only |
+| `O_WRONLY` | 1 | Open for writing only |
+| `O_CREAT` | 64 | Create the file if it does not exist |
+| `O_TRUNC` | 512 | Truncate the file to zero length |
+
+Flags can be combined with the bitwise OR operator (`|`):
+
+```casa
+O_WRONLY O_CREAT | O_TRUNC |    # open for writing, create if needed, truncate
+```
+
+### `file::open`
+
+Opens a file and returns a file descriptor. Returns a negative value on error.
+
+**Signature:** `file::open path:str flags:int mode:int -> int`
+
+**Stack effect:** `str int int -> int`
+
+```casa
+0 O_RDONLY 0 "input.txt" file::open = fd
+```
+
+The `mode` parameter sets file permissions when creating a new file (e.g., 420 for `rw-r--r--`). It is ignored when opening an existing file.
+
+### `file::read`
+
+Reads up to `size` bytes from a file descriptor into a buffer. Returns the number of bytes read, or a negative value on error.
+
+**Signature:** `file::read fd:int buf:ptr size:int -> int`
+
+**Stack effect:** `int ptr int -> int`
+
+```casa
+1024 alloc = buf
+1024 buf fd file::read = bytes_read
+```
+
+### `file::write`
+
+Writes a string to a file descriptor. Returns the number of bytes written, or a negative value on error.
+
+**Signature:** `file::write fd:int data:str -> int`
+
+**Stack effect:** `int str -> int`
+
+```casa
+"Hello, file!\n" fd file::write drop
+```
+
+### `file::close`
+
+Closes a file descriptor. Returns 0 on success, or a negative value on error.
+
+**Signature:** `file::close fd:int -> int`
+
+**Stack effect:** `int -> int`
+
+```casa
+fd file::close drop
+```
+
+### `file::read_all`
+
+Reads the entire contents of a file into a string. Prints an error and exits if the file cannot be opened.
+
+**Signature:** `file::read_all path:str -> str`
+
+**Stack effect:** `str -> str`
+
+```casa
+"input.txt" file::read_all = content
+content print
+```
+
+### `file::write_all`
+
+Writes a string to a file, creating or truncating it. Returns `true` on success, `false` if the file cannot be opened.
+
+**Signature:** `file::write_all path:str content:str -> bool`
+
+**Stack effect:** `str str -> bool`
+
+```casa
+"Hello, world!\n" "output.txt" file::write_all drop
+```
+
+### `file::remove`
+
+Deletes a file. Returns 0 on success, or a negative value on error.
+
+**Signature:** `file::remove path:str -> int`
+
+**Stack effect:** `str -> int`
+
+```casa
+"temp.txt" file::remove drop
+```
+
 ## Character Classification
 
 Methods on `char` for classifying ASCII characters.

--- a/docs/standard-library.md
+++ b/docs/standard-library.md
@@ -504,6 +504,8 @@ Deletes a file. Returns 0 on success, or a negative value on error.
 "temp.txt" file::remove drop
 ```
 
+See [`examples/file_io.casa`](../examples/file_io.casa) for a full program using file I/O.
+
 ## Character Classification
 
 Methods on `char` for classifying ASCII characters.

--- a/examples/file_io.casa
+++ b/examples/file_io.casa
@@ -1,0 +1,29 @@
+# File I/O operations
+# Demonstrates file reading, writing, and low-level file operations
+
+include "../lib/std.casa"
+
+# High-level: write and read a file
+"=== write_all ===" print "\n" print
+"Hello, File I/O!\n" "/tmp/casa_fio_test1.txt" file::write_all .to_str print "\n" print
+
+"=== read_all ===" print "\n" print
+"/tmp/casa_fio_test1.txt" file::read_all = content
+content print
+
+"=== content verification ===" print "\n" print
+"Hello, File I/O!\n" content str::eq .to_str print "\n" print
+
+# Low-level: open, write, close
+"=== low-level write ===" print "\n" print
+420 O_WRONLY O_CREAT | O_TRUNC | "/tmp/casa_fio_test2.txt" file::open = fd
+"Line 1\n" fd file::write drop
+"Line 2\n" fd file::write drop
+fd file::close drop
+"/tmp/casa_fio_test2.txt" file::read_all print
+
+# Clean up temp files
+"=== remove ===" print "\n" print
+"/tmp/casa_fio_test1.txt" file::remove drop
+"/tmp/casa_fio_test2.txt" file::remove drop
+"files cleaned up" print "\n" print

--- a/examples/file_io.casa
+++ b/examples/file_io.casa
@@ -22,8 +22,20 @@ content print
 fd file::close drop
 "/tmp/casa_fio_test2.txt" file::read_all print
 
+# Low-level: read with buffer
+"=== low-level read ===" print "\n" print
+"ABCDE" "/tmp/casa_fio_test3.txt" file::write_all drop
+0 0 "/tmp/casa_fio_test3.txt" file::open = rfd
+64 alloc = buf
+64 buf rfd file::read = bytes_read
+bytes_read print "\n" print
+buf load8 (char) print "\n" print
+buf 4 + load8 (char) print "\n" print
+rfd file::close drop
+
 # Clean up temp files
 "=== remove ===" print "\n" print
 "/tmp/casa_fio_test1.txt" file::remove drop
 "/tmp/casa_fio_test2.txt" file::remove drop
+"/tmp/casa_fio_test3.txt" file::remove drop
 "files cleaned up" print "\n" print

--- a/examples/outputs/file_io.out
+++ b/examples/outputs/file_io.out
@@ -7,5 +7,9 @@ true
 === low-level write ===
 Line 1
 Line 2
+=== low-level read ===
+5
+A
+E
 === remove ===
 files cleaned up

--- a/examples/outputs/file_io.out
+++ b/examples/outputs/file_io.out
@@ -1,0 +1,11 @@
+=== write_all ===
+true
+=== read_all ===
+Hello, File I/O!
+=== content verification ===
+true
+=== low-level write ===
+Line 1
+Line 2
+=== remove ===
+files cleaned up

--- a/lib/std.casa
+++ b/lib/std.casa
@@ -287,7 +287,7 @@ impl file {
     }
 
     fn read_all path:str -> str {
-        0 0 path file::open = ra_fd
+        0 O_RDONLY path file::open = ra_fd
         if 0 ra_fd < then
             "error: could not open file\n" print
             1 60 syscall1 drop

--- a/lib/std.casa
+++ b/lib/std.casa
@@ -262,6 +262,63 @@ impl cstr {
 }
 
 # ---------------------------------------------------------------------------
+# File I/O
+# ---------------------------------------------------------------------------
+0 = O_RDONLY
+1 = O_WRONLY
+64 = O_CREAT
+512 = O_TRUNC
+
+impl file {
+    fn open path:str flags:int mode:int -> int {
+        mode flags path.as_cstr (ptr) 2 syscall3
+    }
+
+    fn read fd:int buf:ptr size:int -> int {
+        size buf fd 0 syscall3
+    }
+
+    fn write fd:int data:str -> int {
+        data .length data.as_cstr (ptr) fd 1 syscall3
+    }
+
+    fn close fd:int -> int {
+        fd 3 syscall1
+    }
+
+    fn read_all path:str -> str {
+        0 0 path file::open = ra_fd
+        if 0 ra_fd < then
+            "error: could not open file\n" print
+            1 60 syscall1 drop
+        fi
+        2 0 ra_fd 8 syscall3 = ra_size
+        0 0 ra_fd 8 syscall3 drop
+        ra_size 9 + alloc (str) = ra_buf
+        ra_size ra_buf (ptr) store64
+        ra_size ra_buf.as_cstr (ptr) ra_fd 0 syscall3 drop
+        0 (char) ra_size ra_buf.set
+        ra_fd file::close drop
+        ra_buf
+    }
+
+    fn write_all path:str content:str -> bool {
+        420 O_WRONLY O_CREAT | O_TRUNC | path file::open = wa_fd
+        if 0 wa_fd < then
+            false
+        else
+            content wa_fd file::write drop
+            wa_fd file::close drop
+            true
+        fi
+    }
+
+    fn remove path:str -> int {
+        path.as_cstr (ptr) 87 syscall1
+    }
+}
+
+# ---------------------------------------------------------------------------
 # Character classification
 # ---------------------------------------------------------------------------
 impl char {


### PR DESCRIPTION
## Summary

- Add file I/O functions to the standard library (`lib/std.casa`) using existing syscall intrinsics
- Functions: `file::open`, `file::read`, `file::write`, `file::close`, `file::read_all`, `file::write_all`, `file::remove`
- Constants: `O_RDONLY`, `O_WRONLY`, `O_CREAT`, `O_TRUNC`
- Phase 3 of the self-hosting roadmap

## Details

All functions are pure Casa, implemented via `impl file { }` block using `syscall0`-`syscall3`. No compiler (Python) changes needed.

- `file::read_all` uses `lseek` to get file size, allocates a string buffer, reads the file, and sets the null terminator
- `file::write_all` opens with `O_WRONLY | O_CREAT | O_TRUNC` (mode 0644), writes, and closes
- `file::remove` wraps `unlink` (syscall 87) for cleanup

## Test plan

- [x] Example program `examples/file_io.casa` demonstrates all functions (write_all, read_all, open, write, read, close, remove)
- [x] Expected output committed to `examples/outputs/file_io.out`
- [x] All 23 example tests pass (`tests/test_examples.sh`)
- [x] All 669 pytest tests pass