### PR TITLE
feat: add enum type with exhaustive match statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Casa compiles to x86-64 Linux executables via GNU assembly. It features static t
 - **Structs and methods** — user-defined types with auto-generated accessors and `impl` blocks
 - **String interpolation** — f-strings with embedded expressions (`f"hello {name}"`)
 - **Compiles to native code** — generates x86-64 assembly with `ld` and `as`
+- **Enums and match** — enum types with exhaustive pattern matching
 - **Traits** — structural trait system with bounded polymorphism (`trait`, `Hashable`)
 - **Standard library** — generic `List[T]`, `Map[K V]`, `Set[K]`, arrays with `map`/`filter`/`reduce`, type conversions, and memory utilities
 
@@ -65,9 +66,10 @@ source → lex → parse → resolve → type check → bytecode → emit asm �
 |----------|--------|
 | [Types and Literals](docs/types-and-literals.md) | Primitive types, composite types, literals, type casting, comments |
 | [Operators](docs/operators.md) | Arithmetic, bitshift, bitwise, comparison, boolean, assignment |
-| [Control Flow](docs/control-flow.md) | Conditionals (`if`/`elif`/`else`/`fi`), loops (`while`/`do`/`done`) |
+| [Control Flow](docs/control-flow.md) | Conditionals (`if`/`elif`/`else`/`fi`), loops (`while`/`do`/`done`), match (`match`/`end`) |
 | [Functions and Lambdas](docs/functions-and-lambdas.md) | Functions, lambdas, closures, variables, stack intrinsics, IO, memory |
 | [Structs and Methods](docs/structs-and-methods.md) | Struct definition, accessors, `impl` blocks, dot/arrow syntax |
+| [Enums](docs/enums.md) | Enum types, variant constructors, exhaustive `match` |
 | [Traits](docs/traits.md) | Trait definitions, structural satisfaction, trait bounds, `Hashable` |
 | [Standard Library](docs/standard-library.md) | `include`, `memcpy`, arrays (`map`, `filter`, `reduce`), `option[T]`, `List[T]`, `Map[K V]`, `Set[K]`, string methods, C string methods, file I/O, character classification, type conversions |
 | [Errors](docs/errors.md) | Error kinds, diagnostics format, multi-error collection |
@@ -87,6 +89,7 @@ source → lex → parse → resolve → type check → bytecode → emit asm �
 | [vec.casa](examples/vec.casa) | Generic `List[T]` with push, pop, get, set, slice |
 | [hash_map.casa](examples/hash_map.casa) | `Map[K V]` and `Set[K]` with the `Hashable` trait |
 | [type_annotations.casa](examples/type_annotations.casa) | Type annotations on variable assignments (`= name:type`) |
+| [enum.casa](examples/enum.casa) | Enum types with `match` pattern matching |
 
 More examples: [examples](./examples/)
 

