### PR TITLE
fix: add error hint for unqualified enum variants in match arms

### DIFF
--- a/casa/parser.py
+++ b/casa/parser.py
@@ -690,7 +690,7 @@ def _handle_keyword_enum(
     GLOBAL_ENUMS[casa_enum.name] = casa_enum
 
 
-def _is_match_arm_boundary(cursor: Cursor[Token]) -> bool:
+def _is_match_arm_boundary(cursor: Cursor[Token], matched_enum_name: str) -> bool:
     """Check if current position looks like a match arm pattern (Ident::Ident => or _ =>)."""
     pos = cursor.position
     seq = cursor.sequence
@@ -701,10 +701,27 @@ def _is_match_arm_boundary(cursor: Cursor[Token]) -> bool:
         return True
     if pos + 2 >= len(seq):
         return False
-    if token.kind != TokenKind.IDENTIFIER or "::" not in token.value:
+    if token.kind != TokenKind.IDENTIFIER:
         return False
     next_token = seq[pos + 1]
-    return next_token.value == "=>"
+    if next_token.value != "=>":
+        return False
+    # Qualified variant (Enum::Variant =>) or bare variant from the matched enum
+    if "::" in token.value:
+        return True
+    if matched_enum_name:
+        casa_enum = GLOBAL_ENUMS.get(matched_enum_name)
+        if casa_enum and token.value in casa_enum.variants:
+            return True
+    return False
+
+
+def _match_arm_example(matched_enum_name: str) -> str:
+    """Return an example like `Color::Red` for error messages."""
+    casa_enum = GLOBAL_ENUMS.get(matched_enum_name)
+    if casa_enum and casa_enum.variants:
+        return f"{casa_enum.name}::{casa_enum.variants[0]}"
+    return "Enum::Variant"
 
 
 def _handle_keyword_match(
@@ -713,6 +730,7 @@ def _handle_keyword_match(
     """Handle the `match` keyword: parse a match block into ops."""
     ops: list[Op] = []
     ops.append(Op(Keyword.MATCH, OpKind.MATCH_START, token.location))
+    matched_enum_name = ""
 
     # Parse arms until `end`
     while True:
@@ -727,9 +745,15 @@ def _handle_keyword_match(
             variant = EnumVariant("", MATCH_WILDCARD, -1)
             ops.append(Op(variant, OpKind.MATCH_ARM, arm_token.location))
         elif arm_token.kind != TokenKind.IDENTIFIER or "::" not in arm_token.value:
+            hint = ""
+            if arm_token.kind == TokenKind.IDENTIFIER and matched_enum_name:
+                casa_enum = GLOBAL_ENUMS.get(matched_enum_name)
+                if casa_enum and arm_token.value in casa_enum.variants:
+                    hint = f". Did you mean `{casa_enum.name}::{arm_token.value}`?"
+            example = _match_arm_example(matched_enum_name)
             raise_error(
                 ErrorKind.UNEXPECTED_TOKEN,
-                "Expected enum variant pattern (e.g. `Color::Red`) or `_`",
+                f"Expected enum variant pattern (e.g. `{example}`) or `_`{hint}",
                 arm_token.location,
                 expected="enum variant or `_`",
                 got=f"`{arm_token.value}`",
@@ -756,11 +780,12 @@ def _handle_keyword_match(
                 )
             ordinal = casa_enum.variants.index(variant_name)
             variant = EnumVariant(enum_name, variant_name, ordinal)
+            matched_enum_name = enum_name
             ops.append(Op(variant, OpKind.MATCH_ARM, arm_token.location))
 
         # Parse arm body until next arm or `end`
         while not cursor.is_finished():
-            if _is_match_arm_boundary(cursor):
+            if _is_match_arm_boundary(cursor, matched_enum_name):
                 break
             next_token = cursor.peek()
             if next_token and next_token.value == "end":

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -96,6 +96,117 @@ class TestEnumParsing:
 
 
 # ---------------------------------------------------------------------------
+# Match arm: bare variant hint
+# ---------------------------------------------------------------------------
+class TestMatchBareVariantHint:
+    def test_bare_variant_error_contains_hint(self):
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            parse_string(
+                "enum Color { Red Green Blue }\n"
+                "Color::Green match\n"
+                "    Color::Red => 1\n"
+                "    Green => 2\n"
+                "    Color::Blue => 3\n"
+                "end\n"
+            )
+        error = exc_info.value.errors[0]
+        assert error.kind == ErrorKind.UNEXPECTED_TOKEN
+        assert "Did you mean `Color::Green`?" in error.message
+
+    def test_bare_variant_from_wrong_enum_no_hint(self):
+        """Bare variant from a different enum is not recognized as an arm boundary."""
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            resolve_string(
+                "enum Shape { Circle Square }\n"
+                "enum Color { Red Green Blue }\n"
+                "Color::Red match\n"
+                "    Color::Red => 1\n"
+                "    Circle => 2\n"
+                "    _ => 3\n"
+                "end\n"
+            )
+        error = exc_info.value.errors[0]
+        assert error.kind == ErrorKind.UNDEFINED_NAME
+
+    def test_bare_variant_second_arm(self):
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            parse_string(
+                "enum Color { Red Green Blue }\n"
+                "Color::Red match\n"
+                "    Color::Red => 1\n"
+                "    Green => 2\n"
+                "    Color::Blue => 3\n"
+                "end\n"
+            )
+        error = exc_info.value.errors[0]
+        assert "Did you mean `Color::Green`?" in error.message
+
+    def test_non_variant_identifier_no_hint(self):
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            parse_string(
+                "enum Color { Red Green Blue }\n"
+                "Color::Red match\n"
+                "    foo => 1\n"
+                "    _ => 2\n"
+                "end\n"
+            )
+        error = exc_info.value.errors[0]
+        assert error.kind == ErrorKind.UNEXPECTED_TOKEN
+        assert "Did you mean" not in error.message
+
+    def test_non_identifier_token_no_hint(self):
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            parse_string(
+                "enum Color { Red Green Blue }\n"
+                "Color::Red match\n"
+                "    42 => 1\n"
+                "    _ => 2\n"
+                "end\n"
+            )
+        error = exc_info.value.errors[0]
+        assert "Did you mean" not in error.message
+
+    def test_dynamic_example_uses_matched_enum(self):
+        """After parsing a valid arm, the example in error uses the matched enum."""
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            parse_string(
+                "enum Color { Red Green Blue }\n"
+                "Color::Red match\n"
+                "    Color::Red => 1\n"
+                "    Green => 2\n"
+                "    Color::Blue => 3\n"
+                "end\n"
+            )
+        error = exc_info.value.errors[0]
+        assert "e.g. `Color::Red`" in error.message
+
+    def test_dynamic_example_fallback_without_prior_arm(self):
+        """When no valid arm has been parsed yet, use a generic example."""
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            parse_string(
+                "enum Color { Red Green Blue }\n"
+                "Color::Red match\n"
+                "    foo => 1\n"
+                "    _ => 2\n"
+                "end\n"
+            )
+        error = exc_info.value.errors[0]
+        assert "e.g. `Enum::Variant`" in error.message
+
+    def test_qualified_variant_still_works(self):
+        ops = parse_string(
+            "enum Color { Red Green Blue }\n"
+            "Color::Red match\n"
+            "    Color::Red => 1\n"
+            "    Color::Green => 2\n"
+            "    Color::Blue => 3\n"
+            "end\n"
+        )
+        arm_ops = find_ops(ops, OpKind.MATCH_ARM)
+        assert len(arm_ops) == 3
+
+
+# ---------------------------------------------------------------------------
 # Match block parsing
 # ---------------------------------------------------------------------------
 class TestMatchParsing:


### PR DESCRIPTION
## Summary
- When a bare variant name (e.g. `Red`) is used in a match arm instead of the qualified form (`Color::Red`), the error now suggests the correct qualified form
- The example in the error message dynamically uses the matched enum name and first variant when known, falling back to `Enum::Variant`
- Only checks variants from the enum being matched, not all enums

## Test plan
- [x] 8 new unit tests in `TestMatchBareVariantHint` covering hint generation, wrong-enum rejection, non-variant identifiers, non-identifier tokens, dynamic examples, and existing behavior
- [x] All 855 tests pass
- [x] All 27 example tests pass