### PR TITLE
feat: add trait system with Hashable, Map[K V], and Set[K]

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Casa compiles to x86-64 Linux executables via GNU assembly. It features static t
 - **Structs and methods** — user-defined types with auto-generated accessors and `impl` blocks
 - **String interpolation** — f-strings with embedded expressions (`f"hello {name}"`)
 - **Compiles to native code** — generates x86-64 assembly with `ld` and `as`
-- **Standard library** — generic `List[T]`, arrays with `map`/`filter`/`reduce`, type conversions, and memory utilities
+- **Traits** — structural trait system with bounded polymorphism (`trait`, `Hashable`)
+- **Standard library** — generic `List[T]`, `Map[K V]`, `Set[K]`, arrays with `map`/`filter`/`reduce`, type conversions, and memory utilities
 
 ## Requirements
 
@@ -67,7 +68,8 @@ source → lex → parse → resolve → type check → bytecode → emit asm �
 | [Control Flow](docs/control-flow.md) | Conditionals (`if`/`elif`/`else`/`fi`), loops (`while`/`do`/`done`) |
 | [Functions and Lambdas](docs/functions-and-lambdas.md) | Functions, lambdas, closures, variables, stack intrinsics, IO, memory |
 | [Structs and Methods](docs/structs-and-methods.md) | Struct definition, accessors, `impl` blocks, dot/arrow syntax |
-| [Standard Library](docs/standard-library.md) | `include`, `memcpy`, arrays (`map`, `filter`, `reduce`), `option[T]`, `List[T]`, string methods, C string methods, file I/O, character classification, type conversions |
+| [Traits](docs/traits.md) | Trait definitions, structural satisfaction, trait bounds, `Hashable` |
+| [Standard Library](docs/standard-library.md) | `include`, `memcpy`, arrays (`map`, `filter`, `reduce`), `option[T]`, `List[T]`, `Map[K V]`, `Set[K]`, string methods, C string methods, file I/O, character classification, type conversions |
 | [Errors](docs/errors.md) | Error kinds, diagnostics format, multi-error collection |
 
 ## Examples
@@ -83,6 +85,7 @@ source → lex → parse → resolve → type check → bytecode → emit asm �
 | [bitwise_operations.casa](examples/bitwise_operations.casa) | Bitwise AND, OR, XOR, and NOT operations |
 | [file_io.casa](examples/file_io.casa) | File I/O operations: read, write, and remove files |
 | [vec.casa](examples/vec.casa) | Generic `List[T]` with push, pop, get, set, slice |
+| [hash_map.casa](examples/hash_map.casa) | `Map[K V]` and `Set[K]` with the `Hashable` trait |
 
 More examples: [examples](./examples/)
 

--- a/casa/common.py
+++ b/casa/common.py
@@ -1,4 +1,3 @@
-import re
 from dataclasses import dataclass, field
 from enum import Enum, auto
 from pathlib import Path
@@ -915,9 +914,11 @@ class Trait:
 TRAIT_SELF_TYPE = "self"
 
 
-def _replace_trait_self(text: str, replacement: str) -> str:
-    """Replace the trait self placeholder as a whole word in a type string."""
-    return re.sub(r"\bself\b", replacement, text)
+def _replace_trait_self(typ: str, replacement: str) -> str:
+    """Replace the trait self placeholder in a type string."""
+    if typ == TRAIT_SELF_TYPE:
+        return replacement
+    return typ
 
 
 def resolve_trait_sig(sig: "Signature", type_var: str) -> "Signature":

--- a/casa/common.py
+++ b/casa/common.py
@@ -83,6 +83,7 @@ class Keyword(Enum):
 
     # Data types
     STRUCT = auto()
+    TRAIT = auto()
 
     # Include files
     INCLUDE = auto()
@@ -732,6 +733,49 @@ def extract_generic_inner(typ: str) -> str | None:
     return typ[len(base) + 1 : -1]
 
 
+def split_type_tokens(s: str) -> list[str]:
+    """Split a space-separated type string into tokens, respecting brackets.
+
+    For 'str int' returns ['str', 'int'].
+    For 'str List[int]' returns ['str', 'List[int]'].
+    For 'int -> int' returns ['int', '->', 'int'].
+    """
+    tokens: list[str] = []
+    current: list[str] = []
+    depth = 0
+    for ch in s.strip():
+        if ch == "[":
+            depth += 1
+            current.append(ch)
+        elif ch == "]":
+            depth -= 1
+            current.append(ch)
+        elif ch == " " and depth == 0:
+            if current:
+                tokens.append("".join(current))
+                current = []
+        else:
+            current.append(ch)
+    if current:
+        tokens.append("".join(current))
+    return tokens
+
+
+def extract_generic_params(typ: str) -> list[str] | None:
+    """Extract multiple generic type parameters respecting bracket depth.
+
+    For 'Map[str int]' returns ['str', 'int'].
+    For 'Map[str List[int]]' returns ['str', 'List[int]'].
+    For 'array[int]' returns ['int'].
+    Returns None for fn types and non-parameterized types.
+    """
+    base = extract_generic_base(typ)
+    if base is None:
+        return None
+    inner = typ[len(base) + 1 : -1]
+    return split_type_tokens(inner)
+
+
 def is_fn_type(typ: str) -> bool:
     """Check if a type is a function type (bare or parameterized)."""
     return typ == "fn" or typ.startswith("fn[")
@@ -764,31 +808,10 @@ class Signature:
     parameters: list[Parameter]
     return_types: list[Type]
     type_vars: set[str] = field(default_factory=set)
+    trait_bounds: dict[str, str] = field(default_factory=dict)
 
     @classmethod
     def from_str(cls, repr: str) -> Self:
-        def tokenize(s: str) -> list[str]:
-            """Split a signature string into type tokens, respecting brackets."""
-            tokens: list[str] = []
-            current: list[str] = []
-            depth = 0
-            for ch in s.strip():
-                if ch == "[":
-                    depth += 1
-                    current.append(ch)
-                elif ch == "]":
-                    depth -= 1
-                    current.append(ch)
-                elif ch == " " and depth == 0:
-                    if current:
-                        tokens.append("".join(current))
-                        current = []
-                else:
-                    current.append(ch)
-            if current:
-                tokens.append("".join(current))
-            return tokens
-
         def split_on_arrow(tokens: list[str]) -> tuple[list[str], list[str]]:
             """Split token list on '->' at bracket depth 0."""
             for i, tok in enumerate(tokens):
@@ -801,7 +824,7 @@ class Signature:
                 return []
             return list(tokens)
 
-        tokens = tokenize(repr)
+        tokens = split_type_tokens(repr)
         param_tokens, return_tokens = split_on_arrow(tokens)
         parameters = [Parameter(p) for p in parse_type_list(param_tokens)]
         return_types = parse_type_list(return_tokens)
@@ -876,6 +899,19 @@ class Struct:
 
 
 @dataclass
+class TraitMethod:
+    name: str
+    signature: Signature
+
+
+@dataclass
+class Trait:
+    name: str
+    methods: list[TraitMethod]
+    location: Location
+
+
+@dataclass
 class Function:
     name: str
     ops: list[Op]
@@ -892,6 +928,7 @@ class Function:
 
 GLOBAL_FUNCTIONS: OrderedDict[str, Function] = OrderedDict()
 GLOBAL_STRUCTS: OrderedDict[str, Struct] = OrderedDict()
+GLOBAL_TRAITS: OrderedDict[str, Trait] = OrderedDict()
 GLOBAL_VARIABLES: OrderedDict[str, Variable] = OrderedDict()
 GLOBAL_SCOPE_LABEL = "_start"
 INCLUDED_FILES: set[Path] = set()

--- a/casa/common.py
+++ b/casa/common.py
@@ -1,3 +1,4 @@
+import re
 from dataclasses import dataclass, field
 from enum import Enum, auto
 from pathlib import Path
@@ -909,6 +910,28 @@ class Trait:
     name: str
     methods: list[TraitMethod]
     location: Location
+
+
+TRAIT_SELF_TYPE = "self"
+
+
+def _replace_trait_self(text: str, replacement: str) -> str:
+    """Replace the trait self placeholder as a whole word in a type string."""
+    return re.sub(r"\bself\b", replacement, text)
+
+
+def resolve_trait_sig(sig: "Signature", type_var: str) -> "Signature":
+    """Create a copy of a trait method signature with self type replaced by type_var.
+
+    Only replaces self in type positions, not in parameter names,
+    since 'self' is a common parameter name.
+    """
+    params = []
+    for p in sig.parameters:
+        resolved_typ = _replace_trait_self(p.typ, type_var)
+        params.append(Parameter(resolved_typ, p.name))
+    ret = [_replace_trait_self(r, type_var) for r in sig.return_types]
+    return Signature(params, ret)
 
 
 @dataclass

--- a/casa/error.py
+++ b/casa/error.py
@@ -25,6 +25,8 @@ class ErrorKind(Enum):
     SIGNATURE_MISMATCH = auto()
     INVALID_VARIABLE = auto()
     UNMATCHED_BLOCK = auto()
+    MISSING_TRAIT_METHOD = auto()
+    TRAIT_SIGNATURE_MISMATCH = auto()
 
 
 SOURCE_CACHE: dict[Path, str] = {}

