### PR TITLE
feat: generic List[T] and header-based arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Casa compiles to x86-64 Linux executables via GNU assembly. It features static t
 - **Structs and methods** — user-defined types with auto-generated accessors and `impl` blocks
 - **String interpolation** — f-strings with embedded expressions (`f"hello {name}"`)
 - **Compiles to native code** — generates x86-64 assembly with `ld` and `as`
-- **Standard library** — dynamic `List`, arrays, type conversions, and memory utilities
+- **Standard library** — generic `List[T]`, arrays with `map`/`filter`/`reduce`, type conversions, and memory utilities
 
 ## Requirements
 
@@ -67,7 +67,7 @@ source → lex → parse → resolve → type check → bytecode → emit asm �
 | [Control Flow](docs/control-flow.md) | Conditionals (`if`/`elif`/`else`/`fi`), loops (`while`/`do`/`done`) |
 | [Functions and Lambdas](docs/functions-and-lambdas.md) | Functions, lambdas, closures, variables, stack intrinsics, IO, memory |
 | [Structs and Methods](docs/structs-and-methods.md) | Struct definition, accessors, `impl` blocks, dot/arrow syntax |
-| [Standard Library](docs/standard-library.md) | `include`, `memcpy`, arrays (`map`, `filter`, `reduce`), `option[T]`, `List`, string methods, C string methods, file I/O, character classification, type conversions |
+| [Standard Library](docs/standard-library.md) | `include`, `memcpy`, arrays (`map`, `filter`, `reduce`), `option[T]`, `List[T]`, string methods, C string methods, file I/O, character classification, type conversions |
 | [Errors](docs/errors.md) | Error kinds, diagnostics format, multi-error collection |
 
 ## Examples
@@ -82,6 +82,7 @@ source → lex → parse → resolve → type check → bytecode → emit asm �
 | [string_operations.casa](examples/string_operations.casa) | String methods, char type, and cstr conversion |
 | [bitwise_operations.casa](examples/bitwise_operations.casa) | Bitwise AND, OR, XOR, and NOT operations |
 | [file_io.casa](examples/file_io.casa) | File I/O operations: read, write, and remove files |
+| [vec.casa](examples/vec.casa) | Generic `List[T]` with push, pop, get, set, slice |
 
 More examples: [examples](./examples/)
 

