### PR TITLE
feat: self-hosting foundation features

### DIFF
--- a/casa/bytecode.py
+++ b/casa/bytecode.py
@@ -72,6 +72,8 @@ DIRECT_OP_TO_INST: dict[OpKind, InstKind] = {
     OpKind.SYSCALL4: InstKind.SYSCALL4,
     OpKind.SYSCALL5: InstKind.SYSCALL5,
     OpKind.SYSCALL6: InstKind.SYSCALL6,
+    OpKind.ARGC: InstKind.ARGC,
+    OpKind.ARGV: InstKind.ARGV,
 }
 
 _label_counter = [0]
@@ -548,8 +550,8 @@ class Compiler:
 
     def compile(self) -> Bytecode:
         """Lower all ops to bytecode instructions."""
-        assert len(InstKind) == 66, "Exhaustive handling for `InstructionKind"
-        assert len(OpKind) == 86, "Exhaustive handling for `OpKind`"
+        assert len(InstKind) == 68, "Exhaustive handling for `InstructionKind"
+        assert len(OpKind) == 88, "Exhaustive handling for `OpKind`"
 
         cursor = Cursor(sequence=self.ops)
         bytecode: list[Inst] = []

--- a/casa/common.py
+++ b/casa/common.py
@@ -1024,6 +1024,7 @@ class Struct:
     name: str
     members: list[Member]
     location: Location
+    type_vars: list[str] = field(default_factory=list)
 
 
 @dataclass

--- a/casa/common.py
+++ b/casa/common.py
@@ -67,6 +67,10 @@ class Intrinsic(Enum):
     SYSCALL5 = auto()
     SYSCALL6 = auto()
 
+    # Command-line arguments
+    ARGC = auto()
+    ARGV = auto()
+
     @classmethod
     def from_lowercase(cls, value: str) -> Self | None:
         """Look up an intrinsic by its lowercase source name."""
@@ -389,6 +393,10 @@ class OpKind(Enum):
     # F-strings
     FSTRING_CONCAT = auto()
 
+    # Command-line arguments
+    ARGC = auto()
+    ARGV = auto()
+
     # Identifiers should be resolved by the parser
     IDENTIFIER = auto()
 
@@ -404,7 +412,7 @@ class Op:
     deferred_return_type: str | None = None
 
     def __post_init__(self):
-        assert len(OpKind) == 86, "Exhaustive handling for `OpKind`"
+        assert len(OpKind) == 88, "Exhaustive handling for `OpKind`"
 
         match self.kind:
             # Value constructors (no value validation needed)
@@ -469,6 +477,8 @@ class Op:
                 | OpKind.SYSCALL4
                 | OpKind.SYSCALL5
                 | OpKind.SYSCALL6
+                | OpKind.ARGC
+                | OpKind.ARGV
             ):
                 if not isinstance(self.value, Intrinsic):
                     raise TypeError(f"`{self.kind}` requires value of type `Intrinsic`")
@@ -632,6 +642,10 @@ class InstKind(Enum):
     SYSCALL5 = auto()
     SYSCALL6 = auto()
 
+    # Command-line arguments
+    ARGC = auto()
+    ARGV = auto()
+
 
 @dataclass
 class Inst:
@@ -656,7 +670,7 @@ class Inst:
         return self.args[0]
 
     def __post_init__(self):
-        assert len(InstKind) == 66, "Exhaustive handling for `InstructionKind`"
+        assert len(InstKind) == 68, "Exhaustive handling for `InstructionKind`"
 
         match self.kind:
             # Should not have a parameter
@@ -709,6 +723,8 @@ class Inst:
                 | InstKind.SYSCALL4
                 | InstKind.SYSCALL5
                 | InstKind.SYSCALL6
+                | InstKind.ARGC
+                | InstKind.ARGV
             ):
                 if self.args:
                     raise TypeError(

--- a/casa/emitter.py
+++ b/casa/emitter.py
@@ -67,6 +67,8 @@ class Emitter:
         self._line(f"return_stack: .skip {RETURN_STACK_SIZE}")
         self._line(f"heap: .skip {HEAP_SIZE}")
         self._line("heap_ptr: .skip 8")
+        self._line("__argc: .skip 8")
+        self._line("__argv: .skip 8")
         self._line("print_buf: .skip 32")
         self._line("")
 
@@ -204,6 +206,10 @@ class Emitter:
         self._line(".globl _start")
         self._line("_start:")
         self._indent("leaq return_stack(%rip), %r14")
+        self._indent("movq (%rsp), %rax")
+        self._indent("movq %rax, __argc(%rip)")
+        self._indent("leaq 8(%rsp), %rax")
+        self._indent("movq %rax, __argv(%rip)")
         self._emit_bytecode(self.program.bytecode, is_global=True)
         self._indent("movq $60, %rax")
         self._indent("xorq %rdi, %rdi")
@@ -538,7 +544,7 @@ class Emitter:
         self._emit_syscall(SYSCALL_ARG_COUNTS[inst.kind])
 
     def _emit_inst(self, inst: Inst, is_global: bool) -> None:
-        assert len(InstKind) == 66, "Exhaustive handling for `InstKind`"
+        assert len(InstKind) == 68, "Exhaustive handling for `InstKind`"
         kind = inst.kind
         match kind:
             case (
@@ -625,6 +631,12 @@ class Emitter:
                 | InstKind.SYSCALL6
             ):
                 self._emit_syscall_ops(inst)
+            case InstKind.ARGC:
+                self._indent("movq __argc(%rip), %rax")
+                self._indent("pushq %rax")
+            case InstKind.ARGV:
+                self._indent("movq __argv(%rip), %rax")
+                self._indent("pushq %rax")
             case _:
                 assert_never(kind)
 

--- a/casa/emitter.py
+++ b/casa/emitter.py
@@ -7,7 +7,9 @@ from casa.common import Bytecode, Inst, InstKind, Program
 INT32_MIN = -(1 << 31)
 INT32_MAX = (1 << 31) - 1
 RETURN_STACK_SIZE = 65536
-HEAP_SIZE = 1048576
+# 64 MB — large enough for self-hosting compiler intermediates.
+# BSS is demand-paged so only touched pages consume physical memory.
+HEAP_SIZE = 67108864
 
 
 class Emitter:

--- a/casa/parser.py
+++ b/casa/parser.py
@@ -263,9 +263,19 @@ def _create_member_accessor(
     member_type: str,
     member_index: int,
     location: Location,
+    *,
+    type_vars: list[str] | None = None,
 ) -> tuple[Function, Function]:
     """Create getter and setter functions for a struct member."""
     offset = member_index * 8
+
+    # Parameterize the struct name when the struct has type vars
+    if type_vars:
+        param_struct_type = f"{struct_name}[{' '.join(type_vars)}]"
+        sig_type_vars = set(type_vars)
+    else:
+        param_struct_type = struct_name
+        sig_type_vars = set()
 
     # Getter
     getter_name = f"{struct_name}::{member_name}"
@@ -276,8 +286,8 @@ def _create_member_accessor(
         Op(Intrinsic.LOAD64, OpKind.LOAD64, location),
         Op(member_type, OpKind.TYPE_CAST, location),
     ]
-    getter_params = [Parameter(struct_name)]
-    getter_signature = Signature(getter_params, [member_type])
+    getter_params = [Parameter(param_struct_type)]
+    getter_signature = Signature(getter_params, [member_type], type_vars=sig_type_vars)
     getter = Function(getter_name, getter_ops, location, getter_signature)
 
     # Setter
@@ -288,8 +298,8 @@ def _create_member_accessor(
         Op(Operator.PLUS, OpKind.ADD, location),
         Op(Intrinsic.STORE64, OpKind.STORE64, location),
     ]
-    setter_params = [Parameter(struct_name), Parameter(member_type)]
-    setter_signature = Signature(setter_params, [])
+    setter_params = [Parameter(param_struct_type), Parameter(member_type)]
+    setter_signature = Signature(setter_params, [], type_vars=sig_type_vars)
     setter = Function(setter_name, setter_ops, location, setter_signature)
 
     return getter, setter
@@ -1015,6 +1025,21 @@ def parse_struct(cursor: Cursor[Token]) -> Struct:
     expect_token(cursor, value="struct")
     struct_name = expect_token(cursor, kind=TokenKind.IDENTIFIER)
 
+    # Parse optional type parameters: struct Foo[T] { ... }
+    # Trait bounds are not allowed on structs — they belong on impl blocks.
+    type_vars: list[str] = []
+    next_token = cursor.peek()
+    if next_token and next_token.value == "[":
+        type_vars_set, trait_bounds = parse_type_vars(cursor)
+        if trait_bounds:
+            raise_error(
+                ErrorKind.UNEXPECTED_TOKEN,
+                "Trait bounds are not allowed on struct definitions. "
+                "Use `impl[K: Bound] StructName[K]` instead",
+                struct_name.location,
+            )
+        type_vars = sorted(type_vars_set)
+
     members: list[Member] = []
     expect_token(cursor, value="{")
     while True:
@@ -1039,6 +1064,7 @@ def parse_struct(cursor: Cursor[Token]) -> Struct:
             member_type_str,
             len(members),
             member_name.location,
+            type_vars=type_vars or None,
         )
         for accessor in (getter, setter):
             if accessor.name in GLOBAL_FUNCTIONS:
