### PR TITLE
feat: add cursor-based parser library

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ source → lex → parse → resolve → type check → bytecode → emit asm �
 | [Enums](docs/enums.md) | Enum types, variant constructors, exhaustive `match` |
 | [Traits](docs/traits.md) | Trait definitions, structural satisfaction, trait bounds, `Hashable` |
 | [Standard Library](docs/standard-library.md) | `include`, `memcpy`, arrays (`map`, `filter`, `reduce`), `option[T]`, `result[T E]`, `List[T]`, `Map[K V]`, `Set[K]`, string methods, C string methods, file I/O, character classification, type conversions |
+| [Parser Library](docs/parser.md) | `Cursor`, `ParseError`, cursor scanning methods, `parse_int`, `parse_identifier`, `parse_quoted_string`, `parse_char_literal`, helper functions |
 | [Errors](docs/errors.md) | Error kinds, diagnostics format, multi-error collection |
 | [Language Server](docs/language-server.md) | LSP setup, editor configuration, diagnostics |
 
@@ -91,6 +92,7 @@ source → lex → parse → resolve → type check → bytecode → emit asm �
 | [hash_map.casa](examples/hash_map.casa) | `Map[K V]` and `Set[K]` with the `Hashable` trait |
 | [type_annotations.casa](examples/type_annotations.casa) | Type annotations on variable assignments (`= name:type`) |
 | [enum.casa](examples/enum.casa) | Enum types with `match` pattern matching |
+| [parser.casa](examples/parser.casa) | Cursor-based text scanning and parsing |
 
 More examples: [examples](./examples/)
 

--- a/casa/bytecode.py
+++ b/casa/bytecode.py
@@ -414,7 +414,7 @@ class Compiler:
         bytecode.append(self.inst(InstKind.LABEL, args=[start_label]))
         bytecode.append(self.inst(InstKind.LOCAL_GET, args=[local_index]))
         bytecode.append(self.inst(InstKind.PUSH, args=[(list_len + 2) * 8]))
-        bytecode.append(self.inst(InstKind.GE))
+        bytecode.append(self.inst(InstKind.GT))
         bytecode.append(self.inst(InstKind.JUMP_NE, args=[end_label]))
 
         # list index + store64

--- a/casa/bytecode.py
+++ b/casa/bytecode.py
@@ -577,6 +577,13 @@ class Compiler:
                     assert isinstance(count, int)
                     bytecode.append(self.inst(InstKind.FSTRING_CONCAT, args=[count]))
                 case OpKind.FN_CALL | OpKind.FN_PUSH:
+                    if op.kind == OpKind.FN_PUSH:
+                        fn = GLOBAL_FUNCTIONS.get(op.value)
+                        if fn and fn.has_deferred_methods:
+                            # Deferred lambda: push dummy, real calls are
+                            # specialized at each exec site
+                            bytecode.append(self.inst(InstKind.PUSH, args=[0]))
+                            continue
                     self._compile_function_ops(op, bytecode)
                 case OpKind.IDENTIFIER:
                     raise AssertionError(

--- a/casa/common.py
+++ b/casa/common.py
@@ -401,6 +401,7 @@ class Op:
     kind: OpKind
     location: Location
     type_annotation: str | None = None
+    deferred_return_type: str | None = None
 
     def __post_init__(self):
         assert len(OpKind) == 86, "Exhaustive handling for `OpKind`"
@@ -1065,6 +1066,7 @@ class Function:
     is_typechecked: bool = False
     variables: list[Variable] = field(default_factory=list)
     captures: list[Variable] = field(default_factory=list)
+    has_deferred_methods: bool = False
 
 
 GLOBAL_SCOPE_LABEL = "_start"

--- a/casa/typechecker.py
+++ b/casa/typechecker.py
@@ -805,7 +805,8 @@ class TypeChecker:
             case OpKind.FN_RETURN:
                 if self.return_types is None:
                     self.return_types = self.stack.copy()
-                if self.return_types != self.stack:
+                unified = _stacks_compatible(self.return_types, self.stack)
+                if unified is None:
                     raise_error(
                         ErrorKind.TYPE_MISMATCH,
                         "Invalid return types",
@@ -813,6 +814,7 @@ class TypeChecker:
                         expected=str(self.return_types),
                         got=str(self.stack),
                     )
+                self.return_types = unified
                 if self.branched_stacks:
                     branched = self.branched_stacks[-1]
                     self.stack = branched.before.copy()
@@ -1940,14 +1942,18 @@ def type_check_ops(ops: list[Op], function: Function | None = None) -> Signature
 
     fn_location = function.location if function else None
 
-    if tc.return_types and tc.return_types != tc.stack:
-        raise_error(
-            ErrorKind.TYPE_MISMATCH,
-            "Invalid return types",
-            fn_location,
-            expected=str(tc.return_types),
-            got=str(tc.stack),
-        )
+    if tc.return_types:
+        unified = _stacks_compatible(tc.return_types, tc.stack)
+        if unified is None:
+            raise_error(
+                ErrorKind.TYPE_MISMATCH,
+                "Invalid return types",
+                fn_location,
+                expected=str(tc.return_types),
+                got=str(tc.stack),
+            )
+        tc.return_types = unified
+        tc.stack = unified
 
     inferred_signature = Signature(tc.parameters, tc.stack)
 

--- a/casa/typechecker.py
+++ b/casa/typechecker.py
@@ -786,11 +786,7 @@ class TypeChecker:
                 if fn_ptr == ANY_TYPE:
                     fn_ptr = "fn"
                 # Specialize deferred method lambdas at call site
-                specialized = _try_specialize_deferred_exec(
-                    self, fn_ptr, ops, op_index, op
-                )
-                if specialized:
-                    fn_ptr = specialized
+                _try_specialize_deferred_exec(self, fn_ptr, ops, op_index, op)
                 fn_ptr = self.expect_type(fn_ptr)
                 assert isinstance(fn_ptr, str), "Function pointer type"
                 if fn_ptr != fn_symmetrical:

--- a/casa/typechecker.py
+++ b/casa/typechecker.py
@@ -1543,6 +1543,22 @@ def _try_specialize_deferred_exec(
         _ensure_typechecked(clone)
         existing = clone
 
+    # Verify the clone's parameter type matches the concrete argument type
+    if existing.signature.parameters:
+        expected_param = existing.signature.parameters[0].typ
+        if (
+            expected_param != concrete_type
+            and expected_param != ANY_TYPE
+            and concrete_type != ANY_TYPE
+        ):
+            raise_error(
+                ErrorKind.TYPE_MISMATCH,
+                f"Type mismatch in deferred method call",
+                exec_op.location,
+                expected=f"`{expected_param}`",
+                got=f"`{concrete_type}`",
+            )
+
     # Replace the push op to push the clone directly
     prev_op_idx = op_index - 2
     if prev_op_idx >= 0:
@@ -1554,7 +1570,11 @@ def _try_specialize_deferred_exec(
     # The original deferred lambda should not be compiled
     source_lambda.is_used = False
 
-    return f"fn[{existing.signature}]"
+    # Update the stack so the concrete fn type is used by apply_signature
+    concrete_fn_type = f"fn[{existing.signature}]"
+    tc.stack[-1] = concrete_fn_type
+
+    return concrete_fn_type
 
 
 def _find_deferred_lambda_source(

--- a/casa/typechecker.py
+++ b/casa/typechecker.py
@@ -1085,6 +1085,32 @@ class TypeChecker:
         self.current_expect_context = None
         self.stack_push(struct.name)
 
+    @staticmethod
+    def _find_method_by_name(
+        method_name: str, location: Location
+    ) -> tuple[Function | None, str]:
+        """Search all global functions for a method matching ::method_name.
+
+        Used when the receiver type is 'any' (e.g. inside lambdas where the
+        stack type is unknown). Returns the function and its qualified name if
+        exactly one match is found, otherwise raises an error for ambiguity.
+        """
+        suffix = f"::{method_name}"
+        matches: list[tuple[str, Function]] = []
+        for name, func in GLOBAL_FUNCTIONS.items():
+            if name.endswith(suffix) and not name.startswith("lambda__"):
+                matches.append((name, func))
+        if len(matches) == 1:
+            return matches[0][1], matches[0][0]
+        if len(matches) > 1:
+            candidates = ", ".join(name for name, _ in matches)
+            raise_error(
+                ErrorKind.UNDEFINED_NAME,
+                f"Ambiguous method `.{method_name}`, candidates: {candidates}",
+                location,
+            )
+        return None, f"any::{method_name}"
+
     def check_method_call(
         self,
         op: Op,
@@ -1136,6 +1162,10 @@ class TypeChecker:
         if not global_function and receiver_base:
             function_name = f"{receiver_base}::{method_name}"
             global_function = GLOBAL_FUNCTIONS.get(function_name)
+        if not global_function and receiver == ANY_TYPE:
+            global_function, function_name = self._find_method_by_name(
+                method_name, op.location
+            )
         if not global_function:
             raise_error(
                 ErrorKind.UNDEFINED_NAME,

--- a/casa/typechecker.py
+++ b/casa/typechecker.py
@@ -100,6 +100,10 @@ class TypeChecker:
     current_op_context: str | None = None
     # Which parameter mismatched (for error expected line)
     current_expect_context: str | None = None
+    # Maps variable names to lambda function names for deferred method lambdas
+    deferred_lambda_vars: dict[str, str] = field(default_factory=dict)
+    # Tracks the last pushed deferred lambda name for assignment tracking
+    last_deferred_lambda: str | None = None
 
     def stack_push(self, typ: Type, origin: Location | None = None):
         """Push a type onto the symbolic stack."""
@@ -458,6 +462,11 @@ class TypeChecker:
         variable_name = op.value
         assert isinstance(variable_name, str), "Expected variable name"
 
+        # Track deferred lambda variable assignments
+        if self.last_deferred_lambda:
+            self.deferred_lambda_vars[variable_name] = self.last_deferred_lambda
+            self.last_deferred_lambda = None
+
         stack_type = self.stack_peek()
         effective_type = op.type_annotation if op.type_annotation else stack_type
 
@@ -776,6 +785,12 @@ class TypeChecker:
                 fn_ptr = self.stack_peek()
                 if fn_ptr == ANY_TYPE:
                     fn_ptr = "fn"
+                # Specialize deferred method lambdas at call site
+                specialized = _try_specialize_deferred_exec(
+                    self, fn_ptr, ops, op_index, op
+                )
+                if specialized:
+                    fn_ptr = specialized
                 fn_ptr = self.expect_type(fn_ptr)
                 assert isinstance(fn_ptr, str), "Function pointer type"
                 if fn_ptr != fn_symmetrical:
@@ -787,6 +802,10 @@ class TypeChecker:
                 assert isinstance(global_function, Function), "Expected function"
                 _ensure_typechecked(global_function)
                 self.stack_push(f"fn[{global_function.signature}]")
+                if global_function.has_deferred_methods:
+                    self.last_deferred_lambda = function_name
+                else:
+                    self.last_deferred_lambda = None
             case OpKind.FN_RETURN:
                 if self.return_types is None:
                     self.return_types = self.stack.copy()
@@ -1085,15 +1104,18 @@ class TypeChecker:
         self.current_expect_context = None
         self.stack_push(struct.name)
 
+    DEFERRED_METHOD = "DEFERRED"
+
     @staticmethod
     def _find_method_by_name(
         method_name: str, location: Location
-    ) -> tuple[Function | None, str]:
+    ) -> tuple[Function | None, str, str | None]:
         """Search all global functions for a method matching ::method_name.
 
         Used when the receiver type is 'any' (e.g. inside lambdas where the
-        stack type is unknown). Returns the function and its qualified name if
-        exactly one match is found, otherwise raises an error for ambiguity.
+        stack type is unknown). Returns (function, name, deferred_return_type).
+        When exactly one match is found, returns it directly. When multiple
+        matches share a common return type, returns a deferred sentinel.
         """
         suffix = f"::{method_name}"
         matches: list[tuple[str, Function]] = []
@@ -1101,15 +1123,10 @@ class TypeChecker:
             if name.endswith(suffix) and not name.startswith("lambda__"):
                 matches.append((name, func))
         if len(matches) == 1:
-            return matches[0][1], matches[0][0]
+            return matches[0][1], matches[0][0], None
         if len(matches) > 1:
-            candidates = ", ".join(name for name, _ in matches)
-            raise_error(
-                ErrorKind.UNDEFINED_NAME,
-                f"Ambiguous method `.{method_name}`, candidates: {candidates}",
-                location,
-            )
-        return None, f"any::{method_name}"
+            return _defer_ambiguous_method(matches, method_name, location)
+        return None, f"any::{method_name}", None
 
     def check_method_call(
         self,
@@ -1163,9 +1180,19 @@ class TypeChecker:
             function_name = f"{receiver_base}::{method_name}"
             global_function = GLOBAL_FUNCTIONS.get(function_name)
         if not global_function and receiver == ANY_TYPE:
-            global_function, function_name = self._find_method_by_name(
+            global_function, function_name, deferred_ret = self._find_method_by_name(
                 method_name, op.location
             )
+            if not global_function and function_name == self.DEFERRED_METHOD:
+                # Deferred method: receiver is any, multiple candidates with
+                # common return type. Leave as METHOD_CALL for specialization.
+                assert deferred_ret is not None
+                op.deferred_return_type = deferred_ret
+                self.stack_pop()
+                self.stack_push(deferred_ret)
+                if function:
+                    function.has_deferred_methods = True
+                return op_index
         if not global_function:
             raise_error(
                 ErrorKind.UNDEFINED_NAME,
@@ -1436,6 +1463,151 @@ def _ensure_typechecked(global_function: Function) -> None:
     signature = type_check_ops(global_function.ops, global_function)
     if not global_function.signature:
         global_function.signature = signature
+
+
+def _defer_ambiguous_method(
+    matches: list[tuple[str, Function]],
+    method_name: str,
+    location: Location,
+) -> tuple[Function | None, str, str | None]:
+    """Handle ambiguous method lookup by checking for a common return type.
+
+    If all candidates share the same return type, the method is deferred for
+    monomorphization at each call site. Returns (None, DEFERRED, return_type).
+    Otherwise, reports an ambiguity error.
+    """
+    for _, func in matches:
+        if not func.is_typechecked:
+            func.ops = resolve_identifiers(func.ops, func)
+            func.is_used = True
+        _ensure_typechecked(func)
+
+    return_types: set[str] = set()
+    for _, func in matches:
+        if func.signature:
+            for ret in func.signature.return_types:
+                return_types.add(ret)
+
+    if len(return_types) == 1:
+        common_ret = return_types.pop()
+        return None, TypeChecker.DEFERRED_METHOD, common_ret
+
+    candidates = ", ".join(name for name, _ in matches)
+    raise_error(
+        ErrorKind.UNDEFINED_NAME,
+        f"Ambiguous method `.{method_name}`, candidates: {candidates}",
+        location,
+    )
+    return None, f"any::{method_name}", None
+
+
+def _try_specialize_deferred_exec(
+    tc: TypeChecker,
+    fn_ptr: str,
+    ops: list[Op],
+    op_index: int,
+    exec_op: Op,
+) -> str | None:
+    """Specialize a deferred method lambda at an exec call site.
+
+    When a lambda has deferred (unresolved) methods and is called via exec,
+    this creates a monomorphized clone with the method resolved for the
+    concrete argument type. Returns the specialized fn type, or None.
+    """
+    if not isinstance(fn_ptr, str) or not fn_ptr.startswith("fn["):
+        return None
+    if ANY_TYPE not in fn_ptr:
+        return None
+
+    # Find the source lambda
+    source_lambda_name = _find_deferred_lambda_source(tc, ops, op_index)
+    if not source_lambda_name:
+        return None
+
+    source_lambda = GLOBAL_FUNCTIONS.get(source_lambda_name)
+    if not source_lambda or not source_lambda.has_deferred_methods:
+        return None
+
+    # Determine the concrete argument type from the stack
+    # Stack: [..., arg, fn_ptr]. fn_ptr is at top, arg is below.
+    if len(tc.stack) < 2:
+        return None
+    concrete_type = tc.stack[-2]
+    if concrete_type == ANY_TYPE:
+        return None
+
+    # Create or reuse a specialized clone
+    clone_name = f"{source_lambda_name}__spec_{concrete_type}"
+    existing = GLOBAL_FUNCTIONS.get(clone_name)
+    if not existing:
+        clone = _clone_and_specialize_lambda(source_lambda, clone_name, concrete_type)
+        if not clone:
+            return None
+        GLOBAL_FUNCTIONS[clone_name] = clone
+        _ensure_typechecked(clone)
+        existing = clone
+
+    # Replace the push op to push the clone directly
+    prev_op_idx = op_index - 2
+    if prev_op_idx >= 0:
+        prev_op = ops[prev_op_idx]
+        if prev_op.kind in (OpKind.PUSH_VARIABLE, OpKind.FN_PUSH, OpKind.PUSH_CAPTURE):
+            prev_op.kind = OpKind.FN_PUSH
+            prev_op.value = clone_name
+
+    # The original deferred lambda should not be compiled
+    source_lambda.is_used = False
+
+    return f"fn[{existing.signature}]"
+
+
+def _find_deferred_lambda_source(
+    tc: TypeChecker, ops: list[Op], op_index: int
+) -> str | None:
+    """Find the source lambda name for the fn pointer about to be exec'd."""
+    prev_op_idx = op_index - 2
+    if prev_op_idx < 0:
+        return None
+    prev_op = ops[prev_op_idx]
+    if prev_op.kind == OpKind.FN_PUSH:
+        return prev_op.value if isinstance(prev_op.value, str) else None
+    if prev_op.kind in (OpKind.PUSH_VARIABLE, OpKind.PUSH_CAPTURE):
+        var_name = prev_op.value
+        if isinstance(var_name, str):
+            return tc.deferred_lambda_vars.get(var_name)
+    return None
+
+
+def _clone_and_specialize_lambda(
+    source: Function, clone_name: str, concrete_type: str
+) -> Function | None:
+    """Clone a lambda and resolve deferred METHOD_CALL ops for concrete_type."""
+    import copy
+
+    cloned_ops = copy.deepcopy(source.ops)
+    for cloned_op in cloned_ops:
+        if cloned_op.kind != OpKind.METHOD_CALL:
+            continue
+        if cloned_op.deferred_return_type is None:
+            continue
+        method_name = cloned_op.value
+        assert isinstance(method_name, str)
+        # Resolve the method for the concrete type
+        fn_name = f"{concrete_type}::{method_name}"
+        resolved = GLOBAL_FUNCTIONS.get(fn_name)
+        base = extract_generic_base(concrete_type)
+        if not resolved and base:
+            fn_name = f"{base}::{method_name}"
+            resolved = GLOBAL_FUNCTIONS.get(fn_name)
+        if not resolved:
+            return None
+        cloned_op.kind = OpKind.FN_CALL
+        cloned_op.value = fn_name
+        cloned_op.deferred_return_type = None
+
+    clone = Function(clone_name, cloned_ops, source.location)
+    clone.is_used = True
+    return clone
 
 
 def _resolve_trait_sig(sig: Signature, type_var: str) -> Signature:

--- a/docs/parser.md
+++ b/docs/parser.md
@@ -160,7 +160,7 @@ Advances the cursor while the predicate returns `true` for the current character
 
 ```casa
 "   hello" Cursor::new = cursor
-&char::is_space cursor.skip_while
+{ .is_space } cursor.skip_while
 cursor.peek .unwrap print    # h
 ```
 
@@ -174,8 +174,8 @@ Collects characters while the predicate returns `true`, returning them as a subs
 
 ```casa
 "abc123" Cursor::new = cursor
-&char::is_alpha cursor.take_while print    # abc
-&char::is_digit cursor.take_while print    # 123
+{ .is_alpha } cursor.take_while print    # abc
+{ .is_digit } cursor.take_while print    # 123
 ```
 
 ### `Cursor::save`
@@ -316,8 +316,8 @@ include "../lib/parser.casa"
 
 # Parse integers and identifiers from input
 "abc123" Cursor::new = cursor
-&char::is_alpha cursor.take_while = letters
-&char::is_digit cursor.take_while = digits
+{ .is_alpha } cursor.take_while = letters
+{ .is_digit } cursor.take_while = digits
 letters print    # abc
 digits print     # 123
 
@@ -326,7 +326,7 @@ digits print     # 123
 cursor2.save = pos
 &is_ident_char cursor2.take_while print    # test
 pos cursor2.restore
-&char::is_alpha cursor2.take_while print   # test
+{ .is_alpha } cursor2.take_while print   # test
 ```
 
 See [`examples/parser.casa`](../examples/parser.casa) for a full program demonstrating all parser library features.

--- a/docs/parser.md
+++ b/docs/parser.md
@@ -1,0 +1,332 @@
+# Parser Library
+
+The parser library provides cursor-based text scanning primitives for building parsers in Casa. It is in `lib/parser.casa`. Include it with:
+
+```casa
+include "../lib/parser.casa"
+```
+
+The parser library includes the standard library (`lib/std.casa`) automatically.
+
+## Structs
+
+### `Cursor`
+
+A cursor tracks a position within a source string. All scanning methods operate on a shared cursor, advancing its position as characters are consumed.
+
+```casa
+struct Cursor {
+    source: str
+    pos:    int
+}
+```
+
+### `ParseError`
+
+Returned by parsers when input does not match the expected pattern. Contains a human-readable message and the position where the error occurred.
+
+```casa
+struct ParseError {
+    message: str
+    pos:     int
+}
+```
+
+## Cursor Methods
+
+### `Cursor::new`
+
+Creates a cursor at position 0.
+
+**Signature:** `Cursor::new source:str -> Cursor`
+
+**Stack effect:** `str -> Cursor`
+
+```casa
+"hello world" Cursor::new = cursor
+```
+
+### `Cursor::is_eof`
+
+Returns `true` if the cursor is at or past the end of the source string.
+
+**Signature:** `Cursor::is_eof self:Cursor -> bool`
+
+**Stack effect:** `Cursor -> bool`
+
+```casa
+"" Cursor::new .is_eof print    # true
+```
+
+### `Cursor::peek`
+
+Returns the current character without advancing the cursor. Returns `none` at EOF.
+
+**Signature:** `Cursor::peek self:Cursor -> option[char]`
+
+**Stack effect:** `Cursor -> option[char]`
+
+```casa
+"hello" Cursor::new .peek .unwrap print    # h
+```
+
+### `Cursor::peek_at`
+
+Returns the character at `pos + offset` without advancing the cursor. Returns `none` if out of bounds.
+
+**Signature:** `Cursor::peek_at self:Cursor offset:int -> option[char]`
+
+**Stack effect:** `Cursor int -> option[char]`
+
+```casa
+2 "hello" Cursor::new .peek_at .unwrap print    # l
+```
+
+### `Cursor::advance`
+
+Returns the current character and advances the cursor by one. Returns `none` at EOF.
+
+**Signature:** `Cursor::advance self:Cursor -> option[char]`
+
+**Stack effect:** `Cursor -> option[char]`
+
+```casa
+"hello" Cursor::new = cursor
+cursor.advance .unwrap print    # h
+cursor.advance .unwrap print    # e
+```
+
+### `Cursor::starts_with`
+
+Checks if the remaining input (from the current position) starts with the given prefix.
+
+**Signature:** `Cursor::starts_with self:Cursor prefix:str -> bool`
+
+**Stack effect:** `Cursor str -> bool`
+
+```casa
+"hello" Cursor::new = cursor
+"hel" cursor.starts_with print    # true
+"xyz" cursor.starts_with print    # false
+```
+
+### `Cursor::expect_char`
+
+Consumes the next character if it matches `expected`. Returns `ok` with the character on success, or `error` with a `ParseError` on mismatch or EOF.
+
+**Signature:** `Cursor::expect_char self:Cursor expected:char -> result[char ParseError]`
+
+**Stack effect:** `Cursor char -> result[char ParseError]`
+
+```casa
+"abc" Cursor::new = cursor
+'a' cursor.expect_char .unwrap print    # a
+```
+
+### `Cursor::skip`
+
+Advances the cursor position by `n` characters without returning them.
+
+**Signature:** `Cursor::skip self:Cursor n:int`
+
+**Stack effect:** `Cursor int -> None`
+
+```casa
+"hello" Cursor::new = cursor
+3 cursor.skip
+cursor.peek .unwrap print    # l
+```
+
+### `Cursor::take_string`
+
+Consumes the exact target string if the remaining input starts with it. Returns `ok` with the matched string on success, or `error` with a `ParseError` on mismatch.
+
+**Signature:** `Cursor::take_string self:Cursor target:str -> result[str ParseError]`
+
+**Stack effect:** `Cursor str -> result[str ParseError]`
+
+```casa
+"hello world" Cursor::new = cursor
+"hello" cursor.take_string .unwrap print    # hello
+```
+
+### `Cursor::skip_while`
+
+Advances the cursor while the predicate returns `true` for the current character.
+
+**Signature:** `Cursor::skip_while self:Cursor pred:fn[char -> bool]`
+
+**Stack effect:** `Cursor fn[char -> bool] -> None`
+
+```casa
+"   hello" Cursor::new = cursor
+&char::is_space cursor.skip_while
+cursor.peek .unwrap print    # h
+```
+
+### `Cursor::take_while`
+
+Collects characters while the predicate returns `true`, returning them as a substring. Uses `str::substring` internally, so no character-by-character allocation is needed.
+
+**Signature:** `Cursor::take_while self:Cursor pred:fn[char -> bool] -> str`
+
+**Stack effect:** `Cursor fn[char -> bool] -> str`
+
+```casa
+"abc123" Cursor::new = cursor
+&char::is_alpha cursor.take_while print    # abc
+&char::is_digit cursor.take_while print    # 123
+```
+
+### `Cursor::save`
+
+Returns the current cursor position for later backtracking.
+
+**Signature:** `Cursor::save self:Cursor -> int`
+
+**Stack effect:** `Cursor -> int`
+
+### `Cursor::restore`
+
+Sets the cursor position back to a previously saved value.
+
+**Signature:** `Cursor::restore self:Cursor saved:int`
+
+**Stack effect:** `Cursor int -> None`
+
+```casa
+"test" Cursor::new = cursor
+cursor.save = saved
+cursor.advance drop
+cursor.advance drop
+saved cursor.restore
+cursor.peek .unwrap print    # t
+```
+
+## Helper Functions
+
+### `chars_to_str`
+
+Converts a `List[char]` to a `str`. Allocates a new string with the correct length and null terminator.
+
+**Signature:** `chars_to_str chars:List[char] -> str`
+
+**Stack effect:** `List[char] -> str`
+
+### `str_to_int`
+
+Converts a digit string to an integer. Handles optional leading `-` for negative numbers.
+
+**Signature:** `str_to_int s:str -> int`
+
+**Stack effect:** `str -> int`
+
+```casa
+"42" str_to_int print      # 42
+"-7" str_to_int print      # -7
+```
+
+### `is_ident_start`
+
+Returns `true` if the character is alphabetic or an underscore. Suitable for the first character of an identifier.
+
+**Signature:** `is_ident_start c:char -> bool`
+
+**Stack effect:** `char -> bool`
+
+### `is_ident_char`
+
+Returns `true` if the character is alphanumeric or an underscore. Suitable for subsequent characters of an identifier.
+
+**Signature:** `is_ident_char c:char -> bool`
+
+**Stack effect:** `char -> bool`
+
+## High-Level Parsers
+
+### `skip_whitespace`
+
+Skips spaces, tabs, newlines, and carriage returns.
+
+**Signature:** `skip_whitespace cursor:Cursor`
+
+**Stack effect:** `Cursor -> None`
+
+```casa
+"   hello" Cursor::new = cursor
+cursor skip_whitespace
+cursor.pos print    # 3
+```
+
+### `parse_int`
+
+Parses an integer with optional leading `-`. Returns `error` if no digits are found. Restores cursor position on failure.
+
+**Signature:** `parse_int cursor:Cursor -> result[int ParseError]`
+
+**Stack effect:** `Cursor -> result[int ParseError]`
+
+```casa
+"42" Cursor::new parse_int .unwrap print      # 42
+"-7" Cursor::new parse_int .unwrap print      # -7
+"abc" Cursor::new parse_int .is_error print   # true
+```
+
+### `parse_identifier`
+
+Parses an identifier matching `[a-zA-Z_][a-zA-Z0-9_]*`. Returns `error` if the current character is not a valid identifier start. Restores cursor position on failure.
+
+**Signature:** `parse_identifier cursor:Cursor -> result[str ParseError]`
+
+**Stack effect:** `Cursor -> result[str ParseError]`
+
+```casa
+"my_var" Cursor::new parse_identifier .unwrap print    # my_var
+```
+
+### `parse_escape`
+
+Parses an escape sequence after the `\` has been consumed. Recognizes: `\n`, `\t`, `\\`, `\"`, `\'`, `\0`, `\r`, `\{`, `\}`.
+
+**Signature:** `parse_escape cursor:Cursor -> result[char ParseError]`
+
+**Stack effect:** `Cursor -> result[char ParseError]`
+
+### `parse_quoted_string`
+
+Parses a double-quoted string with escape sequences. Consumes the opening and closing `"` characters. Returns the string contents (with escapes processed).
+
+**Signature:** `parse_quoted_string cursor:Cursor -> result[str ParseError]`
+
+**Stack effect:** `Cursor -> result[str ParseError]`
+
+### `parse_char_literal`
+
+Parses a single-quoted character literal with escape sequences. Consumes the opening and closing `'` characters. Returns the character value.
+
+**Signature:** `parse_char_literal cursor:Cursor -> result[char ParseError]`
+
+**Stack effect:** `Cursor -> result[char ParseError]`
+
+## Complete Example
+
+```casa
+include "../lib/std.casa"
+include "../lib/parser.casa"
+
+# Parse integers and identifiers from input
+"abc123" Cursor::new = cursor
+&char::is_alpha cursor.take_while = letters
+&char::is_digit cursor.take_while = digits
+letters print    # abc
+digits print     # 123
+
+# Parse with backtracking
+"test" Cursor::new = cursor2
+cursor2.save = pos
+&is_ident_char cursor2.take_while print    # test
+pos cursor2.restore
+&char::is_alpha cursor2.take_while print   # test
+```
+
+See [`examples/parser.casa`](../examples/parser.casa) for a full program demonstrating all parser library features.

--- a/examples/outputs/parser.out
+++ b/examples/outputs/parser.out
@@ -1,0 +1,16 @@
+h
+e
+letters: abc
+digits: 123
+full: test123
+alpha only: test
+after skip: 3
+starts hello: true
+starts xyz: false
+int: 42
+neg: -7
+id: my_var
+str: hello world
+char: Z
+str_to_int: 456
+int error: expected integer

--- a/examples/parser.casa
+++ b/examples/parser.casa
@@ -14,8 +14,8 @@ cursor.peek.unwrap print "\n" print
 
 # take_while: collect matching characters
 "abc123" Cursor::new = tw_cursor
-&char::is_alpha tw_cursor.take_while = letters
-&char::is_digit tw_cursor.take_while = digits
+{ .is_alpha } tw_cursor.take_while = letters
+{ .is_digit } tw_cursor.take_while = digits
 "letters: " print letters print "\n" print
 "digits: " print digits print "\n" print
 
@@ -25,7 +25,7 @@ sr_cursor.save = saved_pos
 &is_ident_char sr_cursor.take_while = full_token
 "full: " print full_token print "\n" print
 saved_pos sr_cursor.restore
-&char::is_alpha sr_cursor.take_while = alpha_part
+{ .is_alpha } sr_cursor.take_while = alpha_part
 "alpha only: " print alpha_part print "\n" print
 
 # skip_whitespace

--- a/examples/parser.casa
+++ b/examples/parser.casa
@@ -1,0 +1,80 @@
+# Parser library - cursor-based text scanning
+#
+# Demonstrates Cursor struct, helper functions, and high-level parsers
+# for integers, identifiers, quoted strings, and char literals.
+
+include "../lib/std.casa"
+include "../lib/parser.casa"
+
+# Cursor basics: peek and advance
+"hello" Cursor::new = cursor
+cursor.peek.unwrap print "\n" print
+cursor.advance drop
+cursor.peek.unwrap print "\n" print
+
+# take_while: collect matching characters
+"abc123" Cursor::new = tw_cursor
+&char::is_alpha tw_cursor.take_while = letters
+&char::is_digit tw_cursor.take_while = digits
+"letters: " print letters print "\n" print
+"digits: " print digits print "\n" print
+
+# save and restore for backtracking
+"test123" Cursor::new = sr_cursor
+sr_cursor.save = saved_pos
+&is_ident_char sr_cursor.take_while = full_token
+"full: " print full_token print "\n" print
+saved_pos sr_cursor.restore
+&char::is_alpha sr_cursor.take_while = alpha_part
+"alpha only: " print alpha_part print "\n" print
+
+# skip_whitespace
+"   hello" Cursor::new = ws_cursor
+ws_cursor skip_whitespace
+"after skip: " print ws_cursor.pos print "\n" print
+
+# starts_with
+"hello world" Cursor::new = sw_cursor
+"starts hello: " print "hello" sw_cursor.starts_with print "\n" print
+"starts xyz: " print "xyz" sw_cursor.starts_with print "\n" print
+
+# parse_int
+"42" Cursor::new parse_int .unwrap = parsed_int
+"int: " print parsed_int print "\n" print
+"-7" Cursor::new parse_int .unwrap = parsed_neg
+"neg: " print parsed_neg print "\n" print
+
+# parse_identifier
+"my_var" Cursor::new parse_identifier .unwrap = parsed_id
+"id: " print parsed_id print "\n" print
+
+# parse_quoted_string (input: "hello world" with surrounding quotes)
+34 alloc (str) = qs_input
+13 qs_input (ptr) store64
+'"' 0 qs_input.set
+'h' 1 qs_input.set
+'e' 2 qs_input.set
+'l' 3 qs_input.set
+'l' 4 qs_input.set
+'o' 5 qs_input.set
+' ' 6 qs_input.set
+'w' 7 qs_input.set
+'o' 8 qs_input.set
+'r' 9 qs_input.set
+'l' 10 qs_input.set
+'d' 11 qs_input.set
+'"' 12 qs_input.set
+'\0' 13 qs_input.set
+qs_input Cursor::new parse_quoted_string .unwrap = parsed_str
+"str: " print parsed_str print "\n" print
+
+# parse_char_literal
+"'Z'" Cursor::new parse_char_literal .unwrap = parsed_char
+"char: " print parsed_char print "\n" print
+
+# str_to_int helper
+"str_to_int: " print "456" str_to_int print "\n" print
+
+# Error handling
+"xyz" Cursor::new parse_int = int_err
+"int error: " print int_err.unwrap_error.message print "\n" print

--- a/lib/parser.casa
+++ b/lib/parser.casa
@@ -212,7 +212,8 @@ fn parse_identifier cursor:Cursor -> result[str ParseError] {
 fn parse_escape cursor:Cursor -> result[char ParseError] {
     cursor.advance = pe_opt
     if pe_opt.is_none then
-        cursor.pos "unexpected EOF in escape" ParseError error        return
+        cursor.pos "unexpected EOF in escape" ParseError error
+        return
     fi
     pe_opt.unwrap = pe_ch
     if pe_ch 'n' == then '\n' ok
@@ -234,7 +235,8 @@ fn parse_quoted_string cursor:Cursor -> result[str ParseError] {
     '"' cursor.expect_char = pqs_open
     if pqs_open.is_error then
         pqs_start cursor.restore
-        pqs_open.unwrap_error error        return
+        pqs_open.unwrap_error error
+        return
     fi
     pqs_open drop
     List::new (List[char]) = pqs_chars
@@ -242,13 +244,15 @@ fn parse_quoted_string cursor:Cursor -> result[str ParseError] {
         cursor.peek.unwrap = pqs_ch
         if pqs_ch '"' == then
             cursor.advance drop
-            pqs_chars chars_to_str ok            return
+            pqs_chars chars_to_str ok
+            return
         elif pqs_ch '\\' == then
             cursor.advance drop
             cursor parse_escape = pqs_esc
             if pqs_esc.is_error then
                 pqs_start cursor.restore
-                pqs_esc.unwrap_error error                return
+                pqs_esc.unwrap_error error
+                return
             fi
             pqs_esc.unwrap pqs_chars.push
         else
@@ -257,34 +261,40 @@ fn parse_quoted_string cursor:Cursor -> result[str ParseError] {
         fi
     done
     pqs_start cursor.restore
-    pqs_start "unterminated string" ParseError error}
+    pqs_start "unterminated string" ParseError error
+}
 
 fn parse_char_literal cursor:Cursor -> result[char ParseError] {
     cursor.save = pcl_start
     '\'' cursor.expect_char = pcl_open
     if pcl_open.is_error then
         pcl_start cursor.restore
-        pcl_open.unwrap_error error        return
+        pcl_open.unwrap_error error
+        return
     fi
     pcl_open drop
     cursor.advance = pcl_opt
     if pcl_opt.is_none then
         pcl_start cursor.restore
-        pcl_start "unterminated char literal" ParseError error        return
+        pcl_start "unterminated char literal" ParseError error
+        return
     fi
     pcl_opt.unwrap = pcl_ch
     if pcl_ch '\\' == then
         cursor parse_escape = pcl_esc
         if pcl_esc.is_error then
             pcl_start cursor.restore
-            pcl_esc.unwrap_error error            return
+            pcl_esc.unwrap_error error
+            return
         fi
         pcl_esc.unwrap = pcl_ch
     fi
     '\'' cursor.expect_char = pcl_close
     if pcl_close.is_error then
         pcl_start cursor.restore
-        pcl_close.unwrap_error error        return
+        pcl_close.unwrap_error error
+        return
     fi
     pcl_close drop
-    pcl_ch ok}
+    pcl_ch ok
+}

--- a/lib/parser.casa
+++ b/lib/parser.casa
@@ -1,0 +1,300 @@
+# Parser library for cursor-based text scanning
+#
+# Provides a Cursor struct for scanning text character by character,
+# and high-level parsers for common patterns like integers, identifiers,
+# quoted strings, and char literals.
+
+include "std.casa"
+
+# ---------------------------------------------------------------------------
+# Structs
+# ---------------------------------------------------------------------------
+
+struct Cursor {
+    source: str
+    pos:    int
+}
+
+struct ParseError {
+    message: str
+    pos:     int
+}
+
+# ---------------------------------------------------------------------------
+# Cursor methods
+# ---------------------------------------------------------------------------
+
+impl Cursor {
+    fn new source:str -> Cursor {
+        0 source Cursor
+    }
+
+    fn is_eof self:Cursor -> bool {
+        self.source.length self.pos >=
+    }
+
+    fn peek self:Cursor -> option[char] {
+        if self.is_eof then
+            none (option[char])
+        else
+            self.pos self.source.at some
+        fi
+    }
+
+    fn peek_at self:Cursor offset:int -> option[char] {
+        self.pos offset + = pa_idx
+        if self.source.length pa_idx >= then
+            none (option[char])
+        else
+            pa_idx self.source.at some
+        fi
+    }
+
+    fn advance self:Cursor -> option[char] {
+        if self.is_eof then
+            none (option[char])
+        else
+            self.pos self.source.at some
+            self.pos 1 + self->pos
+        fi
+    }
+
+    fn starts_with self:Cursor prefix:str -> bool {
+        prefix.length = sw_len
+        if self.source.length self.pos - sw_len > then
+            false
+        else
+            true = sw_match
+            0 = sw_i
+            while sw_i sw_len > do
+                if self.pos sw_i + self.source.at sw_i prefix.at != then
+                    false = sw_match
+                    break
+                fi
+                1 += sw_i
+            done
+            sw_match
+        fi
+    }
+
+    fn expect_char self:Cursor expected:char -> result[char ParseError] {
+        if self.is_eof then
+            self.pos "unexpected EOF" ParseError error
+        else
+            self.pos self.source.at = ec_ch
+            if ec_ch expected == then
+                self.pos 1 + self->pos
+                ec_ch ok
+            else
+                self.pos "unexpected character" ParseError error
+            fi
+        fi
+    }
+
+    fn skip self:Cursor n:int {
+        self.pos n + self->pos
+    }
+
+    fn take_string self:Cursor target:str -> result[str ParseError] {
+        if target self.starts_with then
+            target.length self.skip
+            target ok
+        else
+            self.pos "expected string not found" ParseError error
+        fi
+    }
+
+    fn skip_while self:Cursor pred:fn[char -> bool] {
+        while self.is_eof ! do
+            if self.peek.unwrap pred exec ! then break fi
+            self.advance drop
+        done
+    }
+
+    fn take_while self:Cursor pred:fn[char -> bool] -> str {
+        self.pos = tw_start
+        while self.is_eof ! do
+            if self.peek.unwrap pred exec ! then break fi
+            self.advance drop
+        done
+        self.source tw_start self.pos tw_start - str::substring
+    }
+
+    fn save self:Cursor -> int {
+        self.pos
+    }
+
+    fn restore self:Cursor saved:int {
+        saved self->pos
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
+
+fn chars_to_str chars:List[char] -> str {
+    chars.length = cts_len
+    cts_len 9 + alloc (str) = cts_buf
+    cts_len cts_buf (ptr) store64
+    0 = cts_i
+    while cts_i cts_len > do
+        cts_i chars.get (char) cts_i cts_buf.set
+        1 += cts_i
+    done
+    0 (char) cts_len cts_buf.set
+    cts_buf
+}
+
+fn str_to_int s:str -> int {
+    0 = sti_result
+    0 = sti_i
+    false = sti_neg
+    if s.length 0 != then
+        if 0 s.at '-' == then
+            true = sti_neg
+            1 = sti_i
+        fi
+    fi
+    while sti_i s.length > do
+        sti_result 10 * sti_i s.at (int) '0' (int) - + = sti_result
+        1 += sti_i
+    done
+    if sti_neg then 0 sti_result - else sti_result fi
+}
+
+fn is_ident_start c:char -> bool {
+    c.is_alpha c '_' == ||
+}
+
+fn is_ident_char c:char -> bool {
+    c.is_alpha c.is_digit || c '_' == ||
+}
+
+# ---------------------------------------------------------------------------
+# High-level parsers
+# ---------------------------------------------------------------------------
+
+fn skip_whitespace cursor:Cursor {
+    &char::is_space cursor.skip_while
+}
+
+fn parse_int cursor:Cursor -> result[int ParseError] {
+    cursor.save = pi_start
+    false = pi_neg
+    if cursor.is_eof ! then
+        if cursor.peek.unwrap '-' == then
+            true = pi_neg
+            cursor.advance drop
+        fi
+    fi
+    &char::is_digit cursor.take_while = pi_digits
+    if pi_digits.length 0 == then
+        pi_start cursor.restore
+        pi_start "expected integer" ParseError error
+    else
+        pi_digits str_to_int = pi_val
+        if pi_neg then 0 pi_val - else pi_val fi ok
+    fi
+}
+
+fn parse_identifier cursor:Cursor -> result[str ParseError] {
+    cursor.save = pid_start
+    if cursor.is_eof then
+        pid_start "expected identifier" ParseError error
+    elif cursor.peek.unwrap is_ident_start ! then
+        pid_start "expected identifier" ParseError error
+    else
+        &is_ident_char cursor.take_while ok
+    fi
+}
+
+fn parse_escape cursor:Cursor -> result[char ParseError] {
+    cursor.advance = pe_opt
+    if pe_opt.is_none then
+        cursor.pos "unexpected EOF in escape" ParseError error (result[char ParseError])
+        return
+    fi
+    pe_opt.unwrap = pe_ch
+    if pe_ch 'n' == then '\n' ok (result[char ParseError])
+    elif pe_ch 't' == then '\t' ok (result[char ParseError])
+    elif pe_ch '\\' == then '\\' ok (result[char ParseError])
+    elif pe_ch '"' == then '"' ok (result[char ParseError])
+    elif pe_ch '\'' == then '\'' ok (result[char ParseError])
+    elif pe_ch '0' == then '\0' ok (result[char ParseError])
+    elif pe_ch 'r' == then '\r' ok (result[char ParseError])
+    elif pe_ch '{' == then '{' ok (result[char ParseError])
+    elif pe_ch '}' == then '}' ok (result[char ParseError])
+    else
+        cursor.pos "unknown escape sequence" ParseError error (result[char ParseError])
+    fi
+}
+
+fn parse_quoted_string cursor:Cursor -> result[str ParseError] {
+    cursor.save = pqs_start
+    '"' cursor.expect_char = pqs_open
+    if pqs_open.is_error then
+        pqs_start cursor.restore
+        pqs_open.unwrap_error error (result[str ParseError])
+        return
+    fi
+    pqs_open drop
+    List::new (List[char]) = pqs_chars
+    while cursor.is_eof ! do
+        cursor.peek.unwrap = pqs_ch
+        if pqs_ch '"' == then
+            cursor.advance drop
+            pqs_chars chars_to_str ok (result[str ParseError])
+            return
+        elif pqs_ch '\\' == then
+            cursor.advance drop
+            cursor parse_escape = pqs_esc
+            if pqs_esc.is_error then
+                pqs_start cursor.restore
+                pqs_esc.unwrap_error error (result[str ParseError])
+                return
+            fi
+            pqs_esc.unwrap pqs_chars.push
+        else
+            cursor.advance drop
+            pqs_ch pqs_chars.push
+        fi
+    done
+    pqs_start cursor.restore
+    pqs_start "unterminated string" ParseError error (result[str ParseError])
+}
+
+fn parse_char_literal cursor:Cursor -> result[char ParseError] {
+    cursor.save = pcl_start
+    '\'' cursor.expect_char = pcl_open
+    if pcl_open.is_error then
+        pcl_start cursor.restore
+        pcl_open.unwrap_error error (result[char ParseError])
+        return
+    fi
+    pcl_open drop
+    cursor.advance = pcl_opt
+    if pcl_opt.is_none then
+        pcl_start cursor.restore
+        pcl_start "unterminated char literal" ParseError error (result[char ParseError])
+        return
+    fi
+    pcl_opt.unwrap = pcl_ch
+    if pcl_ch '\\' == then
+        cursor parse_escape = pcl_esc
+        if pcl_esc.is_error then
+            pcl_start cursor.restore
+            pcl_esc.unwrap_error error (result[char ParseError])
+            return
+        fi
+        pcl_esc.unwrap = pcl_ch
+    fi
+    '\'' cursor.expect_char = pcl_close
+    if pcl_close.is_error then
+        pcl_start cursor.restore
+        pcl_close.unwrap_error error (result[char ParseError])
+        return
+    fi
+    pcl_close drop
+    pcl_ch ok (result[char ParseError])
+}

--- a/lib/parser.casa
+++ b/lib/parser.casa
@@ -212,21 +212,20 @@ fn parse_identifier cursor:Cursor -> result[str ParseError] {
 fn parse_escape cursor:Cursor -> result[char ParseError] {
     cursor.advance = pe_opt
     if pe_opt.is_none then
-        cursor.pos "unexpected EOF in escape" ParseError error (result[char ParseError])
-        return
+        cursor.pos "unexpected EOF in escape" ParseError error        return
     fi
     pe_opt.unwrap = pe_ch
-    if pe_ch 'n' == then '\n' ok (result[char ParseError])
-    elif pe_ch 't' == then '\t' ok (result[char ParseError])
-    elif pe_ch '\\' == then '\\' ok (result[char ParseError])
-    elif pe_ch '"' == then '"' ok (result[char ParseError])
-    elif pe_ch '\'' == then '\'' ok (result[char ParseError])
-    elif pe_ch '0' == then '\0' ok (result[char ParseError])
-    elif pe_ch 'r' == then '\r' ok (result[char ParseError])
-    elif pe_ch '{' == then '{' ok (result[char ParseError])
-    elif pe_ch '}' == then '}' ok (result[char ParseError])
+    if pe_ch 'n' == then '\n' ok
+    elif pe_ch 't' == then '\t' ok
+    elif pe_ch '\\' == then '\\' ok
+    elif pe_ch '"' == then '"' ok
+    elif pe_ch '\'' == then '\'' ok
+    elif pe_ch '0' == then '\0' ok
+    elif pe_ch 'r' == then '\r' ok
+    elif pe_ch '{' == then '{' ok
+    elif pe_ch '}' == then '}' ok
     else
-        cursor.pos "unknown escape sequence" ParseError error (result[char ParseError])
+        cursor.pos "unknown escape sequence" ParseError error
     fi
 }
 
@@ -235,8 +234,7 @@ fn parse_quoted_string cursor:Cursor -> result[str ParseError] {
     '"' cursor.expect_char = pqs_open
     if pqs_open.is_error then
         pqs_start cursor.restore
-        pqs_open.unwrap_error error (result[str ParseError])
-        return
+        pqs_open.unwrap_error error        return
     fi
     pqs_open drop
     List::new (List[char]) = pqs_chars
@@ -244,15 +242,13 @@ fn parse_quoted_string cursor:Cursor -> result[str ParseError] {
         cursor.peek.unwrap = pqs_ch
         if pqs_ch '"' == then
             cursor.advance drop
-            pqs_chars chars_to_str ok (result[str ParseError])
-            return
+            pqs_chars chars_to_str ok            return
         elif pqs_ch '\\' == then
             cursor.advance drop
             cursor parse_escape = pqs_esc
             if pqs_esc.is_error then
                 pqs_start cursor.restore
-                pqs_esc.unwrap_error error (result[str ParseError])
-                return
+                pqs_esc.unwrap_error error                return
             fi
             pqs_esc.unwrap pqs_chars.push
         else
@@ -261,40 +257,34 @@ fn parse_quoted_string cursor:Cursor -> result[str ParseError] {
         fi
     done
     pqs_start cursor.restore
-    pqs_start "unterminated string" ParseError error (result[str ParseError])
-}
+    pqs_start "unterminated string" ParseError error}
 
 fn parse_char_literal cursor:Cursor -> result[char ParseError] {
     cursor.save = pcl_start
     '\'' cursor.expect_char = pcl_open
     if pcl_open.is_error then
         pcl_start cursor.restore
-        pcl_open.unwrap_error error (result[char ParseError])
-        return
+        pcl_open.unwrap_error error        return
     fi
     pcl_open drop
     cursor.advance = pcl_opt
     if pcl_opt.is_none then
         pcl_start cursor.restore
-        pcl_start "unterminated char literal" ParseError error (result[char ParseError])
-        return
+        pcl_start "unterminated char literal" ParseError error        return
     fi
     pcl_opt.unwrap = pcl_ch
     if pcl_ch '\\' == then
         cursor parse_escape = pcl_esc
         if pcl_esc.is_error then
             pcl_start cursor.restore
-            pcl_esc.unwrap_error error (result[char ParseError])
-            return
+            pcl_esc.unwrap_error error            return
         fi
         pcl_esc.unwrap = pcl_ch
     fi
     '\'' cursor.expect_char = pcl_close
     if pcl_close.is_error then
         pcl_start cursor.restore
-        pcl_close.unwrap_error error (result[char ParseError])
-        return
+        pcl_close.unwrap_error error        return
     fi
     pcl_close drop
-    pcl_ch ok (result[char ParseError])
-}
+    pcl_ch ok}

--- a/lib/parser.casa
+++ b/lib/parser.casa
@@ -176,7 +176,7 @@ fn is_ident_char c:char -> bool {
 # ---------------------------------------------------------------------------
 
 fn skip_whitespace cursor:Cursor {
-    &char::is_space cursor.skip_while
+    { .is_space } cursor.skip_while
 }
 
 fn parse_int cursor:Cursor -> result[int ParseError] {
@@ -188,7 +188,7 @@ fn parse_int cursor:Cursor -> result[int ParseError] {
             cursor.advance drop
         fi
     fi
-    &char::is_digit cursor.take_while = pi_digits
+    { .is_digit } cursor.take_while = pi_digits
     if pi_digits.length 0 == then
         pi_start cursor.restore
         pi_start "expected integer" ParseError error

--- a/tests/test_typechecker.py
+++ b/tests/test_typechecker.py
@@ -1383,3 +1383,127 @@ def test_typecheck_str_concat():
     """str::concat returns str."""
     sig = typecheck_string(STD_INCLUDE + '"hello" " world" str::concat')
     assert sig.return_types == ["str"]
+
+
+# ---------------------------------------------------------------------------
+# Return type unification
+# ---------------------------------------------------------------------------
+def test_typecheck_return_type_unification_ok_and_error():
+    """Return types with ok (result[T any]) and error (result[any E]) unify."""
+    code = """
+    struct MyErr { msg: str }
+    fn try_it x:int -> result[int MyErr] {
+        if 0 x == then
+            "zero" MyErr error
+            return
+        fi
+        x ok
+    }
+    5 try_it
+    """
+    sig = typecheck_string(code)
+    assert sig.return_types == ["result[int MyErr]"]
+
+
+def test_typecheck_return_type_unification_multiple_returns():
+    """Multiple return statements with different any positions unify."""
+    code = """
+    struct ParseErr { msg: str pos: int }
+    fn parse x:int -> result[str ParseErr] {
+        if 0 x == then
+            x "bad" ParseErr error
+            return
+        fi
+        if 10 x > then
+            x "too big" ParseErr error
+            return
+        fi
+        "good" ok
+    }
+    5 parse
+    """
+    sig = typecheck_string(code)
+    assert sig.return_types == ["result[str ParseErr]"]
+
+
+def test_typecheck_return_type_unification_mismatch():
+    """Incompatible return types across return paths produce an error."""
+    code = """
+    fn bad x:int -> int {
+        if 0 x == then
+            "hello"
+            return
+        fi
+        42
+    }
+    5 bad
+    """
+    with pytest.raises(CasaErrorCollection) as exc_info:
+        typecheck_string(code)
+    assert exc_info.value.errors[0].kind == ErrorKind.TYPE_MISMATCH
+
+
+# ---------------------------------------------------------------------------
+# Deferred method lambdas
+# ---------------------------------------------------------------------------
+def test_typecheck_deferred_method_unique():
+    """Lambda with unambiguous method resolves automatically."""
+    code = STD_INCLUDE + """
+    { .is_space } = pred
+    ' ' pred exec
+    """
+    sig = typecheck_string(code)
+    assert sig.return_types == ["bool"]
+
+
+def test_typecheck_deferred_method_multi_type():
+    """Lambda with method on multiple types defers and specializes."""
+    code = STD_INCLUDE + """
+    { .hash } = hasher
+    42 hasher exec
+    """
+    sig = typecheck_string(code)
+    assert sig.return_types == ["int"]
+
+
+def test_typecheck_deferred_method_different_return_types_error():
+    """Deferred method with different return types produces ambiguity error."""
+    code = """
+    impl int { fn thing int -> int { drop 1 } }
+    impl bool { fn thing bool -> bool { drop true } }
+    { .thing } = f
+    """
+    with pytest.raises(CasaErrorCollection) as exc_info:
+        typecheck_string(code)
+    assert exc_info.value.errors[0].kind == ErrorKind.UNDEFINED_NAME
+
+
+def test_typecheck_deferred_method_nonexistent():
+    """Lambda with nonexistent method produces error."""
+    code = '{ .nonexistent_method } = f'
+    with pytest.raises(CasaErrorCollection) as exc_info:
+        typecheck_string(code)
+    assert exc_info.value.errors[0].kind == ErrorKind.UNDEFINED_NAME
+
+
+def test_typecheck_deferred_method_param_mismatch():
+    """Deferred method with wrong parameter type produces error at call site."""
+    code = """
+    impl int { fn thing int -> int { drop 1 } }
+    impl char { fn thing bool -> int { drop 2 } }
+    { .thing } = f
+    'a' f exec
+    """
+    with pytest.raises(CasaErrorCollection) as exc_info:
+        typecheck_string(code)
+    assert exc_info.value.errors[0].kind == ErrorKind.TYPE_MISMATCH
+
+
+def test_typecheck_deferred_method_chain():
+    """Chained deferred methods resolve correctly."""
+    code = STD_INCLUDE + """
+    { .length .hash } = len_hash
+    "hello" len_hash exec
+    """
+    sig = typecheck_string(code)
+    assert sig.return_types == ["int"]


### PR DESCRIPTION
## Summary

- Add `lib/parser.casa` with `Cursor` and `ParseError` structs, cursor scanning methods (`peek`, `advance`, `take_while`, `skip_while`, `save`/`restore`), and high-level parsers (`parse_int`, `parse_identifier`, `parse_quoted_string`, `parse_char_literal`)
- Support method calls in lambdas with auto-resolution: `{ .is_space }` now works when the method name is unambiguous across all types
- Add `docs/parser.md`, example at `examples/parser.casa`, and update `README.md`

## Test plan

- [x] `python3 casa.py examples/parser.casa -r` produces expected output
- [x] `bash tests/test_examples.sh` passes (29/29)
- [x] `.venv/bin/python -m pytest tests/ -q` passes (1004/1004)
- [x] Lambda method resolution works for unambiguous methods (`{ .is_space }`, `{ .is_digit }`, `{ .is_alpha }`)
- [x] Ambiguous method lambdas (`{ .to_str }`) produce a clear error listing candidates