### PR TITLE
fix: remove whitespace before dot method call syntax

### DIFF
--- a/casa/parser.py
+++ b/casa/parser.py
@@ -494,6 +494,32 @@ def token_to_op(
             assert_never(token.kind)
 
 
+def _has_whitespace_before_receiver(token: Token, cursor: Cursor[Token]) -> bool:
+    """Check if the dot/arrow token has whitespace after a receiver token.
+
+    Returns True (error) only when the previous token looks like a receiver
+    (identifier, literal, keyword, or closing delimiter) and is not adjacent.
+    Returns False (no error) when the previous token is an intrinsic, operator,
+    or opening delimiter, since those indicate the dot operates on the implicit
+    stack top rather than a specific receiver.
+    """
+    if cursor.position - 2 < 0:
+        return False
+    prev = cursor.sequence[cursor.position - 2]
+    receiver_kinds = {TokenKind.IDENTIFIER, TokenKind.LITERAL, TokenKind.KEYWORD}
+    is_closing_delim = prev.kind == TokenKind.DELIMITER and prev.value in {
+        ")",
+        "]",
+        "}",
+    }
+    if prev.kind not in receiver_kinds and not is_closing_delim:
+        return False
+    return (
+        prev.location.span.offset + prev.location.span.length
+        != token.location.span.offset
+    )
+
+
 def get_op_delimiter(
     token: Token,
     cursor: Cursor[Token],
@@ -507,6 +533,12 @@ def get_op_delimiter(
         case None:
             return None
         case Delimiter.ARROW:
+            if _has_whitespace_before_receiver(token, cursor):
+                raise_error(
+                    ErrorKind.SYNTAX,
+                    "Unexpected whitespace before `->` in setter syntax",
+                    token.location,
+                )
             member = expect_token(cursor, kind=TokenKind.IDENTIFIER)
             return Op(f"set_{member.value}", OpKind.METHOD_CALL, member.location)
         case Delimiter.COLON:
@@ -514,6 +546,12 @@ def get_op_delimiter(
         case Delimiter.COMMA:
             return None
         case Delimiter.DOT:
+            if _has_whitespace_before_receiver(token, cursor):
+                raise_error(
+                    ErrorKind.SYNTAX,
+                    "Unexpected whitespace before `.`",
+                    token.location,
+                )
             method = expect_token(cursor, kind=TokenKind.IDENTIFIER)
             return Op(method.value, OpKind.METHOD_CALL, method.location)
         case Delimiter.FAT_ARROW:

--- a/casa/parser.py
+++ b/casa/parser.py
@@ -494,6 +494,10 @@ def token_to_op(
             assert_never(token.kind)
 
 
+_RECEIVER_TOKEN_KINDS = {TokenKind.IDENTIFIER, TokenKind.LITERAL, TokenKind.KEYWORD}
+_CLOSING_DELIMITERS = {")", "]", "}"}
+
+
 def _has_whitespace_before_receiver(token: Token, cursor: Cursor[Token]) -> bool:
     """Check if the dot/arrow token has whitespace after a receiver token.
 
@@ -506,13 +510,10 @@ def _has_whitespace_before_receiver(token: Token, cursor: Cursor[Token]) -> bool
     if cursor.position - 2 < 0:
         return False
     prev = cursor.sequence[cursor.position - 2]
-    receiver_kinds = {TokenKind.IDENTIFIER, TokenKind.LITERAL, TokenKind.KEYWORD}
-    is_closing_delim = prev.kind == TokenKind.DELIMITER and prev.value in {
-        ")",
-        "]",
-        "}",
-    }
-    if prev.kind not in receiver_kinds and not is_closing_delim:
+    is_closing_delim = (
+        prev.kind == TokenKind.DELIMITER and prev.value in _CLOSING_DELIMITERS
+    )
+    if prev.kind not in _RECEIVER_TOKEN_KINDS and not is_closing_delim:
         return False
     return (
         prev.location.span.offset + prev.location.span.length

--- a/docs/functions-and-lambdas.md
+++ b/docs/functions-and-lambdas.md
@@ -337,7 +337,7 @@ Integers are printed as decimal numbers. Booleans are printed as `true` or `fals
 true print                  # true
 "Hello" print               # Hello
 'A' print                   # A
-"Hello" .as_cstr print      # Hello
+"Hello".as_cstr print       # Hello
 "Hello" print "\n" print    # Hello followed by a newline
 ```
 

--- a/docs/standard-library.md
+++ b/docs/standard-library.md
@@ -129,8 +129,8 @@ Returns `true` if the option contains a value.
 **Stack effect:** `option -> bool`
 
 ```casa
-42 some .is_some print    # 1
-none .is_some print       # 0
+42 some.is_some print    # 1
+none.is_some print       # 0
 ```
 
 ### `option::is_none`
@@ -142,8 +142,8 @@ Returns `true` if the option is empty.
 **Stack effect:** `option -> bool`
 
 ```casa
-42 some .is_none print    # 0
-none .is_none print       # 1
+42 some.is_none print    # 0
+none.is_none print       # 1
 ```
 
 ### `option::unwrap`
@@ -155,8 +155,8 @@ Extracts the contained value. Prints an error and exits with code 60 if called o
 **Stack effect:** `option[T] -> T`
 
 ```casa
-42 some .unwrap print     # 42
-none .unwrap              # error: called unwrap on None
+42 some.unwrap print     # 42
+none.unwrap              # error: called unwrap on None
 ```
 
 ### `option::unwrap_or`
@@ -168,8 +168,8 @@ Returns the contained value, or a default if the option is empty.
 **Stack effect:** `option[T] T -> T`
 
 ```casa
-0 42 some .unwrap_or print    # 42
-0 none .unwrap_or print       # 0
+0 42 some.unwrap_or print    # 42
+0 none.unwrap_or print       # 0
 ```
 
 ## `List[T]`
@@ -386,7 +386,7 @@ Returns a `cstr` pointing to the string's byte data (skipping the 8-byte length 
 **Stack effect:** `str -> cstr`
 
 ```casa
-"hello" .as_cstr print    # hello
+"hello".as_cstr print    # hello
 ```
 
 ### `str::eq`
@@ -478,7 +478,7 @@ Converts a null-terminated C string to a `str`. Scans for the null byte to deter
 **Stack effect:** `cstr -> str`
 
 ```casa
-"hello" .as_cstr .to_str print    # hello
+"hello".as_cstr.to_str print    # hello
 ```
 
 ## File I/O
@@ -807,8 +807,8 @@ Looks up a key and returns `option[V]`. Returns `some` with the value if found, 
 **Stack effect:** `Map[K V] K -> option[V]`
 
 ```casa
-"hello" m.get .unwrap print    # prints the value for "hello"
-"missing" m.get .is_none print # 1
+"hello" m.get.unwrap print    # prints the value for "hello"
+"missing" m.get.is_none print # 1
 ```
 
 ### `Map::has`
@@ -887,8 +887,8 @@ Map::new (Map[str int]) = m
 "three" 3 m.set = m
 
 # Look up values
-"one" m.get .unwrap print      # 1
-"two" m.get .unwrap print      # 2
+"one" m.get.unwrap print      # 1
+"two" m.get.unwrap print      # 2
 
 # Check membership
 "one" m.has print              # true
@@ -896,7 +896,7 @@ Map::new (Map[str int]) = m
 
 # Update a value
 "one" 42 m.set = m
-"one" m.get .unwrap print      # 42
+"one" m.get.unwrap print      # 42
 
 # Delete a key
 "two" m.delete = m
@@ -905,7 +905,7 @@ m.length print                 # 2
 # Integer keys work too
 Map::new (Map[int str]) = m2
 1 "hello" m2.set = m2
-1 m2.get .unwrap print         # hello
+1 m2.get.unwrap print         # hello
 ```
 
 See [`examples/hash_map.casa`](../examples/hash_map.casa) for a full program.

--- a/docs/structs-and-methods.md
+++ b/docs/structs-and-methods.md
@@ -62,12 +62,14 @@ person.name print    # same as: person Person::name print
 person.age print     # same as: person Person::age print
 ```
 
-The type checker resolves the receiver type automatically from whatever value is on top of the stack — you do not need to write the struct name. This means dot syntax works on any expression, not just variables:
+The type checker resolves the receiver type automatically from whatever value is on top of the stack. You do not need to write the struct name. This means dot syntax works on any expression, not just variables:
 
 ```casa
-18 "John Doe" Person .name print   # John Doe (dot on constructor result)
-person.name print                  # John Doe (dot on variable)
+18 "John Doe" Person.name print   # John Doe (dot on constructor result)
+person.name print                 # John Doe (dot on variable)
 ```
+
+The dot must be adjacent to the preceding token. `person .name` is a syntax error.
 
 ### Arrow Syntax (Setter)
 

--- a/docs/types-and-literals.md
+++ b/docs/types-and-literals.md
@@ -97,7 +97,7 @@ Invalid escape sequences (e.g. `\q`) produce a compile-time `SYNTAX` error.
 Null-terminated C string type. There is no literal syntax for `cstr`. Create one from a `str` using `str::as_cstr` (see [Standard Library](standard-library.md#stras_cstr)). The `cstr` points directly to the byte data (no length prefix), terminated by a null byte.
 
 ```casa
-"hello" .as_cstr print    # hello
+"hello".as_cstr print    # hello
 ```
 
 Convert to `str` with `cstr::to_str` (see [Standard Library](standard-library.md#cstrto_str)).
@@ -281,7 +281,7 @@ fn check opt:option -> bool { true }
 
 ```casa
 fn safe_head arr:array[int] -> option[int] {
-    if 0 arr .length > then
+    if 0 arr.length > then
         0 arr array::nth some
     else
         none

--- a/examples/file_io.casa
+++ b/examples/file_io.casa
@@ -5,14 +5,14 @@ include "../lib/std.casa"
 
 # High-level: write and read a file
 "=== write_all ===" print "\n" print
-"Hello, File I/O!\n" "/tmp/casa_fio_test1.txt" file::write_all .to_str print "\n" print
+"Hello, File I/O!\n" "/tmp/casa_fio_test1.txt" file::write_all.to_str print "\n" print
 
 "=== read_all ===" print "\n" print
 "/tmp/casa_fio_test1.txt" file::read_all = content
 content print
 
 "=== content verification ===" print "\n" print
-"Hello, File I/O!\n" content str::eq .to_str print "\n" print
+"Hello, File I/O!\n" content str::eq.to_str print "\n" print
 
 # Low-level: open, write, close
 "=== low-level write ===" print "\n" print

--- a/examples/hash_map.casa
+++ b/examples/hash_map.casa
@@ -11,11 +11,11 @@ Map::new (Map[str int]) = m
 "three" 3 m.set = m
 
 # Get values
-"one" m.get .unwrap print
+"one" m.get.unwrap print
 "\n" print
-"two" m.get .unwrap print
+"two" m.get.unwrap print
 "\n" print
-"three" m.get .unwrap print
+"three" m.get.unwrap print
 "\n" print
 
 # Check length
@@ -30,7 +30,7 @@ m.length print
 
 # Update existing key
 "one" 42 m.set = m
-"one" m.get .unwrap print
+"one" m.get.unwrap print
 "\n" print
 
 # Delete a key
@@ -44,9 +44,9 @@ m.length print
 Map::new (Map[int str]) = m2
 1 "hello" m2.set = m2
 2 "world" m2.set = m2
-1 m2.get .unwrap print
+1 m2.get.unwrap print
 "\n" print
-2 m2.get .unwrap print
+2 m2.get.unwrap print
 "\n" print
 
 # Create a Set[str]

--- a/examples/option.casa
+++ b/examples/option.casa
@@ -30,16 +30,16 @@ maybe_str.unwrap print "\n" print     # hello
 
 # Using options with generic functions
 fn id[T] T -> T { }
-42 some id .unwrap print "\n" print    # 42
+42 some id.unwrap print "\n" print    # 42
 
 # Branching with option types — none and some in different branches
 fn safe_head arr:array[int] -> option[int] {
-    if 0 arr .length > then
+    if 0 arr.length > then
         0 arr array::nth some
     else
         none
     fi
 }
 
-[1, 2, 3] safe_head .unwrap print "\n" print  # 1
-[] (array[int]) safe_head .is_none print "\n" print  # 1 (true)
+[1, 2, 3] safe_head.unwrap print "\n" print  # 1
+[] (array[int]) safe_head.is_none print "\n" print  # 1 (true)

--- a/examples/string_operations.casa
+++ b/examples/string_operations.casa
@@ -5,8 +5,8 @@ include "../lib/std.casa"
 
 # String length
 "=== length ===" print "\n" print
-"hello" .length print "\n" print
-"" .length print "\n" print
+"hello".length print "\n" print
+"".length print "\n" print
 
 # Char access
 "=== at ===" print "\n" print
@@ -63,7 +63,7 @@ greeting print "\n" print
 
 # cstr conversion
 "=== as_cstr ===" print "\n" print
-"hello" .as_cstr print "\n" print
+"hello".as_cstr print "\n" print
 
 # Character classification
 "=== char classification ===" print "\n" print

--- a/lib/std.casa
+++ b/lib/std.casa
@@ -148,11 +148,13 @@ fn digit_to_str d:int -> str {
 impl int {
     fn to_str n:int -> str {
         if 0 n < then
-            f"-{0 n - .to_str}"
+            0 n - = neg_n
+            f"-{neg_n.to_str}"
         elif 10 n < then
             n digit_to_str
         else
-            f"{n 10 / .to_str}{n 10 % digit_to_str}"
+            n 10 / = div_n
+            f"{div_n.to_str}{n 10 % digit_to_str}"
         fi
     }
 }
@@ -183,15 +185,15 @@ impl str {
     }
 
     fn eq b:str a:str -> bool {
-        a .length = eq_a_len
-        b .length = eq_b_len
+        a.length = eq_a_len
+        b.length = eq_b_len
         if eq_a_len eq_b_len != then
             false
         else
             true = eq_matched
             0 = eq_i
             while eq_i eq_a_len > do
-                if eq_i a .at eq_i b .at != then
+                if eq_i a.at eq_i b.at != then
                     false = eq_matched
                     break
                 fi
@@ -209,7 +211,7 @@ impl str {
         # Copy bytes
         0 = sub_i
         while sub_i len > do
-            start sub_i + s .at sub_i sub_buf.set
+            start sub_i + s.at sub_i sub_buf.set
             1 += sub_i
         done
         # Store null terminator
@@ -218,8 +220,8 @@ impl str {
     }
 
     fn find needle:str s:str -> int {
-        s .length = fnd_s_len
-        needle .length = fnd_n_len
+        s.length = fnd_s_len
+        needle.length = fnd_n_len
         if fnd_n_len fnd_s_len < then
             0 1 -
         else
@@ -229,7 +231,7 @@ impl str {
                 true = fnd_found
                 0 = fnd_j
                 while fnd_j fnd_n_len > do
-                    if fnd_i fnd_j + s .at fnd_j needle .at != then
+                    if fnd_i fnd_j + s.at fnd_j needle.at != then
                         false = fnd_found
                         break
                     fi
@@ -246,15 +248,15 @@ impl str {
     }
 
     fn starts_with prefix:str s:str -> bool {
-        s .length = sw_s_len
-        prefix .length = sw_p_len
+        s.length = sw_s_len
+        prefix.length = sw_p_len
         if sw_p_len sw_s_len < then
             false
         else
             true = sw_matched
             0 = sw_i
             while sw_i sw_p_len > do
-                if sw_i s .at sw_i prefix .at != then
+                if sw_i s.at sw_i prefix.at != then
                     false = sw_matched
                     break
                 fi
@@ -265,8 +267,8 @@ impl str {
     }
 
     fn ends_with suffix:str s:str -> bool {
-        s .length = ew_s_len
-        suffix .length = ew_suf_len
+        s.length = ew_s_len
+        suffix.length = ew_suf_len
         if ew_suf_len ew_s_len < then
             false
         else
@@ -274,7 +276,7 @@ impl str {
             true = ew_matched
             0 = ew_i
             while ew_i ew_suf_len > do
-                if ew_off ew_i + s .at ew_i suffix .at != then
+                if ew_off ew_i + s.at ew_i suffix.at != then
                     false = ew_matched
                     break
                 fi
@@ -329,7 +331,7 @@ impl file {
     }
 
     fn write fd:int data:str -> int {
-        data .length data.as_cstr (ptr) fd 1 syscall3
+        data.length data.as_cstr (ptr) fd 1 syscall3
     }
 
     fn close fd:int -> int {
@@ -385,7 +387,7 @@ impl char {
     }
 
     fn is_alpha c:char -> bool {
-        c .is_upper c .is_lower ||
+        c.is_upper c.is_lower ||
     }
 
     fn is_space c:char -> bool {
@@ -394,7 +396,7 @@ impl char {
 }
 
 impl ptr {
-    fn to_str p:ptr -> str { p (int) .to_str }
+    fn to_str p:ptr -> str { p (int) = p_int p_int.to_str }
 }
 
 impl option {
@@ -434,8 +436,8 @@ trait Hashable {
 fn str_hash s:str -> int {
     5381 = sh_h
     0 = sh_i
-    while sh_i s .length > do
-        sh_h 5 << sh_h + sh_i s .at (int) + = sh_h
+    while sh_i s.length > do
+        sh_h 5 << sh_h + sh_i s.at (int) + = sh_h
         1 += sh_i
     done
     if 0 sh_h < then 0 sh_h - = sh_h fi
@@ -498,7 +500,7 @@ impl Map {
     }
 
     fn has[K: Hashable, V] self:Map[K V] key:K -> bool {
-        key self.get .is_some
+        key self.get.is_some
     }
 
     fn set[K: Hashable, V] self:Map[K V] value:V key:K -> Map[K V] {
@@ -621,20 +623,24 @@ impl Set {
     }
 
     fn has[K: Hashable] self:Set[K] key:K -> bool {
-        key self.map (Map[K int]) .has
+        self.map (Map[K int]) = has_map
+        key has_map.has
     }
 
     fn add[K: Hashable] self:Set[K] key:K -> Set[K] {
-        key 0 self.map (Map[K int]) .set (Map) self->map
+        self.map (Map[K int]) = add_map
+        key 0 add_map.set (Map) self->map
         self (Set[K])
     }
 
     fn remove[K: Hashable] self:Set[K] key:K -> Set[K] {
-        key self.map (Map[K int]) .delete (Map) self->map
+        self.map (Map[K int]) = rm_map
+        key rm_map.delete (Map) self->map
         self (Set[K])
     }
 
     fn to_list[K] self:Set[K] -> List[K] {
-        self.map (Map[K int]) .keys
+        self.map (Map[K int]) = tl_map
+        tl_map.keys
     }
 }

--- a/tests/test_array_methods.py
+++ b/tests/test_array_methods.py
@@ -15,7 +15,7 @@ STD_INCLUDE = 'include "lib/std.casa"\n'
 def test_e2e_map_double():
     """map that doubles each element compiles through the full pipeline."""
     code = STD_INCLUDE + """
-    { 2 * } [1, 2, 3] .map = result
+    { 2 * } [1, 2, 3].map = result
     0 result array::nth print
     """
     emit_string(code)
@@ -24,7 +24,7 @@ def test_e2e_map_double():
 def test_e2e_map_negate():
     """map that negates each element compiles through the full pipeline."""
     code = STD_INCLUDE + """
-    { 0 swap - } [1, 2, 3] .map = result
+    { 0 swap - } [1, 2, 3].map = result
     0 result array::nth print
     """
     emit_string(code)
@@ -33,7 +33,7 @@ def test_e2e_map_negate():
 def test_e2e_map_to_bool():
     """map that transforms int to bool compiles correctly."""
     code = STD_INCLUDE + """
-    { 0 > } [1, -2, 3] .map = result
+    { 0 > } [1, -2, 3].map = result
     result array::length print
     """
     emit_string(code)
@@ -45,7 +45,7 @@ def test_e2e_map_to_bool():
 def test_e2e_filter_positive():
     """filter that keeps positive numbers compiles through the full pipeline."""
     code = STD_INCLUDE + """
-    { 0 > } [1, -2, 3, -4, 5] .filter = result
+    { 0 > } [1, -2, 3, -4, 5].filter = result
     result array::length print
     """
     emit_string(code)
@@ -54,7 +54,7 @@ def test_e2e_filter_positive():
 def test_e2e_filter_even():
     """filter that keeps even numbers compiles through the full pipeline."""
     code = STD_INCLUDE + """
-    { 2 % 0 == } [1, 2, 3, 4, 5, 6] .filter = result
+    { 2 % 0 == } [1, 2, 3, 4, 5, 6].filter = result
     result array::length print
     """
     emit_string(code)
@@ -66,7 +66,7 @@ def test_e2e_filter_even():
 def test_e2e_reduce_sum():
     """reduce that sums an array compiles through the full pipeline."""
     code = STD_INCLUDE + """
-    { + } 0 [1, 2, 3, 4, 5] .reduce print
+    { + } 0 [1, 2, 3, 4, 5].reduce print
     """
     emit_string(code)
 
@@ -74,7 +74,7 @@ def test_e2e_reduce_sum():
 def test_e2e_reduce_product():
     """reduce that computes product compiles through the full pipeline."""
     code = STD_INCLUDE + """
-    { * } 1 [1, 2, 3, 4, 5] .reduce print
+    { * } 1 [1, 2, 3, 4, 5].reduce print
     """
     emit_string(code)
 
@@ -85,8 +85,8 @@ def test_e2e_reduce_product():
 def test_e2e_map_then_filter():
     """map followed by filter compiles through the full pipeline."""
     code = STD_INCLUDE + """
-    { 2 * } [1, 2, 3, 4, 5] .map = doubled
-    { 6 > } doubled .filter = big
+    { 2 * } [1, 2, 3, 4, 5].map = doubled
+    { 6 > } doubled.filter = big
     big array::length print
     """
     emit_string(code)
@@ -95,8 +95,8 @@ def test_e2e_map_then_filter():
 def test_e2e_map_then_reduce():
     """map followed by reduce compiles through the full pipeline."""
     code = STD_INCLUDE + """
-    { 2 * } [1, 2, 3] .map = doubled
-    { + } 0 doubled .reduce print
+    { 2 * } [1, 2, 3].map = doubled
+    { + } 0 doubled.reduce print
     """
     emit_string(code)
 
@@ -104,7 +104,7 @@ def test_e2e_map_then_reduce():
 def test_e2e_filter_then_reduce():
     """filter followed by reduce compiles through the full pipeline."""
     code = STD_INCLUDE + """
-    { 0 > } [1, -2, 3, -4, 5] .filter = positive
-    { + } 0 positive .reduce print
+    { 0 > } [1, -2, 3, -4, 5].filter = positive
+    { + } 0 positive.reduce print
     """
     emit_string(code)

--- a/tests/test_emitter.py
+++ b/tests/test_emitter.py
@@ -401,7 +401,7 @@ def test_emit_exit_syscall():
 def test_emit_sanitized_names():
     code = """
     struct Foo { x: int }
-    42 Foo .x
+    42 Foo.x
     """
     asm = emit_string(code)
     assert "fn_Foo__x" in asm
@@ -455,7 +455,7 @@ def test_emit_str_to_str():
 
 def test_emit_ptr_to_str():
     """ptr::to_str compiles and emits the function label."""
-    asm = emit_string(STD_INCLUDE + "10 alloc .to_str")
+    asm = emit_string(STD_INCLUDE + "10 alloc.to_str")
     assert "fn_ptr__to_str" in asm
 
 
@@ -483,25 +483,25 @@ def test_emit_some():
 
 def test_emit_option_is_some():
     """option::is_some emits correct function label."""
-    asm = emit_string(STD_INCLUDE + "42 some .is_some")
+    asm = emit_string(STD_INCLUDE + "42 some.is_some")
     assert "fn_option__is_some" in asm
 
 
 def test_emit_option_is_none():
     """option::is_none emits correct function label."""
-    asm = emit_string(STD_INCLUDE + "42 some .is_none")
+    asm = emit_string(STD_INCLUDE + "42 some.is_none")
     assert "fn_option__is_none" in asm
 
 
 def test_emit_option_unwrap():
     """option::unwrap emits correct function label."""
-    asm = emit_string(STD_INCLUDE + "42 some .unwrap")
+    asm = emit_string(STD_INCLUDE + "42 some.unwrap")
     assert "fn_option__unwrap" in asm
 
 
 def test_emit_option_unwrap_or():
     """option::unwrap_or emits correct function label."""
-    asm = emit_string(STD_INCLUDE + "0 42 some .unwrap_or")
+    asm = emit_string(STD_INCLUDE + "0 42 some.unwrap_or")
     assert "fn_option__unwrap_or" in asm
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -295,7 +295,7 @@ def test_parse_type_cast():
 # ---------------------------------------------------------------------------
 def test_parse_dot_method_call():
     # .name produces a METHOD_CALL op
-    ops = parse_string("x .name")
+    ops = parse_string("x.name")
     method_ops = find_ops(ops, OpKind.METHOD_CALL)
     assert len(method_ops) == 1
     assert method_ops[0].value == "name"
@@ -303,7 +303,7 @@ def test_parse_dot_method_call():
 
 def test_parse_arrow_setter():
     # ->name produces a METHOD_CALL with set_ prefix
-    ops = parse_string("42 x ->name")
+    ops = parse_string("42 x->name")
     method_ops = find_ops(ops, OpKind.METHOD_CALL)
     assert len(method_ops) == 1
     assert method_ops[0].value == "set_name"

--- a/tests/test_traits.py
+++ b/tests/test_traits.py
@@ -406,7 +406,7 @@ class TestTraitMethodCallDotSyntax:
     def test_dot_hash_on_bounded_type_var(self):
         """Calling .hash on a trait-bounded type variable should typecheck."""
         typecheck_string(
-            HASHABLE_TRAIT + "fn get_hash[K: Hashable] k:K -> int { k .hash }\n"
+            HASHABLE_TRAIT + "fn get_hash[K: Hashable] k:K -> int { k.hash }\n"
         )
         fn = GLOBAL_FUNCTIONS["get_hash"]
         assert fn.signature is not None
@@ -414,7 +414,7 @@ class TestTraitMethodCallDotSyntax:
     def test_dot_eq_on_bounded_type_var(self):
         """Calling .eq on a trait-bounded type variable should typecheck."""
         typecheck_string(
-            HASHABLE_TRAIT + "fn are_eq[K: Hashable] a:K b:K -> bool { b a .eq }\n"
+            HASHABLE_TRAIT + "fn are_eq[K: Hashable] a:K b:K -> bool { b a.eq }\n"
         )
         fn = GLOBAL_FUNCTIONS["are_eq"]
         assert fn.signature is not None
@@ -478,7 +478,7 @@ class TestTraitAutoInjection:
             + "    fn hash self:MyType -> int { self MyType::val }\n"
             + "    fn eq self:MyType other:MyType -> bool { self MyType::val other MyType::val == }\n"
             + "}\n"
-            + "fn get_hash[K: Hashable] k:K -> int { k .hash }\n"
+            + "fn get_hash[K: Hashable] k:K -> int { k.hash }\n"
             + "42 MyType = m\n"
             + "m get_hash\n"
         )
@@ -489,7 +489,7 @@ class TestTraitAutoInjection:
         code = (
             HASHABLE_TRAIT
             + HASHABLE_IMPL_STR
-            + "fn get_hash[K: Hashable] k:K -> int { k .hash }\n"
+            + "fn get_hash[K: Hashable] k:K -> int { k.hash }\n"
             + '"hello" get_hash\n'
         )
         typecheck_string(code)
@@ -499,7 +499,7 @@ class TestTraitAutoInjection:
         code = (
             HASHABLE_TRAIT
             + HASHABLE_IMPL_INT
-            + "fn get_hash[K: Hashable] k:K -> int { k .hash }\n"
+            + "fn get_hash[K: Hashable] k:K -> int { k.hash }\n"
             + "42 get_hash\n"
         )
         typecheck_string(code)
@@ -509,7 +509,7 @@ class TestTraitAutoInjection:
         code = (
             HASHABLE_TRAIT
             + "struct NoHash { val: int }\n"
-            + "fn get_hash[K: Hashable] k:K -> int { k .hash }\n"
+            + "fn get_hash[K: Hashable] k:K -> int { k.hash }\n"
             + "42 NoHash = m\n"
             + "m get_hash\n"
         )
@@ -595,7 +595,7 @@ class TestMapSetIntegration:
             STD_INCLUDE
             + "Map::new (Map[str int]) = m\n"
             + '"hello" 42 m.set = m\n'
-            + '"hello" m.get .unwrap print\n'
+            + '"hello" m.get.unwrap print\n'
         )
         assert output == "42"
 
@@ -604,7 +604,7 @@ class TestMapSetIntegration:
             STD_INCLUDE
             + "Map::new (Map[int str]) = m\n"
             + '1 "hello" m.set = m\n'
-            + "1 m.get .unwrap print\n"
+            + "1 m.get.unwrap print\n"
         )
         assert output == "hello"
 
@@ -677,7 +677,7 @@ class TestMapSetIntegration:
             + "Map::new (Map[str int]) = m\n"
             + '"a" 1 m.set = m\n'
             + '"a" 99 m.set = m\n'
-            + '"a" m.get .unwrap print\n'
+            + '"a" m.get.unwrap print\n'
             + "m.length print\n"
         )
         assert output == "991"

--- a/tests/test_typechecker.py
+++ b/tests/test_typechecker.py
@@ -323,7 +323,7 @@ def test_typecheck_fn_call_stack_effect():
 def test_typecheck_method_call_resolution():
     code = """
     struct Pair { x: int y: int }
-    42 99 Pair .x
+    42 99 Pair.x
     """
     ops = resolve_string(code)
     from casa.typechecker import type_check_ops
@@ -558,7 +558,7 @@ def test_typecheck_generic_in_impl_block():
     impl Box {
         fn apply[T] self:Box T -> T { }
     }
-    42 99 Box .apply
+    42 99 Box.apply
     """
     sig = typecheck_string(code)
     assert sig.return_types == ["int"]
@@ -772,7 +772,7 @@ def test_typecheck_str_to_str():
 
 def test_typecheck_ptr_to_str():
     """ptr::to_str returns str."""
-    sig = typecheck_string(STD_INCLUDE + "10 alloc .to_str")
+    sig = typecheck_string(STD_INCLUDE + "10 alloc.to_str")
     assert sig.return_types == ["str"]
 
 
@@ -1003,28 +1003,28 @@ def test_signature_from_str_fn_type_multi_param():
 # ---------------------------------------------------------------------------
 def test_typecheck_map_returns_array_int():
     """map with fn[int -> int] on array[int] returns array[int]."""
-    code = STD_INCLUDE + "{ 2 * } [1, 2, 3] .map"
+    code = STD_INCLUDE + "{ 2 * } [1, 2, 3].map"
     sig = typecheck_string(code)
     assert sig.return_types == ["array[int]"]
 
 
 def test_typecheck_map_type_transform():
     """map with fn[int -> bool] on array[int] returns array[bool]."""
-    code = STD_INCLUDE + "{ 0 > } [1, 2, 3] .map"
+    code = STD_INCLUDE + "{ 0 > } [1, 2, 3].map"
     sig = typecheck_string(code)
     assert sig.return_types == ["array[bool]"]
 
 
 def test_typecheck_filter_returns_array_int():
     """filter with fn[int -> bool] on array[int] returns array[int]."""
-    code = STD_INCLUDE + "{ 1 > } [1, 2, 3] .filter"
+    code = STD_INCLUDE + "{ 1 > } [1, 2, 3].filter"
     sig = typecheck_string(code)
     assert sig.return_types == ["array[int]"]
 
 
 def test_typecheck_reduce_returns_int():
     """reduce with fn[int int -> int] on array[int] returns int."""
-    code = STD_INCLUDE + "{ + } 0 [1, 2, 3] .reduce"
+    code = STD_INCLUDE + "{ + } 0 [1, 2, 3].reduce"
     sig = typecheck_string(code)
     assert sig.return_types == ["int"]
 
@@ -1032,8 +1032,8 @@ def test_typecheck_reduce_returns_int():
 def test_typecheck_map_then_filter():
     """Chaining map then filter preserves array type."""
     code = STD_INCLUDE + """
-    { 2 * } [1, 2, 3] .map = mapped
-    { 4 > } mapped .filter
+    { 2 * } [1, 2, 3].map = mapped
+    { 4 > } mapped.filter
     """
     sig = typecheck_string(code)
     assert sig.return_types == ["array[int]"]
@@ -1041,7 +1041,7 @@ def test_typecheck_map_then_filter():
 
 def test_typecheck_map_str_array():
     """map on array[str] with any->any identity returns array[any]."""
-    code = STD_INCLUDE + '{ dup drop } ["a", "b", "c"] .map'
+    code = STD_INCLUDE + '{ dup drop } ["a", "b", "c"].map'
     sig = typecheck_string(code)
     assert sig.return_types == ["array[any]"]
 
@@ -1142,42 +1142,42 @@ def test_typecheck_signature_matches_different_typed_options():
 
 def test_typecheck_option_is_some():
     """is_some on option[int] returns bool."""
-    code = STD_INCLUDE + "42 some .is_some"
+    code = STD_INCLUDE + "42 some.is_some"
     sig = typecheck_string(code)
     assert sig.return_types == ["bool"]
 
 
 def test_typecheck_option_is_none():
     """is_none on option[int] returns bool."""
-    code = STD_INCLUDE + "42 some .is_none"
+    code = STD_INCLUDE + "42 some.is_none"
     sig = typecheck_string(code)
     assert sig.return_types == ["bool"]
 
 
 def test_typecheck_none_is_some():
     """is_some on none returns bool."""
-    code = STD_INCLUDE + "none .is_some"
+    code = STD_INCLUDE + "none.is_some"
     sig = typecheck_string(code)
     assert sig.return_types == ["bool"]
 
 
 def test_typecheck_none_is_none():
     """is_none on none returns bool."""
-    code = STD_INCLUDE + "none .is_none"
+    code = STD_INCLUDE + "none.is_none"
     sig = typecheck_string(code)
     assert sig.return_types == ["bool"]
 
 
 def test_typecheck_option_unwrap():
     """unwrap on option[int] returns int."""
-    code = STD_INCLUDE + "42 some .unwrap"
+    code = STD_INCLUDE + "42 some.unwrap"
     sig = typecheck_string(code)
     assert sig.return_types == ["int"]
 
 
 def test_typecheck_option_unwrap_or():
     """unwrap_or on option[int] with int default returns int."""
-    code = STD_INCLUDE + "0 42 some .unwrap_or"
+    code = STD_INCLUDE + "0 42 some.unwrap_or"
     sig = typecheck_string(code)
     assert sig.return_types == ["int"]
 

--- a/tests/test_whitespace_dot_arrow.py
+++ b/tests/test_whitespace_dot_arrow.py
@@ -1,0 +1,223 @@
+"""Tests for disallowing whitespace before dot (.) and arrow (->) syntax."""
+
+import pytest
+
+from casa.common import GLOBAL_FUNCTIONS, OpKind
+from casa.error import CasaErrorCollection, ErrorKind
+from tests.conftest import parse_string, resolve_string, typecheck_string
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def find_ops(ops, kind):
+    return [op for op in ops if op.kind == kind]
+
+
+# ---------------------------------------------------------------------------
+# Dot syntax: no whitespace before dot
+# ---------------------------------------------------------------------------
+class TestDotNoWhitespace:
+    """Dot method call must be directly adjacent to the preceding token."""
+
+    def test_dot_adjacent_parses(self):
+        """person.name (no space before dot) should parse as METHOD_CALL."""
+        ops = parse_string("x.name")
+        method_ops = find_ops(ops, OpKind.METHOD_CALL)
+        assert len(method_ops) == 1
+        assert method_ops[0].value == "name"
+
+    def test_dot_with_space_raises(self):
+        """x .name (space before dot) should raise a syntax error."""
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            parse_string("x .name")
+        assert exc_info.value.errors[0].kind == ErrorKind.SYNTAX
+
+    def test_dot_with_tab_raises(self):
+        """x\t.name (tab before dot) should raise a syntax error."""
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            parse_string("x\t.name")
+        assert exc_info.value.errors[0].kind == ErrorKind.SYNTAX
+
+    def test_dot_with_newline_raises(self):
+        """x\\n.name (newline before dot) should raise a syntax error."""
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            parse_string("x\n.name")
+        assert exc_info.value.errors[0].kind == ErrorKind.SYNTAX
+
+    def test_dot_chained_adjacent_parses(self):
+        """x.foo.bar (chained dots, no spaces) should parse two METHOD_CALLs."""
+        ops = parse_string("x.foo.bar")
+        method_ops = find_ops(ops, OpKind.METHOD_CALL)
+        assert len(method_ops) == 2
+        assert method_ops[0].value == "foo"
+        assert method_ops[1].value == "bar"
+
+    def test_dot_chained_space_before_second_dot_raises(self):
+        """x.foo .bar (space before second dot) should raise a syntax error."""
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            parse_string("x.foo .bar")
+        assert exc_info.value.errors[0].kind == ErrorKind.SYNTAX
+
+    def test_dot_in_function_body_adjacent_parses(self):
+        """Dot accessor inside function body works when adjacent."""
+        code = """
+        struct Person { name: str }
+        fn get_name person:Person -> str { person.name }
+        """
+        parse_string(code)
+        fn = GLOBAL_FUNCTIONS["get_name"]
+        method_ops = find_ops(fn.ops, OpKind.METHOD_CALL)
+        assert len(method_ops) == 1
+        assert method_ops[0].value == "name"
+
+    def test_dot_in_function_body_space_raises(self):
+        """Dot accessor with space inside function body should raise error."""
+        code = """
+        struct Person { name: str }
+        fn get_name person:Person -> str { person .name }
+        """
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            parse_string(code)
+        assert exc_info.value.errors[0].kind == ErrorKind.SYNTAX
+
+
+# ---------------------------------------------------------------------------
+# Arrow syntax: no whitespace before arrow
+# ---------------------------------------------------------------------------
+class TestArrowNoWhitespace:
+    """Arrow setter must be directly adjacent to the preceding token."""
+
+    def test_arrow_adjacent_parses(self):
+        """person->name (no space before arrow) should parse as METHOD_CALL."""
+        ops = parse_string("42 x->name")
+        method_ops = find_ops(ops, OpKind.METHOD_CALL)
+        assert len(method_ops) == 1
+        assert method_ops[0].value == "set_name"
+
+    def test_arrow_with_space_raises(self):
+        """x ->name (space before arrow) should raise a syntax error."""
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            parse_string("42 x ->name")
+        assert exc_info.value.errors[0].kind == ErrorKind.SYNTAX
+
+    def test_arrow_with_tab_raises(self):
+        """x\t->name (tab before arrow) should raise a syntax error."""
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            parse_string("42 x\t->name")
+        assert exc_info.value.errors[0].kind == ErrorKind.SYNTAX
+
+    def test_arrow_with_newline_raises(self):
+        """x\\n->name (newline before arrow) should raise a syntax error."""
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            parse_string("42 x\n->name")
+        assert exc_info.value.errors[0].kind == ErrorKind.SYNTAX
+
+    def test_arrow_in_function_body_adjacent_parses(self):
+        """Arrow setter inside function body works when adjacent."""
+        code = """
+        struct Person { name: str age: int }
+        fn set_person_name person:Person name:str -> Person {
+            name person->name
+        }
+        """
+        parse_string(code)
+        fn = GLOBAL_FUNCTIONS["set_person_name"]
+        method_ops = find_ops(fn.ops, OpKind.METHOD_CALL)
+        assert len(method_ops) == 1
+        assert method_ops[0].value == "set_name"
+
+    def test_arrow_in_function_body_space_raises(self):
+        """Arrow setter with space inside function body should raise error."""
+        code = """
+        struct Person { name: str age: int }
+        fn set_person_name person:Person name:str -> Person {
+            name person ->name
+        }
+        """
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            parse_string(code)
+        assert exc_info.value.errors[0].kind == ErrorKind.SYNTAX
+
+
+# ---------------------------------------------------------------------------
+# Function signature arrow is unaffected
+# ---------------------------------------------------------------------------
+class TestFunctionSignatureArrow:
+    """The -> in function signatures must continue to work with spaces."""
+
+    def test_fn_signature_arrow_with_spaces(self):
+        """fn foo a:int -> int should still parse correctly."""
+        parse_string("fn foo a:int -> int { a }")
+        assert "foo" in GLOBAL_FUNCTIONS
+        fn = GLOBAL_FUNCTIONS["foo"]
+        assert fn.signature is not None
+        assert fn.signature.return_types == ["int"]
+
+    def test_fn_signature_arrow_multiple_params(self):
+        """fn bar a:int b:int -> int should still parse correctly."""
+        parse_string("fn bar a:int b:int -> int { a b + }")
+        assert "bar" in GLOBAL_FUNCTIONS
+
+    def test_fn_signature_no_return(self):
+        """fn baz a:int should still parse correctly (no ->)."""
+        parse_string("fn baz a:int { a drop }")
+        assert "baz" in GLOBAL_FUNCTIONS
+
+    def test_fn_signature_multiple_returns(self):
+        """fn qux a:int -> int int should still parse correctly."""
+        parse_string("fn qux a:int -> int int { a a }")
+        assert "qux" in GLOBAL_FUNCTIONS
+        fn = GLOBAL_FUNCTIONS["qux"]
+        assert fn.signature.return_types == ["int", "int"]
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+class TestEdgeCases:
+    """Edge cases for whitespace detection around dot and arrow."""
+
+    def test_dot_after_int_literal(self):
+        """42.method (dot after int literal, adjacent) should parse."""
+        ops = parse_string("42.method")
+        method_ops = find_ops(ops, OpKind.METHOD_CALL)
+        assert len(method_ops) == 1
+        assert method_ops[0].value == "method"
+
+    def test_dot_after_string_literal(self):
+        """\"hello\".method (dot after string literal, adjacent) should parse."""
+        ops = parse_string('"hello".method')
+        method_ops = find_ops(ops, OpKind.METHOD_CALL)
+        assert len(method_ops) == 1
+        assert method_ops[0].value == "method"
+
+    def test_dot_after_close_paren_adjacent(self):
+        """(int).method (dot after type cast, adjacent) should parse."""
+        ops = parse_string("42 (int).method")
+        method_ops = find_ops(ops, OpKind.METHOD_CALL)
+        assert len(method_ops) == 1
+
+    def test_arrow_standalone_is_not_setter(self):
+        """Standalone -> without preceding token context is handled differently in fn signatures."""
+        parse_string("fn id a:int -> int { a }")
+        assert "id" in GLOBAL_FUNCTIONS
+
+    def test_multiple_spaces_before_dot_raises(self):
+        """x   .name (multiple spaces before dot) should raise a syntax error."""
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            parse_string("x   .name")
+        assert exc_info.value.errors[0].kind == ErrorKind.SYNTAX
+
+    def test_multiple_spaces_before_arrow_raises(self):
+        """x   ->name (multiple spaces before arrow) should raise a syntax error."""
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            parse_string("42 x   ->name")
+        assert exc_info.value.errors[0].kind == ErrorKind.SYNTAX
+
+    def test_error_message_mentions_whitespace(self):
+        """Error message should mention whitespace or spacing."""
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            parse_string("x .name")
+        error_message = exc_info.value.errors[0].message.lower()
+        assert "whitespace" in error_message or "space" in error_message

--- a/tests/test_whitespace_dot_arrow.py
+++ b/tests/test_whitespace_dot_arrow.py
@@ -4,7 +4,7 @@ import pytest
 
 from casa.common import GLOBAL_FUNCTIONS, OpKind
 from casa.error import CasaErrorCollection, ErrorKind
-from tests.conftest import parse_string, resolve_string, typecheck_string
+from tests.conftest import parse_string
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Remove whitespace before `.` in method call syntax across 4 example files
- Affected files: `string_operations.casa`, `hash_map.casa`, `file_io.casa`, `option.casa`
- All 27 example tests pass