@@ -1051,7 +1077,12 @@ def parse_struct(cursor: Cursor[Token]) -> Struct:
 
         members.append(Member(member_name.value, member_type_str))
 
-    return Struct(struct_name.value, members, struct_name.location)
+    return Struct(
+        struct_name.value,
+        members,
+        struct_name.location,
+        type_vars=type_vars,
+    )
 
 
 def parse_trait(cursor: Cursor[Token]) -> Trait:

--- a/casa/parser.py
+++ b/casa/parser.py
@@ -1003,12 +1003,26 @@ def get_op_type_cast(cursor: Cursor[Token]) -> Op:
 def parse_impl_block(cursor: Cursor[Token]):
     """Parse an impl block and register its methods as namespaced functions."""
     expect_token(cursor, value="impl")
+
+    # Parse optional type parameters: impl[K: Hashable] Set[K] { ... }
+    impl_type_vars: set[str] = set()
+    impl_trait_bounds: dict[str, str] = {}
+    next_token = cursor.peek()
+    if next_token and next_token.value == "[":
+        impl_type_vars, impl_trait_bounds = parse_type_vars(cursor)
+
     impl_type = parse_type(cursor)
+    # Use the base type name (without type params) for method namespacing
+    impl_base_type = impl_type.split("[")[0] if "[" in impl_type else impl_type
 
     expect_token(cursor, value="{")
     while (fn := cursor.peek()) and fn.value == "fn":
