### PR TITLE
fix: remove whitespace before dot method calls in std.casa

### DIFF
--- a/lib/std.casa
+++ b/lib/std.casa
@@ -148,11 +148,13 @@ fn digit_to_str d:int -> str {
 impl int {
     fn to_str n:int -> str {
         if 0 n < then
-            f"-{0 n - .to_str}"
+            0 n - = neg_n
+            f"-{neg_n.to_str}"
         elif 10 n < then
             n digit_to_str
         else
-            f"{n 10 / .to_str}{n 10 % digit_to_str}"
+            n 10 / = div_n
+            f"{div_n.to_str}{n 10 % digit_to_str}"
         fi
     }
 }
@@ -183,15 +185,15 @@ impl str {
     }
 
     fn eq b:str a:str -> bool {
-        a .length = eq_a_len
-        b .length = eq_b_len
+        a.length = eq_a_len
+        b.length = eq_b_len
         if eq_a_len eq_b_len != then
             false
         else
             true = eq_matched
             0 = eq_i
             while eq_i eq_a_len > do
-                if eq_i a .at eq_i b .at != then
+                if eq_i a.at eq_i b.at != then
                     false = eq_matched
                     break
                 fi
@@ -209,7 +211,7 @@ impl str {
         # Copy bytes
         0 = sub_i
         while sub_i len > do
-            start sub_i + s .at sub_i sub_buf.set
+            start sub_i + s.at sub_i sub_buf.set
             1 += sub_i
         done
         # Store null terminator
@@ -218,8 +220,8 @@ impl str {
     }
 
     fn find needle:str s:str -> int {
-        s .length = fnd_s_len
-        needle .length = fnd_n_len
+        s.length = fnd_s_len
+        needle.length = fnd_n_len
         if fnd_n_len fnd_s_len < then
             0 1 -
         else
@@ -229,7 +231,7 @@ impl str {
                 true = fnd_found
                 0 = fnd_j
                 while fnd_j fnd_n_len > do
-                    if fnd_i fnd_j + s .at fnd_j needle .at != then
+                    if fnd_i fnd_j + s.at fnd_j needle.at != then
                         false = fnd_found
                         break
                     fi
@@ -246,15 +248,15 @@ impl str {
     }
 
     fn starts_with prefix:str s:str -> bool {
-        s .length = sw_s_len
-        prefix .length = sw_p_len
+        s.length = sw_s_len
+        prefix.length = sw_p_len
         if sw_p_len sw_s_len < then
             false
         else
             true = sw_matched
             0 = sw_i
             while sw_i sw_p_len > do
-                if sw_i s .at sw_i prefix .at != then
+                if sw_i s.at sw_i prefix.at != then
                     false = sw_matched
                     break
                 fi
@@ -265,8 +267,8 @@ impl str {
     }
 
     fn ends_with suffix:str s:str -> bool {
-        s .length = ew_s_len
-        suffix .length = ew_suf_len
+        s.length = ew_s_len
+        suffix.length = ew_suf_len
         if ew_suf_len ew_s_len < then
             false
         else
@@ -274,7 +276,7 @@ impl str {
             true = ew_matched
             0 = ew_i
             while ew_i ew_suf_len > do
-                if ew_off ew_i + s .at ew_i suffix .at != then
+                if ew_off ew_i + s.at ew_i suffix.at != then
                     false = ew_matched
                     break
                 fi
@@ -329,7 +331,7 @@ impl file {
     }
 
     fn write fd:int data:str -> int {
-        data .length data.as_cstr (ptr) fd 1 syscall3
+        data.length data.as_cstr (ptr) fd 1 syscall3
     }
 
     fn close fd:int -> int {
@@ -385,7 +387,7 @@ impl char {
     }
 
     fn is_alpha c:char -> bool {
-        c .is_upper c .is_lower ||
+        c.is_upper c.is_lower ||
     }
 
     fn is_space c:char -> bool {
@@ -394,7 +396,7 @@ impl char {
 }
 
 impl ptr {
-    fn to_str p:ptr -> str { p (int) .to_str }
+    fn to_str p:ptr -> str { p (int) = p_int p_int.to_str }
 }
 
 impl option {
@@ -434,8 +436,8 @@ trait Hashable {
 fn str_hash s:str -> int {
     5381 = sh_h
     0 = sh_i
-    while sh_i s .length > do
-        sh_h 5 << sh_h + sh_i s .at (int) + = sh_h
+    while sh_i s.length > do
+        sh_h 5 << sh_h + sh_i s.at (int) + = sh_h
         1 += sh_i
     done
     if 0 sh_h < then 0 sh_h - = sh_h fi
@@ -498,7 +500,7 @@ impl Map {
     }
 
     fn has[K: Hashable, V] self:Map[K V] key:K -> bool {
-        key self.get .is_some
+        key self.get.is_some
     }
 
     fn set[K: Hashable, V] self:Map[K V] value:V key:K -> Map[K V] {
@@ -621,20 +623,24 @@ impl Set {
     }
 
     fn has[K: Hashable] self:Set[K] key:K -> bool {
-        key self.map (Map[K int]) .has
+        self.map (Map[K int]) = has_map
+        key has_map.has
     }
 
     fn add[K: Hashable] self:Set[K] key:K -> Set[K] {
-        key 0 self.map (Map[K int]) .set (Map) self->map
+        self.map (Map[K int]) = add_map
+        key 0 add_map.set (Map) self->map
         self (Set[K])
     }
 
     fn remove[K: Hashable] self:Set[K] key:K -> Set[K] {
-        key self.map (Map[K int]) .delete (Map) self->map
+        self.map (Map[K int]) = rm_map
+        key rm_map.delete (Map) self->map
         self (Set[K])
     }
 
     fn to_list[K] self:Set[K] -> List[K] {
-        self.map (Map[K int]) .keys
+        self.map (Map[K int]) = tl_map
+        tl_map.keys
     }
 }


### PR DESCRIPTION
## Summary
- Removed whitespace before `.` in all method call syntax in `lib/std.casa`
- For simple cases (variable before dot), removed the space directly
- For expression-result cases (operator or cast before dot), introduced temporary variables to hold the value before calling the dot method

## Test plan
- [x] All 27 example tests pass (`tests/test_examples.sh`)