### PR TITLE
feat: add type annotations for variable assignments

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ source → lex → parse → resolve → type check → bytecode → emit asm �
 | [file_io.casa](examples/file_io.casa) | File I/O operations: read, write, and remove files |
 | [vec.casa](examples/vec.casa) | Generic `List[T]` with push, pop, get, set, slice |
 | [hash_map.casa](examples/hash_map.casa) | `Map[K V]` and `Set[K]` with the `Hashable` trait |
+| [type_annotations.casa](examples/type_annotations.casa) | Type annotations on variable assignments (`= name:type`) |
 
 More examples: [examples](./examples/)
 

--- a/casa/common.py
+++ b/casa/common.py
@@ -347,6 +347,7 @@ class Op:
     value: Any
     kind: OpKind
     location: Location
+    type_annotation: str | None = None
 
     def __post_init__(self):
         assert len(OpKind) == 79, "Exhaustive handling for `OpKind`"

--- a/casa/error.py
+++ b/casa/error.py
@@ -191,6 +191,7 @@ class WarningKind(Enum):
     """Categories of compiler warnings."""
 
     UNUSED_PARAMETER = auto()
+    LOSSY_TYPE_ANNOTATION = auto()
 
 
 @dataclass

--- a/casa/parser.py
+++ b/casa/parser.py
@@ -1069,7 +1069,18 @@ def get_op_operator(token: Token, cursor: Cursor[Token], function_name: str) -> 
             variable_name = identifier.value
             assert isinstance(variable_name, str), "Expected variable name"
 
-            return Op(variable_name, OpKind.ASSIGN_VARIABLE, identifier.location)
+            type_annotation = None
+            colon = cursor.peek()
+            if colon and colon.value == ":":
+                cursor.position += 1
+                type_annotation = parse_type(cursor)
+
+            return Op(
+                variable_name,
+                OpKind.ASSIGN_VARIABLE,
+                identifier.location,
+                type_annotation=type_annotation,
+            )
         case Operator.ASSIGN_DECREMENT:
             next_token = expect_token(cursor, kind=TokenKind.IDENTIFIER)
             identifier = token_to_op(next_token, cursor, function_name)

--- a/casa/typechecker.py
+++ b/casa/typechecker.py
@@ -766,6 +766,29 @@ def type_check_ops(ops: list[Op], function: Function | None = None) -> Signature
                     op.type_annotation if op.type_annotation else stack_type
                 )
 
+                if op.type_annotation:
+                    annotation = op.type_annotation
+                    if annotation == ANY_TYPE:
+                        WARNINGS.append(
+                            CasaWarning(
+                                WarningKind.LOSSY_TYPE_ANNOTATION,
+                                f"Type annotation `any` discards type information from `{stack_type}`",
+                                op.location,
+                            )
+                        )
+                    elif (
+                        extract_generic_base(stack_type) is not None
+                        and extract_generic_base(annotation) is None
+                        and extract_generic_base(stack_type) == annotation
+                    ):
+                        WARNINGS.append(
+                            CasaWarning(
+                                WarningKind.LOSSY_TYPE_ANNOTATION,
+                                f"Type annotation `{annotation}` discards type parameter from `{stack_type}`",
+                                op.location,
+                            )
+                        )
+
                 # Local variable (shadows global with same name)
                 local_variable = None
                 if function:

--- a/casa/typechecker.py
+++ b/casa/typechecker.py
@@ -788,6 +788,7 @@ def type_check_ops(ops: list[Op], function: Function | None = None) -> Signature
                                 op.location,
                             )
                         )
+                        effective_type = stack_type
 
                 # Local variable (shadows global with same name)
                 local_variable = None