-        function = parse_function(cursor)
-        function.name = f"{impl_type}::{function.name}"
+        function = parse_function(
+            cursor,
+            inherited_type_vars=impl_type_vars or None,
+            inherited_trait_bounds=impl_trait_bounds or None,
+        )
+        function.name = f"{impl_base_type}::{function.name}"
         if GLOBAL_FUNCTIONS.get(function.name):
             raise_error(
                 ErrorKind.DUPLICATE_NAME,
@@ -1220,7 +1234,12 @@ def parse_type_vars(
     raise_error(ErrorKind.SYNTAX, "Expected `]` to close type parameters")
 
 
-def parse_function(cursor: Cursor[Token]) -> Function:
+def parse_function(
+    cursor: Cursor[Token],
+    *,
+    inherited_type_vars: set[str] | None = None,
+    inherited_trait_bounds: dict[str, str] | None = None,
+) -> Function:
     """Parse a function definition with optional type parameters and signature."""
     expect_token(cursor, value="fn")
     name = expect_token(cursor, kind=TokenKind.IDENTIFIER)
@@ -1231,6 +1250,12 @@ def parse_function(cursor: Cursor[Token]) -> Function:
     next_token = cursor.peek()
     if next_token and next_token.value == "[":
         type_vars, trait_bounds = parse_type_vars(cursor)
+
+    # Merge inherited type vars/bounds from impl block
+    if inherited_type_vars:
+        type_vars |= inherited_type_vars
+    if inherited_trait_bounds:
+        trait_bounds = {**inherited_trait_bounds, **trait_bounds}
 
     signature = parse_signature(cursor)
     signature.type_vars = type_vars

--- a/casa/parser.py
+++ b/casa/parser.py
@@ -75,6 +75,8 @@ INTRINSIC_TO_OPKIND = {
     Intrinsic.SOME: OpKind.SOME,
     Intrinsic.OK: OpKind.OK,
     Intrinsic.ERROR: OpKind.ERROR,
+    Intrinsic.ARGC: OpKind.ARGC,
+    Intrinsic.ARGV: OpKind.ARGV,
 }
 
 

--- a/casa/typechecker.py
+++ b/casa/typechecker.py
@@ -1337,6 +1337,8 @@ OP_STACK_EFFECTS: dict[OpKind, tuple[str, str]] = {
     OpKind.SYSCALL4: ("syscall4", "any any any any int -> int"),
     OpKind.SYSCALL5: ("syscall5", "any any any any any int -> int"),
     OpKind.SYSCALL6: ("syscall6", "any any any any any any int -> int"),
+    OpKind.ARGC: ("argc", "None -> int"),
+    OpKind.ARGV: ("argv", "None -> ptr"),
 }
 
 
@@ -1816,7 +1818,7 @@ def type_satisfies_trait(
 
 def type_check_ops(ops: list[Op], function: Function | None = None) -> Signature:
     """Type-check a list of ops and return the inferred signature."""
-    assert len(OpKind) == 86, "Exhaustive handling for `OpKind`"
+    assert len(OpKind) == 88, "Exhaustive handling for `OpKind`"
 
     tc = TypeChecker(ops=ops)
     op_index = 0
@@ -1914,6 +1916,10 @@ def type_check_ops(ops: list[Op], function: Function | None = None) -> Signature
                 | OpKind.SYSCALL6
             ):
                 tc.check_syscalls(op)
+            case OpKind.ARGC:
+                tc.stack_push("int")
+            case OpKind.ARGV:
+                tc.stack_push("ptr")
             case OpKind.PUSH_ENUM_VARIANT:
                 tc.check_enum_variant(op)
             case OpKind.MATCH_START | OpKind.MATCH_ARM | OpKind.MATCH_END:

--- a/casa/typechecker.py
+++ b/casa/typechecker.py
@@ -1095,12 +1095,29 @@ class TypeChecker:
         struct = op.value
         assert isinstance(struct, Struct), "Expected struct"
         member_types = " ".join(m.typ for m in struct.members)
-        self.current_op_context = f"`{struct.name}` ({member_types} -> {struct.name})"
-        for member in struct.members:
-            self.current_expect_context = f"member `{member.name}` of `{struct.name}`"
-            self.expect_type(member.typ)
-        self.current_expect_context = None
-        self.stack_push(struct.name)
+
+        if not struct.type_vars:
+            self.current_op_context = (
+                f"`{struct.name}` ({member_types} -> {struct.name})"
+            )
+            for member in struct.members:
+                self.current_expect_context = (
+                    f"member `{member.name}` of `{struct.name}`"
+                )
+                self.expect_type(member.typ)
+            self.current_expect_context = None
+            self.stack_push(struct.name)
+            return
+
+        # Generic struct: bind type vars from actual stack types
+        param_struct_type = f"{struct.name}[{' '.join(struct.type_vars)}]"
+        params = [Parameter(m.typ) for m in struct.members]
+        sig = Signature(
+            params,
+            [param_struct_type],
+            type_vars=set(struct.type_vars),
+        )
+        self.apply_signature(sig, struct.name)
 
     DEFERRED_METHOD = "DEFERRED"
 

--- a/docs/standard-library.md
+++ b/docs/standard-library.md
@@ -839,13 +839,17 @@ struct Map {
     size:     int
     capacity: int
 }
+
+impl[K: Hashable, V] Map[K V] { ... }
 ```
+
+All Map methods are defined in an `impl` block with `K: Hashable` and `V` type parameters. Individual methods inherit these bounds.
 
 ### `Map::new`
 
 Creates an empty map with an initial capacity of 16.
 
-**Signature:** `Map::new[K: Hashable, V] -> Map[K V]`
+**Signature:** `Map::new -> Map[K V]`
 
 **Stack effect:** `-> Map[K V]`
 
@@ -859,9 +863,9 @@ The type cast `(Map[str int])` tells the compiler the concrete types for `K` and
 
 Returns the number of key-value pairs in the map.
 
-**Signature:** `Map::length self:Map -> int`
+**Signature:** `Map::length self:Map[K V] -> int`
 
-**Stack effect:** `Map -> int`
+**Stack effect:** `Map[K V] -> int`
 
 ```casa
 m.length print    # 0
@@ -871,7 +875,7 @@ m.length print    # 0
 
 Looks up a key and returns `option[V]`. Returns `some` with the value if found, `none` otherwise.
 
-**Signature:** `Map::get[K: Hashable, V] self:Map[K V] key:K -> option[V]`
+**Signature:** `Map::get self:Map[K V] key:K -> option[V]`
 
 **Stack effect:** `Map[K V] K -> option[V]`
 
@@ -884,7 +888,7 @@ Looks up a key and returns `option[V]`. Returns `some` with the value if found, 
 
 Returns `true` if the key exists in the map.
 
-**Signature:** `Map::has[K: Hashable, V] self:Map[K V] key:K -> bool`
+**Signature:** `Map::has self:Map[K V] key:K -> bool`
 
 **Stack effect:** `Map[K V] K -> bool`
 
@@ -896,7 +900,7 @@ Returns `true` if the key exists in the map.
 
 Inserts or updates a key-value pair. Returns the updated map. Automatically resizes at 75% load factor.
 
-**Signature:** `Map::set[K: Hashable, V] self:Map[K V] value:V key:K -> Map[K V]`
+**Signature:** `Map::set self:Map[K V] value:V key:K -> Map[K V]`
 
 **Stack effect:** `Map[K V] V K -> Map[K V]`
 
@@ -910,7 +914,7 @@ Note: the key is on top of the stack, the value is below it, and the map is belo
 
 Removes a key from the map. Returns the updated map. If the key does not exist, the map is returned unchanged.
 
-**Signature:** `Map::delete[K: Hashable, V] self:Map[K V] key:K -> Map[K V]`
+**Signature:** `Map::delete self:Map[K V] key:K -> Map[K V]`
 
 **Stack effect:** `Map[K V] K -> Map[K V]`
 
@@ -920,9 +924,9 @@ Removes a key from the map. Returns the updated map. If the key does not exist, 
 
 ### `Map::keys`
 
-Returns a `List[K]` of all keys in the map. Does not require `Hashable` bound.
+Returns a `List[K]` of all keys in the map.
 
-**Signature:** `Map::keys[K V] self:Map[K V] -> List[K]`
+**Signature:** `Map::keys self:Map[K V] -> List[K]`
 
 **Stack effect:** `Map[K V] -> List[K]`
 
@@ -932,9 +936,9 @@ m.keys = key_list
 
 ### `Map::values`
 
-Returns a `List[V]` of all values in the map. Does not require `Hashable` bound.
+Returns a `List[V]` of all values in the map.
 
-**Signature:** `Map::values[K V] self:Map[K V] -> List[V]`
+**Signature:** `Map::values self:Map[K V] -> List[V]`
 
 **Stack effect:** `Map[K V] -> List[V]`
 
@@ -986,16 +990,20 @@ A generic hash set backed by a `Map[K int]`. Keys must satisfy the `Hashable` tr
 ### Definition
 
 ```casa
-struct Set {
-    map: Map
+struct Set[K] {
+    map: Map[K int]
 }
+
+impl[K: Hashable] Set[K] { ... }
 ```
+
+Set uses a struct-level type parameter `K` with a typed `Map[K int]` field. All methods are in an `impl` block with the `K: Hashable` bound.
 
 ### `Set::new`
 
 Creates an empty set.
 
-**Signature:** `Set::new[K: Hashable] -> Set[K]`
+**Signature:** `Set::new -> Set[K]`
 
 **Stack effect:** `-> Set[K]`
 
@@ -1007,9 +1015,9 @@ Set::new (Set[str]) = s
 
 Returns the number of elements in the set.
 
-**Signature:** `Set::length self:Set -> int`
+**Signature:** `Set::length self:Set[K] -> int`
 
-**Stack effect:** `Set -> int`
+**Stack effect:** `Set[K] -> int`
 
 ```casa
 s.length print    # 0
@@ -1019,7 +1027,7 @@ s.length print    # 0
 
 Returns `true` if the element is in the set.
 
-**Signature:** `Set::has[K: Hashable] self:Set[K] key:K -> bool`
+**Signature:** `Set::has self:Set[K] key:K -> bool`
 
 **Stack effect:** `Set[K] K -> bool`
 
@@ -1031,7 +1039,7 @@ Returns `true` if the element is in the set.
 
 Adds an element to the set. Returns the updated set. Adding a duplicate has no effect.
 
-**Signature:** `Set::add[K: Hashable] self:Set[K] key:K -> Set[K]`
+**Signature:** `Set::add self:Set[K] key:K -> Set[K]`
 
 **Stack effect:** `Set[K] K -> Set[K]`
 
@@ -1043,7 +1051,7 @@ Adds an element to the set. Returns the updated set. Adding a duplicate has no e
 
 Removes an element from the set. Returns the updated set. If the element does not exist, the set is returned unchanged.
 
-**Signature:** `Set::remove[K: Hashable] self:Set[K] key:K -> Set[K]`
+**Signature:** `Set::remove self:Set[K] key:K -> Set[K]`
 
 **Stack effect:** `Set[K] K -> Set[K]`
 
@@ -1053,9 +1061,9 @@ Removes an element from the set. Returns the updated set. If the element does no
 
 ### `Set::to_list`
 
-Returns a `List[K]` of all elements in the set. Does not require `Hashable` bound.
+Returns a `List[K]` of all elements in the set.
 
-**Signature:** `Set::to_list[K] self:Set[K] -> List[K]`
+**Signature:** `Set::to_list self:Set[K] -> List[K]`
 
 **Stack effect:** `Set[K] -> List[K]`
 
@@ -1087,3 +1095,156 @@ s.length print         # 2
 ```
 
 See [`examples/hash_map.casa`](../examples/hash_map.casa) for a full program using both Map and Set.
+
+## Stderr Output
+
+### `eprint`
+
+Writes a string to stderr (file descriptor 2).
+
+**Signature:** `eprint msg:str`
+
+**Stack effect:** `str -> None`
+
+```casa
+"warning: something happened\n" eprint
+```
+
+### `eprintln`
+
+Writes a string followed by a newline to stderr.
+
+**Signature:** `eprintln msg:str`
+
+**Stack effect:** `str -> None`
+
+```casa
+"error: file not found" eprintln
+```
+
+## Command-Line Arguments
+
+### `argc`
+
+Pushes the number of command-line arguments onto the stack.
+
+**Stack effect:** `-> int`
+
+```casa
+argc print    # prints the argument count
+```
+
+### `argv`
+
+Pushes a pointer to the argument array onto the stack.
+
+**Stack effect:** `-> ptr`
+
+### `get_arg`
+
+Returns the nth command-line argument as a string (zero-indexed). Prints an error to stderr and exits if the index is out of bounds.
+
+**Signature:** `get_arg n:int -> str`
+
+**Stack effect:** `int -> str`
+
+```casa
+0 get_arg print    # prints the program name
+1 get_arg print    # prints the first argument
+```
+
+## `StringBuilder`
+
+A mutable string builder backed by `List[char]`. Useful for efficiently constructing strings from many parts.
+
+### Definition
+
+```casa
+struct StringBuilder {
+    chars: List[char]
+}
+```
+
+### `StringBuilder::new`
+
+Creates an empty `StringBuilder`.
+
+**Signature:** `StringBuilder::new -> StringBuilder`
+
+**Stack effect:** `-> StringBuilder`
+
+```casa
+StringBuilder::new = sb
+```
+
+### `StringBuilder::append`
+
+Appends a string to the builder.
+
+**Signature:** `StringBuilder::append self:StringBuilder s:str`
+
+**Stack effect:** `StringBuilder str -> None`
+
+```casa
+"hello " sb.append
+"world" sb.append
+```
+
+### `StringBuilder::append_char`
+
+Appends a single character to the builder.
+
+**Signature:** `StringBuilder::append_char self:StringBuilder c:char`
+
+**Stack effect:** `StringBuilder char -> None`
+
+```casa
+'!' sb.append_char
+```
+
+### `StringBuilder::build`
+
+Converts the builder's contents into a string.
+
+**Signature:** `StringBuilder::build self:StringBuilder -> str`
+
+**Stack effect:** `StringBuilder -> str`
+
+```casa
+sb.build print    # hello world!
+```
+
+### `StringBuilder::length`
+
+Returns the number of characters in the builder.
+
+**Signature:** `StringBuilder::length self:StringBuilder -> int`
+
+**Stack effect:** `StringBuilder -> int`
+
+## Process Execution
+
+### `run_command`
+
+Executes an external command using fork/execve/wait4. Takes a `List[str]` where the first element is the executable path and the remaining elements are arguments. Returns the child process exit code.
+
+**Signature:** `run_command args:List[str] -> int`
+
+**Stack effect:** `List[str] -> int`
+
+```casa
+List::new (List[str]) = args
+"/bin/echo" args.push
+"hello" args.push
+args run_command = exit_code
+```
+
+Prints an error to stderr and exits if fork fails. If execve fails (command not found), the child process exits with code 1.
+
+### `chars_to_str`
+
+Converts a `List[char]` to a `str`. Used internally by `StringBuilder::build`.
+
+**Signature:** `chars_to_str chars:List[char] -> str`
+
+**Stack effect:** `List[char] -> str`

--- a/docs/structs-and-methods.md
+++ b/docs/structs-and-methods.md
@@ -77,6 +77,42 @@ person.name print                  # John Doe (dot on variable)
 "Jane Doe" person->name    # same as: "Jane Doe" person Person::set_name
 ```
 
+## Generic Structs
+
+Structs can have type parameters. These are declared in square brackets after the struct name.
+
+```casa
+struct Box[T] {
+    value: T
+}
+```
+
+Generic structs infer their type parameters from the values on the stack:
+
+```casa
+42 Box          # inferred as Box[int]
+"hello" Box     # inferred as Box[str]
+```
+
+Auto-generated getters and setters are parameterized automatically:
+
+```casa
+42 Box .value print    # 42 — getter returns int
+```
+
+Struct-level type parameters can be used in field types:
+
+```casa
+struct Pair[A B] {
+    first: A
+    second: B
+}
+
+true 42 Pair    # Pair[int bool] — first=42 (top), second=true
+```
+
+Trait bounds are not allowed on struct definitions. Use `impl`-level bounds instead (see below).
+
 ## `impl` Blocks
 
 Add methods to a type with `impl`:
@@ -129,6 +165,32 @@ impl Person {
     }
 }
 ```
+
+### `impl` with Type Parameters
+
+`impl` blocks can declare type parameters with trait bounds. These are inherited by all methods in the block, so individual methods do not need to redeclare them.
+
+```casa
+struct Set[K] {
+    map: Map[K int]
+}
+
+impl[K: Hashable] Set[K] {
+    fn new -> Set[K] { ... }
+    fn has self:Set[K] key:K -> bool { ... }
+    fn add self:Set[K] key:K -> Set[K] { ... }
+}
+```
+
+All methods in this block inherit the `K: Hashable` bound. Methods can still declare additional type parameters of their own:
+
+```casa
+impl[K: Hashable] Set[K] {
+    fn convert[V] self:Set[K] -> List[V] { ... }
+}
+```
+
+Here `K: Hashable` comes from the `impl` block and `V` is the method's own type parameter.
 
 ## `impl` on Built-In Types
 

--- a/docs/traits.md
+++ b/docs/traits.md
@@ -57,12 +57,13 @@ impl Point {
 
 ## Trait Bounds
 
-Functions declare trait bounds on type variables using the `K: TraitName` syntax inside square brackets. Multiple type variables are separated by commas.
+Functions and `impl` blocks declare trait bounds on type variables using the `K: TraitName` syntax inside square brackets. Multiple type variables are separated by commas.
+
+### On Functions
 
 ```casa
-fn get[K: Hashable, V] self:Map[K V] key:K -> option[V] {
-    key K::hash self.capacity % = idx
-    ...
+fn example[K: Hashable] key:K -> int {
+    key K::hash
 }
 ```
 
@@ -71,10 +72,29 @@ Here `K` must satisfy `Hashable`. The compiler verifies this at every call site 
 Type variables without bounds have no restrictions:
 
 ```casa
-fn keys[K V] self:Map[K V] -> List[K] { ... }
+fn identity[T] x:T -> T { x }
 ```
 
-Here `K` and `V` can be any type.
+### On `impl` Blocks
+
+`impl` blocks can declare trait bounds that are inherited by all methods. This avoids repeating the same bounds on every method. See [Structs and Methods](structs-and-methods.md) for details.
+
+```casa
+impl[K: Hashable, V] Map[K V] {
+    fn get self:Map[K V] key:K -> option[V] {
+        key K::hash self.capacity % = idx
+        ...
+    }
+}
+```
+
+Trait bounds belong on `impl` blocks, not on struct definitions. Structs only declare bare type parameters:
+
+```casa
+struct Set[K] { map: Map[K int] }       # correct
+# struct Set[K: Hashable] { ... }       # error
+impl[K: Hashable] Set[K] { ... }        # bounds go here
+```
 
 ## Calling Trait Methods
 

--- a/examples/command_line_args.casa
+++ b/examples/command_line_args.casa
@@ -1,0 +1,22 @@
+# Command-line arguments
+# Demonstrates argc, argv, and get_arg
+# Usage: ./command_line_args hello world
+
+include "../lib/std.casa"
+
+# Print number of user arguments (excluding program name)
+argc 1 - = num_args
+f"number of arguments: {num_args .to_str}" print "\n" print
+
+# Print each user argument
+1 = i
+while i argc > do
+    i get_arg = arg
+    f"  arg {i 1 - .to_str}: {arg}" print "\n" print
+    1 += i
+done
+
+# Check if a specific argument was given
+if 0 num_args == then
+    "no arguments provided" print "\n" print
+fi

--- a/examples/outputs/command_line_args.out
+++ b/examples/outputs/command_line_args.out
@@ -1,0 +1,2 @@
+number of arguments: 0
+no arguments provided

--- a/examples/outputs/run_command.out
+++ b/examples/outputs/run_command.out
@@ -1,0 +1,4 @@
+hello from casa
+echo exit code: 0
+true exit code: 0
+false exit code: 1

--- a/examples/run_command.casa
+++ b/examples/run_command.casa
@@ -4,13 +4,13 @@
 include "../lib/std.casa"
 
 # Run echo
-["/bin/echo", "hello", "from", "casa"] List::from_array run_command = exit_code
+["/usr/bin/env", "echo", "hello", "from", "casa"] List::from_array run_command = exit_code
 f"echo exit code: {exit_code .to_str}" print "\n" print
 
 # Run true (exits 0)
-["/bin/true"] List::from_array run_command = exit_code
+["/usr/bin/env", "true"] List::from_array run_command = exit_code
 f"true exit code: {exit_code .to_str}" print "\n" print
 
 # Run false (exits 1)
-["/bin/false"] List::from_array run_command = exit_code
+["/usr/bin/env", "false"] List::from_array run_command = exit_code
 f"false exit code: {exit_code .to_str}" print "\n" print

--- a/examples/run_command.casa
+++ b/examples/run_command.casa
@@ -1,0 +1,16 @@
+# Running external commands
+# Demonstrates run_command which uses fork + execve
+
+include "../lib/std.casa"
+
+# Run echo
+["/bin/echo", "hello", "from", "casa"] List::from_array run_command = exit_code
+f"echo exit code: {exit_code .to_str}" print "\n" print
+
+# Run true (exits 0)
+["/bin/true"] List::from_array run_command = exit_code
+f"true exit code: {exit_code .to_str}" print "\n" print
+
+# Run false (exits 1)
+["/bin/false"] List::from_array run_command = exit_code
+f"false exit code: {exit_code .to_str}" print "\n" print

--- a/lib/parser.casa
+++ b/lib/parser.casa
@@ -133,19 +133,6 @@ impl Cursor {
 # Helper functions
 # ---------------------------------------------------------------------------
 
-fn chars_to_str chars:List[char] -> str {
-    chars.length = cts_len
-    cts_len 9 + alloc (str) = cts_buf
-    cts_len cts_buf (ptr) store64
-    0 = cts_i
-    while cts_i cts_len > do
-        cts_i chars.get (char) cts_i cts_buf.set
-        1 += cts_i
-    done
-    0 (char) cts_len cts_buf.set
-    cts_buf
-}
-
 fn str_to_int s:str -> int {
     0 = sti_result
     0 = sti_i

--- a/lib/std.casa
+++ b/lib/std.casa
@@ -747,7 +747,7 @@ impl StringBuilder {
 fn run_command args:List[str] -> int {
     # fork()
     57 syscall0 = rc_pid
-    if 0 rc_pid > then
+    if rc_pid 0 > then
         "error: fork failed\n" eprint
         1 60 syscall1 drop
     fi

--- a/lib/std.casa
+++ b/lib/std.casa
@@ -683,3 +683,14 @@ fn eprint msg:str {
 fn eprintln msg:str {
     f"{msg}\n" eprint
 }
+
+# ---------------------------------------------------------------------------
+# Command-line arguments
+# ---------------------------------------------------------------------------
+fn get_arg n:int -> str {
+    if argc n >= then
+        "error: argument index out of bounds\n" eprint
+        1 60 syscall1 drop
+    fi
+    argv n 8 * + load64 (cstr) cstr::to_str
+}

--- a/lib/std.casa
+++ b/lib/std.casa
@@ -740,3 +740,35 @@ impl StringBuilder {
         self.chars .length
     }
 }
+
+# ---------------------------------------------------------------------------
+# Process execution
+# ---------------------------------------------------------------------------
+fn run_command args:List[str] -> int {
+    # fork()
+    57 syscall0 = rc_pid
+    if 0 rc_pid > then
+        "error: fork failed\n" eprint
+        1 60 syscall1 drop
+    fi
+    if 0 rc_pid == then
+        # Child process: build execve argv array
+        args.length 1 + 8 * alloc = rc_argv
+        0 = rc_i
+        while rc_i args.length > do
+            rc_i args.get .as_cstr (ptr) rc_argv rc_i 8 * + store64
+            1 += rc_i
+        done
+        # Null terminator
+        0 rc_argv args.length 8 * + store64
+        # execve(argv[0], argv, envp=NULL)
+        0 (ptr) rc_argv rc_argv load64 (ptr) 59 syscall3 drop
+        # If execve returns, it failed — exit directly via syscall
+        1 60 syscall1 drop
+    fi
+    # Parent: wait4(pid, &status, 0, 0)
+    8 alloc = rc_status
+    0 (ptr) 0 rc_status rc_pid 61 syscall4 drop
+    # Extract exit code: bits 8-15 of status word
+    rc_status load64 8 >> 255 &
+}

--- a/lib/std.casa
+++ b/lib/std.casa
@@ -672,3 +672,14 @@ impl Set {
         self.map (Map[K int]) .keys
     }
 }
+
+# ---------------------------------------------------------------------------
+# Stderr output
+# ---------------------------------------------------------------------------
+fn eprint msg:str {
+    msg.length msg.as_cstr (ptr) 2 1 syscall3 drop
+}
+
+fn eprintln msg:str {
+    f"{msg}\n" eprint
+}

--- a/lib/std.casa
+++ b/lib/std.casa
@@ -694,3 +694,49 @@ fn get_arg n:int -> str {
     fi
     argv n 8 * + load64 (cstr) cstr::to_str
 }
+
+# ---------------------------------------------------------------------------
+# StringBuilder
+# ---------------------------------------------------------------------------
+fn chars_to_str chars:List[char] -> str {
+    chars.length = cts_len
+    cts_len 9 + alloc (str) = cts_buf
+    cts_len cts_buf (ptr) store64
+    0 = cts_i
+    while cts_i cts_len > do
+        cts_i chars.get (char) cts_i cts_buf.set
+        1 += cts_i
+    done
+    0 (char) cts_len cts_buf.set
+    cts_buf
+}
+
+struct StringBuilder {
+    chars: List[char]
+}
+
+impl StringBuilder {
+    fn new -> StringBuilder {
+        List::new (List[char]) StringBuilder
+    }
+
+    fn append self:StringBuilder s:str {
+        0 = sb_i
+        while sb_i s.length > do
+            sb_i s.at self.chars .push
+            1 += sb_i
+        done
+    }
+
+    fn append_char self:StringBuilder c:char {
+        c self.chars .push
+    }
+
+    fn build self:StringBuilder -> str {
+        self.chars chars_to_str
+    }
+
+    fn length self:StringBuilder -> int {
+        self.chars .length
+    }
+}

--- a/lib/std.casa
+++ b/lib/std.casa
@@ -502,8 +502,8 @@ struct Map {
     capacity: int
 }
 
-impl Map {
-    fn new[K: Hashable, V] -> Map[K V] {
+impl[K: Hashable, V] Map[K V] {
+    fn new -> Map[K V] {
         MAP_INITIAL_CAP 8 * alloc = mb
         0 = mb_i
         while mb_i MAP_INITIAL_CAP > do
@@ -513,11 +513,11 @@ impl Map {
         MAP_INITIAL_CAP 0 mb Map (Map[K V])
     }
 
-    fn length self:Map -> int {
+    fn length self:Map[K V] -> int {
         self.size
     }
 
-    fn get[K: Hashable, V] self:Map[K V] key:K -> option[V] {
+    fn get self:Map[K V] key:K -> option[V] {
         key K::hash self.capacity % = mg_idx
         self.buckets mg_idx 8 * + load64 = mg_entry
         while 0 mg_entry != do
@@ -531,11 +531,11 @@ impl Map {
         none (option[V])
     }
 
-    fn has[K: Hashable, V] self:Map[K V] key:K -> bool {
+    fn has self:Map[K V] key:K -> bool {
         key self.get .is_some
     }
 
-    fn set[K: Hashable, V] self:Map[K V] value:V key:K -> Map[K V] {
+    fn set self:Map[K V] value:V key:K -> Map[K V] {
         key K::hash self.capacity % = ms_idx
         self.buckets ms_idx 8 * + load64 = ms_entry
         while 0 ms_entry != do
@@ -561,7 +561,7 @@ impl Map {
         self (Map[K V])
     }
 
-    fn delete[K: Hashable, V] self:Map[K V] key:K -> Map[K V] {
+    fn delete self:Map[K V] key:K -> Map[K V] {
         key K::hash self.capacity % = md_idx
         0 = md_prev
         self.buckets md_idx 8 * + load64 = md_entry
@@ -585,7 +585,7 @@ impl Map {
         self (Map[K V])
     }
 
-    fn resize[K: Hashable, V] self:Map[K V] {
+    fn resize self:Map[K V] {
         self.capacity 2 * = mr_new_cap
         mr_new_cap 8 * alloc = mr_new_bk
         0 = mr_i
@@ -609,7 +609,7 @@ impl Map {
         mr_new_cap self->capacity
     }
 
-    fn keys[K V] self:Map[K V] -> List[K] {
+    fn keys self:Map[K V] -> List[K] {
         List::new (List[K]) = mk_list
         0 = mk_i
         while mk_i self.capacity > do
@@ -623,7 +623,7 @@ impl Map {
         mk_list
     }
 
-    fn values[K V] self:Map[K V] -> List[V] {
+    fn values self:Map[K V] -> List[V] {
         List::new (List[V]) = mv_list
         0 = mv_i
         while mv_i self.capacity > do
@@ -641,47 +641,36 @@ impl Map {
 # ---------------------------------------------------------------------------
 # Set[K] - Hash set backed by Map
 # ---------------------------------------------------------------------------
-struct Set {
-    map: Map
+struct Set[K] {
+    map: Map[K int]
 }
 
-impl Set {
-    fn new[K: Hashable] -> Set[K] {
-        Map::new (Map[K int]) Set (Set[K])
+impl[K: Hashable] Set[K] {
+    fn new -> Set[K] {
+        Map::new (Map[K int]) Set
     }
 
-    fn length self:Set -> int {
+    fn length self:Set[K] -> int {
         self.map.length
     }
 
-    fn has[K: Hashable] self:Set[K] key:K -> bool {
-        key self.map (Map[K int]) .has
+    fn has self:Set[K] key:K -> bool {
+        key self.map.has
     }
 
-    fn add[K: Hashable] self:Set[K] key:K -> Set[K] {
-        key 0 self.map (Map[K int]) .set (Map) self->map
-        self (Set[K])
+    fn add self:Set[K] key:K -> Set[K] {
+        key 0 self.map.set self->map
+        self
     }
 
-    fn remove[K: Hashable] self:Set[K] key:K -> Set[K] {
-        key self.map (Map[K int]) .delete (Map) self->map
-        self (Set[K])
+    fn remove self:Set[K] key:K -> Set[K] {
+        key self.map.delete self->map
+        self
     }
 
-    fn to_list[K] self:Set[K] -> List[K] {
-        self.map (Map[K int]) .keys
+    fn to_list self:Set[K] -> List[K] {
+        self.map.keys
     }
-}
-
-# ---------------------------------------------------------------------------
-# Stderr output
-# ---------------------------------------------------------------------------
-fn eprint msg:str {
-    msg.length msg.as_cstr (ptr) 2 1 syscall3 drop
-}
-
-fn eprintln msg:str {
-    f"{msg}\n" eprint
 }
 
 # ---------------------------------------------------------------------------
@@ -693,6 +682,17 @@ fn get_arg n:int -> str {
         1 60 syscall1 drop
     fi
     argv n 8 * + load64 (cstr) cstr::to_str
+}
+
+# ---------------------------------------------------------------------------
+# Stderr output
+# ---------------------------------------------------------------------------
+fn eprint msg:str {
+    msg.length msg.as_cstr (ptr) 2 1 syscall3 drop
+}
+
+fn eprintln msg:str {
+    f"{msg}\n" eprint
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/test_argv.py
+++ b/tests/test_argv.py
@@ -1,0 +1,154 @@
+"""Tests for the `argc` and `argv` intrinsics across all pipeline stages."""
+
+from casa.common import InstKind, Intrinsic, OpKind
+from tests.conftest import (
+    compile_string,
+    emit_string,
+    lex_string,
+    resolve_string,
+    typecheck_string,
+)
+
+
+# ---------------------------------------------------------------------------
+# Lexer
+# ---------------------------------------------------------------------------
+def test_lex_argc():
+    """argc is lexed as an intrinsic token."""
+    tokens = lex_string("argc")
+    intrinsic_tokens = [t for t in tokens if t.value == "argc"]
+    assert len(intrinsic_tokens) == 1
+    assert intrinsic_tokens[0].kind.name == "INTRINSIC"
+
+
+def test_lex_argv():
+    """argv is lexed as an intrinsic token."""
+    tokens = lex_string("argv")
+    intrinsic_tokens = [t for t in tokens if t.value == "argv"]
+    assert len(intrinsic_tokens) == 1
+    assert intrinsic_tokens[0].kind.name == "INTRINSIC"
+
+
+# ---------------------------------------------------------------------------
+# Parser
+# ---------------------------------------------------------------------------
+def test_parse_argc():
+    """argc parses into OpKind.ARGC."""
+    ops = resolve_string("argc")
+    argc_ops = [op for op in ops if op.kind == OpKind.ARGC]
+    assert len(argc_ops) == 1
+    assert argc_ops[0].value == Intrinsic.ARGC
+
+
+def test_parse_argv():
+    """argv parses into OpKind.ARGV."""
+    ops = resolve_string("argv")
+    argv_ops = [op for op in ops if op.kind == OpKind.ARGV]
+    assert len(argv_ops) == 1
+    assert argv_ops[0].value == Intrinsic.ARGV
+
+
+# ---------------------------------------------------------------------------
+# Type checker
+# ---------------------------------------------------------------------------
+def test_typecheck_argc_pushes_int():
+    """argc pushes one int onto the stack."""
+    sig = typecheck_string("argc")
+    assert sig.return_types == ["int"]
+
+
+def test_typecheck_argv_pushes_ptr():
+    """argv pushes one ptr onto the stack."""
+    sig = typecheck_string("argv")
+    assert sig.return_types == ["ptr"]
+
+
+def test_typecheck_argc_no_inputs():
+    """argc requires nothing on the stack."""
+    sig = typecheck_string("argc")
+    assert sig.parameters == []
+
+
+def test_typecheck_argv_no_inputs():
+    """argv requires nothing on the stack."""
+    sig = typecheck_string("argv")
+    assert sig.parameters == []
+
+
+def test_typecheck_argc_in_arithmetic():
+    """argc result can be used in int arithmetic."""
+    sig = typecheck_string("argc 1 +")
+    assert sig.return_types == ["int"]
+
+
+def test_typecheck_argv_with_load():
+    """argv result can be used with load64."""
+    sig = typecheck_string("argv load64")
+    assert sig.return_types == ["int"]
+
+
+# ---------------------------------------------------------------------------
+# Bytecode
+# ---------------------------------------------------------------------------
+def test_bytecode_argc():
+    """argc compiles to InstKind.ARGC."""
+    program = compile_string("argc")
+    kinds = [i.kind for i in program.bytecode]
+    assert InstKind.ARGC in kinds
+
+
+def test_bytecode_argv():
+    """argv compiles to InstKind.ARGV."""
+    program = compile_string("argv")
+    kinds = [i.kind for i in program.bytecode]
+    assert InstKind.ARGV in kinds
+
+
+def test_bytecode_argc_no_args():
+    """ARGC instruction has no arguments."""
+    program = compile_string("argc")
+    argc_insts = [i for i in program.bytecode if i.kind == InstKind.ARGC]
+    assert len(argc_insts) == 1
+    assert argc_insts[0].args == []
+
+
+def test_bytecode_argv_no_args():
+    """ARGV instruction has no arguments."""
+    program = compile_string("argv")
+    argv_insts = [i for i in program.bytecode if i.kind == InstKind.ARGV]
+    assert len(argv_insts) == 1
+    assert argv_insts[0].args == []
+
+
+# ---------------------------------------------------------------------------
+# Emitter
+# ---------------------------------------------------------------------------
+def test_emit_argc_loads_from_bss():
+    """argc emits a load from the __argc BSS slot."""
+    asm = emit_string("argc")
+    assert "__argc(%rip)" in asm
+
+
+def test_emit_argv_loads_from_bss():
+    """argv emits a load from the __argv BSS slot."""
+    asm = emit_string("argv")
+    assert "__argv(%rip)" in asm
+
+
+def test_emit_bss_has_argc_argv_slots():
+    """BSS section declares __argc and __argv storage."""
+    asm = emit_string("42")
+    assert "__argc: .skip 8" in asm
+    assert "__argv: .skip 8" in asm
+
+
+def test_emit_start_saves_argc_argv():
+    """_start saves argc and argv before user code."""
+    asm = emit_string("42")
+    start_idx = asm.index("_start:")
+    # The saves must appear between _start and any user code
+    after_start = asm[start_idx:]
+    assert "movq (%rsp), %rax" in after_start
+    assert "__argc(%rip)" in after_start
+    assert "leaq 8(%rsp)" in after_start
+    assert "__argv(%rip)" in after_start

--- a/tests/test_generic_structs.py
+++ b/tests/test_generic_structs.py
@@ -1,0 +1,178 @@
+"""Tests for generic struct type parameters (struct Name[T] { ... })."""
+
+import pytest
+
+from casa.common import GLOBAL_FUNCTIONS, GLOBAL_STRUCTS, Op, OpKind, Struct
+from casa.error import CasaErrorCollection, ErrorKind
+from tests.conftest import (
+    compile_string,
+    emit_string,
+    parse_string,
+    resolve_string,
+    typecheck_string,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def find_ops(ops: list[Op], kind: OpKind) -> list[Op]:
+    return [op for op in ops if op.kind == kind]
+
+
+# ---------------------------------------------------------------------------
+# Parser
+# ---------------------------------------------------------------------------
+def test_parse_generic_struct():
+    parse_string("struct Box[T] { value: T }")
+    assert "Box" in GLOBAL_STRUCTS
+    struct = GLOBAL_STRUCTS["Box"]
+    assert struct.type_vars == ["T"]
+    assert struct.members[0].name == "value"
+    assert struct.members[0].typ == "T"
+
+
+def test_parse_generic_struct_multiple_type_vars():
+    parse_string("struct Pair[A B] { first: A second: B }")
+    struct = GLOBAL_STRUCTS["Pair"]
+    assert struct.type_vars == ["A", "B"]
+
+
+def test_parse_struct_rejects_trait_bounds():
+    """Struct definitions must not have trait bounds — those belong on impl blocks."""
+    with pytest.raises(CasaErrorCollection):
+        parse_string(
+            "trait Hashable { fn hash int -> int }\nstruct Set[K: Hashable] { data: K }"
+        )
+
+
+def test_parse_generic_struct_generates_generic_getter():
+    parse_string("struct Box[T] { value: T }")
+    getter = GLOBAL_FUNCTIONS["Box::value"]
+    assert getter.signature.type_vars == {"T"}
+    assert getter.signature.parameters[0].typ == "Box[T]"
+    assert getter.signature.return_types == ["T"]
+
+
+def test_parse_generic_struct_generates_generic_setter():
+    parse_string("struct Box[T] { value: T }")
+    setter = GLOBAL_FUNCTIONS["Box::set_value"]
+    assert setter.signature.type_vars == {"T"}
+    assert setter.signature.parameters[0].typ == "Box[T]"
+    assert setter.signature.parameters[1].typ == "T"
+
+
+def test_parse_impl_with_type_params():
+    """impl[K: Bound] Type[K] propagates type vars and bounds to methods."""
+    code = (
+        "trait Hashable { fn hash int -> int }\n"
+        "struct Box[K] { data: K }\n"
+        "impl[K: Hashable] Box[K] {\n"
+        "    fn get self:Box[K] -> K { self .data }\n"
+        "}\n"
+    )
+    parse_string(code)
+    getter = GLOBAL_FUNCTIONS["Box::get"]
+    assert "K" in getter.signature.type_vars
+    assert getter.signature.trait_bounds == {"K": "Hashable"}
+
+
+def test_parse_nongeneric_struct_has_empty_type_vars():
+    parse_string("struct Point { x: int y: int }")
+    struct = GLOBAL_STRUCTS["Point"]
+    assert struct.type_vars == []
+
+
+# ---------------------------------------------------------------------------
+# Resolver
+# ---------------------------------------------------------------------------
+def test_resolve_generic_struct_new():
+    ops = resolve_string("struct Box[T] { value: T } 42 Box")
+    struct_new_ops = find_ops(ops, OpKind.STRUCT_NEW)
+    assert len(struct_new_ops) == 1
+    assert isinstance(struct_new_ops[0].value, Struct)
+    assert struct_new_ops[0].value.type_vars == ["T"]
+
+
+# ---------------------------------------------------------------------------
+# Type checker
+# ---------------------------------------------------------------------------
+def test_typecheck_generic_struct_infers_type():
+    code = "struct Box[T] { value: T } 42 Box"
+    sig = typecheck_string(code)
+    assert sig.return_types == ["Box[int]"]
+
+
+def test_typecheck_generic_struct_str():
+    code = 'struct Box[T] { value: T } "hello" Box'
+    sig = typecheck_string(code)
+    assert sig.return_types == ["Box[str]"]
+
+
+def test_typecheck_generic_struct_bool():
+    code = "struct Box[T] { value: T } true Box"
+    sig = typecheck_string(code)
+    assert sig.return_types == ["Box[bool]"]
+
+
+def test_typecheck_generic_struct_getter():
+    code = "struct Box[T] { value: T } 42 Box .value"
+    sig = typecheck_string(code)
+    assert sig.return_types == ["int"]
+
+
+def test_typecheck_generic_struct_setter():
+    code = "struct Box[T] { value: T } 42 Box = b 99 b ->value"
+    sig = typecheck_string(code)
+    assert sig.return_types == []
+
+
+def test_typecheck_generic_struct_two_fields():
+    # Stack order: second pushed first, first pushed last (on top)
+    code = "struct Pair[A B] { first: A second: B } true 42 Pair"
+    sig = typecheck_string(code)
+    assert sig.return_types == ["Pair[int bool]"]
+
+
+def test_typecheck_generic_struct_two_fields_getter():
+    code = "struct Pair[A B] { first: A second: B } true 42 Pair .second"
+    sig = typecheck_string(code)
+    assert sig.return_types == ["bool"]
+
+
+def test_typecheck_generic_struct_nested():
+    code = """
+    struct Box[T] { value: T }
+    struct Wrapper[U] { inner: U }
+    42 Box Wrapper
+    """
+    sig = typecheck_string(code)
+    assert sig.return_types == ["Wrapper[Box[int]]"]
+
+
+def test_typecheck_generic_struct_in_function():
+    code = """
+    struct Box[T] { value: T }
+    fn unbox[T] b:Box[T] -> T { b .value }
+    42 Box unbox
+    """
+    sig = typecheck_string(code)
+    assert sig.return_types == ["int"]
+
+
+# ---------------------------------------------------------------------------
+# Bytecode
+# ---------------------------------------------------------------------------
+def test_bytecode_generic_struct():
+    code = "struct Box[T] { value: T } 42 Box"
+    program = compile_string(code)
+    assert program.bytecode
+
+
+# ---------------------------------------------------------------------------
+# Emitter
+# ---------------------------------------------------------------------------
+def test_emit_generic_struct():
+    code = "struct Box[T] { value: T } 42 Box drop"
+    asm = emit_string(code)
+    assert "_start:" in asm

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -73,6 +73,8 @@ ALL_INTRINSICS = [
     "some",
     "ok",
     "error",
+    "argc",
+    "argv",
 ]
 assert len(ALL_INTRINSICS) == len(Intrinsic)
 


### PR DESCRIPTION
## Summary

- Add `argc` and `argv` intrinsics with full pipeline support (lexer → emitter)
- Add `eprint`, `eprintln` for stderr output, `get_arg` for CLI argument access
- Add `StringBuilder` struct and move `chars_to_str` to std.casa
- Add `run_command` for process execution via fork/execve/wait4
- Increase heap size to 64MB (BSS demand-paged)
- Add generic type parameters to struct definitions (`struct Box[T]`)
- Add type parameters to impl blocks (`impl[K: Hashable] Set[K]`), propagating bounds to all methods
- Refactor Map and Set to use impl-level type parameters, removing per-method bound repetition
- Reject trait bounds on struct definitions with a helpful error message
- Fix inverted fork error check in `run_command`

## Test plan

- [x] 1052 unit tests pass (`pytest tests/`)
- [x] 31 example tests pass (`tests/test_examples.sh`)
- [x] 18 new tests for argc/argv across all pipeline stages
- [x] 19 new tests for generic structs and impl type parameters
- [x] Pylint score unchanged at 9.80/10
- [x] New examples: `run_command.casa`, `command_line_args.casa`