--- a/examples/dynamic_list.casa
+++ b/examples/dynamic_list.casa
@@ -15,8 +15,8 @@ list.print_metadata
 impl List {
     fn print_items self:List {
         0 = i
-        while i self.size > do
-            i self.nth print "\n" print
+        while i self.length > do
+            i self.get print "\n" print
             1 += i
         done
     }

--- a/examples/outputs/vec.out
+++ b/examples/outputs/vec.out
@@ -1,0 +1,22 @@
+=== List::new and push ===
+Length: 3
+[0]: 10
+[1]: 20
+[2]: 30
+=== set ===
+[1] after set: 99
+=== pop ===
+Popped: 30
+Length after pop: 2
+=== from_array ===
+Length: 5
+[0]: 100
+[4]: 500
+=== slice ===
+Slice length: 2
+Slice[0]: 200
+Slice[1]: 300
+=== to_array ===
+Array length: 5
+Array[0]: 100
+Array[4]: 500

--- a/examples/vec.casa
+++ b/examples/vec.casa
@@ -1,0 +1,49 @@
+# Vec - comprehensive List[T] demonstration
+#
+# Shows all List methods: new, push, get, set, pop, length,
+# from_array, slice, to_array
+
+include "../lib/std.casa"
+
+# Create empty list and push elements
+"=== List::new and push ===" print "\n" print
+List::new = v
+10 v.push
+20 v.push
+30 v.push
+"Length: " print v.length print "\n" print
+"[0]: " print 0 v.get print "\n" print
+"[1]: " print 1 v.get print "\n" print
+"[2]: " print 2 v.get print "\n" print
+
+# Set element at index
+"=== set ===" print "\n" print
+99 1 v.set
+"[1] after set: " print 1 v.get print "\n" print
+
+# Pop last element
+"=== pop ===" print "\n" print
+v.pop = popped
+"Popped: " print popped print "\n" print
+"Length after pop: " print v.length print "\n" print
+
+# Create list from array
+"=== from_array ===" print "\n" print
+[100, 200, 300, 400, 500] List::from_array = v2
+"Length: " print v2.length print "\n" print
+"[0]: " print 0 v2.get print "\n" print
+"[4]: " print 4 v2.get print "\n" print
+
+# Slice returns an array view
+"=== slice ===" print "\n" print
+3 1 v2.slice = sliced
+"Slice length: " print sliced.length print "\n" print
+"Slice[0]: " print 0 sliced array::nth print "\n" print
+"Slice[1]: " print 1 sliced array::nth print "\n" print
+
+# Convert entire list to array
+"=== to_array ===" print "\n" print
+v2.to_array = arr
+"Array length: " print arr.length print "\n" print
+"Array[0]: " print 0 arr array::nth print "\n" print
+"Array[4]: " print 4 arr array::nth print "\n" print

--- a/lib/std.casa
+++ b/lib/std.casa
@@ -9,22 +9,26 @@ fn memcpy dst:ptr src:ptr n:int {
 
 impl array {
     fn length array -> int {
-        # The first item of an array is its length
-        (ptr) load64
+        # Length is at offset 8 in the header
+        (ptr) 8 + load64
     }
 
     fn nth[T] array:array[T] n:int -> T {
-        # The first item of an array is its length
-        array (ptr) n 1 + 8 * + load64 (T)
+        # Data pointer is at offset 0 in the header
+        array (ptr) load64 (ptr) n 8 * + load64 (T)
     }
+
     fn map[T1 T2] arr:array[T1] f:fn[T1 -> T2] -> array[T2] {
         arr.length = map_len
-        map_len 1 + 8 * alloc = map_buf
-        map_len map_buf (ptr) store64
+        map_len 2 + 8 * alloc = map_buf
+        # Store data_ptr (map_buf + 16) at offset 0
+        map_buf (ptr) 16 + map_buf (ptr) store64
+        # Store length at offset 8
+        map_len map_buf (ptr) 8 + store64
         0 = map_i
         while map_i map_len > do
             map_i arr.nth f exec
-            map_buf (ptr) map_i 1 + 8 * + store64
+            map_buf (ptr) load64 (ptr) map_i 8 * + store64
             1 += map_i
         done
         map_buf (array)
@@ -32,18 +36,23 @@ impl array {
 
     fn filter[T] arr:array[T] f:fn[T -> bool] -> array[T] {
         arr.length = flt_len
-        flt_len 1 + 8 * alloc = flt_buf
+        flt_len 2 + 8 * alloc = flt_buf
+        # Store data_ptr (flt_buf + 16) at offset 0
+        flt_buf (ptr) 16 + flt_buf (ptr) store64
+        # Store initial length 0 at offset 8
+        0 flt_buf (ptr) 8 + store64
         0 = flt_count
         0 = flt_i
         while flt_i flt_len > do
             flt_i arr.nth = flt_elem
             if flt_elem f exec then
-                flt_elem flt_buf (ptr) flt_count 1 + 8 * + store64
+                flt_elem flt_buf (ptr) load64 (ptr) flt_count 8 * + store64
                 1 += flt_count
             fi
             1 += flt_i
         done
-        flt_count flt_buf (ptr) store64
+        # Update length at offset 8
+        flt_count flt_buf (ptr) 8 + store64
         flt_buf (array)
     }
 
@@ -59,32 +68,73 @@ impl array {
 }
 
 struct List {
-    size: int
+    data:     ptr
+    size:     int
     capacity: int
-    array: array
 }
 
 impl List {
-    fn from_array array:array -> List {
-        array array.length dup List
+    fn new -> List {
+        8 0 64 alloc List
     }
 
-    fn nth List int -> any {
-        List::array.nth
+    fn from_array[T] arr:array[T] -> List[T] {
+        arr.length dup arr (ptr) load64 (ptr) List
     }
 
-    fn push self:List item:any {
-        # Allocate new bigger array if necessary
-        if self.capacity self.size >= then
-            self.size 2 * self->capacity
-            self.capacity 1 + 8 * alloc (array) = new_arr
-            self.size 1 + 8 * self.array (ptr) new_arr (ptr) memcpy
-            new_arr self->array
+    fn length self:List -> int {
+        self.size
+    }
+
+    fn get[T] self:List[T] n:int -> T {
+        if self.size n >= 0 n < || then
+            "error: List index out of bounds\n" print
+            1 60 syscall1 drop
         fi
+        self.data n 8 * + load64 (T)
+    }
 
-        # Push the item to the array
+    fn set[T] self:List[T] n:int item:T {
+        if self.size n >= 0 n < || then
+            "error: List index out of bounds\n" print
+            1 60 syscall1 drop
+        fi
+        item self.data n 8 * + store64
+    }
+
+    fn push[T] self:List[T] item:T {
+        if self.capacity self.size >= then
+            self.capacity 2 * self->capacity
+            self.capacity 8 * alloc = new_data
+            self.size 8 * self.data new_data memcpy
+            new_data self->data
+        fi
+        item self.data self.size 8 * + store64
         self.size 1 + self->size
-        item self.array (ptr) self.size 8 * + store64
+    }
+
+    fn pop[T] self:List[T] -> T {
+        if 0 self.size <= then
+            "error: pop from empty List\n" print
+            1 60 syscall1 drop
+        fi
+        self.size 1 - self->size
+        self.data self.size 8 * + load64 (T)
+    }
+
+    fn slice[T] self:List[T] start:int end:int -> array[T] {
+        if 0 start < self.size end > || end start > || then
+            "error: List slice out of bounds\n" print
+            1 60 syscall1 drop
+        fi
+        16 alloc = hdr
+        self.data start 8 * + hdr (ptr) store64
+        end start - hdr (ptr) 8 + store64
+        hdr (array)
+    }
+
+    fn to_array[T] self:List[T] -> array[T] {
+        self.size 0 self.slice
     }
 }
 


### PR DESCRIPTION
## Summary

- Switch arrays to header-based layout: `[data_ptr, length]` header instead of length-prefixed `[length, data...]`
- Add general user-defined generic type support (`extract_generic_base`/`extract_generic_inner` helpers that work for any `Foo[T]` pattern)
- Replace non-generic `List` with generic `List[T]` with methods: `new`, `from_array`, `length`, `get`, `set`, `push`, `pop`, `slice`, `to_array`
- Zero-copy `slice` and `to_array` return `array[T]` views into List data

## Test plan

- [x] All 24 example tests pass (`bash tests/test_examples.sh`)
- [x] All 669 pytest tests pass
- [x] New `examples/vec.casa` demonstrates all List[T] methods
- [x] Updated `examples/dynamic_list.casa` works with new API
- [x] Existing examples unaffected by array layout change