--- a/docs/functions-and-lambdas.md
+++ b/docs/functions-and-lambdas.md
@@ -221,6 +221,7 @@ fn fizzbuzz number:int {
 | Operator | Stack Effect | Description |
 |----------|-------------|-------------|
 | `= name` | `a -> None` | Assign top of stack to `name` |
+| `= name:type` | `a -> None` | Assign with type annotation |
 | `+= name` | `int -> None` | Add to `name` |
 | `-= name` | `int -> None` | Subtract from `name` |
 
@@ -229,6 +230,13 @@ A variable's type is set on first assignment and cannot change:
 ```casa
 42 = x       # x is int
 "hi" = x     # ERROR: cannot assign str to int variable
+```
+
+The `= name:type` form annotates the variable type explicitly. The type checker verifies the stack value is compatible and uses the annotated type for the variable. This is useful for narrowing `any` or bare `option` to a concrete type:
+
+```casa
+42 (any) = x:int            # narrow any to int
+none = empty:option[int]    # narrow bare option to option[int]
 ```
 
 ## Lambdas

--- a/docs/operators.md
+++ b/docs/operators.md
@@ -110,6 +110,7 @@ Assignment operators pop a value from the stack and store it in a named variable
 | Operator | Stack Effect | Description |
 |----------|-------------|-------------|
 | `= name` | `a -> None` | Assign top of stack to variable `name` |
+| `= name:type` | `a -> None` | Assign with type annotation, verifies and narrows the type |
 | `+= name` | `int -> None` | Add top of stack to variable `name` |
 | `-= name` | `int -> None` | Subtract top of stack from variable `name` |
 
@@ -117,6 +118,16 @@ Assignment operators pop a value from the stack and store it in a named variable
 42 = count        # count is now 42
 1 += count        # count is now 43
 10 -= count       # count is now 33
+```
+
+### Type annotations
+
+The `= name:type` form lets you annotate the type of a variable at assignment time. The type checker verifies the stack value is compatible and uses the annotated type for the variable.
+
+```casa
+42 = x:int                  # explicit int annotation
+none = empty:option[int]    # narrow bare option to option[int]
+42 (any) = val:int          # narrow any to int
 ```
 
 Variables are created on first assignment. See [Functions and Lambdas — Variables](functions-and-lambdas.md#variables) for scoping rules.

--- a/examples/outputs/type_annotations.out
+++ b/examples/outputs/type_annotations.out
@@ -1,0 +1,8 @@
+42
+hello
+true
+maybe_val has value: 42
+empty_val is none
+20
+10
+100

--- a/examples/type_annotations.casa
+++ b/examples/type_annotations.casa
@@ -1,0 +1,45 @@
+# Type annotations on variable assignments
+#
+# The = name:type syntax allows explicit type annotation when assigning variables.
+# This is useful for narrowing 'any' or bare 'option' types to concrete types.
+
+include "../lib/std.casa"
+
+# Basic type annotations
+42 = x:int
+"hello" = greeting:str
+true = flag:bool
+
+# Print annotated variables
+x print "\n" print
+greeting print "\n" print
+flag print "\n" print
+
+# Type annotations with option types
+42 some = maybe_val:option[int]
+none = empty_val:option[int]
+
+# Check option values
+if maybe_val.is_some then
+    "maybe_val has value: " print
+    maybe_val.unwrap print "\n" print
+fi
+
+if empty_val.is_none then
+    "empty_val is none\n" print
+fi
+
+# Type annotations in functions
+fn make_pair a:int b:int -> int int {
+    a = first:int
+    b = second:int
+    first second
+}
+
+10 20 make_pair = y:int = z:int
+z print "\n" print
+y print "\n" print
+
+# Reassignment with annotated variable
+100 = x
+x print "\n" print

--- a/tests/test_type_annotations.py
+++ b/tests/test_type_annotations.py
@@ -1,0 +1,219 @@
+"""Tests for type annotations on variable assignments (= name:type)."""
+
+import pytest
+
+from casa.common import (
+    GLOBAL_FUNCTIONS,
+    GLOBAL_VARIABLES,
+    OpKind,
+    Variable,
+)
+from casa.error import CasaErrorCollection, ErrorKind
+from tests.conftest import parse_string, resolve_string, typecheck_string
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def find_ops(ops: list, kind: OpKind) -> list:
+    return [op for op in ops if op.kind == kind]
+
+
+# ---------------------------------------------------------------------------
+# Parser tests
+# ---------------------------------------------------------------------------
+class TestParserTypeAnnotation:
+    """Parser correctly attaches type_annotation to ASSIGN_VARIABLE ops."""
+
+    def test_annotation_int(self):
+        """= x:int produces Op with type_annotation='int'."""
+        ops = parse_string("42 = x:int")
+        assign_ops = find_ops(ops, OpKind.ASSIGN_VARIABLE)
+        assert len(assign_ops) == 1
+        assert assign_ops[0].value == "x"
+        assert assign_ops[0].type_annotation == "int"
+
+    def test_annotation_str(self):
+        """= x:str produces Op with type_annotation='str'."""
+        ops = parse_string('"hello" = x:str')
+        assign_ops = find_ops(ops, OpKind.ASSIGN_VARIABLE)
+        assert assign_ops[0].type_annotation == "str"
+
+    def test_annotation_bool(self):
+        """= x:bool produces Op with type_annotation='bool'."""
+        ops = parse_string("true = x:bool")
+        assign_ops = find_ops(ops, OpKind.ASSIGN_VARIABLE)
+        assert assign_ops[0].type_annotation == "bool"
+
+    def test_annotation_option_int(self):
+        """= x:option[int] produces Op with type_annotation='option[int]'."""
+        ops = parse_string("42 some = x:option[int]")
+        assign_ops = find_ops(ops, OpKind.ASSIGN_VARIABLE)
+        assert assign_ops[0].type_annotation == "option[int]"
+
+    def test_annotation_bare_option(self):
+        """= x:option produces Op with type_annotation='option'."""
+        ops = parse_string("none = x:option")
+        assign_ops = find_ops(ops, OpKind.ASSIGN_VARIABLE)
+        assert assign_ops[0].type_annotation == "option"
+
+    def test_annotation_generic_list(self):
+        """= x:List[int] produces Op with type_annotation='List[int]'."""
+        ops = parse_string("0 = x:List[int]")
+        assign_ops = find_ops(ops, OpKind.ASSIGN_VARIABLE)
+        assert assign_ops[0].type_annotation == "List[int]"
+
+    def test_annotation_ptr(self):
+        """= x:ptr produces Op with type_annotation='ptr'."""
+        ops = parse_string("0 = x:ptr")
+        assign_ops = find_ops(ops, OpKind.ASSIGN_VARIABLE)
+        assert assign_ops[0].type_annotation == "ptr"
+
+    def test_no_annotation(self):
+        """= x (no annotation) produces Op with type_annotation=None."""
+        ops = parse_string("42 = x")
+        assign_ops = find_ops(ops, OpKind.ASSIGN_VARIABLE)
+        assert len(assign_ops) == 1
+        assert assign_ops[0].value == "x"
+        assert assign_ops[0].type_annotation is None
+
+    def test_annotation_in_function(self):
+        """Type annotation works inside function bodies."""
+        parse_string("fn foo { 42 = x:int x drop }")
+        fn = GLOBAL_FUNCTIONS["foo"]
+        assign_ops = find_ops(fn.ops, OpKind.ASSIGN_VARIABLE)
+        # Function params are also ASSIGN_VARIABLE, but foo has none
+        assert any(op.value == "x" and op.type_annotation == "int" for op in assign_ops)
+
+    def test_annotation_array_type(self):
+        """= x:array[int] produces Op with type_annotation='array[int]'."""
+        ops = parse_string("[1, 2] = x:array[int]")
+        assign_ops = find_ops(ops, OpKind.ASSIGN_VARIABLE)
+        assert assign_ops[0].type_annotation == "array[int]"
+
+    def test_annotation_char(self):
+        """= x:char produces Op with type_annotation='char'."""
+        ops = parse_string("'a' = x:char")
+        assign_ops = find_ops(ops, OpKind.ASSIGN_VARIABLE)
+        assert assign_ops[0].type_annotation == "char"
+
+    def test_no_annotation_on_increment(self):
+        """Increment (+=) does not support type annotations."""
+        ops = parse_string("42 = x 1 += x")
+        inc_ops = find_ops(ops, OpKind.ASSIGN_INCREMENT)
+        assert len(inc_ops) == 1
+        assert (
+            not hasattr(inc_ops[0], "type_annotation")
+            or inc_ops[0].type_annotation is None
+        )
+
+    def test_no_annotation_on_decrement(self):
+        """Decrement (-=) does not support type annotations."""
+        ops = parse_string("42 = x 1 -= x")
+        dec_ops = find_ops(ops, OpKind.ASSIGN_DECREMENT)
+        assert len(dec_ops) == 1
+        assert (
+            not hasattr(dec_ops[0], "type_annotation")
+            or dec_ops[0].type_annotation is None
+        )
+
+
+# ---------------------------------------------------------------------------
+# Type checker tests
+# ---------------------------------------------------------------------------
+class TestTypecheckerTypeAnnotation:
+    """Type checker uses type_annotation for variable type inference."""
+
+    def test_basic_annotation_int(self):
+        """42 = x:int assigns x with type int."""
+        sig = typecheck_string("42 = x:int x")
+        assert sig.return_types == ["int"]
+
+    def test_basic_annotation_str(self):
+        """'hello' = x:str assigns x with type str."""
+        sig = typecheck_string('"hello" = x:str x')
+        assert sig.return_types == ["str"]
+
+    def test_basic_annotation_bool(self):
+        """true = x:bool assigns x with type bool."""
+        sig = typecheck_string("true = x:bool x")
+        assert sig.return_types == ["bool"]
+
+    def test_annotation_matches_stack_type(self):
+        """Annotation that matches stack type works fine."""
+        sig = typecheck_string("42 = x:int x")
+        assert sig.return_types == ["int"]
+
+    def test_narrow_any_to_int(self):
+        """Type annotation narrows 'any' to concrete type."""
+        # Use type cast to get 'any' on stack, then annotate
+        sig = typecheck_string("42 (any) = x:int x")
+        assert sig.return_types == ["int"]
+
+    def test_narrow_any_to_str(self):
+        """Type annotation narrows 'any' to str."""
+        sig = typecheck_string('"hello" (any) = x:str x')
+        assert sig.return_types == ["str"]
+
+    def test_narrow_bare_option_to_option_int(self):
+        """Type annotation narrows bare 'option' to 'option[int]'."""
+        sig = typecheck_string("none = x:option[int] x")
+        assert sig.return_types == ["option[int]"]
+
+    def test_type_mismatch_raises(self):
+        """Annotating str value as int raises TYPE_MISMATCH."""
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            typecheck_string('"hello" = x:int')
+        assert exc_info.value.errors[0].kind == ErrorKind.TYPE_MISMATCH
+
+    def test_type_mismatch_int_annotated_bool(self):
+        """Annotating int value as bool raises TYPE_MISMATCH."""
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            typecheck_string("42 = x:bool")
+        assert exc_info.value.errors[0].kind == ErrorKind.TYPE_MISMATCH
+
+    def test_type_mismatch_bool_annotated_str(self):
+        """Annotating bool value as str raises TYPE_MISMATCH."""
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            typecheck_string("true = x:str")
+        assert exc_info.value.errors[0].kind == ErrorKind.TYPE_MISMATCH
+
+    def test_reassignment_keeps_annotated_type(self):
+        """Variable typed via annotation keeps its type on reassignment."""
+        sig = typecheck_string("42 = x:int 99 = x x")
+        assert sig.return_types == ["int"]
+
+    def test_reassignment_type_mismatch(self):
+        """Reassigning annotated variable with wrong type raises error."""
+        with pytest.raises(CasaErrorCollection):
+            typecheck_string('42 = x:int "hello" = x')
+
+    def test_annotation_in_function_body(self):
+        """Type annotation works in function-local variables."""
+        sig = typecheck_string("fn foo -> int { 42 = x:int x } foo")
+        assert sig.return_types == ["int"]
+
+    def test_annotation_option_int_with_some(self):
+        """42 some = x:option[int] assigns x with type option[int]."""
+        sig = typecheck_string("42 some = x:option[int] x")
+        assert sig.return_types == ["option[int]"]
+
+    def test_without_annotation_still_works(self):
+        """Assignment without annotation still infers type normally."""
+        sig = typecheck_string("42 = x x")
+        assert sig.return_types == ["int"]
+
+    def test_narrow_any_in_function(self):
+        """Type annotation narrows 'any' inside a function body."""
+        sig = typecheck_string("fn foo -> int { 42 (any) = x:int x } foo")
+        assert sig.return_types == ["int"]
+
+    def test_annotation_with_struct_type(self):
+        """Type annotation works with user-defined struct types."""
+        code = """
+        struct Point { x: int y: int }
+        0 0 Point = p:Point
+        p
+        """
+        sig = typecheck_string(code)
+        assert sig.return_types == ["Point"]

--- a/tests/test_type_annotations.py
+++ b/tests/test_type_annotations.py
@@ -229,19 +229,21 @@ class TestTypecheckerTypeAnnotationWarnings:
         assert WARNINGS[0].kind == WarningKind.LOSSY_TYPE_ANNOTATION
         assert "any" in WARNINGS[0].message
 
-    def test_warn_bare_option_loses_param(self):
-        """Annotating option[int] as bare option warns."""
-        typecheck_string("42 some = x:option")
+    def test_warn_bare_option_retains_type(self):
+        """Annotating option[int] as bare option warns and retains original type."""
+        sig = typecheck_string("42 some = x:option x")
         assert len(WARNINGS) == 1
         assert WARNINGS[0].kind == WarningKind.LOSSY_TYPE_ANNOTATION
         assert "option" in WARNINGS[0].message
+        assert sig.return_types == ["option[int]"]
 
-    def test_warn_bare_array_loses_param(self):
-        """Annotating array[int] as bare array warns."""
-        typecheck_string("[1, 2] = x:array")
+    def test_warn_bare_array_retains_type(self):
+        """Annotating array[int] as bare array warns and retains original type."""
+        sig = typecheck_string("[1, 2] = x:array x")
         assert len(WARNINGS) == 1
         assert WARNINGS[0].kind == WarningKind.LOSSY_TYPE_ANNOTATION
         assert "array" in WARNINGS[0].message
+        assert sig.return_types == ["array[int]"]
 
     def test_no_warn_matching_types(self):
         """No warning when annotation matches stack type."""


### PR DESCRIPTION
## Summary

- Add `= name:type` syntax for annotating variable types at assignment time
- The type checker verifies stack value compatibility and uses the annotated type for the variable
- Useful for narrowing `any` or bare `option` to concrete types (e.g. `none = x:option[int]`)

## Test plan

- [x] 30 new tests (12 parser, 18 typechecker) in `tests/test_type_annotations.py`
- [x] All 773 tests pass
- [x] All 26 example tests pass (`tests/test_examples.sh`)
- [x] New example: `examples/type_annotations.casa`
- [x] Documentation updated: `docs/operators.md`, `docs/functions-and-lambdas.md`, `README.md`