--- a/casa/bytecode.py
+++ b/casa/bytecode.py
@@ -9,6 +9,7 @@ from casa.common import (
     GLOBAL_VARIABLES,
     Bytecode,
     Cursor,
+    EnumVariant,
     Function,
     Inst,
     InstKind,
@@ -435,6 +436,50 @@ class Compiler:
         # Push array to the stack
         bytecode.append(self.inst(InstKind.LOCAL_GET, args=[local_list]))
 
+    def _compile_match_block(self, op: Op, bytecode: list[Inst]) -> None:
+        """Compile MATCH_START, MATCH_ARM, MATCH_END ops."""
+        match op.kind:
+            case OpKind.MATCH_START:
+                pass
+            case OpKind.MATCH_ARM:
+                variant = op.value
+                assert isinstance(variant, EnumVariant)
+
+                end_label = self._require_matching_label(
+                    op,
+                    OpKind.MATCH_START,
+                    OpKind.MATCH_END,
+                    "`match` arm without matching `end`",
+                )
+                is_first = id(op) not in _op_label_map
+
+                if not is_first:
+                    # End of previous arm body: jump to end, then label for this arm
+                    bytecode.append(self.inst(InstKind.JUMP, args=[end_label]))
+                    bytecode.append(
+                        self.inst(InstKind.LABEL, args=[_op_label_map[id(op)]])
+                    )
+
+                next_arm = self.find_matching_label(
+                    op=op,
+                    start_kind=OpKind.MATCH_START,
+                    end_kind=OpKind.MATCH_END,
+                    target_kinds=[OpKind.MATCH_ARM],
+                )
+                is_last = next_arm is None
+                if is_last:
+                    bytecode.append(self.inst(InstKind.DROP))
+                else:
+                    bytecode.append(self.inst(InstKind.DUP))
+                    bytecode.append(self.inst(InstKind.PUSH, args=[variant.ordinal]))
+                    bytecode.append(self.inst(InstKind.EQ))
+                    bytecode.append(self.inst(InstKind.JUMP_NE, args=[next_arm]))
+                    bytecode.append(self.inst(InstKind.DROP))
+
+            case OpKind.MATCH_END:
+                end_label = op_to_label(op)
+                bytecode.append(self.inst(InstKind.LABEL, args=[end_label]))
+
     def _compile_some(self, bytecode: list[Inst]) -> None:
         """Compile SOME op -- wraps top of stack in an option."""
         local_ptr = self.locals_count
@@ -500,7 +545,7 @@ class Compiler:
     def compile(self) -> Bytecode:
         """Lower all ops to bytecode instructions."""
         assert len(InstKind) == 66, "Exhaustive handling for `InstructionKind"
-        assert len(OpKind) == 79, "Exhaustive handling for `OpKind`"
+        assert len(OpKind) == 83, "Exhaustive handling for `OpKind`"
 
         cursor = Cursor(sequence=self.ops)
         bytecode: list[Inst] = []
@@ -543,6 +588,12 @@ class Compiler:
                     self._compile_if_block(op, bytecode)
                 case OpKind.INCLUDE_FILE | OpKind.TYPE_CAST:
                     pass
+                case OpKind.PUSH_ENUM_VARIANT:
+                    variant = op.value
+                    assert isinstance(variant, EnumVariant)
+                    bytecode.append(self.inst(InstKind.PUSH, args=[variant.ordinal]))
+                case OpKind.MATCH_START | OpKind.MATCH_ARM | OpKind.MATCH_END:
+                    self._compile_match_block(op, bytecode)
                 case OpKind.METHOD_CALL:
                     raise AssertionError(
                         "Method call should be transpiled to function call during type checking"
@@ -647,8 +698,8 @@ class Compiler:
         reverse: bool = False,
     ) -> LabelId | None:
         """Search for a matching block boundary and return its label."""
-        START_KINDS = [OpKind.IF_START, OpKind.WHILE_START]
-        END_KINDS = [OpKind.IF_END, OpKind.WHILE_END]
+        START_KINDS = [OpKind.IF_START, OpKind.WHILE_START, OpKind.MATCH_START]
+        END_KINDS = [OpKind.IF_END, OpKind.WHILE_END, OpKind.MATCH_END]
         assert start_kind in START_KINDS, f"Invalid start for block: {start_kind}"
         assert end_kind in END_KINDS, f"Invalid end for block: {end_kind}"
 
@@ -672,10 +723,10 @@ class Compiler:
             elif other_op.kind in END_KINDS:
                 depth -= direction
 
-            if depth < START_DEPTH and (
-                (op.kind in START_KINDS and not reverse)
-                or (op.kind in END_KINDS and reverse)
-            ):
-                return None
+            if depth < START_DEPTH:
+                is_boundary_op = op.kind in START_KINDS or op.kind in END_KINDS
+                hit_enclosing_end = other_op.kind == end_kind
+                if is_boundary_op or hit_enclosing_end:
+                    return None
 
         return None

--- a/casa/common.py
+++ b/casa/common.py
@@ -91,8 +91,13 @@ class Keyword(Enum):
     FI = auto()
 
     # Data types
+    ENUM = auto()
     STRUCT = auto()
     TRAIT = auto()
+
+    # Match
+    END = auto()
+    MATCH = auto()
 
     # Include files
     INCLUDE = auto()
@@ -110,6 +115,7 @@ class Delimiter(Enum):
 
     ARROW = auto()
     COMMA = auto()
+    FAT_ARROW = auto()
     COLON = auto()
     DOT = auto()
     HASHTAG = auto()
@@ -129,6 +135,7 @@ class Delimiter(Enum):
 _DELIMITER_SOURCE_MAP: dict[str, Delimiter] = {
     "->": Delimiter.ARROW,
     ",": Delimiter.COMMA,
+    "=>": Delimiter.FAT_ARROW,
     ":": Delimiter.COLON,
     ".": Delimiter.DOT,
     "#": Delimiter.HASHTAG,
@@ -352,6 +359,14 @@ class OpKind(Enum):
     PUSH_CAPTURE = auto()
     PUSH_VARIABLE = auto()
 
+    # Enums
+    PUSH_ENUM_VARIANT = auto()
+
+    # Match
+    MATCH_START = auto()
+    MATCH_ARM = auto()
+    MATCH_END = auto()
+
     # Structs
     STRUCT_NEW = auto()
 
@@ -378,7 +393,7 @@ class Op:
     type_annotation: str | None = None
 
     def __post_init__(self):
-        assert len(OpKind) == 79, "Exhaustive handling for `OpKind`"
+        assert len(OpKind) == 83, "Exhaustive handling for `OpKind`"
 
         match self.kind:
             # Requires Python `None`
@@ -446,6 +461,12 @@ class Op:
             ):
                 if not isinstance(self.value, Intrinsic):
                     raise TypeError(f"`{self.kind}` requires value of type `Intrinsic`")
+            # Requires `EnumVariant`
+            case OpKind.PUSH_ENUM_VARIANT | OpKind.MATCH_ARM:
+                if not isinstance(self.value, EnumVariant):
+                    raise TypeError(
+                        f"`{self.kind}` requires value of type `EnumVariant`"
+                    )
             # Requires `Keyword`
             case (
                 OpKind.FN_RETURN
@@ -454,6 +475,8 @@ class Op:
                 | OpKind.IF_ELIF
                 | OpKind.IF_ELSE
                 | OpKind.IF_END
+                | OpKind.MATCH_START
+                | OpKind.MATCH_END
                 | OpKind.WHILE_START
                 | OpKind.WHILE_CONDITION
                 | OpKind.WHILE_BREAK
@@ -939,6 +962,32 @@ class Member:
         return False
 
 
+MATCH_WILDCARD = "_"
+
+
+@dataclass
+class EnumVariant:
+    """A single variant of an enum type."""
+
+    enum_name: str
+    variant_name: str
+    ordinal: int
+
+    @property
+    def is_wildcard(self) -> bool:
+        """Check if this variant is a wildcard pattern."""
+        return self.variant_name == MATCH_WILDCARD
+
+
+@dataclass
+class CasaEnum:
+    """A user-defined enum type with named variants."""
+
+    name: str
+    variants: list[str]
+    location: Location
+
+
 @dataclass
 class Struct:
     """A user-defined struct type with named members."""
@@ -1013,6 +1062,7 @@ GLOBAL_SCOPE_LABEL = "_start"
 class CompilationContext:
     """Groups all mutable compilation state. Module-level globals alias the default instance."""
 
+    enums: OrderedDict[str, CasaEnum] = field(default_factory=OrderedDict)
     functions: OrderedDict[str, Function] = field(default_factory=OrderedDict)
     structs: OrderedDict[str, Struct] = field(default_factory=OrderedDict)
     traits: OrderedDict[str, Trait] = field(default_factory=OrderedDict)
@@ -1021,6 +1071,7 @@ class CompilationContext:
 
 
 _DEFAULT_CONTEXT = CompilationContext()
+GLOBAL_ENUMS = _DEFAULT_CONTEXT.enums
 GLOBAL_FUNCTIONS = _DEFAULT_CONTEXT.functions
 GLOBAL_STRUCTS = _DEFAULT_CONTEXT.structs
 GLOBAL_TRAITS = _DEFAULT_CONTEXT.traits

--- a/casa/lexer.py
+++ b/casa/lexer.py
@@ -80,9 +80,12 @@ class Lexer:
                 break
             if char.isspace():
                 break
-            if word == "->":
+            if word in ("->", "=>"):
                 break
             if word.endswith("->"):
+                word = word[:-2]
+                break
+            if word.endswith("=>"):
                 word = word[:-2]
                 break
             word += char

--- a/casa/parser.py
+++ b/casa/parser.py
@@ -5,14 +5,18 @@ from typing import assert_never
 
 from casa.common import (
     BUILTIN_TYPES,
+    GLOBAL_ENUMS,
     GLOBAL_FUNCTIONS,
     GLOBAL_SCOPE_LABEL,
     GLOBAL_STRUCTS,
     GLOBAL_TRAITS,
     GLOBAL_VARIABLES,
     INCLUDED_FILES,
+    MATCH_WILDCARD,
+    CasaEnum,
     Cursor,
     Delimiter,
+    EnumVariant,
     Function,
     Intrinsic,
     Keyword,
@@ -75,8 +79,7 @@ def _parse_fstring_expr(
         if expr_token.kind == TokenKind.FSTRING_START:
             handle_fstring(expr_token, cursor, function_name, expr_ops)
             continue
-        if op := token_to_op(expr_token, cursor, function_name):
-            expr_ops.append(op)
+        _append_op_result(expr_ops, token_to_op(expr_token, cursor, function_name))
     return expr_ops
 
 
@@ -118,8 +121,7 @@ def parse_ops(tokens: list[Token]) -> list[Op]:
         if token.kind == TokenKind.FSTRING_START:
             handle_fstring(token, cursor, GLOBAL_SCOPE_LABEL, ops)
             continue
-        if op := token_to_op(token, cursor):
-            ops.append(op)
+        _append_op_result(ops, token_to_op(token, cursor))
     return ops
 
 
@@ -350,6 +352,27 @@ def resolve_identifiers(
                     _resolve_fn_ref(identifier, op, function, errors)
                     continue
 
+                # Enum variant: EnumName::Variant
+                if "::" in identifier:
+                    parts = identifier.split("::", 1)
+                    casa_enum = GLOBAL_ENUMS.get(parts[0])
+                    if casa_enum:
+                        variant_name = parts[1]
+                        if variant_name not in casa_enum.variants:
+                            errors.append(
+                                CasaError(
+                                    ErrorKind.UNDEFINED_NAME,
+                                    f"Variant `{variant_name}` is not defined"
+                                    f" in enum `{casa_enum.name}`",
+                                    op.location,
+                                )
+                            )
+                            continue
+                        ordinal = casa_enum.variants.index(variant_name)
+                        op.kind = OpKind.PUSH_ENUM_VARIANT
+                        op.value = EnumVariant(casa_enum.name, variant_name, ordinal)
+                        continue
+
                 # Check trait bound call: K::method -> push var + exec
                 trait_var = _resolve_trait_ref(identifier, function)
                 if trait_var:
@@ -378,6 +401,10 @@ def resolve_identifiers(
                     op.kind = OpKind.STRUCT_NEW
                     op.value = struct
                     continue
+                if casa_enum := GLOBAL_ENUMS.get(identifier):
+                    op.kind = OpKind.PUSH_INT
+                    op.value = len(casa_enum.variants)
+                    continue
 
                 errors.append(
                     CasaError(
@@ -404,11 +431,21 @@ def resolve_identifiers(
     return ops
 
 
+def _append_op_result(ops: list[Op], result: "Op | list[Op] | None") -> None:
+    """Append a token_to_op result (single op, list, or None) to the ops list."""
+    if result is None:
+        return
+    if isinstance(result, list):
+        ops.extend(result)
+    else:
+        ops.append(result)
+
+
 def token_to_op(
     token: Token,
     cursor: Cursor[Token],
     function_name: str = GLOBAL_SCOPE_LABEL,
-) -> Op | None:
+) -> Op | list[Op] | None:
     """Convert a single token into its corresponding op."""
     assert len(TokenKind) == 12, "Exhaustive handling for `TokenKind`"
 
@@ -447,7 +484,7 @@ def get_op_delimiter(
     function_name: str,
 ) -> Op | None:
     """Convert a delimiter token into its op."""
-    assert len(Delimiter) == 11, "Exhaustive handling for `Delimiter`"
+    assert len(Delimiter) == 12, "Exhaustive handling for `Delimiter`"
 
     delimiter = Delimiter.from_str(token.value)
     match delimiter:
@@ -463,6 +500,8 @@ def get_op_delimiter(
         case Delimiter.DOT:
             method = expect_token(cursor, kind=TokenKind.IDENTIFIER)
             return Op(method.value, OpKind.METHOD_CALL, method.location)
+        case Delimiter.FAT_ARROW:
+            return None
         case Delimiter.HASHTAG:
             return None
         # Lambda function
@@ -523,8 +562,7 @@ def parse_block_ops(cursor: Cursor[Token], function_name: str) -> list[Op]:
         if token.kind == TokenKind.FSTRING_START:
             handle_fstring(token, cursor, function_name, ops)
             continue
-        if op := token_to_op(token, cursor, function_name):
-            ops.append(op)
+        _append_op_result(ops, token_to_op(token, cursor, function_name))
     raise_error(ErrorKind.UNMATCHED_BLOCK, "Unclosed block", open_brace.location)
 
 
@@ -534,8 +572,8 @@ def get_op_array(cursor: Cursor[Token]) -> Op:
 
     array_items = []
     while not expect_delimiter(cursor, Delimiter.CLOSE_BRACKET):
-        next_tok = cursor.peek()
-        if next_tok and next_tok.value == "[":
+        next_token = cursor.peek()
+        if next_token and next_token.value == "[":
             array_items.append(get_op_array(cursor))
             expect_delimiter(cursor, Delimiter.COMMA)
             continue
@@ -554,7 +592,7 @@ def get_op_array(cursor: Cursor[Token]) -> Op:
                 got=got,
             )
         item_op = token_to_op(value_token, cursor)
-        assert item_op is not None, "Array item token always produces an Op"
+        assert isinstance(item_op, Op), "Array item token always produces an Op"
         array_items.append(item_op)
         expect_delimiter(cursor, Delimiter.COMMA)
 
@@ -594,6 +632,148 @@ def _handle_keyword_fn(token: Token, cursor: Cursor[Token], function_name: str) 
             function.location,
         )
     GLOBAL_FUNCTIONS[function.name] = function
+
+
+def parse_enum(cursor: Cursor[Token]) -> CasaEnum:
+    """Parse an enum definition."""
+    expect_token(cursor, value="enum")
+    name = expect_token(cursor, kind=TokenKind.IDENTIFIER)
+    expect_token(cursor, value="{")
+    variants: list[str] = []
+    while True:
+        variant_token = expect_token(cursor)
+        if variant_token.value == "}":
+            break
+        if variant_token.kind != TokenKind.IDENTIFIER:
+            raise_error(
+                ErrorKind.UNEXPECTED_TOKEN,
+                "Unexpected token in enum definition",
+                variant_token.location,
+                expected="identifier",
+                got=f"`{variant_token.value}`",
+            )
+        if variant_token.value in variants:
+            raise_error(
+                ErrorKind.DUPLICATE_NAME,
+                f"Duplicate variant `{variant_token.value}` in enum",
+                variant_token.location,
+            )
+        variants.append(variant_token.value)
+    if not variants:
+        raise_error(
+            ErrorKind.SYNTAX,
+            "Enum must have at least one variant",
+            name.location,
+        )
+    return CasaEnum(name.value, variants, name.location)
+
+
+def _handle_keyword_enum(
+    token: Token, cursor: Cursor[Token], function_name: str
+) -> None:
+    """Handle the `enum` keyword: parse and register an enum definition."""
+    _require_global_scope(function_name, "Enums", token.location)
+    cursor.position -= 1
+    casa_enum = parse_enum(cursor)
+    if casa_enum.name in GLOBAL_ENUMS:
+        raise_error(
+            ErrorKind.DUPLICATE_NAME,
+            f"Enum `{casa_enum.name}` is already defined",
+            casa_enum.location,
+        )
+    if casa_enum.name in GLOBAL_STRUCTS:
+        raise_error(
+            ErrorKind.DUPLICATE_NAME,
+            f"Identifier `{casa_enum.name}` is already defined as a struct",
+            casa_enum.location,
+        )
+    GLOBAL_ENUMS[casa_enum.name] = casa_enum
+
+
+def _is_match_arm_boundary(cursor: Cursor[Token]) -> bool:
+    """Check if current position looks like a match arm pattern (Ident::Ident => or _ =>)."""
+    pos = cursor.position
+    seq = cursor.sequence
+    if pos + 1 >= len(seq):
+        return False
+    token = seq[pos]
+    if token.value == MATCH_WILDCARD and seq[pos + 1].value == "=>":
+        return True
+    if pos + 2 >= len(seq):
+        return False
+    if token.kind != TokenKind.IDENTIFIER or "::" not in token.value:
+        return False
+    next_token = seq[pos + 1]
+    return next_token.value == "=>"
+
+
+def _handle_keyword_match(
+    token: Token, cursor: Cursor[Token], function_name: str
+) -> list[Op]:
+    """Handle the `match` keyword: parse a match block into ops."""
+    ops: list[Op] = []
+    ops.append(Op(Keyword.MATCH, OpKind.MATCH_START, token.location))
+
+    # Parse arms until `end`
+    while True:
+        arm_token = expect_token(cursor)
+        if arm_token.value == "end":
+            ops.append(Op(Keyword.END, OpKind.MATCH_END, arm_token.location))
+            break
+
+        # Wildcard arm: _ =>
+        if arm_token.value == MATCH_WILDCARD:
+            expect_token(cursor, value="=>")
+            variant = EnumVariant("", MATCH_WILDCARD, -1)
+            ops.append(Op(variant, OpKind.MATCH_ARM, arm_token.location))
+        elif arm_token.kind != TokenKind.IDENTIFIER or "::" not in arm_token.value:
+            raise_error(
+                ErrorKind.UNEXPECTED_TOKEN,
+                "Expected enum variant pattern (e.g. `Color::Red`) or `_`",
+                arm_token.location,
+                expected="enum variant or `_`",
+                got=f"`{arm_token.value}`",
+            )
+        else:
+            # Parse the => delimiter
+            expect_token(cursor, value="=>")
+
+            # Resolve the variant
+            parts = arm_token.value.split("::", 1)
+            enum_name, variant_name = parts[0], parts[1]
+            casa_enum = GLOBAL_ENUMS.get(enum_name)
+            if not casa_enum:
+                raise_error(
+                    ErrorKind.UNDEFINED_NAME,
+                    f"Enum `{enum_name}` is not defined",
+                    arm_token.location,
+                )
+            if variant_name not in casa_enum.variants:
+                raise_error(
+                    ErrorKind.UNDEFINED_NAME,
+                    f"Variant `{variant_name}` is not defined in enum `{enum_name}`",
+                    arm_token.location,
+                )
+            ordinal = casa_enum.variants.index(variant_name)
+            variant = EnumVariant(enum_name, variant_name, ordinal)
+            ops.append(Op(variant, OpKind.MATCH_ARM, arm_token.location))
+
+        # Parse arm body until next arm or `end`
+        while not cursor.is_finished():
+            if _is_match_arm_boundary(cursor):
+                break
+            next_token = cursor.peek()
+            if next_token and next_token.value == "end":
+                break
+            body_token = cursor.pop()
+            if body_token is None:
+                break
+            if body_token.kind == TokenKind.FSTRING_START:
+                handle_fstring(body_token, cursor, function_name, ops)
+                continue
+            _append_op_result(ops, token_to_op(body_token, cursor, function_name))
+
+    return ops
 
 
 def _handle_keyword_struct(
@@ -668,9 +848,9 @@ def get_op_keyword(
     token: Token,
     cursor: Cursor[Token],
     function_name: str,
-) -> Op | None:
+) -> Op | list[Op] | None:
     """Convert a keyword token into its op, parsing any nested blocks."""
-    assert len(Keyword) == 16, "Exhaustive handling for `Keyword"
+    assert len(Keyword) == 19, "Exhaustive handling for `Keyword"
 
     keyword = Keyword.from_lowercase(token.value)
     assert keyword, f"Token `{token.value}` is not a keyword"
@@ -679,6 +859,15 @@ def get_op_keyword(
         return Op(keyword, SIMPLE_KEYWORD_OPS[keyword], token.location)
 
     match keyword:
+        case Keyword.END:
+            raise_error(
+                ErrorKind.UNMATCHED_BLOCK,
+                "`end` without matching `match`",
+                token.location,
+            )
+        case Keyword.ENUM:
+            _handle_keyword_enum(token, cursor, function_name)
+            return None
         case Keyword.FN:
             _handle_keyword_fn(token, cursor, function_name)
             return None
@@ -691,6 +880,8 @@ def get_op_keyword(
             return None
         case Keyword.INCLUDE:
             return _handle_keyword_include(token, cursor)
+        case Keyword.MATCH:
+            return _handle_keyword_match(token, cursor, function_name)
         case Keyword.STRUCT:
             _handle_keyword_struct(token, cursor, function_name)
             return None
@@ -931,6 +1122,12 @@ def parse_type_vars(
                     f"Type variable `{token.value}` shadows struct type `{token.value}`",
                     token.location,
                 )
+            if token.value in GLOBAL_ENUMS:
+                raise_error(
+                    ErrorKind.DUPLICATE_NAME,
+                    f"Type variable `{token.value}` shadows enum type `{token.value}`",
+                    token.location,
+                )
             type_vars.add(token.value)
             # Check for trait bound: K: Hashable
             next_tok = cursor.peek()
@@ -1113,7 +1310,7 @@ def _parse_compound_assign(
     """Parse a compound assignment operator (+= or -=)."""
     next_token = expect_token(cursor, kind=TokenKind.IDENTIFIER)
     identifier = token_to_op(next_token, cursor, function_name)
-    assert identifier, "Expected identifier"
+    assert isinstance(identifier, Op), "Expected identifier"
     variable_name = identifier.value
     assert isinstance(variable_name, str), "Expected variable name"
     return Op(variable_name, op_kind, token.location)
@@ -1140,7 +1337,7 @@ def get_op_operator(token: Token, cursor: Cursor[Token], function_name: str) -> 
         case Operator.ASSIGN:
             next_token = expect_token(cursor, kind=TokenKind.IDENTIFIER)
             identifier = token_to_op(next_token, cursor, function_name)
-            assert identifier, "Expected identifier"
+            assert isinstance(identifier, Op), "Expected identifier"
 
             variable_name = identifier.value
             assert isinstance(variable_name, str), "Expected variable name"

--- a/casa/typechecker.py
+++ b/casa/typechecker.py
@@ -6,9 +6,12 @@ from typing import assert_never
 
 from casa.common import (
     ANY_TYPE,
+    GLOBAL_ENUMS,
     GLOBAL_FUNCTIONS,
     GLOBAL_TRAITS,
     GLOBAL_VARIABLES,
+    MATCH_WILDCARD,
+    EnumVariant,
     Function,
     Intrinsic,
     Location,
@@ -53,6 +56,7 @@ class BranchedStack:
     current_branch_label: str | None
     current_branch_location: Location | None
     if_location: Location | None
+    if_location_enum_name: str | None
 
     def __init__(
         self,
@@ -73,6 +77,7 @@ class BranchedStack:
         self.current_branch_label = None
         self.current_branch_location = None
         self.if_location = None
+        self.if_location_enum_name = None
 
 
 @dataclass
@@ -351,10 +356,25 @@ class TypeChecker:
                 self.expect_type("int")
                 self.stack_push("int")
 
-    def check_comparison(self) -> None:
+    def check_comparison(self, op: Op) -> None:
         """Handle EQ, NE, LT, LE, GT, GE."""
-        self.stack_pop()
-        self.stack_pop()
+        t1 = self.stack_pop()
+        t2 = self.stack_pop()
+        t1_is_enum = t1 in GLOBAL_ENUMS
+        t2_is_enum = t2 in GLOBAL_ENUMS
+        if t1_is_enum or t2_is_enum:
+            if t1 != t2:
+                raise_error(
+                    ErrorKind.TYPE_MISMATCH,
+                    f"Cannot compare `{t2}` with `{t1}`",
+                    self.current_location,
+                )
+            if op.kind not in (OpKind.EQ, OpKind.NE):
+                raise_error(
+                    ErrorKind.TYPE_MISMATCH,
+                    f"Enum type `{t1}` only supports `==` and `!=` comparison",
+                    self.current_location,
+                )
         self.stack_push("bool")
 
     def check_boolean(self, op: Op) -> None:
@@ -835,6 +855,8 @@ class TypeChecker:
             op.kind = OpKind.PRINT_CHAR
         elif typ == "cstr":
             op.kind = OpKind.PRINT_CSTR
+        elif typ in GLOBAL_ENUMS:
+            op.kind = OpKind.PRINT_INT
         else:
             op.kind = OpKind.PRINT_INT
 
@@ -845,6 +867,175 @@ class TypeChecker:
         for _ in range(arg_count):
             self.stack_pop()
         self.stack_push("int")
+
+    def check_enum_variant(self, op: Op) -> None:
+        """Handle PUSH_ENUM_VARIANT."""
+        variant = op.value
+        assert isinstance(variant, EnumVariant)
+        self.stack_push(variant.enum_name)
+
+    def check_match(self, op: Op) -> None:
+        """Handle MATCH_START, MATCH_ARM, MATCH_END."""
+        match op.kind:
+            case OpKind.MATCH_START:
+                typ = self.stack_pop()
+                if typ not in GLOBAL_ENUMS:
+                    raise_error(
+                        ErrorKind.TYPE_MISMATCH,
+                        f"Match requires an enum type, got `{typ}`",
+                        op.location,
+                    )
+                bs = BranchedStack(self.stack, self.stack_origins)
+                bs.if_location = op.location
+                bs.if_location_enum_name = typ
+                bs.default_present = True
+                self.branched_stacks.append(bs)
+            case OpKind.MATCH_ARM:
+                variant = op.value
+                assert isinstance(variant, EnumVariant)
+                assert self.branched_stacks, "Match block stack state is saved"
+                branched = self.branched_stacks[-1]
+
+                enum_name = branched.if_location_enum_name
+                assert enum_name is not None
+
+                # Check for arms after wildcard
+                wildcard_key = f"__covered:{MATCH_WILDCARD}"
+                has_wildcard = (
+                    any(
+                        label == wildcard_key for label, _, _ in branched.branch_records
+                    )
+                    or branched.current_branch_label == wildcard_key
+                )
+
+                if has_wildcard:
+                    raise_error(
+                        ErrorKind.SYNTAX,
+                        "Match arms after wildcard `_` are unreachable",
+                        op.location,
+                    )
+
+                if variant.is_wildcard:
+                    covered_key = wildcard_key
+                else:
+                    if variant.enum_name != enum_name:
+                        raise_error(
+                            ErrorKind.TYPE_MISMATCH,
+                            f"Match arm variant `{variant.enum_name}::{variant.variant_name}`"
+                            f" does not belong to enum `{enum_name}`",
+                            op.location,
+                        )
+
+                    covered_key = f"__covered:{variant.variant_name}"
+                    # Check for duplicate: in branch_records or the current label
+                    for label, _, _ in branched.branch_records:
+                        if label == covered_key:
+                            raise_error(
+                                ErrorKind.DUPLICATE_NAME,
+                                f"Duplicate match arm for"
+                                f" `{variant.enum_name}::{variant.variant_name}`",
+                                op.location,
+                            )
+                    if branched.current_branch_label == covered_key:
+                        raise_error(
+                            ErrorKind.DUPLICATE_NAME,
+                            f"Duplicate match arm for `{variant.enum_name}::{variant.variant_name}`",
+                            op.location,
+                        )
+
+                # Handle branch state like elif
+                if branched.condition_present:
+                    # Record the PREVIOUS arm's stack state
+                    if branched.current_branch_location:
+                        prev_covered = branched.current_branch_label
+                        if prev_covered and prev_covered.startswith("__covered:"):
+                            branched.branch_records.append(
+                                (
+                                    prev_covered,
+                                    self.stack.copy(),
+                                    branched.current_branch_location,
+                                )
+                            )
+                    if self.stack == branched.before == branched.after:
+                        pass
+                    else:
+                        unified = _stacks_compatible(self.stack, branched.after)
+                        if unified is not None and branched.before != branched.after:
+                            branched.after = unified
+                        elif branched.before == branched.after:
+                            branched.after = self.stack.copy()
+                            branched.after_origins = self.stack_origins.copy()
+                        else:
+                            raise_error(
+                                ErrorKind.STACK_MISMATCH,
+                                "Match arms have incompatible stack effects",
+                                op.location,
+                                notes=_branch_mismatch_notes(branched),
+                            )
+                    self.stack = branched.before.copy()
+                    self.stack_origins = branched.before_origins.copy()
+                else:
+                    branched.condition_present = True
+                    branched.before = self.stack.copy()
+                    branched.before_origins = self.stack_origins.copy()
+                    branched.after = branched.before
+                    branched.after_origins = branched.before_origins
+
+                branched.current_branch_label = covered_key
+                branched.current_branch_location = op.location
+
+            case OpKind.MATCH_END:
+                assert self.branched_stacks, "Match block stack state is saved"
+                branched = self.branched_stacks.pop()
+
+                # Record last arm
+                if (
+                    branched.current_branch_label
+                    and branched.current_branch_label.startswith("__covered:")
+                    and branched.current_branch_location
+                ):
+                    branched.branch_records.append(
+                        (
+                            branched.current_branch_label,
+                            self.stack.copy(),
+                            branched.current_branch_location,
+                        )
+                    )
+
+                # Extract enum name from if_location metadata
+                enum_name = branched.if_location_enum_name
+                assert enum_name is not None
+                casa_enum = GLOBAL_ENUMS[enum_name]
+                covered = {
+                    label.split(":", 1)[1]
+                    for label, _, _ in branched.branch_records
+                    if label.startswith("__covered:")
+                }
+                has_wildcard = MATCH_WILDCARD in covered
+                if not has_wildcard:
+                    missing = [v for v in casa_enum.variants if v not in covered]
+                    if missing:
+                        names = ", ".join(f"`{enum_name}::{v}`" for v in missing)
+                        raise_error(
+                            ErrorKind.TYPE_MISMATCH,
+                            f"Non-exhaustive match, missing arms: {names}",
+                            op.location,
+                        )
+
+                # Apply final stack state
+                unified = _stacks_compatible(self.stack, branched.after)
+                if unified is not None:
+                    self.stack = unified
+                    self.stack_origins = branched.after_origins.copy()
+                elif self.stack == branched.before == branched.after:
+                    pass
+                else:
+                    raise_error(
+                        ErrorKind.STACK_MISMATCH,
+                        "Match arms have incompatible stack effects",
+                        op.location,
+                        notes=_branch_mismatch_notes(branched),
+                    )
 
     def check_struct_new(self, op: Op) -> None:
         """Handle STRUCT_NEW."""
@@ -1341,7 +1532,7 @@ def type_satisfies_trait(
 
 def type_check_ops(ops: list[Op], function: Function | None = None) -> Signature:
     """Type-check a list of ops and return the inferred signature."""
-    assert len(OpKind) == 79, "Exhaustive handling for `OpKind`"
+    assert len(OpKind) == 83, "Exhaustive handling for `OpKind`"
 
     tc = TypeChecker(ops=ops)
     op_index = 0
@@ -1360,7 +1551,7 @@ def type_check_ops(ops: list[Op], function: Function | None = None) -> Signature
             case OpKind.ADD | OpKind.SUB | OpKind.DIV | OpKind.MOD | OpKind.MUL:
                 tc.check_arithmetic(op)
             case OpKind.EQ | OpKind.NE | OpKind.LT | OpKind.LE | OpKind.GT | OpKind.GE:
-                tc.check_comparison()
+                tc.check_comparison(op)
             case OpKind.AND | OpKind.OR | OpKind.NOT:
                 tc.check_boolean(op)
             case (
@@ -1435,6 +1626,10 @@ def type_check_ops(ops: list[Op], function: Function | None = None) -> Signature
                 | OpKind.SYSCALL6
             ):
                 tc.check_syscalls(op)
+            case OpKind.PUSH_ENUM_VARIANT:
+                tc.check_enum_variant(op)
+            case OpKind.MATCH_START | OpKind.MATCH_ARM | OpKind.MATCH_END:
+                tc.check_match(op)
             case OpKind.STRUCT_NEW:
                 tc.check_struct_new(op)
             case OpKind.METHOD_CALL:

--- a/docs/control-flow.md
+++ b/docs/control-flow.md
@@ -153,6 +153,60 @@ The stack state must be identical:
 
 The type checker enforces that loops do not accumulate or consume stack values across iterations.
 
+## Match
+
+Casa has exhaustive pattern matching on enum types using `match`/`end`.
+
+### Syntax
+
+```
+<enum_value> match
+    EnumName::Variant1 => <body>
+    EnumName::Variant2 => <body>
+    ...
+end
+```
+
+The `match` keyword pops an enum value from the stack. Each arm specifies a variant pattern followed by `=>` and a body. The block is closed with `end`.
+
+### Basic Example
+
+```casa
+enum Color { Red Green Blue }
+
+Color::Green match
+    Color::Red => "red" print
+    Color::Green => "green" print
+    Color::Blue => "blue" print
+end
+```
+
+### Exhaustiveness
+
+All variants of the enum must be covered. Missing a variant is a compile-time error. Duplicate arms are also rejected. A wildcard `_ =>` arm can be used to match all remaining variants:
+
+```casa
+color match
+    Color::Red => "red" print
+    _ => "other" print
+end
+```
+
+### Match as Expression
+
+Match arms can leave values on the stack. All arms must produce the same stack effect:
+
+```casa
+Color::Blue match
+    Color::Red => 0
+    Color::Green => 1
+    Color::Blue => 2
+end
+print    # 2
+```
+
+See [Enums](enums.md) for full details on enum types and match.
+
 ## Nested Control Flow
 
 Conditionals and loops can be freely nested:

--- a/docs/enums.md
+++ b/docs/enums.md
@@ -1,0 +1,245 @@
+# Enums
+
+Enums define a type with a fixed set of named variants.
+
+## Defining an Enum
+
+Use the `enum` keyword followed by the type name and a list of variants in braces.
+
+```casa
+enum Color { Red Green Blue }
+enum Direction { North South East West }
+```
+
+Each variant is a distinct value of the enum type. An enum must have at least one variant. Variant names must be unique within the enum.
+
+## Variant Constructors
+
+Access variants using the `EnumName::VariantName` syntax.
+
+**Stack effect:** `-> EnumName`
+
+```casa
+Color::Red        # pushes a Color value
+Direction::North  # pushes a Direction value
+```
+
+Variants can be assigned to variables:
+
+```casa
+Color::Blue = my_color
+```
+
+## Comparison
+
+Enum values of the same type can be compared with `==` and `!=`.
+
+**Stack effect:** `EnumName EnumName -> bool`
+
+```casa
+Color::Red Color::Red == print     # true
+Color::Red Color::Blue != print    # true
+```
+
+Comparing values of different enum types is a compile-time error:
+
+```casa
+# ERROR: cannot compare Color and Direction
+Color::Red Direction::North ==
+```
+
+Comparing an enum value with a non-enum type (e.g. `int`) is also a compile-time error.
+
+## Printing
+
+Printing an enum value outputs its ordinal (0-based index in the declaration order).
+
+```casa
+Color::Red print     # 0
+Color::Green print   # 1
+Color::Blue print    # 2
+```
+
+## Match Statement
+
+The `match` keyword provides exhaustive pattern matching on enum values. It consumes the enum value from the stack and executes the matching arm.
+
+### Syntax
+
+```
+<enum_value> match
+    EnumName::Variant1 => <body>
+    EnumName::Variant2 => <body>
+    ...
+end
+```
+
+The `match` keyword pops the enum value from the stack. Each arm specifies a variant pattern followed by `=>` and a body. The block is closed with `end`.
+
+### Basic Example
+
+```casa
+enum Color { Red Green Blue }
+
+Color::Green match
+    Color::Red => "red" print
+    Color::Green => "green" print
+    Color::Blue => "blue" print
+end
+# prints: green
+```
+
+### Exhaustiveness
+
+All variants must be covered. Missing a variant is a compile-time error:
+
+```casa
+# ERROR: Non-exhaustive match, missing arms: `Color::Blue`
+Color::Red match
+    Color::Red => "red" print
+    Color::Green => "green" print
+end
+```
+
+Duplicate arms are also compile-time errors.
+
+### Wildcard Arm
+
+The `_ =>` wildcard arm matches any remaining variants. When used, it must be the last arm. No further arms are allowed after it.
+
+```casa
+enum Direction { North South East West }
+
+Direction::North match
+    Direction::North => "up" print
+    _ => "not up" print
+end
+```
+
+The wildcard satisfies exhaustiveness on its own, so you do not need to list every variant:
+
+```casa
+# Only handle one variant explicitly, catch the rest
+color match
+    Color::Red => "red" print
+    _ => "other" print
+end
+```
+
+Arms after a wildcard are unreachable and produce a compile-time error:
+
+```casa
+# ERROR: unreachable match arm after wildcard `_`
+color match
+    _ => "any" print
+    Color::Red => "red" print
+end
+```
+
+### Match as Expression
+
+Match arms can leave values on the stack. All arms must produce the same stack effect (same types).
+
+```casa
+Color::Green match
+    Color::Red => 10
+    Color::Green => 20
+    Color::Blue => 30
+end
+print    # 20
+```
+
+This is useful for mapping enum values to other types:
+
+```casa
+fn color_name c:Color -> str {
+    c match
+        Color::Red => "red"
+        Color::Green => "green"
+        Color::Blue => "blue"
+    end
+}
+```
+
+### Stack Consistency
+
+All arms must leave the stack in the same state. The following is a compile-time error:
+
+```casa
+# ERROR: arms produce different types
+Color::Red match
+    Color::Red => 1
+    Color::Green => "two"
+    Color::Blue => 3
+end
+```
+
+## Enums in Functions
+
+Enum types work as function parameters and return types.
+
+```casa
+enum Direction { North South East West }
+
+fn is_vertical d:Direction -> bool {
+    d match
+        Direction::North => true
+        Direction::South => true
+        Direction::East => false
+        Direction::West => false
+    end
+}
+
+Direction::North is_vertical print   # true
+```
+
+## Enums in Conditionals
+
+Enum values can be used in `if` conditions with comparison operators:
+
+```casa
+Color::Red = my_color
+
+if my_color Color::Red == then
+    "it is red" print
+fi
+```
+
+## Complete Example
+
+```casa
+enum Color { Red Green Blue }
+
+# Variant constructor
+Color::Green = color
+
+# Comparison
+color Color::Green == print    # true
+
+# Match as expression
+color match
+    Color::Red => "red"
+    Color::Green => "green"
+    Color::Blue => "blue"
+end
+print    # green
+
+# Print ordinal
+Color::Blue print    # 2
+```
+
+## Variant Count
+
+Using the enum name as a value pushes the number of variants as an `int`.
+
+**Stack effect:** `-> int`
+
+```casa
+enum Color { Red Green Blue }
+
+Color print    # 3
+```
+
+This is resolved at compile time.
+
+See [`examples/enum.casa`](../examples/enum.casa).

--- a/docs/standard-library.md
+++ b/docs/standard-library.md
@@ -279,9 +279,9 @@ list.length print       # 3
 
 ### `List::slice`
 
-Returns an `array[T]` view into the list's data from index `start` (inclusive) to `end` (exclusive). This is a zero-copy operation. Prints an error and exits if the range is out of bounds.
+Returns an `array[T]` view into the list's data from index `start` (inclusive) to `stop` (exclusive). This is a zero-copy operation. Prints an error and exits if the range is out of bounds.
 
-**Signature:** `List::slice[T] self:List[T] start:int end:int -> array[T]`
+**Signature:** `List::slice[T] self:List[T] start:int stop:int -> array[T]`
 
 **Stack effect:** `List[T] int int -> array[T]`
 

--- a/docs/types-and-literals.md
+++ b/docs/types-and-literals.md
@@ -306,6 +306,20 @@ struct Point {
 
 See [Structs and Methods](structs-and-methods.md) for details.
 
+### User-Defined Enums
+
+Enum names are types. After defining an enum, its name can be used as a type. Variants are accessed with `EnumName::VariantName`.
+
+```casa
+enum Color { Red Green Blue }
+
+Color::Red = c    # c has type Color
+```
+
+Enum values support `==` and `!=` comparison (same enum type only). Printing outputs the ordinal. Pattern matching is done with `match`/`end`.
+
+See [Enums](enums.md) for details.
+
 ## Type Variables (Generics)
 
 Type variables let functions declare type relationships between inputs and outputs. They are declared in square brackets after the function name and are resolved to concrete types at each call site.

--- a/examples/enum.casa
+++ b/examples/enum.casa
@@ -1,0 +1,64 @@
+# Enums - fixed set of named variants
+#
+# Variants are accessed with EnumName::VariantName syntax.
+# Match provides exhaustive pattern matching.
+
+enum Color { Red Green Blue }
+
+# Variant constructors push an enum value onto the stack
+Color::Green = color
+
+# Print outputs the ordinal (0-based)
+Color::Red print "\n" print
+Color::Green print "\n" print
+Color::Blue print "\n" print
+
+# Comparison with == and !=
+color Color::Green == print "\n" print
+color Color::Red != print "\n" print
+
+# Match statement with side effects
+color match
+    Color::Red => "red" print
+    Color::Green => "green" print
+    Color::Blue => "blue" print
+end
+"\n" print
+
+# Match as expression (leaves value on the stack)
+Color::Blue match
+    Color::Red => "warm"
+    Color::Green => "cool"
+    Color::Blue => "cool"
+end
+print "\n" print
+
+# Match inside a function
+fn color_code c:Color -> int {
+    c match
+        Color::Red => 0
+        Color::Green => 1
+        Color::Blue => 2
+    end
+}
+
+Color::Red color_code print "\n" print
+Color::Blue color_code print "\n" print
+
+# Wildcard match arm
+enum Direction { North South East West }
+Direction::West match
+    Direction::North => "up"
+    _ => "not up"
+end
+print "\n" print
+
+# Enum name resolves to variant count
+Color print "\n" print
+Direction print "\n" print
+
+# Enum in conditionals
+Color::Red = my_color
+if my_color Color::Red == then
+    "it is red\n" print
+fi

--- a/examples/outputs/enum.out
+++ b/examples/outputs/enum.out
@@ -1,0 +1,13 @@
+0
+1
+2
+true
+true
+green
+cool
+0
+2
+not up
+3
+4
+it is red

--- a/lib/std.casa
+++ b/lib/std.casa
@@ -122,14 +122,14 @@ impl List {
         self.data self.size 8 * + load64 (T)
     }
 
-    fn slice[T] self:List[T] start:int end:int -> array[T] {
-        if 0 start < self.size end > || end start > || then
+    fn slice[T] self:List[T] start:int stop:int -> array[T] {
+        if 0 start < self.size stop > || stop start > || then
             "error: List slice out of bounds\n" print
             1 60 syscall1 drop
         fi
         16 alloc = hdr
         self.data start 8 * + hdr (ptr) store64
-        end start - hdr (ptr) 8 + store64
+        stop start - hdr (ptr) 8 + store64
         hdr (array)
     }
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 import pytest
 
 from casa.common import (
+    GLOBAL_ENUMS,
     GLOBAL_FUNCTIONS,
     GLOBAL_STRUCTS,
     GLOBAL_TRAITS,
@@ -31,6 +32,7 @@ TEST_FILE = Path("test.casa")
 
 def _clear_globals():
     """Reset all module-level mutable state to a clean slate."""
+    GLOBAL_ENUMS.clear()
     GLOBAL_FUNCTIONS.clear()
     GLOBAL_STRUCTS.clear()
     GLOBAL_TRAITS.clear()

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -1,0 +1,603 @@
+"""Tests for the enum feature: parsing, type checking, bytecode, and end-to-end."""
+
+import os
+import subprocess
+
+import pytest
+
+from casa.common import (
+    GLOBAL_ENUMS,
+    CasaEnum,
+    EnumVariant,
+    InstKind,
+    OpKind,
+    Program,
+)
+from casa.error import CasaErrorCollection, ErrorKind
+from tests.conftest import (
+    compile_string,
+    parse_string,
+    resolve_string,
+    typecheck_string,
+)
+
+CASA_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+COLOR_ENUM = "enum Color { Red Green Blue }\n"
+DIRECTION_ENUM = "enum Direction { North South East West }\n"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def find_ops(ops: list, kind: OpKind) -> list:
+    return [op for op in ops if op.kind == kind]
+
+
+# ---------------------------------------------------------------------------
+# Enum declaration parsing
+# ---------------------------------------------------------------------------
+class TestEnumParsing:
+    def test_parse_enum_registers_globally(self):
+        parse_string("enum Color { Red Green Blue }")
+        assert "Color" in GLOBAL_ENUMS
+
+    def test_parse_enum_is_casa_enum(self):
+        parse_string("enum Color { Red Green Blue }")
+        assert isinstance(GLOBAL_ENUMS["Color"], CasaEnum)
+
+    def test_parse_enum_name(self):
+        parse_string("enum Color { Red Green Blue }")
+        assert GLOBAL_ENUMS["Color"].name == "Color"
+
+    def test_parse_enum_variant_count(self):
+        parse_string("enum Color { Red Green Blue }")
+        assert len(GLOBAL_ENUMS["Color"].variants) == 3
+
+    def test_parse_enum_variant_names(self):
+        parse_string("enum Color { Red Green Blue }")
+        assert GLOBAL_ENUMS["Color"].variants == ["Red", "Green", "Blue"]
+
+    def test_parse_enum_has_location(self):
+        parse_string("enum Color { Red Green Blue }")
+        assert GLOBAL_ENUMS["Color"].location is not None
+
+    def test_parse_enum_single_variant(self):
+        parse_string("enum Unit { Only }")
+        assert GLOBAL_ENUMS["Unit"].variants == ["Only"]
+
+    def test_parse_enum_many_variants(self):
+        parse_string("enum Direction { North South East West }")
+        assert len(GLOBAL_ENUMS["Direction"].variants) == 4
+
+    def test_parse_duplicate_enum_raises(self):
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            parse_string(
+                "enum Color { Red Green Blue }\n" "enum Color { Cyan Magenta Yellow }\n"
+            )
+        assert exc_info.value.errors[0].kind == ErrorKind.DUPLICATE_NAME
+
+    def test_parse_enum_empty_raises(self):
+        with pytest.raises(CasaErrorCollection):
+            parse_string("enum Empty { }")
+
+    def test_parse_duplicate_variant_raises(self):
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            parse_string("enum Dup { A B A }\n")
+        assert exc_info.value.errors[0].kind == ErrorKind.DUPLICATE_NAME
+
+    def test_parse_enum_name_conflicts_with_struct_raises(self):
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            parse_string("struct Color { val: int }\nenum Color { Red Green }\n")
+        assert exc_info.value.errors[0].kind == ErrorKind.DUPLICATE_NAME
+
+    def test_parse_enum_unclosed_block_raises(self):
+        with pytest.raises(CasaErrorCollection):
+            parse_string("enum Color { Red Green Blue")
+
+
+# ---------------------------------------------------------------------------
+# Match block parsing
+# ---------------------------------------------------------------------------
+class TestMatchParsing:
+    def test_parse_match_produces_match_ops(self):
+        code = (
+            "enum Color { Red Green Blue }\n"
+            "Color::Red match\n"
+            "    Color::Red => 1\n"
+            "    Color::Green => 2\n"
+            "    Color::Blue => 3\n"
+            "end\n"
+        )
+        ops = parse_string(code)
+        kinds = [op.kind for op in ops]
+        assert OpKind.MATCH_START in kinds
+        assert OpKind.MATCH_ARM in kinds
+        assert OpKind.MATCH_END in kinds
+
+    def test_parse_match_arm_count(self):
+        code = (
+            "enum Color { Red Green Blue }\n"
+            "Color::Red match\n"
+            "    Color::Red => 1\n"
+            "    Color::Green => 2\n"
+            "    Color::Blue => 3\n"
+            "end\n"
+        )
+        ops = parse_string(code)
+        arm_ops = find_ops(ops, OpKind.MATCH_ARM)
+        assert len(arm_ops) == 3
+
+
+# ---------------------------------------------------------------------------
+# Identifier resolution: Color::Red -> PUSH_ENUM_VARIANT
+# ---------------------------------------------------------------------------
+class TestEnumResolution:
+    def test_resolve_enum_variant(self):
+        ops = resolve_string("enum Color { Red Green Blue } Color::Red")
+        variant_ops = find_ops(ops, OpKind.PUSH_ENUM_VARIANT)
+        assert len(variant_ops) == 1
+
+    def test_resolve_enum_variant_value_is_enum_variant(self):
+        ops = resolve_string("enum Color { Red Green Blue } Color::Red")
+        variant_ops = find_ops(ops, OpKind.PUSH_ENUM_VARIANT)
+        assert isinstance(variant_ops[0].value, EnumVariant)
+
+    def test_resolve_enum_variant_ordinal_first(self):
+        ops = resolve_string("enum Color { Red Green Blue } Color::Red")
+        variant_ops = find_ops(ops, OpKind.PUSH_ENUM_VARIANT)
+        assert variant_ops[0].value.ordinal == 0
+
+    def test_resolve_enum_variant_ordinal_second(self):
+        ops = resolve_string("enum Color { Red Green Blue } Color::Green")
+        variant_ops = find_ops(ops, OpKind.PUSH_ENUM_VARIANT)
+        assert variant_ops[0].value.ordinal == 1
+
+    def test_resolve_enum_variant_ordinal_third(self):
+        ops = resolve_string("enum Color { Red Green Blue } Color::Blue")
+        variant_ops = find_ops(ops, OpKind.PUSH_ENUM_VARIANT)
+        assert variant_ops[0].value.ordinal == 2
+
+    def test_resolve_enum_variant_enum_name(self):
+        ops = resolve_string("enum Color { Red Green Blue } Color::Red")
+        variant_ops = find_ops(ops, OpKind.PUSH_ENUM_VARIANT)
+        assert variant_ops[0].value.enum_name == "Color"
+
+    def test_resolve_enum_variant_variant_name(self):
+        ops = resolve_string("enum Color { Red Green Blue } Color::Green")
+        variant_ops = find_ops(ops, OpKind.PUSH_ENUM_VARIANT)
+        assert variant_ops[0].value.variant_name == "Green"
+
+    def test_resolve_undefined_enum_raises(self):
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            resolve_string("Nonexistent::Foo")
+        assert exc_info.value.errors[0].kind == ErrorKind.UNDEFINED_NAME
+
+    def test_resolve_undefined_variant_raises(self):
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            resolve_string("enum Color { Red Green Blue } Color::Yellow")
+        assert exc_info.value.errors[0].kind == ErrorKind.UNDEFINED_NAME
+
+    def test_resolve_multiple_variants(self):
+        ops = resolve_string(COLOR_ENUM + "Color::Red Color::Green Color::Blue\n")
+        variant_ops = find_ops(ops, OpKind.PUSH_ENUM_VARIANT)
+        assert len(variant_ops) == 3
+        ordinals = [op.value.ordinal for op in variant_ops]
+        assert ordinals == [0, 1, 2]
+
+
+# ---------------------------------------------------------------------------
+# Type checking: enum variants
+# ---------------------------------------------------------------------------
+class TestEnumTypeChecking:
+    def test_enum_variant_pushes_enum_type(self):
+        sig = typecheck_string("enum Color { Red Green Blue } Color::Red")
+        assert sig.return_types == ["Color"]
+
+    def test_enum_eq_same_type(self):
+        sig = typecheck_string(
+            "enum Color { Red Green Blue } Color::Red Color::Green =="
+        )
+        assert sig.return_types == ["bool"]
+
+    def test_enum_ne_same_type(self):
+        sig = typecheck_string(
+            "enum Color { Red Green Blue } Color::Red Color::Blue !="
+        )
+        assert sig.return_types == ["bool"]
+
+    def test_enum_eq_different_types_raises(self):
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            typecheck_string(
+                "enum Color { Red Green Blue }\n"
+                "enum Shape { Circle Square }\n"
+                "Color::Red Shape::Circle ==\n"
+            )
+        assert exc_info.value.errors[0].kind == ErrorKind.TYPE_MISMATCH
+
+    def test_enum_assign_variable(self):
+        sig = typecheck_string("enum Color { Red Green Blue } Color::Red = c c")
+        assert sig.return_types == ["Color"]
+
+    def test_enum_in_function_param(self):
+        typecheck_string(
+            "enum Color { Red Green Blue }\n"
+            "fn is_red c:Color -> bool { c Color::Red == }\n"
+            "Color::Red is_red\n"
+        )
+
+    def test_enum_int_comparison_raises(self):
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            typecheck_string(COLOR_ENUM + "Color::Red 42 ==\n")
+        assert exc_info.value.errors[0].kind == ErrorKind.TYPE_MISMATCH
+
+    def test_enum_as_return_type(self):
+        typecheck_string(
+            COLOR_ENUM + "fn get_color -> Color { Color::Blue }\n" + "get_color\n"
+        )
+
+    def test_wrong_enum_type_in_function_raises(self):
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            typecheck_string(
+                COLOR_ENUM
+                + DIRECTION_ENUM
+                + "fn is_red c:Color -> bool { c Color::Red == }\n"
+                + "Direction::North is_red\n"
+            )
+        assert exc_info.value.errors[0].kind == ErrorKind.TYPE_MISMATCH
+
+    def test_enum_print(self):
+        sig = typecheck_string("enum Color { Red Green Blue } Color::Red print")
+        assert sig.return_types == []
+
+
+# ---------------------------------------------------------------------------
+# Type checking: match exhaustiveness
+# ---------------------------------------------------------------------------
+class TestMatchExhaustiveness:
+    def test_match_exhaustive_passes(self):
+        typecheck_string(
+            "enum Color { Red Green Blue }\n"
+            "Color::Red match\n"
+            "    Color::Red => 1\n"
+            "    Color::Green => 2\n"
+            "    Color::Blue => 3\n"
+            "end\n"
+            "drop\n"
+        )
+
+    def test_match_missing_variant_raises(self):
+        with pytest.raises(CasaErrorCollection):
+            typecheck_string(
+                "enum Color { Red Green Blue }\n"
+                "Color::Red match\n"
+                "    Color::Red => 1\n"
+                "    Color::Green => 2\n"
+                "end\n"
+                "drop\n"
+            )
+
+    def test_match_wrong_enum_variant_raises(self):
+        with pytest.raises(CasaErrorCollection):
+            typecheck_string(
+                "enum Color { Red Green Blue }\n"
+                "enum Shape { Circle Square }\n"
+                "Color::Red match\n"
+                "    Color::Red => 1\n"
+                "    Color::Green => 2\n"
+                "    Shape::Circle => 3\n"
+                "end\n"
+                "drop\n"
+            )
+
+    def test_match_arms_inconsistent_stack_raises(self):
+        with pytest.raises(CasaErrorCollection):
+            typecheck_string(
+                "enum Color { Red Green Blue }\n"
+                "Color::Red match\n"
+                "    Color::Red => 1\n"
+                '    Color::Green => "hello"\n'
+                "    Color::Blue => 3\n"
+                "end\n"
+                "drop\n"
+            )
+
+    def test_match_as_expression(self):
+        sig = typecheck_string(
+            "enum Color { Red Green Blue }\n"
+            "Color::Red match\n"
+            "    Color::Red => 10\n"
+            "    Color::Green => 20\n"
+            "    Color::Blue => 30\n"
+            "end\n"
+        )
+        assert sig.return_types == ["int"]
+
+    def test_match_duplicate_arm_raises(self):
+        with pytest.raises(CasaErrorCollection):
+            typecheck_string(
+                COLOR_ENUM
+                + "Color::Red match\n"
+                + "    Color::Red => 1\n"
+                + "    Color::Red => 2\n"
+                + "    Color::Green => 3\n"
+                + "    Color::Blue => 4\n"
+                + "end\n"
+                + "drop\n"
+            )
+
+    def test_match_as_expression_str(self):
+        sig = typecheck_string(
+            COLOR_ENUM
+            + "Color::Red match\n"
+            + '    Color::Red => "red"\n'
+            + '    Color::Green => "green"\n'
+            + '    Color::Blue => "blue"\n'
+            + "end\n"
+        )
+        assert sig.return_types == ["str"]
+
+    def test_match_all_arms_drop_is_consistent(self):
+        typecheck_string(
+            COLOR_ENUM
+            + "Color::Red match\n"
+            + '    Color::Red => "red" print\n'
+            + '    Color::Green => "green" print\n'
+            + '    Color::Blue => "blue" print\n'
+            + "end\n"
+        )
+
+    def test_match_arms_must_have_same_type(self):
+        with pytest.raises(CasaErrorCollection):
+            typecheck_string(
+                "enum Color { Red Green Blue }\n"
+                "Color::Red match\n"
+                "    Color::Red => 1\n"
+                '    Color::Green => "two"\n'
+                "    Color::Blue => 3\n"
+                "end\n"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Match inside functions
+# ---------------------------------------------------------------------------
+class TestMatchInFunction:
+    def test_match_inside_function(self):
+        typecheck_string(
+            COLOR_ENUM
+            + "fn color_name c:Color -> str {\n"
+            + "    c match\n"
+            + '        Color::Red => "red"\n'
+            + '        Color::Green => "green"\n'
+            + '        Color::Blue => "blue"\n'
+            + "    end\n"
+            + "}\n"
+            + "Color::Blue color_name\n"
+        )
+
+    def test_match_result_used_in_function(self):
+        sig = typecheck_string(
+            COLOR_ENUM
+            + "fn color_value c:Color -> int {\n"
+            + "    c match\n"
+            + "        Color::Red => 0\n"
+            + "        Color::Green => 1\n"
+            + "        Color::Blue => 2\n"
+            + "    end\n"
+            + "}\n"
+            + "Color::Green color_value\n"
+        )
+        assert sig.return_types == ["int"]
+
+
+# ---------------------------------------------------------------------------
+# Bytecode: PUSH_ENUM_VARIANT compiles to PUSH(ordinal)
+# ---------------------------------------------------------------------------
+def find_insts(program: Program, kind: InstKind, in_functions: bool = False):
+    results = [i for i in program.bytecode if i.kind == kind]
+    if in_functions:
+        for fn_bc in program.functions.values():
+            results += [i for i in fn_bc if i.kind == kind]
+    return results
+
+
+class TestEnumBytecode:
+    def test_enum_variant_compiles_to_push_ordinal_0(self):
+        program = compile_string(COLOR_ENUM + "Color::Red\n")
+        pushes = find_insts(program, InstKind.PUSH)
+        assert any(i.args == [0] for i in pushes)
+
+    def test_enum_variant_compiles_to_push_ordinal_1(self):
+        program = compile_string(COLOR_ENUM + "Color::Green\n")
+        pushes = find_insts(program, InstKind.PUSH)
+        assert any(i.args == [1] for i in pushes)
+
+    def test_enum_variant_compiles_to_push_ordinal_2(self):
+        program = compile_string(COLOR_ENUM + "Color::Blue\n")
+        pushes = find_insts(program, InstKind.PUSH)
+        assert any(i.args == [2] for i in pushes)
+
+    def test_match_compiles_to_dup_eq_jump_pattern(self):
+        program = compile_string(
+            COLOR_ENUM
+            + "Color::Red match\n"
+            + "    Color::Red => 1 drop\n"
+            + "    Color::Green => 2 drop\n"
+            + "    Color::Blue => 3 drop\n"
+            + "end\n"
+        )
+        # Last arm is optimized: no DUP/EQ/JUMP_NE (exhaustiveness guaranteed)
+        assert len(find_insts(program, InstKind.DUP)) >= 2
+        assert len(find_insts(program, InstKind.EQ)) >= 2
+        assert len(find_insts(program, InstKind.JUMP_NE)) >= 2
+        assert len(find_insts(program, InstKind.DROP)) >= 3
+        assert len(find_insts(program, InstKind.LABEL)) >= 3
+
+    def test_enum_print_compiles_to_print_int(self):
+        program = compile_string(COLOR_ENUM + "Color::Red print\n")
+        assert len(find_insts(program, InstKind.PRINT_INT)) >= 1
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: compile and run enum programs
+# ---------------------------------------------------------------------------
+class TestEnumEndToEnd:
+    @pytest.fixture
+    def run_casa(self, tmp_path):
+        def _run(code: str) -> str:
+            src = tmp_path / "test.casa"
+            src.write_text(code)
+            binary = tmp_path / "test"
+            result = subprocess.run(
+                ["python3", "casa.py", str(src), "-o", str(binary)],
+                capture_output=True,
+                text=True,
+                cwd=CASA_ROOT,
+                timeout=30,
+            )
+            if result.returncode != 0:
+                pytest.fail(
+                    f"Compilation failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+                )
+            run_result = subprocess.run(
+                [str(binary)],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            return run_result.stdout
+
+        return _run
+
+    def test_enum_print_ordinal(self, run_casa):
+        output = run_casa("enum Color { Red Green Blue }\n" "Color::Red print\n")
+        assert output == "0"
+
+    def test_enum_print_second_variant(self, run_casa):
+        output = run_casa("enum Color { Red Green Blue }\n" "Color::Green print\n")
+        assert output == "1"
+
+    def test_enum_eq_true(self, run_casa):
+        output = run_casa(
+            "enum Color { Red Green Blue }\n" "Color::Red Color::Red == print\n"
+        )
+        assert output == "true"
+
+    def test_enum_eq_false(self, run_casa):
+        output = run_casa(
+            "enum Color { Red Green Blue }\n" "Color::Red Color::Green == print\n"
+        )
+        assert output == "false"
+
+    def test_enum_ne(self, run_casa):
+        output = run_casa(
+            "enum Color { Red Green Blue }\n" "Color::Red Color::Blue != print\n"
+        )
+        assert output == "true"
+
+    def test_enum_match_first_arm(self, run_casa):
+        output = run_casa(
+            "enum Color { Red Green Blue }\n"
+            "Color::Red match\n"
+            '    Color::Red => "red" print\n'
+            '    Color::Green => "green" print\n'
+            '    Color::Blue => "blue" print\n'
+            "end\n"
+        )
+        assert output == "red"
+
+    def test_enum_match_second_arm(self, run_casa):
+        output = run_casa(
+            "enum Color { Red Green Blue }\n"
+            "Color::Green match\n"
+            '    Color::Red => "red" print\n'
+            '    Color::Green => "green" print\n'
+            '    Color::Blue => "blue" print\n'
+            "end\n"
+        )
+        assert output == "green"
+
+    def test_enum_match_third_arm(self, run_casa):
+        output = run_casa(
+            "enum Color { Red Green Blue }\n"
+            "Color::Blue match\n"
+            '    Color::Red => "red" print\n'
+            '    Color::Green => "green" print\n'
+            '    Color::Blue => "blue" print\n'
+            "end\n"
+        )
+        assert output == "blue"
+
+    def test_enum_match_as_expression(self, run_casa):
+        output = run_casa(
+            "enum Color { Red Green Blue }\n"
+            "Color::Green match\n"
+            "    Color::Red => 10\n"
+            "    Color::Green => 20\n"
+            "    Color::Blue => 30\n"
+            "end\n"
+            "print\n"
+        )
+        assert output == "20"
+
+    def test_enum_variable_match(self, run_casa):
+        output = run_casa(
+            "enum Color { Red Green Blue }\n"
+            "Color::Blue = my_color\n"
+            "my_color match\n"
+            '    Color::Red => "r"\n'
+            '    Color::Green => "g"\n'
+            '    Color::Blue => "b"\n'
+            "end\n"
+            "print\n"
+        )
+        assert output == "b"
+
+    def test_enum_in_function(self, run_casa):
+        output = run_casa(
+            "enum Color { Red Green Blue }\n"
+            "fn color_name c:Color -> str {\n"
+            "    c match\n"
+            '        Color::Red => "red"\n'
+            '        Color::Green => "green"\n'
+            '        Color::Blue => "blue"\n'
+            "    end\n"
+            "}\n"
+            "Color::Green color_name print\n"
+        )
+        assert output == "green"
+
+    def test_enum_match_all_arms(self, run_casa):
+        output = run_casa(
+            DIRECTION_ENUM
+            + "fn dir_str d:Direction -> str {\n"
+            + "    d match\n"
+            + '        Direction::North => "N"\n'
+            + '        Direction::South => "S"\n'
+            + '        Direction::East => "E"\n'
+            + '        Direction::West => "W"\n'
+            + "    end\n"
+            + "}\n"
+            + "Direction::North dir_str print\n"
+            + "Direction::South dir_str print\n"
+            + "Direction::East dir_str print\n"
+            + "Direction::West dir_str print\n"
+        )
+        assert output == "NSEW"
+
+    def test_enum_in_if_condition(self, run_casa):
+        output = run_casa(
+            COLOR_ENUM
+            + "Color::Red = my_color\n"
+            + 'if my_color Color::Red == then "yes" print fi\n'
+        )
+        assert output == "yes"
+
+    def test_multiple_enums(self, run_casa):
+        output = run_casa(
+            COLOR_ENUM
+            + DIRECTION_ENUM
+            + "Color::Red print\n"
+            + "Direction::West print\n"
+        )
+        assert output == "03"

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -23,8 +23,11 @@ ALL_KEYWORDS = [
     "elif",
     "else",
     "fi",
+    "end",
+    "enum",
     "struct",
     "trait",
+    "match",
     "include",
 ]
 assert len(ALL_KEYWORDS) == len(Keyword)
@@ -750,7 +753,7 @@ def test_operator_from_str_returns_none_for_unknown():
 # ---------------------------------------------------------------------------
 def test_delimiter_from_str_consistent_with_enum():
     """Every Delimiter enum member has a from_str mapping."""
-    all_strings = ["->", ",", ":", ".", "#", "{", "}", "[", "]", "(", ")"]
+    all_strings = ["->", ",", "=>", ":", ".", "#", "{", "}", "[", "]", "(", ")"]
     assert len(all_strings) == len(Delimiter)
     for s in all_strings:
         assert Delimiter.from_str(s) is not None


### PR DESCRIPTION
## Summary

- Add enum declarations (`enum Color { Red Green Blue }`) with variant constructors (`Color::Red`)
- Add exhaustive `match` statements with `EnumName::Variant =>` arms and `end` keyword
- Support `==` and `!=` comparison between same enum types
- Enums are integers at runtime with compile-time type safety
- Rename `List::slice` `end` parameter to `stop` to avoid keyword conflict

## Test plan

- [x] 847 tests pass (65 new enum tests)
- [x] 27/27 example tests pass (new enum example)
- [x] mypy passes (2 pre-existing errors only)
- [x] black formatting clean
- [x] pylint passes