--- a/casa/parser.py
+++ b/casa/parser.py
@@ -6,6 +6,7 @@ from casa.common import (
     GLOBAL_FUNCTIONS,
     GLOBAL_SCOPE_LABEL,
     GLOBAL_STRUCTS,
+    GLOBAL_TRAITS,
     GLOBAL_VARIABLES,
     INCLUDED_FILES,
     Cursor,
@@ -24,6 +25,8 @@ from casa.common import (
     Struct,
     Token,
     TokenKind,
+    Trait,
+    TraitMethod,
     Type,
     Variable,
 )
@@ -142,6 +145,47 @@ def _resolve_array_identifiers(
                 )
 
 
+def _resolve_trait_method_sig(sig: Signature, type_var: str) -> Signature:
+    """Create a copy of a trait method signature with Self replaced by type_var."""
+    params = []
+    for p in sig.parameters:
+        resolved_typ = p.typ.replace("Self", type_var)
+        resolved_name = p.name
+        if resolved_name:
+            resolved_name = resolved_name.replace("Self", type_var)
+        params.append(Parameter(resolved_typ, resolved_name))
+    ret = [r.replace("Self", type_var) for r in sig.return_types]
+    return Signature(params, ret)
+
+
+def _resolve_trait_ref(
+    name: str,
+    function: Function | None,
+    location: Location,
+) -> str | None:
+    """Check if name is a trait-bound method call like K::hash.
+
+    Returns the hidden variable name (e.g. __trait_K_hash) if it matches,
+    or None if not a trait reference.
+    """
+    if not function or not function.signature:
+        return None
+    if "::" not in name:
+        return None
+    parts = name.split("::", 1)
+    tv, method_name = parts[0], parts[1]
+    trait_name = function.signature.trait_bounds.get(tv)
+    if not trait_name:
+        return None
+    trait = GLOBAL_TRAITS.get(trait_name)
+    if not trait:
+        return None
+    for method in trait.methods:
+        if method.name == method_name:
+            return f"__trait_{tv}_{method_name}"
+    return None
+
+
 def resolve_identifiers(
     ops: list[Op],
     function: Function | None = None,
@@ -224,6 +268,14 @@ def resolve_identifiers(
                             )
                         )
                         continue
+                    # Check trait bound reference: &K::method
+                    trait_var = _resolve_trait_ref(
+                        function_name, function, op.location
+                    )
+                    if trait_var:
+                        op.kind = OpKind.PUSH_VARIABLE
+                        op.value = trait_var
+                        continue
                     global_function = GLOBAL_FUNCTIONS.get(function_name)
                     if not global_function:
                         errors.append(
@@ -237,6 +289,18 @@ def resolve_identifiers(
                     op.kind = OpKind.FN_PUSH
                     op.value = function_name
                     _mark_used_and_resolve(global_function)
+                    continue
+
+                # Check trait bound call: K::method -> push var + exec
+                trait_var = _resolve_trait_ref(identifier, function, op.location)
+                if trait_var:
+                    op.kind = OpKind.PUSH_VARIABLE
+                    op.value = trait_var
+                    exec_op = Op(
+                        Intrinsic.EXEC, OpKind.FN_EXEC, op.location
+                    )
+                    ops.insert(index, exec_op)
+                    index += 1
                     continue
 
                 # Check different identifiers
@@ -449,7 +513,7 @@ def get_op_keyword(
     cursor: Cursor[Token],
     function_name: str,
 ) -> Op | None:
-    assert len(Keyword) == 15, "Exhaustive handling for `Keyword"
+    assert len(Keyword) == 16, "Exhaustive handling for `Keyword"
 
     keyword = Keyword.from_lowercase(token.value)
     assert keyword, f"Token `{token.value}` is not a keyword"
@@ -546,6 +610,24 @@ def get_op_keyword(
                         struct.location,
                     )
             return None
+        case Keyword.TRAIT:
+            if function_name != GLOBAL_SCOPE_LABEL:
+                raise_error(
+                    ErrorKind.INVALID_SCOPE,
+                    "Traits should be defined in the global scope",
+                    token.location,
+                )
+
+            cursor.position -= 1
+            trait = parse_trait(cursor)
+            if trait.name in GLOBAL_TRAITS:
+                raise_error(
+                    ErrorKind.DUPLICATE_NAME,
+                    f"Trait `{trait.name}` is already defined",
+                    trait.location,
+                )
+            GLOBAL_TRAITS[trait.name] = trait
+            return None
         case Keyword.THEN:
             return Op(keyword, OpKind.IF_CONDITION, token.location)
         case Keyword.WHILE:
@@ -586,8 +668,14 @@ def parse_type(cursor: Cursor[Token]) -> Type:
                 result.append(token.value)
         return f"fn[{''.join(result)}]"
 
-    inner = parse_type(cursor)
-    expect_token(cursor, value="]")
+    inner_types: list[str] = []
+    while True:
+        next_tok = cursor.peek()
+        if next_tok and next_tok.value == "]":
+            cursor.pop()
+            break
+        inner_types.append(parse_type(cursor))
+    inner = " ".join(inner_types)
     return f"{base.value}[{inner}]"
 
 
@@ -689,9 +777,86 @@ def parse_struct(cursor: Cursor[Token]) -> Struct:
     return Struct(struct_name.value, members, struct_name.location)
 
 
-def parse_type_vars(cursor: Cursor[Token]) -> set[str]:
+def parse_trait(cursor: Cursor[Token]) -> Trait:
+    expect_token(cursor, value="trait")
+    trait_name = expect_token(cursor, kind=TokenKind.IDENTIFIER)
+
+    methods: list[TraitMethod] = []
+    expect_token(cursor, value="{")
+    while True:
+        next_tok = cursor.peek()
+        if not next_tok:
+            raise_error(
+                ErrorKind.UNMATCHED_BLOCK,
+                "Unclosed trait block",
+                trait_name.location,
+            )
+        if next_tok.value == "}":
+            cursor.pop()
+            break
+        if next_tok.value != "fn":
+            raise_error(
+                ErrorKind.UNEXPECTED_TOKEN,
+                "Expected method declaration in trait",
+                next_tok.location,
+                expected="`fn`",
+                got=f"`{next_tok.value}`",
+            )
+        cursor.pop()  # consume fn
+        method_name = expect_token(cursor, kind=TokenKind.IDENTIFIER)
+        signature = parse_trait_method_signature(cursor)
+        methods.append(TraitMethod(method_name.value, signature))
+
+    return Trait(trait_name.value, methods, trait_name.location)
+
+
+def parse_trait_method_signature(cursor: Cursor[Token]) -> Signature:
+    """Parse a trait method signature (no body, stops at fn or })."""
+    parameters: list[Parameter] = []
+
+    # Parse parameters, stopping at ->, fn, or }
+    while name_or_type := cursor.peek():
+        if name_or_type.value in ("->", "{", "fn", "}"):
+            break
+        cursor.pop()
+
+        if name_or_type.kind != TokenKind.IDENTIFIER and name_or_type.value != "fn":
+            raise_error(
+                ErrorKind.UNEXPECTED_TOKEN,
+                "Unexpected token in trait method parameter list",
+                name_or_type.location,
+                expected="identifier",
+                got=f"`{name_or_type.kind.name}`",
+            )
+
+        next_token = cursor.peek()
+        if next_token and next_token.value == ":":
+            cursor.pop()
+            typ = parse_type(cursor)
+            parameters.append(Parameter(typ, name_or_type.value))
+        else:
+            cursor.position -= 1
+            typ = parse_type(cursor)
+            parameters.append(Parameter(typ))
+
+    return_types: list[Type] = []
+    next_token = cursor.peek()
+    if next_token and next_token.value == "->":
+        cursor.pop()
+        while cursor.peek():
+            if cursor.peek().value in ("fn", "}"):  # type: ignore[union-attr]
+                break
+            return_types.append(parse_type(cursor))
+
+    return Signature(parameters, return_types)
+
+
+def parse_type_vars(
+    cursor: Cursor[Token],
+) -> tuple[set[str], dict[str, str]]:
     expect_token(cursor, value="[")
     type_vars: set[str] = set()
+    trait_bounds: dict[str, str] = {}
     while token := cursor.pop():
         if token.value == "]":
             if not type_vars:
@@ -700,7 +865,7 @@ def parse_type_vars(cursor: Cursor[Token]) -> set[str]:
                     "Empty type parameter list `[]` is not allowed",
                     token.location,
                 )
-            return type_vars
+            return type_vars, trait_bounds
         if token.kind == TokenKind.IDENTIFIER:
             if token.value in BUILTIN_TYPES:
                 raise_error(
@@ -715,6 +880,19 @@ def parse_type_vars(cursor: Cursor[Token]) -> set[str]:
                     token.location,
                 )
             type_vars.add(token.value)
+            # Check for trait bound: K: Hashable
+            next_tok = cursor.peek()
+            if next_tok and next_tok.value == ":":
+                cursor.pop()  # consume :
+                trait_tok = expect_token(cursor, kind=TokenKind.IDENTIFIER)
+                trait = GLOBAL_TRAITS.get(trait_tok.value)
+                if not trait:
+                    raise_error(
+                        ErrorKind.UNDEFINED_NAME,
+                        f"Trait `{trait_tok.value}` is not defined",
+                        trait_tok.location,
+                    )
+                trait_bounds[token.value] = trait_tok.value
         elif token.value != ",":
             raise_error(
                 ErrorKind.UNEXPECTED_TOKEN,
@@ -730,22 +908,40 @@ def parse_function(cursor: Cursor[Token]) -> Function:
     expect_token(cursor, value="fn")
     name = expect_token(cursor, kind=TokenKind.IDENTIFIER)
 
-    # Parse optional type parameters: fn name[T1 T2] ...
+    # Parse optional type parameters: fn name[T1 T2] or fn name[K: Hashable, V]
     type_vars: set[str] = set()
+    trait_bounds: dict[str, str] = {}
     next_token = cursor.peek()
     if next_token and next_token.value == "[":
-        type_vars = parse_type_vars(cursor)
+        type_vars, trait_bounds = parse_type_vars(cursor)
 
     signature = parse_signature(cursor)
     signature.type_vars = type_vars
+    signature.trait_bounds = trait_bounds
 
     ops: list[Op] = []
     variables: list[Variable] = []
+
+    # Expand trait bounds into hidden parameters and variables.
+    # For each bound (K: Hashable), add hidden fn pointer params for each
+    # trait method. These are prepended to the signature so they sit on top
+    # of the stack before the user-visible params.
+    # Replace Self with the type variable name in signatures.
+    hidden_params: list[Parameter] = []
+    for tv, trait_name in trait_bounds.items():
+        trait = GLOBAL_TRAITS[trait_name]
+        for method in trait.methods:
+            hidden_name = f"__trait_{tv}_{method.name}"
+            resolved_sig = _resolve_trait_method_sig(method.signature, tv)
+            hidden_type = f"fn[{resolved_sig}]"
+            hidden_params.append(Parameter(hidden_type, hidden_name))
+            variables.append(Variable(hidden_name, hidden_type))
+            ops.append(Op(hidden_name, OpKind.ASSIGN_VARIABLE, name.location))
+
+    signature.parameters = hidden_params + signature.parameters
+
     for param in signature.parameters:
-        # Named parameters are popped from the stack into local variables via
-        # implicit `ASSIGN_VARIABLE` ops prepended to the function body.
-        # Unnamed parameters stay on the stack as passthrough values.
-        if param.name:
+        if param.name and not param.name.startswith("__trait_"):
             variables.append(Variable(param.name, param.typ))
             ops.append(Op(param.name, OpKind.ASSIGN_VARIABLE, name.location))
 

--- a/casa/parser.py
+++ b/casa/parser.py
@@ -269,9 +269,7 @@ def resolve_identifiers(
                         )
                         continue
                     # Check trait bound reference: &K::method
-                    trait_var = _resolve_trait_ref(
-                        function_name, function, op.location
-                    )
+                    trait_var = _resolve_trait_ref(function_name, function, op.location)
                     if trait_var:
                         op.kind = OpKind.PUSH_VARIABLE
                         op.value = trait_var
@@ -296,9 +294,7 @@ def resolve_identifiers(
                 if trait_var:
                     op.kind = OpKind.PUSH_VARIABLE
                     op.value = trait_var
-                    exec_op = Op(
-                        Intrinsic.EXEC, OpKind.FN_EXEC, op.location
-                    )
+                    exec_op = Op(Intrinsic.EXEC, OpKind.FN_EXEC, op.location)
                     ops.insert(index, exec_op)
                     index += 1
                     continue
@@ -425,6 +421,8 @@ def get_op_delimiter(
         case Delimiter.OPEN_PAREN:
             cursor.position -= 1
             return get_op_type_cast(cursor)
+        case Delimiter.CLOSE_PAREN:
+            return None
         case _:
             assert_never(delimiter)
 

--- a/casa/typechecker.py
+++ b/casa/typechecker.py
@@ -818,16 +818,16 @@ def type_check_ops(ops: list[Op], function: Function | None = None) -> Signature
                 _ensure_typechecked(global_function)
 
                 assert global_function.signature, "Signature is defined"
-                sig = global_function.signature
+                fn_sig = global_function.signature
 
                 # Auto-inject trait fn pointers if needed
-                if sig.trait_bounds:
+                if fn_sig.trait_bounds:
                     injected = _inject_trait_fn_ptrs(
-                        tc, sig, ops, op_index, op.location, function
+                        tc, fn_sig, ops, op_index, op.location, function
                     )
                     op_index += injected
 
-                tc.apply_signature(sig, function_name)
+                tc.apply_signature(fn_sig, function_name)
             case OpKind.FN_EXEC:
                 # Lambdas from other functions are typed as `any`
                 fn_symmetrical = "fn"
@@ -1023,7 +1023,9 @@ def type_check_ops(ops: list[Op], function: Function | None = None) -> Signature
                                 )
                                 # Push receiver back and apply sig
                                 tc.stack_push(receiver)
-                                tc.apply_signature(resolved_sig, f"{receiver}::{method_name}")
+                                tc.apply_signature(
+                                    resolved_sig, f"{receiver}::{method_name}"
+                                )
                                 # Rewrite op to push hidden fn ptr + exec
                                 op.kind = OpKind.PUSH_VARIABLE
                                 op.value = hidden_var
@@ -1065,16 +1067,16 @@ def type_check_ops(ops: list[Op], function: Function | None = None) -> Signature
                 _ensure_typechecked(global_function)
 
                 assert global_function.signature, "Signature is defined"
-                sig = global_function.signature
+                fn_sig = global_function.signature
 
                 # Auto-inject trait fn pointers for method calls too
-                if sig.trait_bounds:
+                if fn_sig.trait_bounds:
                     injected = _inject_trait_fn_ptrs(
-                        tc, sig, ops, op_index, op.location, function
+                        tc, fn_sig, ops, op_index, op.location, function
                     )
                     op_index += injected
 
-                tc.apply_signature(sig, function_name)
+                tc.apply_signature(fn_sig, function_name)
 
                 op.value = function_name
                 op.kind = OpKind.FN_CALL

--- a/casa/typechecker.py
+++ b/casa/typechecker.py
@@ -5,8 +5,10 @@ from typing import assert_never
 from casa.common import (
     ANY_TYPE,
     GLOBAL_FUNCTIONS,
+    GLOBAL_TRAITS,
     GLOBAL_VARIABLES,
     Function,
+    Intrinsic,
     Location,
     Op,
     OpKind,
@@ -18,6 +20,7 @@ from casa.common import (
     extract_fn_signature_str,
     extract_generic_base,
     extract_generic_inner,
+    extract_generic_params,
     is_fn_type,
 )
 from casa.error import (
@@ -130,10 +133,19 @@ class TypeChecker:
         exp_base = extract_generic_base(expected)
         act_base = extract_generic_base(typ)
         if exp_base is not None and exp_base == act_base:
-            exp_inner = extract_generic_inner(expected)
-            act_inner = extract_generic_inner(typ)
-            if exp_inner == ANY_TYPE or act_inner == ANY_TYPE:
-                return expected
+            exp_params = extract_generic_params(expected)
+            act_params = extract_generic_params(typ)
+            if exp_params and act_params and len(exp_params) == len(act_params):
+                if all(
+                    ep == ANY_TYPE or ap == ANY_TYPE or ep == ap
+                    for ep, ap in zip(exp_params, act_params)
+                ):
+                    return expected
+            else:
+                exp_inner = extract_generic_inner(expected)
+                act_inner = extract_generic_inner(typ)
+                if exp_inner == ANY_TYPE or act_inner == ANY_TYPE:
+                    return expected
         # Match fn[sig] types using Signature.matches (handles ANY_TYPE)
         exp_sig_str = extract_fn_signature_str(expected)
         act_sig_str = extract_fn_signature_str(typ)
@@ -211,30 +223,45 @@ class TypeChecker:
             if expected.typ in signature.type_vars:
                 self._bind_type_var(bindings, expected.typ, self.stack_pop())
                 continue
-            # Handle parameterized types containing type vars, e.g. array[T], option[T], Foo[T]
+            # Handle parameterized types containing type vars
             generic_base = extract_generic_base(expected.typ)
-            generic_inner = extract_generic_inner(expected.typ)
-            if generic_base and generic_inner and generic_inner in signature.type_vars:
-                actual = self.stack_pop()
-                actual_base = extract_generic_base(actual)
-                if actual_base == generic_base:
-                    actual_inner = extract_generic_inner(actual)
-                    self._bind_type_var(
-                        bindings, generic_inner, actual_inner or ANY_TYPE
-                    )
-                elif actual == generic_base:
-                    self._bind_type_var(bindings, generic_inner, ANY_TYPE)
-                elif actual == ANY_TYPE:
-                    self._bind_type_var(bindings, generic_inner, ANY_TYPE)
-                else:
-                    raise_error(
-                        ErrorKind.TYPE_MISMATCH,
-                        "Type mismatch",
-                        self.current_location,
-                        expected=f"`{expected.typ}`",
-                        got=f"`{actual}`",
-                    )
-                continue
+            if generic_base:
+                exp_params = extract_generic_params(expected.typ)
+                has_tv = exp_params and any(
+                    p in signature.type_vars for p in exp_params
+                )
+                if has_tv:
+                    actual = self.stack_pop()
+                    actual_base = extract_generic_base(actual)
+                    if actual_base == generic_base:
+                        act_params = extract_generic_params(actual)
+                        if act_params and exp_params and len(act_params) == len(exp_params):
+                            for ep, ap in zip(exp_params, act_params):
+                                if ep in signature.type_vars:
+                                    self._bind_type_var(bindings, ep, ap)
+                        elif exp_params:
+                            for ep in exp_params:
+                                if ep in signature.type_vars:
+                                    self._bind_type_var(bindings, ep, ANY_TYPE)
+                    elif actual == generic_base:
+                        if exp_params:
+                            for ep in exp_params:
+                                if ep in signature.type_vars:
+                                    self._bind_type_var(bindings, ep, ANY_TYPE)
+                    elif actual == ANY_TYPE:
+                        if exp_params:
+                            for ep in exp_params:
+                                if ep in signature.type_vars:
+                                    self._bind_type_var(bindings, ep, ANY_TYPE)
+                    else:
+                        raise_error(
+                            ErrorKind.TYPE_MISMATCH,
+                            "Type mismatch",
+                            self.current_location,
+                            expected=f"`{expected.typ}`",
+                            got=f"`{actual}`",
+                        )
+                    continue
             # Handle fn[sig] types containing type vars, e.g. fn[T -> T]
             fn_sig_str = extract_fn_signature_str(expected.typ)
             if fn_sig_str and any(tv in fn_sig_str for tv in signature.type_vars):
@@ -272,12 +299,18 @@ class TypeChecker:
             if return_type in bindings:
                 self.stack_push(bindings[return_type])
                 continue
-            # Handle parameterized return types like array[T], option[T], Foo[T]
+            # Handle parameterized return types with multi-param support
             generic_base = extract_generic_base(return_type)
-            generic_inner = extract_generic_inner(return_type)
-            if generic_base and generic_inner and generic_inner in bindings:
-                self.stack_push(f"{generic_base}[{bindings[generic_inner]}]")
-                continue
+            if generic_base:
+                ret_params = extract_generic_params(return_type)
+                if ret_params and any(p in bindings for p in ret_params):
+                    resolved_params = [
+                        bindings.get(p, p) for p in ret_params
+                    ]
+                    self.stack_push(
+                        f"{generic_base}[{' '.join(resolved_params)}]"
+                    )
+                    continue
             # Handle fn[sig] return types with bound type vars
             fn_sig_str = extract_fn_signature_str(return_type)
             if fn_sig_str and any(tv in fn_sig_str for tv in bindings):
@@ -428,14 +461,21 @@ def _unify_type(a: Type, b: Type) -> Type | None:
     base_a = extract_generic_base(a)
     base_b = extract_generic_base(b)
     if base_a is not None and base_a == base_b:
-        inner_a = extract_generic_inner(a)
-        inner_b = extract_generic_inner(b)
-        if inner_a is None:
+        params_a = extract_generic_params(a)
+        params_b = extract_generic_params(b)
+        if params_a is None:
             return b
-        if inner_b is None:
+        if params_b is None:
             return a
-        unified = _unify_type(inner_a, inner_b)
-        return f"{base_a}[{unified}]" if unified is not None else None
+        if len(params_a) != len(params_b):
+            return None
+        unified_params = []
+        for pa, pb in zip(params_a, params_b):
+            u = _unify_type(pa, pb)
+            if u is None:
+                return None
+            unified_params.append(u)
+        return f"{base_a}[{' '.join(unified_params)}]"
     if base_a is not None and base_a == b:
         return a
     if base_b is not None and base_b == a:
@@ -480,11 +520,176 @@ def _ensure_typechecked(global_function: Function) -> None:
         global_function.signature = signature
 
 
+def _resolve_trait_sig(sig: Signature, type_var: str) -> Signature:
+    """Create a copy of a trait method signature with Self replaced by type_var."""
+    params = []
+    for p in sig.parameters:
+        resolved_typ = p.typ.replace("Self", type_var)
+        params.append(Parameter(resolved_typ, p.name))
+    ret = [r.replace("Self", type_var) for r in sig.return_types]
+    return Signature(params, ret)
+
+
+def _inject_trait_fn_ptrs(
+    tc: "TypeChecker",
+    sig: Signature,
+    ops: list[Op],
+    op_index: int,
+    location: Location,
+    function: Function | None,
+) -> int:
+    """Auto-inject FN_PUSH ops for trait-bounded function calls.
+
+    Determines concrete types for type variables, checks structural trait
+    satisfaction, and inserts FN_PUSH ops before the call. Returns the
+    number of ops inserted.
+    """
+    bindings: dict[str, str] = {}
+
+    # Non-hidden parameters (user-visible)
+    non_hidden = [
+        p for p in sig.parameters if not p.name or not p.name.startswith("__trait_")
+    ]
+
+    # Bind type vars from the stack (peek at stack positions)
+    stack_depth = len(tc.stack)
+    for i, p in enumerate(non_hidden):
+        stack_idx = stack_depth - 1 - i
+        if stack_idx < 0:
+            break
+        actual = tc.stack[stack_idx]
+        if p.typ in sig.type_vars:
+            if p.typ not in bindings:
+                bindings[p.typ] = actual
+        else:
+            exp_base = extract_generic_base(p.typ)
+            if exp_base:
+                act_base = extract_generic_base(actual)
+                if act_base == exp_base:
+                    exp_params = extract_generic_params(p.typ)
+                    act_params = extract_generic_params(actual)
+                    if exp_params and act_params:
+                        for ep, ap in zip(exp_params, act_params):
+                            if ep in sig.type_vars and ep not in bindings:
+                                bindings[ep] = ap
+
+    # Also check TYPE_CAST look-ahead for return type binding
+    if op_index < len(ops) and ops[op_index].kind == OpKind.TYPE_CAST:
+        cast_type = ops[op_index].value
+        assert isinstance(cast_type, str)
+        for ret in sig.return_types:
+            ret_base = extract_generic_base(ret)
+            cast_base = extract_generic_base(cast_type)
+            if ret_base and cast_base and ret_base == cast_base:
+                ret_params = extract_generic_params(ret)
+                cast_params = extract_generic_params(cast_type)
+                if ret_params and cast_params:
+                    for rp, cp in zip(ret_params, cast_params):
+                        if rp in sig.type_vars and rp not in bindings:
+                            bindings[rp] = cp
+
+    # Inject FN_PUSH ops for each trait bound's methods.
+    # Methods are pushed in reverse order so the first method ends up on top
+    # (first declared param = top of stack).
+    inserted = 0
+    insert_pos = op_index - 1  # Insert before the FN_CALL
+    for tv, trait_name in sig.trait_bounds.items():
+        concrete_type = bindings.get(tv)
+        if not concrete_type:
+            raise_error(
+                ErrorKind.TYPE_MISMATCH,
+                f"Cannot determine concrete type for type variable `{tv}`",
+                location,
+            )
+        trait = GLOBAL_TRAITS[trait_name]
+        # For type variables, forward the hidden fn ptrs
+        is_forwarding = (
+            function
+            and function.signature
+            and function.signature.trait_bounds.get(concrete_type) == trait_name
+        )
+        if is_forwarding:
+            for method in reversed(trait.methods):
+                hidden_var = f"__trait_{concrete_type}_{method.name}"
+                push_op = Op(hidden_var, OpKind.PUSH_VARIABLE, location)
+                ops.insert(insert_pos, push_op)
+                insert_pos += 1
+                inserted += 1
+                fn_sig = _resolve_trait_sig(method.signature, concrete_type)
+                tc.stack_push(f"fn[{fn_sig}]")
+            continue
+        # Verify structural satisfaction
+        if not type_satisfies_trait(concrete_type, trait_name, function):
+            raise_error(
+                ErrorKind.MISSING_TRAIT_METHOD,
+                f"Type `{concrete_type}` does not satisfy trait `{trait_name}`",
+                location,
+            )
+        for method in reversed(trait.methods):
+            fn_name = f"{concrete_type}::{method.name}"
+            global_fn = GLOBAL_FUNCTIONS.get(fn_name)
+            assert global_fn, f"Function `{fn_name}` should exist"
+            if not global_fn.is_used:
+                from casa.parser import resolve_identifiers as _resolve
+
+                global_fn.is_used = True
+                global_fn.ops = _resolve(global_fn.ops, global_fn)
+            _ensure_typechecked(global_fn)
+            push_op = Op(fn_name, OpKind.FN_PUSH, location)
+            ops.insert(insert_pos, push_op)
+            insert_pos += 1
+            inserted += 1
+            assert global_fn.signature
+            tc.stack_push(f"fn[{global_fn.signature}]")
+    return inserted
+
+
+def type_satisfies_trait(
+    type_name: str,
+    trait_name: str,
+    function: Function | None = None,
+) -> bool:
+    """Check if a type structurally satisfies a trait.
+
+    A type satisfies a trait when its impl block contains all required methods
+    with matching signatures (Self replaced by the concrete type).
+    For type variables, checks if the type var has a matching trait bound.
+    """
+    trait = GLOBAL_TRAITS.get(trait_name)
+    if not trait:
+        return False
+    # Type variable with matching bound satisfies the trait
+    if function and function.signature and function.signature.trait_bounds:
+        bound = function.signature.trait_bounds.get(type_name)
+        if bound == trait_name:
+            return True
+    for method in trait.methods:
+        fn_name = f"{type_name}::{method.name}"
+        fn = GLOBAL_FUNCTIONS.get(fn_name)
+        if not fn:
+            return False
+        if not fn.signature:
+            return False
+        # Check signature matches with Self replaced by type_name
+        for tp, mp in zip(fn.signature.parameters, method.signature.parameters):
+            expected = mp.typ.replace("Self", type_name)
+            if tp.typ != expected and tp.typ != ANY_TYPE and expected != ANY_TYPE:
+                return False
+        for tr, mr in zip(fn.signature.return_types, method.signature.return_types):
+            expected = mr.replace("Self", type_name)
+            if tr != expected and tr != ANY_TYPE and expected != ANY_TYPE:
+                return False
+    return True
+
+
 def type_check_ops(ops: list[Op], function: Function | None = None) -> Signature:
     assert len(OpKind) == 79, "Exhaustive handling for `OpKind`"
 
     tc = TypeChecker(ops=ops)
-    for op in ops:
+    op_index = 0
+    while op_index < len(ops):
+        op = ops[op_index]
+        op_index += 1
         tc.current_location = op.location
         tc.current_expect_context = None
         effect = OP_STACK_EFFECTS.get(op.kind)
@@ -587,14 +792,22 @@ def type_check_ops(ops: list[Op], function: Function | None = None) -> Signature
                 function_name = op.value
                 assert isinstance(function_name, str), "Expected function name"
 
-                function_name = function_name
                 global_function = GLOBAL_FUNCTIONS.get(function_name)
                 assert global_function, "Expected function"
 
                 _ensure_typechecked(global_function)
 
                 assert global_function.signature, "Signature is defined"
-                tc.apply_signature(global_function.signature, function_name)
+                sig = global_function.signature
+
+                # Auto-inject trait fn pointers if needed
+                if sig.trait_bounds:
+                    injected = _inject_trait_fn_ptrs(
+                        tc, sig, ops, op_index, op.location, function
+                    )
+                    op_index += injected
+
+                tc.apply_signature(sig, function_name)
             case OpKind.FN_EXEC:
                 # Lambdas from other functions are typed as `any`
                 fn_symmetrical = "fn"
@@ -768,6 +981,48 @@ def type_check_ops(ops: list[Op], function: Function | None = None) -> Signature
                 assert isinstance(method_name, str), "Expected method name"
 
                 receiver = tc.stack_peek()
+
+                # Trait method call on a type variable
+                if (
+                    function
+                    and function.signature
+                    and function.signature.trait_bounds
+                    and receiver in function.signature.trait_bounds
+                ):
+                    trait_name = function.signature.trait_bounds[receiver]
+                    trait = GLOBAL_TRAITS.get(trait_name)
+                    if trait:
+                        for tm in trait.methods:
+                            if tm.name == method_name:
+                                hidden_var = f"__trait_{receiver}_{method_name}"
+                                # Pop the receiver
+                                tc.stack_pop()
+                                # Build signature with Self replaced
+                                resolved_sig = _resolve_trait_sig(
+                                    tm.signature, receiver
+                                )
+                                # Push receiver back and apply sig
+                                tc.stack_push(receiver)
+                                tc.apply_signature(resolved_sig, f"{receiver}::{method_name}")
+                                # Rewrite op to push hidden fn ptr + exec
+                                op.kind = OpKind.PUSH_VARIABLE
+                                op.value = hidden_var
+                                exec_op = Op(
+                                    Intrinsic.EXEC,
+                                    OpKind.FN_EXEC,
+                                    op.location,
+                                )
+                                ops.insert(op_index, exec_op)
+                                op_index += 1
+                                break
+                        else:
+                            raise_error(
+                                ErrorKind.UNDEFINED_NAME,
+                                f"Method `{method_name}` not found in trait `{trait_name}`",
+                                op.location,
+                            )
+                        continue
+
                 function_name = f"{receiver}::{method_name}"
 
                 global_function = GLOBAL_FUNCTIONS.get(function_name)
@@ -790,7 +1045,16 @@ def type_check_ops(ops: list[Op], function: Function | None = None) -> Signature
                 _ensure_typechecked(global_function)
 
                 assert global_function.signature, "Signature is defined"
-                tc.apply_signature(global_function.signature, function_name)
+                sig = global_function.signature
+
+                # Auto-inject trait fn pointers for method calls too
+                if sig.trait_bounds:
+                    injected = _inject_trait_fn_ptrs(
+                        tc, sig, ops, op_index, op.location, function
+                    )
+                    op_index += injected
+
+                tc.apply_signature(sig, function_name)
 
                 op.value = function_name
                 op.kind = OpKind.FN_CALL
@@ -1072,9 +1336,11 @@ def type_check_ops(ops: list[Op], function: Function | None = None) -> Signature
         for p in function.signature.parameters:
             if p.typ in function.signature.type_vars:
                 param_tvs.add(p.typ)
-            generic_inner = extract_generic_inner(p.typ)
-            if generic_inner and generic_inner in function.signature.type_vars:
-                param_tvs.add(generic_inner)
+            gen_params = extract_generic_params(p.typ)
+            if gen_params:
+                for gp in gen_params:
+                    if gp in function.signature.type_vars:
+                        param_tvs.add(gp)
             fn_sig_str = extract_fn_signature_str(p.typ)
             if fn_sig_str:
                 for tv in function.signature.type_vars:

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -216,6 +216,27 @@ The compiler collects as many errors as possible within each compilation phase b
 
 Within a single function, type checking stops at the first error because the stack state becomes unreliable. However, when checking all functions, errors from different functions are collected and reported together.
 
+### `MISSING_TRAIT_METHOD`
+
+A type is used where a trait bound is required, but it does not implement all required methods.
+
+```casa
+struct Foo { x: int }
+Map::new (Map[Foo int]) = m    # Foo has no hash or eq methods
+```
+
+```
+error[MISSING_TRAIT_METHOD]: Type `Foo` does not satisfy trait `Hashable`
+```
+
+### `TRAIT_SIGNATURE_MISMATCH`
+
+A type has a method with the right name for a trait, but its signature does not match the trait's requirement.
+
+```
+error[TRAIT_SIGNATURE_MISMATCH]: Method signature does not match trait requirement
+```
+
 ## Warnings
 
 The compiler also reports non-fatal warnings. Currently the only warning kind is:

--- a/docs/functions-and-lambdas.md
+++ b/docs/functions-and-lambdas.md
@@ -161,6 +161,19 @@ impl Box {
 }
 ```
 
+### Trait Bounds
+
+Type variables can have trait bounds that restrict which types are accepted. Use `K: TraitName` syntax:
+
+```casa
+fn get[K: Hashable, V] self:Map[K V] key:K -> option[V] {
+    key K::hash self.capacity % = idx
+    ...
+}
+```
+
+Multiple type variables are separated by commas. Variables without a `:` have no bounds. See [Traits](traits.md) for details on defining and satisfying traits.
+
 Every type variable must appear in at least one parameter (return-only type variables are not allowed).
 
 Type variable names must not collide with built-in types (`int`, `bool`, `char`, `cstr`, `str`, `ptr`, `array`, `any`) or user-defined struct names:

--- a/docs/structs-and-methods.md
+++ b/docs/structs-and-methods.md
@@ -176,3 +176,28 @@ person.age print        # 19
 ```
 
 See [`examples/struct.casa`](../examples/struct.casa).
+
+## Traits
+
+Types can satisfy traits by implementing the required methods in their `impl` blocks. Trait satisfaction is structural: no special declaration is needed. See [Traits](traits.md) for details.
+
+```casa
+trait Hashable {
+    fn hash self:Self -> int
+    fn eq self:Self other:Self -> bool
+}
+
+struct Point {
+    x: int
+    y: int
+}
+
+impl Point {
+    fn hash self:Point -> int { self.x 31 * self.y + }
+    fn eq self:Point other:Point -> bool {
+        self.x other.x == self.y other.y == &&
+    }
+}
+
+# Point now satisfies Hashable and can be used as a Map key
+```

--- a/docs/structs-and-methods.md
+++ b/docs/structs-and-methods.md
@@ -183,8 +183,8 @@ Types can satisfy traits by implementing the required methods in their `impl` bl
 
 ```casa
 trait Hashable {
-    fn hash self:Self -> int
-    fn eq self:Self other:Self -> bool
+    fn hash self:self -> int
+    fn eq self:self other:self -> bool
 }
 
 struct Point {

--- a/docs/traits.md
+++ b/docs/traits.md
@@ -1,0 +1,160 @@
+# Traits
+
+Traits define a set of required methods that a type must implement. They enable bounded polymorphism: functions can require that a type variable satisfies a trait, and the compiler verifies this at each call site.
+
+## Defining a Trait
+
+Use the `trait` keyword to declare a trait with one or more method signatures. Method bodies are not allowed in trait definitions. Use `Self` as a placeholder for the implementing type.
+
+```casa
+trait Hashable {
+    fn hash self:Self -> int
+    fn eq self:Self other:Self -> bool
+}
+```
+
+This declares that any type satisfying `Hashable` must have a `hash` method (taking self, returning `int`) and an `eq` method (taking self and another value of the same type, returning `bool`).
+
+## Implementing a Trait
+
+Traits use structural satisfaction. A type satisfies a trait when its `impl` block contains all required methods with matching signatures. There is no `impl Trait for Type` syntax.
+
+```casa
+impl str {
+    fn hash self:str -> int { self str_hash }
+    # str::eq is already defined in the standard library
+}
+
+impl int {
+    fn hash self:int -> int { self int_hash }
+    fn eq self:int other:int -> bool { self other == }
+}
+```
+
+The compiler checks that `str::hash` and `str::eq` exist with signatures matching what `Hashable` requires (with `Self` replaced by `str`). If any method is missing or has a wrong signature, a compile-time error is reported.
+
+## Custom Types
+
+User-defined structs can satisfy traits by implementing the required methods:
+
+```casa
+struct Point {
+    x: int
+    y: int
+}
+
+impl Point {
+    fn hash self:Point -> int {
+        self.x 31 * self.y +
+    }
+    fn eq self:Point other:Point -> bool {
+        self.x other.x == self.y other.y == &&
+    }
+}
+```
+
+`Point` now satisfies `Hashable` and can be used as a `Map` key or `Set` element.
+
+## Trait Bounds
+
+Functions declare trait bounds on type variables using the `K: TraitName` syntax inside square brackets. Multiple type variables are separated by commas.
+
+```casa
+fn get[K: Hashable, V] self:Map[K V] key:K -> option[V] {
+    key K::hash self.capacity % = idx
+    ...
+}
+```
+
+Here `K` must satisfy `Hashable`. The compiler verifies this at every call site by checking that the concrete type bound to `K` has the required methods.
+
+Type variables without bounds have no restrictions:
+
+```casa
+fn keys[K V] self:Map[K V] -> List[K] { ... }
+```
+
+Here `K` and `V` can be any type.
+
+## Calling Trait Methods
+
+Inside a trait-bounded function, there are two ways to call a trait method.
+
+### Namespace syntax
+
+Use `K::method` to call a trait method on a value:
+
+```casa
+fn example[K: Hashable] key:K -> int {
+    key K::hash
+}
+```
+
+### Dot syntax
+
+Dot syntax also works when the receiver is a trait-bounded type variable:
+
+```casa
+fn example[K: Hashable] key:K -> int {
+    key.hash
+}
+```
+
+Both forms are equivalent. The compiler resolves them to the correct method for the concrete type at each call site.
+
+## Trait Method References
+
+Use `&K::method` to push a trait method as a function pointer without calling it:
+
+```casa
+fn get_hasher[K: Hashable] -> fn[K -> int] {
+    &K::hash
+}
+```
+
+This pushes the function pointer for the concrete type's method.
+
+## Auto-Injection at Call Sites
+
+When calling a function with trait bounds, the compiler automatically injects the correct function pointers. You do not need to pass them manually.
+
+```casa
+Map::new (Map[str int]) = m
+```
+
+The compiler sees that `Map::new` requires `[K: Hashable, V]`, determines `K=str` from the type cast `(Map[str int])`, verifies that `str` satisfies `Hashable`, and injects `&str::hash` and `&str::eq` behind the scenes.
+
+## Built-in Trait: `Hashable`
+
+The standard library defines the `Hashable` trait and provides implementations for `str` and `int`:
+
+```casa
+trait Hashable {
+    fn hash self:Self -> int
+    fn eq self:Self other:Self -> bool
+}
+```
+
+Built-in implementations:
+- `str::hash` uses the djb2 hash algorithm (via `str_hash`)
+- `str::eq` compares strings by content
+- `int::hash` returns the absolute value (via `int_hash`)
+- `int::eq` compares integers with `==`
+
+## Errors
+
+### `MISSING_TRAIT_METHOD`
+
+Reported when a type is used with a trait bound but does not implement all required methods.
+
+```
+error[MISSING_TRAIT_METHOD]: Type `Foo` does not satisfy trait `Hashable`
+```
+
+### `TRAIT_SIGNATURE_MISMATCH`
+
+Reported when a type has a method with the right name but the wrong signature.
+
+```
+error[TRAIT_SIGNATURE_MISMATCH]: Method signature does not match trait requirement
+```

--- a/docs/traits.md
+++ b/docs/traits.md
@@ -4,12 +4,12 @@ Traits define a set of required methods that a type must implement. They enable 
 
 ## Defining a Trait
 
-Use the `trait` keyword to declare a trait with one or more method signatures. Method bodies are not allowed in trait definitions. Use `Self` as a placeholder for the implementing type.
+Use the `trait` keyword to declare a trait with one or more method signatures. Method bodies are not allowed in trait definitions. Use `self` as a placeholder for the implementing type.
 
 ```casa
 trait Hashable {
-    fn hash self:Self -> int
-    fn eq self:Self other:Self -> bool
+    fn hash self:self -> int
+    fn eq self:self other:self -> bool
 }
 ```
 
@@ -31,7 +31,7 @@ impl int {
 }
 ```
 
-The compiler checks that `str::hash` and `str::eq` exist with signatures matching what `Hashable` requires (with `Self` replaced by `str`). If any method is missing or has a wrong signature, a compile-time error is reported.
+The compiler checks that `str::hash` and `str::eq` exist with signatures matching what `Hashable` requires (with `self` replaced by `str`). If any method is missing or has a wrong signature, a compile-time error is reported.
 
 ## Custom Types
 
@@ -130,8 +130,8 @@ The standard library defines the `Hashable` trait and provides implementations f
 
 ```casa
 trait Hashable {
-    fn hash self:Self -> int
-    fn eq self:Self other:Self -> bool
+    fn hash self:self -> int
+    fn eq self:self other:self -> bool
 }
 ```
 

--- a/docs/types-and-literals.md
+++ b/docs/types-and-literals.md
@@ -316,7 +316,15 @@ fn id[T] T -> T { }
 "hi" id      # T=str, returns str
 ```
 
-Type variables are purely compile-time — they have no runtime cost. See [Functions and Lambdas — Generic Functions](functions-and-lambdas.md#generic-functions) for details.
+Type variables can have trait bounds to constrain which types are accepted:
+
+```casa
+fn hash_key[K: Hashable] key:K -> int {
+    key K::hash
+}
+```
+
+Type variables are purely compile-time, including trait bounds. See [Functions and Lambdas — Generic Functions](functions-and-lambdas.md#generic-functions) and [Traits](traits.md) for details.
 
 ## The `any` Type
 

--- a/examples/hash_map.casa
+++ b/examples/hash_map.casa
@@ -1,0 +1,69 @@
+include "../lib/std.casa"
+
+# Create a Map[str int]
+Map::new (Map[str int]) = m
+
+# Set some key-value pairs
+# fn set[K: Hashable, V] self:Map[K V] value:V key:K -> Map[K V]
+# Stack order (bottom to top): key, value, self
+"one" 1 m.set = m
+"two" 2 m.set = m
+"three" 3 m.set = m
+
+# Get values
+"one" m.get .unwrap print
+"\n" print
+"two" m.get .unwrap print
+"\n" print
+"three" m.get .unwrap print
+"\n" print
+
+# Check length
+m.length print
+"\n" print
+
+# Check has
+"one" m.has print
+"\n" print
+"four" m.has print
+"\n" print
+
+# Update existing key
+"one" 42 m.set = m
+"one" m.get .unwrap print
+"\n" print
+
+# Delete a key
+"two" m.delete = m
+m.length print
+"\n" print
+"two" m.has print
+"\n" print
+
+# Create a Map[int str]
+Map::new (Map[int str]) = m2
+1 "hello" m2.set = m2
+2 "world" m2.set = m2
+1 m2.get .unwrap print
+"\n" print
+2 m2.get .unwrap print
+"\n" print
+
+# Create a Set[str]
+Set::new (Set[str]) = s
+"apple" s.add = s
+"banana" s.add = s
+"cherry" s.add = s
+s.length print
+"\n" print
+"apple" s.has print
+"\n" print
+"grape" s.has print
+"\n" print
+
+# Remove from set
+"banana" s.remove = s
+s.length print
+"\n" print
+"banana" s.has print
+"\n" print

--- a/examples/outputs/hash_map.out
+++ b/examples/outputs/hash_map.out
@@ -1,0 +1,16 @@
+1
+2
+3
+3
+true
+false
+42
+2
+false
+hello
+world
+3
+true
+false
+2
+false

--- a/lib/std.casa
+++ b/lib/std.casa
@@ -424,8 +424,8 @@ impl option {
 # Traits
 # ---------------------------------------------------------------------------
 trait Hashable {
-    fn hash self:Self -> int
-    fn eq self:Self other:Self -> bool
+    fn hash self:self -> int
+    fn eq self:self other:self -> bool
 }
 
 # ---------------------------------------------------------------------------
@@ -533,19 +533,20 @@ impl Map {
         self.buckets md_idx 8 * + load64 = md_entry
         while 0 md_entry != do
             md_entry (ptr) load64 (K) = md_nk
-            if key md_nk K::eq then
-                md_entry (ptr) 16 + load64 = md_next
-                if 0 md_prev == then
-                    md_next self.buckets md_idx 8 * + store64
-                else
-                    md_next md_prev (ptr) 16 + store64
-                fi
-                self.size 1 - self->size
-                self (Map[K V])
-                return
+            if key md_nk K::eq ! then
+                md_entry = md_prev
+                md_entry (ptr) 16 + load64 = md_entry
+                continue
             fi
-            md_entry = md_prev
-            md_entry (ptr) 16 + load64 = md_entry
+            md_entry (ptr) 16 + load64 = md_next
+            if 0 md_prev == then
+                md_next self.buckets md_idx 8 * + store64
+            else
+                md_next md_prev (ptr) 16 + store64
+            fi
+            self.size 1 - self->size
+            self (Map[K V])
+            return
         done
         self (Map[K V])
     }

--- a/lib/std.casa
+++ b/lib/std.casa
@@ -419,3 +419,221 @@ impl option {
         fi
     }
 }
+
+# ---------------------------------------------------------------------------
+# Traits
+# ---------------------------------------------------------------------------
+trait Hashable {
+    fn hash self:Self -> int
+    fn eq self:Self other:Self -> bool
+}
+
+# ---------------------------------------------------------------------------
+# Hash helpers
+# ---------------------------------------------------------------------------
+fn str_hash s:str -> int {
+    5381 = sh_h
+    0 = sh_i
+    while sh_i s .length > do
+        sh_h 5 << sh_h + sh_i s .at (int) + = sh_h
+        1 += sh_i
+    done
+    if 0 sh_h < then 0 sh_h - = sh_h fi
+    sh_h
+}
+
+fn int_hash n:int -> int {
+    if 0 n < then 0 n - else n fi
+}
+
+impl str {
+    fn hash self:str -> int { self str_hash }
+}
+
+impl int {
+    fn hash self:int -> int { self int_hash }
+    fn eq self:int other:int -> bool { self other == }
+}
+
+# ---------------------------------------------------------------------------
+# Map[K V] - Hash map with separate chaining
+# ---------------------------------------------------------------------------
+# Entry layout: 24 bytes per entry (key:8, value:8, next:8)
+# Bucket array: capacity * 8 bytes (each slot is a ptr to entry or 0)
+16 = MAP_INITIAL_CAP
+
+struct Map {
+    buckets:  ptr
+    size:     int
+    capacity: int
+}
+
+impl Map {
+    fn new[K: Hashable, V] -> Map[K V] {
+        MAP_INITIAL_CAP 8 * alloc = mb
+        0 = mb_i
+        while mb_i MAP_INITIAL_CAP > do
+            0 mb mb_i 8 * + store64
+            1 += mb_i
+        done
+        MAP_INITIAL_CAP 0 mb Map (Map[K V])
+    }
+
+    fn length self:Map -> int {
+        self.size
+    }
+
+    fn get[K: Hashable, V] self:Map[K V] key:K -> option[V] {
+        key K::hash self.capacity % = mg_idx
+        self.buckets mg_idx 8 * + load64 = mg_entry
+        while 0 mg_entry != do
+            mg_entry (ptr) load64 (K) = mg_nk
+            if key mg_nk K::eq then
+                mg_entry (ptr) 8 + load64 (V) some
+                return
+            fi
+            mg_entry (ptr) 16 + load64 = mg_entry
+        done
+        none (option[V])
+    }
+
+    fn has[K: Hashable, V] self:Map[K V] key:K -> bool {
+        key self.get .is_some
+    }
+
+    fn set[K: Hashable, V] self:Map[K V] value:V key:K -> Map[K V] {
+        key K::hash self.capacity % = ms_idx
+        self.buckets ms_idx 8 * + load64 = ms_entry
+        while 0 ms_entry != do
+            ms_entry (ptr) load64 (K) = ms_nk
+            if key ms_nk K::eq then
+                value ms_entry (ptr) 8 + store64
+                self (Map[K V])
+                return
+            fi
+            ms_entry (ptr) 16 + load64 = ms_entry
+        done
+        # New entry
+        24 alloc = ms_new
+        key ms_new (ptr) store64
+        value ms_new (ptr) 8 + store64
+        self.buckets ms_idx 8 * + load64 ms_new (ptr) 16 + store64
+        ms_new self.buckets ms_idx 8 * + store64
+        self.size 1 + self->size
+        # Resize at 75% load
+        if self.capacity 3 * 4 / self.size >= then
+            self Map::resize
+        fi
+        self (Map[K V])
+    }
+
+    fn delete[K: Hashable, V] self:Map[K V] key:K -> Map[K V] {
+        key K::hash self.capacity % = md_idx
+        0 = md_prev
+        self.buckets md_idx 8 * + load64 = md_entry
+        while 0 md_entry != do
+            md_entry (ptr) load64 (K) = md_nk
+            if key md_nk K::eq then
+                md_entry (ptr) 16 + load64 = md_next
+                if 0 md_prev == then
+                    md_next self.buckets md_idx 8 * + store64
+                else
+                    md_next md_prev (ptr) 16 + store64
+                fi
+                self.size 1 - self->size
+                self (Map[K V])
+                return
+            fi
+            md_entry = md_prev
+            md_entry (ptr) 16 + load64 = md_entry
+        done
+        self (Map[K V])
+    }
+
+    fn resize[K: Hashable, V] self:Map[K V] {
+        self.capacity 2 * = mr_new_cap
+        mr_new_cap 8 * alloc = mr_new_bk
+        0 = mr_i
+        while mr_i mr_new_cap > do
+            0 mr_new_bk mr_i 8 * + store64
+            1 += mr_i
+        done
+        0 = mr_i
+        while mr_i self.capacity > do
+            self.buckets mr_i 8 * + load64 = mr_entry
+            while 0 mr_entry != do
+                mr_entry (ptr) 16 + load64 = mr_next
+                mr_entry (ptr) load64 (K) K::hash mr_new_cap % = mr_idx
+                mr_new_bk mr_idx 8 * + load64 mr_entry (ptr) 16 + store64
+                mr_entry mr_new_bk mr_idx 8 * + store64
+                mr_next = mr_entry
+            done
+            1 += mr_i
+        done
+        mr_new_bk self->buckets
+        mr_new_cap self->capacity
+    }
+
+    fn keys[K V] self:Map[K V] -> List[K] {
+        List::new (List[K]) = mk_list
+        0 = mk_i
+        while mk_i self.capacity > do
+            self.buckets mk_i 8 * + load64 = mk_entry
+            while 0 mk_entry != do
+                mk_entry (ptr) load64 (K) mk_list.push
+                mk_entry (ptr) 16 + load64 = mk_entry
+            done
+            1 += mk_i
+        done
+        mk_list
+    }
+
+    fn values[K V] self:Map[K V] -> List[V] {
+        List::new (List[V]) = mv_list
+        0 = mv_i
+        while mv_i self.capacity > do
+            self.buckets mv_i 8 * + load64 = mv_entry
+            while 0 mv_entry != do
+                mv_entry (ptr) 8 + load64 (V) mv_list.push
+                mv_entry (ptr) 16 + load64 = mv_entry
+            done
+            1 += mv_i
+        done
+        mv_list
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Set[K] - Hash set backed by Map
+# ---------------------------------------------------------------------------
+struct Set {
+    map: Map
+}
+
+impl Set {
+    fn new[K: Hashable] -> Set[K] {
+        Map::new (Map[K int]) Set (Set[K])
+    }
+
+    fn length self:Set -> int {
+        self.map.length
+    }
+
+    fn has[K: Hashable] self:Set[K] key:K -> bool {
+        key self.map (Map[K int]) .has
+    }
+
+    fn add[K: Hashable] self:Set[K] key:K -> Set[K] {
+        key 0 self.map (Map[K int]) .set (Map) self->map
+        self (Set[K])
+    }
+
+    fn remove[K: Hashable] self:Set[K] key:K -> Set[K] {
+        key self.map (Map[K int]) .delete (Map) self->map
+        self (Set[K])
+    }
+
+    fn to_list[K] self:Set[K] -> List[K] {
+        self.map (Map[K int]) .keys
+    }
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ import pytest
 from casa.common import (
     GLOBAL_FUNCTIONS,
     GLOBAL_STRUCTS,
+    GLOBAL_TRAITS,
     GLOBAL_VARIABLES,
     INCLUDED_FILES,
     Cursor,
@@ -32,6 +33,7 @@ def _clear_globals():
     """Reset all module-level mutable state to a clean slate."""
     GLOBAL_FUNCTIONS.clear()
     GLOBAL_STRUCTS.clear()
+    GLOBAL_TRAITS.clear()
     GLOBAL_VARIABLES.clear()
     INCLUDED_FILES.clear()
     SOURCE_CACHE.clear()

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -24,6 +24,7 @@ ALL_KEYWORDS = [
     "else",
     "fi",
     "struct",
+    "trait",
     "include",
 ]
 assert len(ALL_KEYWORDS) == len(Keyword)

--- a/tests/test_traits.py
+++ b/tests/test_traits.py
@@ -1,0 +1,701 @@
+"""Tests for the trait system: parsing, type checking, and auto-injection."""
+
+import os
+import subprocess
+
+import pytest
+
+from casa.common import (
+    GLOBAL_FUNCTIONS,
+    GLOBAL_TRAITS,
+    Function,
+    OpKind,
+    Parameter,
+    Signature,
+    Trait,
+    TraitMethod,
+    extract_generic_params,
+    split_type_tokens,
+)
+from casa.error import CasaErrorCollection, ErrorKind
+from tests.conftest import parse_string, resolve_string, typecheck_string
+
+CASA_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+STD_LIB_PATH = os.path.join(CASA_ROOT, "lib", "std.casa")
+STD_INCLUDE = f'include "{STD_LIB_PATH}"\n'
+
+# Inline Hashable trait definition for tests that go through typecheck_string
+# (include is only processed during resolve_identifiers, not during parse_ops,
+# so trait bounds on functions would fail if the trait comes from an include)
+HASHABLE_TRAIT = (
+    "trait Hashable { fn hash self:Self -> int  fn eq self:Self other:Self -> bool }\n"
+)
+
+HASHABLE_IMPL_STR = (
+    "impl str {\n"
+    "    fn hash self:str -> int { 0 }\n"
+    "    fn eq b:str a:str -> bool { true }\n"
+    "}\n"
+)
+
+HASHABLE_IMPL_INT = (
+    "impl int {\n"
+    "    fn hash self:int -> int { self }\n"
+    "    fn eq self:int other:int -> bool { self other == }\n"
+    "}\n"
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def find_ops(ops: list, kind: OpKind) -> list:
+    return [op for op in ops if op.kind == kind]
+
+
+# ---------------------------------------------------------------------------
+# extract_generic_params
+# ---------------------------------------------------------------------------
+class TestExtractGenericParams:
+    def test_single_param(self):
+        assert extract_generic_params("array[int]") == ["int"]
+
+    def test_single_param_list(self):
+        assert extract_generic_params("List[int]") == ["int"]
+
+    def test_two_params(self):
+        assert extract_generic_params("Map[str int]") == ["str", "int"]
+
+    def test_nested_param(self):
+        assert extract_generic_params("Map[str List[int]]") == ["str", "List[int]"]
+
+    def test_two_nested_params(self):
+        assert extract_generic_params("Map[List[str] List[int]]") == [
+            "List[str]",
+            "List[int]",
+        ]
+
+    def test_option_param(self):
+        assert extract_generic_params("option[int]") == ["int"]
+
+    def test_fn_type_returns_none(self):
+        assert extract_generic_params("fn[int -> int]") is None
+
+    def test_bare_type_returns_none(self):
+        assert extract_generic_params("int") is None
+
+    def test_bare_generic_returns_none(self):
+        assert extract_generic_params("fn") is None
+
+    def test_set_single_param(self):
+        assert extract_generic_params("Set[str]") == ["str"]
+
+    def test_three_levels_deep(self):
+        assert extract_generic_params("Map[str Map[int List[str]]]") == [
+            "str",
+            "Map[int List[str]]",
+        ]
+
+
+# ---------------------------------------------------------------------------
+# split_type_tokens
+# ---------------------------------------------------------------------------
+class TestSplitTypeTokens:
+    def test_simple_types(self):
+        assert split_type_tokens("str int") == ["str", "int"]
+
+    def test_single_type(self):
+        assert split_type_tokens("int") == ["int"]
+
+    def test_generic_type(self):
+        assert split_type_tokens("str List[int]") == ["str", "List[int]"]
+
+    def test_arrow(self):
+        assert split_type_tokens("int -> int") == ["int", "->", "int"]
+
+    def test_nested_brackets(self):
+        assert split_type_tokens("Map[str List[int]]") == ["Map[str List[int]]"]
+
+    def test_empty_string(self):
+        assert split_type_tokens("") == []
+
+
+# ---------------------------------------------------------------------------
+# Trait parsing
+# ---------------------------------------------------------------------------
+class TestTraitParsing:
+    def test_parse_trait_registers_globally(self):
+        parse_string(HASHABLE_TRAIT)
+        assert "Hashable" in GLOBAL_TRAITS
+
+    def test_parse_trait_name(self):
+        parse_string("trait Hashable { fn hash self:Self -> int }")
+        trait = GLOBAL_TRAITS["Hashable"]
+        assert trait.name == "Hashable"
+
+    def test_parse_trait_is_trait_type(self):
+        parse_string("trait Hashable { fn hash self:Self -> int }")
+        trait = GLOBAL_TRAITS["Hashable"]
+        assert isinstance(trait, Trait)
+
+    def test_parse_trait_method_count(self):
+        parse_string(HASHABLE_TRAIT)
+        trait = GLOBAL_TRAITS["Hashable"]
+        assert len(trait.methods) == 2
+
+    def test_parse_trait_method_names(self):
+        parse_string(HASHABLE_TRAIT)
+        trait = GLOBAL_TRAITS["Hashable"]
+        names = [m.name for m in trait.methods]
+        assert names == ["hash", "eq"]
+
+    def test_parse_trait_method_is_trait_method(self):
+        parse_string("trait Hashable { fn hash self:Self -> int }")
+        trait = GLOBAL_TRAITS["Hashable"]
+        assert isinstance(trait.methods[0], TraitMethod)
+
+    def test_parse_trait_method_signature_params(self):
+        parse_string(HASHABLE_TRAIT)
+        trait = GLOBAL_TRAITS["Hashable"]
+        hash_method = trait.methods[0]
+        assert len(hash_method.signature.parameters) == 1
+        assert hash_method.signature.parameters[0].typ == "Self"
+        assert hash_method.signature.parameters[0].name == "self"
+
+    def test_parse_trait_method_signature_return(self):
+        parse_string(HASHABLE_TRAIT)
+        trait = GLOBAL_TRAITS["Hashable"]
+        hash_method = trait.methods[0]
+        assert hash_method.signature.return_types == ["int"]
+
+    def test_parse_trait_eq_method_params(self):
+        parse_string(HASHABLE_TRAIT)
+        trait = GLOBAL_TRAITS["Hashable"]
+        eq_method = trait.methods[1]
+        assert len(eq_method.signature.parameters) == 2
+        assert eq_method.signature.parameters[0].typ == "Self"
+        assert eq_method.signature.parameters[1].typ == "Self"
+
+    def test_parse_trait_eq_method_return(self):
+        parse_string(HASHABLE_TRAIT)
+        trait = GLOBAL_TRAITS["Hashable"]
+        eq_method = trait.methods[1]
+        assert eq_method.signature.return_types == ["bool"]
+
+    def test_parse_empty_trait(self):
+        parse_string("trait Empty { }")
+        assert "Empty" in GLOBAL_TRAITS
+        assert len(GLOBAL_TRAITS["Empty"].methods) == 0
+
+    def test_parse_trait_single_method(self):
+        parse_string("trait Printable { fn to_str self:Self -> str }")
+        trait = GLOBAL_TRAITS["Printable"]
+        assert len(trait.methods) == 1
+        assert trait.methods[0].name == "to_str"
+
+    def test_parse_trait_unclosed_block_raises(self):
+        with pytest.raises(CasaErrorCollection):
+            parse_string("trait Foo { fn bar self:Self -> int")
+
+    def test_parse_trait_unexpected_token_raises(self):
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            parse_string("trait Foo { 42 }")
+        assert exc_info.value.errors[0].kind == ErrorKind.UNEXPECTED_TOKEN
+
+    def test_parse_duplicate_trait_raises(self):
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            parse_string(
+                "trait Foo { fn bar self:Self -> int }\n"
+                "trait Foo { fn baz self:Self -> int }\n"
+            )
+        assert exc_info.value.errors[0].kind == ErrorKind.DUPLICATE_NAME
+
+    def test_parse_trait_has_location(self):
+        parse_string("trait MyTrait { fn do_thing self:Self -> int }")
+        trait = GLOBAL_TRAITS["MyTrait"]
+        assert trait.location is not None
+
+
+# ---------------------------------------------------------------------------
+# Trait bounds parsing (parse_type_vars)
+# ---------------------------------------------------------------------------
+class TestTraitBoundsParsing:
+    def test_trait_bound_basic(self):
+        parse_string(
+            "trait Hashable { fn hash self:Self -> int }\n"
+            "fn test_fn[K: Hashable] K -> int { .hash }"
+        )
+        fn = GLOBAL_FUNCTIONS["test_fn"]
+        assert fn.signature is not None
+        assert "K" in fn.signature.type_vars
+        assert fn.signature.trait_bounds == {"K": "Hashable"}
+
+    def test_trait_bound_with_unbounded_var(self):
+        parse_string(
+            "trait Hashable { fn hash self:Self -> int }\n"
+            "fn test_fn[K: Hashable, V] K V -> int { drop .hash }"
+        )
+        fn = GLOBAL_FUNCTIONS["test_fn"]
+        assert fn.signature.type_vars == {"K", "V"}
+        assert fn.signature.trait_bounds == {"K": "Hashable"}
+
+    def test_trait_bound_multiple_bounded(self):
+        parse_string(
+            "trait Hashable { fn hash self:Self -> int }\n"
+            "trait Printable { fn to_str self:Self -> str }\n"
+            "fn test_fn[K: Hashable, V: Printable] K V -> int { .to_str drop .hash }"
+        )
+        fn = GLOBAL_FUNCTIONS["test_fn"]
+        assert fn.signature.trait_bounds == {"K": "Hashable", "V": "Printable"}
+
+    def test_trait_bound_undefined_trait_raises(self):
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            parse_string("fn test_fn[K: Nonexistent] K -> int { 0 }")
+        assert exc_info.value.errors[0].kind == ErrorKind.UNDEFINED_NAME
+
+    def test_trait_bound_hidden_params_prepended(self):
+        parse_string(
+            "trait Hashable { fn hash self:Self -> int }\n"
+            "fn test_fn[K: Hashable] K -> int { .hash }"
+        )
+        fn = GLOBAL_FUNCTIONS["test_fn"]
+        sig = fn.signature
+        hidden = [p for p in sig.parameters if p.name and p.name.startswith("__trait_")]
+        assert len(hidden) == 1
+        assert hidden[0].name == "__trait_K_hash"
+        assert hidden[0].typ == "fn[K -> int]"
+
+    def test_trait_bound_two_methods_hidden_params(self):
+        parse_string(
+            HASHABLE_TRAIT + "fn test_fn[K: Hashable] K -> int { .hash }"
+        )
+        fn = GLOBAL_FUNCTIONS["test_fn"]
+        sig = fn.signature
+        hidden = [p for p in sig.parameters if p.name and p.name.startswith("__trait_")]
+        assert len(hidden) == 2
+        names = [p.name for p in hidden]
+        assert "__trait_K_hash" in names
+        assert "__trait_K_eq" in names
+
+    def test_trait_bound_hidden_params_have_correct_types(self):
+        parse_string(
+            HASHABLE_TRAIT + "fn test_fn[K: Hashable] K -> int { .hash }"
+        )
+        fn = GLOBAL_FUNCTIONS["test_fn"]
+        hidden = {
+            p.name: p.typ
+            for p in fn.signature.parameters
+            if p.name and p.name.startswith("__trait_")
+        }
+        assert hidden["__trait_K_hash"] == "fn[K -> int]"
+        assert hidden["__trait_K_eq"] == "fn[K K -> bool]"
+
+    def test_trait_bound_creates_variables_for_hidden_params(self):
+        parse_string(
+            "trait Hashable { fn hash self:Self -> int }\n"
+            "fn test_fn[K: Hashable] K -> int { .hash }"
+        )
+        fn = GLOBAL_FUNCTIONS["test_fn"]
+        var_names = [v.name for v in fn.variables]
+        assert "__trait_K_hash" in var_names
+
+    def test_trait_bound_creates_assign_ops_for_hidden_params(self):
+        parse_string(
+            "trait Hashable { fn hash self:Self -> int }\n"
+            "fn test_fn[K: Hashable] K -> int { .hash }"
+        )
+        fn = GLOBAL_FUNCTIONS["test_fn"]
+        assign_ops = find_ops(fn.ops, OpKind.ASSIGN_VARIABLE)
+        assign_values = [op.value for op in assign_ops]
+        assert "__trait_K_hash" in assign_values
+
+
+# ---------------------------------------------------------------------------
+# Structural trait satisfaction (type_satisfies_trait)
+# ---------------------------------------------------------------------------
+class TestTypeSatisfiesTrait:
+    def _setup_hashable_with_foo(self):
+        """Set up the Hashable trait and a Foo struct with impl."""
+        parse_string(
+            HASHABLE_TRAIT
+            + "struct Foo { val: int }\n"
+            + "impl Foo { fn hash self:Foo -> int { self Foo::val } fn eq self:Foo other:Foo -> bool { self Foo::val other Foo::val == } }\n"
+        )
+
+    def test_struct_with_impl_satisfies(self):
+        from casa.typechecker import type_satisfies_trait
+
+        self._setup_hashable_with_foo()
+        assert type_satisfies_trait("Foo", "Hashable") is True
+
+    def test_struct_without_impl_does_not_satisfy(self):
+        from casa.typechecker import type_satisfies_trait
+
+        parse_string(
+            HASHABLE_TRAIT + "struct Bar { val: int }\n"
+        )
+        assert type_satisfies_trait("Bar", "Hashable") is False
+
+    def test_partial_impl_does_not_satisfy(self):
+        from casa.typechecker import type_satisfies_trait
+
+        parse_string(
+            HASHABLE_TRAIT
+            + "struct Baz { val: int }\n"
+            + "impl Baz { fn hash self:Baz -> int { self Baz::val } }\n"
+        )
+        assert type_satisfies_trait("Baz", "Hashable") is False
+
+    def test_undefined_trait_returns_false(self):
+        from casa.typechecker import type_satisfies_trait
+
+        assert type_satisfies_trait("int", "Nonexistent") is False
+
+    def test_type_var_with_matching_bound_satisfies(self):
+        from casa.typechecker import type_satisfies_trait
+
+        parse_string(HASHABLE_TRAIT)
+        fn = Function(
+            name="test_fn",
+            ops=[],
+            location=None,  # type: ignore[arg-type]
+            signature=Signature(
+                parameters=[],
+                return_types=[],
+                type_vars={"K"},
+                trait_bounds={"K": "Hashable"},
+            ),
+        )
+        assert type_satisfies_trait("K", "Hashable", fn) is True
+
+    def test_type_var_without_bound_does_not_satisfy(self):
+        from casa.typechecker import type_satisfies_trait
+
+        parse_string(HASHABLE_TRAIT)
+        fn = Function(
+            name="test_fn",
+            ops=[],
+            location=None,  # type: ignore[arg-type]
+            signature=Signature(
+                parameters=[],
+                return_types=[],
+                type_vars={"K"},
+                trait_bounds={},
+            ),
+        )
+        assert type_satisfies_trait("K", "Hashable", fn) is False
+
+    def test_type_var_with_wrong_bound_does_not_satisfy(self):
+        from casa.typechecker import type_satisfies_trait
+
+        parse_string(
+            HASHABLE_TRAIT + "trait Printable { fn to_str self:Self -> str }\n"
+        )
+        fn = Function(
+            name="test_fn",
+            ops=[],
+            location=None,  # type: ignore[arg-type]
+            signature=Signature(
+                parameters=[],
+                return_types=[],
+                type_vars={"K"},
+                trait_bounds={"K": "Printable"},
+            ),
+        )
+        assert type_satisfies_trait("K", "Hashable", fn) is False
+
+
+# ---------------------------------------------------------------------------
+# Trait method resolution via dot syntax on type variables
+# ---------------------------------------------------------------------------
+class TestTraitMethodCallDotSyntax:
+    def test_dot_hash_on_bounded_type_var(self):
+        """Calling .hash on a trait-bounded type variable should typecheck."""
+        typecheck_string(
+            HASHABLE_TRAIT
+            + "fn get_hash[K: Hashable] k:K -> int { k .hash }\n"
+        )
+        fn = GLOBAL_FUNCTIONS["get_hash"]
+        assert fn.signature is not None
+
+    def test_dot_eq_on_bounded_type_var(self):
+        """Calling .eq on a trait-bounded type variable should typecheck."""
+        typecheck_string(
+            HASHABLE_TRAIT
+            + "fn are_eq[K: Hashable] a:K b:K -> bool { b a .eq }\n"
+        )
+        fn = GLOBAL_FUNCTIONS["are_eq"]
+        assert fn.signature is not None
+
+
+# ---------------------------------------------------------------------------
+# Trait ref resolution (K::hash, &K::hash)
+# ---------------------------------------------------------------------------
+class TestTraitRefResolution:
+    def test_k_coloncolon_method_resolved_as_push_variable_exec(self):
+        """K::hash inside a trait-bounded fn resolves to PUSH_VARIABLE + FN_EXEC."""
+        code = (
+            HASHABLE_TRAIT
+            + "struct MyType { val: int }\n"
+            + "impl MyType {\n"
+            + "    fn hash self:MyType -> int { self MyType::val }\n"
+            + "    fn eq self:MyType other:MyType -> bool { self MyType::val other MyType::val == }\n"
+            + "}\n"
+            + "fn get_hash[K: Hashable] k:K -> int { k K::hash }\n"
+            + "42 MyType = m\n"
+            + "m get_hash\n"
+        )
+        resolve_string(code)
+        fn = GLOBAL_FUNCTIONS["get_hash"]
+        push_var_ops = find_ops(fn.ops, OpKind.PUSH_VARIABLE)
+        push_var_values = [op.value for op in push_var_ops]
+        assert "__trait_K_hash" in push_var_values
+        exec_ops = find_ops(fn.ops, OpKind.FN_EXEC)
+        assert len(exec_ops) >= 1
+
+    def test_ampersand_k_coloncolon_method_resolved_as_push_variable(self):
+        """&K::hash inside a trait-bounded fn resolves to PUSH_VARIABLE (fn ref)."""
+        code = (
+            HASHABLE_TRAIT
+            + "struct MyType { val: int }\n"
+            + "impl MyType {\n"
+            + "    fn hash self:MyType -> int { self MyType::val }\n"
+            + "    fn eq self:MyType other:MyType -> bool { self MyType::val other MyType::val == }\n"
+            + "}\n"
+            + "fn get_hash_fn[K: Hashable] -> fn[K -> int] { &K::hash }\n"
+            + "42 MyType = m\n"
+            + "m get_hash_fn\n"
+        )
+        resolve_string(code)
+        fn = GLOBAL_FUNCTIONS["get_hash_fn"]
+        push_var_ops = find_ops(fn.ops, OpKind.PUSH_VARIABLE)
+        push_var_values = [op.value for op in push_var_ops]
+        assert "__trait_K_hash" in push_var_values
+
+
+# ---------------------------------------------------------------------------
+# Auto-injection of FN_PUSH ops for trait-bounded calls
+# ---------------------------------------------------------------------------
+class TestTraitAutoInjection:
+    def test_calling_trait_bounded_fn_injects_fn_push(self):
+        """Calling a trait-bounded function with a concrete type should auto-inject FN_PUSH."""
+        code = (
+            HASHABLE_TRAIT
+            + "struct MyType { val: int }\n"
+            + "impl MyType {\n"
+            + "    fn hash self:MyType -> int { self MyType::val }\n"
+            + "    fn eq self:MyType other:MyType -> bool { self MyType::val other MyType::val == }\n"
+            + "}\n"
+            + "fn get_hash[K: Hashable] k:K -> int { k .hash }\n"
+            + "42 MyType = m\n"
+            + "m get_hash\n"
+        )
+        typecheck_string(code)
+
+    def test_trait_bounded_fn_with_str(self):
+        """str satisfies Hashable, so calling a bounded fn with str should work."""
+        code = (
+            HASHABLE_TRAIT
+            + HASHABLE_IMPL_STR
+            + "fn get_hash[K: Hashable] k:K -> int { k .hash }\n"
+            + '"hello" get_hash\n'
+        )
+        typecheck_string(code)
+
+    def test_trait_bounded_fn_with_int(self):
+        """int satisfies Hashable, so calling a bounded fn with int should work."""
+        code = (
+            HASHABLE_TRAIT
+            + HASHABLE_IMPL_INT
+            + "fn get_hash[K: Hashable] k:K -> int { k .hash }\n"
+            + "42 get_hash\n"
+        )
+        typecheck_string(code)
+
+    def test_trait_bounded_fn_with_non_satisfying_type_raises(self):
+        """Calling a trait-bounded fn with a type that does not satisfy the trait should error."""
+        code = (
+            HASHABLE_TRAIT
+            + "struct NoHash { val: int }\n"
+            + "fn get_hash[K: Hashable] k:K -> int { k .hash }\n"
+            + "42 NoHash = m\n"
+            + "m get_hash\n"
+        )
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            typecheck_string(code)
+        assert exc_info.value.errors[0].kind == ErrorKind.MISSING_TRAIT_METHOD
+
+
+# ---------------------------------------------------------------------------
+# Signature.trait_bounds field
+# ---------------------------------------------------------------------------
+class TestSignatureTraitBounds:
+    def test_trait_bounds_default_empty(self):
+        sig = Signature([], [])
+        assert sig.trait_bounds == {}
+
+    def test_trait_bounds_preserved_in_signature(self):
+        sig = Signature([], [], type_vars={"K"}, trait_bounds={"K": "Hashable"})
+        assert sig.trait_bounds == {"K": "Hashable"}
+
+
+# ---------------------------------------------------------------------------
+# Multi-parameter generic types in function signatures
+# ---------------------------------------------------------------------------
+class TestMultiParamGenerics:
+    def test_parse_map_type_in_signature(self):
+        parse_string(
+            "trait Hashable { fn hash self:Self -> int }\n"
+            "struct MapStruct { data: ptr }\n"
+            "fn test_fn m:MapStruct -> int { 0 }"
+        )
+
+    def test_map_kv_type_params(self):
+        params = extract_generic_params("Map[str int]")
+        assert params == ["str", "int"]
+
+    def test_set_k_type_params(self):
+        params = extract_generic_params("Set[str]")
+        assert params == ["str"]
+
+    def test_nested_generic_params(self):
+        params = extract_generic_params("Map[str List[int]]")
+        assert params == ["str", "List[int]"]
+
+
+# ---------------------------------------------------------------------------
+# Integration: compile and run Map/Set programs
+# ---------------------------------------------------------------------------
+class TestMapSetIntegration:
+    """Integration tests that compile and run Casa programs with Map and Set."""
+
+    @pytest.fixture
+    def run_casa(self, tmp_path):
+        """Fixture to compile and run a Casa program, returning stdout."""
+
+        def _run(code: str) -> str:
+            src = tmp_path / "test.casa"
+            src.write_text(code)
+            binary = tmp_path / "test"
+            result = subprocess.run(
+                ["python3", "casa.py", str(src), "-o", str(binary)],
+                capture_output=True,
+                text=True,
+                cwd=CASA_ROOT,
+                timeout=30,
+            )
+            if result.returncode != 0:
+                pytest.fail(
+                    f"Compilation failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+                )
+            run_result = subprocess.run(
+                [str(binary)],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            return run_result.stdout
+
+        return _run
+
+    def test_map_str_int_set_and_get(self, run_casa):
+        output = run_casa(
+            STD_INCLUDE
+            + "Map::new (Map[str int]) = m\n"
+            + '"hello" 42 m.set = m\n'
+            + '"hello" m.get .unwrap print\n'
+        )
+        assert output == "42"
+
+    def test_map_int_str_set_and_get(self, run_casa):
+        output = run_casa(
+            STD_INCLUDE
+            + "Map::new (Map[int str]) = m\n"
+            + '1 "hello" m.set = m\n'
+            + "1 m.get .unwrap print\n"
+        )
+        assert output == "hello"
+
+    def test_map_length(self, run_casa):
+        output = run_casa(
+            STD_INCLUDE
+            + "Map::new (Map[str int]) = m\n"
+            + '"a" 1 m.set = m\n'
+            + '"b" 2 m.set = m\n'
+            + "m.length print\n"
+        )
+        assert output == "2"
+
+    def test_map_has(self, run_casa):
+        output = run_casa(
+            STD_INCLUDE
+            + "Map::new (Map[str int]) = m\n"
+            + '"a" 1 m.set = m\n'
+            + '"a" m.has print\n'
+            + '"b" m.has print\n'
+        )
+        assert output == "truefalse"
+
+    def test_map_delete(self, run_casa):
+        output = run_casa(
+            STD_INCLUDE
+            + "Map::new (Map[str int]) = m\n"
+            + '"a" 1 m.set = m\n'
+            + '"a" m.delete = m\n'
+            + "m.length print\n"
+            + '"a" m.has print\n'
+        )
+        assert output == "0false"
+
+    def test_set_add_and_has(self, run_casa):
+        output = run_casa(
+            STD_INCLUDE
+            + "Set::new (Set[str]) = s\n"
+            + '"apple" s.add = s\n'
+            + '"apple" s.has print\n'
+            + '"banana" s.has print\n'
+        )
+        assert output == "truefalse"
+
+    def test_set_length(self, run_casa):
+        output = run_casa(
+            STD_INCLUDE
+            + "Set::new (Set[str]) = s\n"
+            + '"a" s.add = s\n'
+            + '"b" s.add = s\n'
+            + '"c" s.add = s\n'
+            + "s.length print\n"
+        )
+        assert output == "3"
+
+    def test_set_remove(self, run_casa):
+        output = run_casa(
+            STD_INCLUDE
+            + "Set::new (Set[str]) = s\n"
+            + '"a" s.add = s\n'
+            + '"a" s.remove = s\n'
+            + "s.length print\n"
+            + '"a" s.has print\n'
+        )
+        assert output == "0false"
+
+    def test_map_update_existing_key(self, run_casa):
+        output = run_casa(
+            STD_INCLUDE
+            + "Map::new (Map[str int]) = m\n"
+            + '"a" 1 m.set = m\n'
+            + '"a" 99 m.set = m\n'
+            + '"a" m.get .unwrap print\n'
+            + "m.length print\n"
+        )
+        assert output == "991"
+
+    def test_set_add_duplicate(self, run_casa):
+        output = run_casa(
+            STD_INCLUDE
+            + "Set::new (Set[str]) = s\n"
+            + '"a" s.add = s\n'
+            + '"a" s.add = s\n'
+            + "s.length print\n"
+        )
+        assert output == "1"


### PR DESCRIPTION
## Summary

- Add trait definitions with `self` type placeholder and structural satisfaction
- Implement multi-parameter generic types (e.g., `Map[K V]`)
- Add trait bounds on type variables (`[K: Hashable, V]`) with auto-injection of function pointers at call sites
- Implement `Map[K V]` (separate chaining hash map) and `Set[K]` (backed by Map) in the standard library
- Add `Hashable` trait with `str` and `int` implementations
- Support `K::method`, `key.method`, and `&K::method` syntax for trait method calls

## Test plan

- [x] 73 new unit tests for trait parsing, structural satisfaction, auto-injection, and Map/Set integration
- [x] All 743 unit tests pass
- [x] All 25 example tests pass (including new `hash_map.casa`)
- [x] mypy, black, and pylint clean
- [x] Documentation updated in `docs/traits.md`, `docs/standard-library.md`, `docs/errors.md`, `docs/functions-and-lambdas.md`, `docs/types-and-literals.md`, `docs/structs-and-methods.md`, and `README.md`