### PR TITLE
feat: add self-hosted Casa compiler

### DIFF
--- a/self_hosted/bytecode.casa
+++ b/self_hosted/bytecode.casa
@@ -1,0 +1,28 @@
+# Op-to-Inst bytecode lowering for the Casa compiler.
+
+include "common.casa"
+
+fn compile_bytecode ops:List[Op] -> List[Inst] {
+    List::new (List[Inst]) = bytecode
+    0 = op_index
+
+    while op_index ops.length > do
+        op_index ops.get = op
+        op.kind = kind
+
+        if kind OpKind::PushInt == then
+            op.value InstKind::Push Inst bytecode .push
+        elif kind OpKind::Add == then
+            0 InstKind::Add Inst bytecode .push
+        elif kind OpKind::PrintInt == then
+            0 InstKind::PrintInt Inst bytecode .push
+        else
+            "unknown op kind in bytecode compiler" eprintln
+            1 exit
+        fi
+
+        1 += op_index
+    done
+
+    bytecode
+}

--- a/self_hosted/casa.casa
+++ b/self_hosted/casa.casa
@@ -27,9 +27,9 @@ if 4 argc == then
 fi
 
 # Pipeline: lex -> parse -> bytecode -> emit -> compile
-input_path file::read_all = src
-src lex = toks
-toks parse = program_ops
-program_ops compile_bytecode = program_bc
-program_bc emit_program = asm_output
-output_path asm_output compile_binary
+input_path file::read_all = source
+source lex = token_list
+token_list parse = parsed_ops
+parsed_ops compile_bytecode = program
+program emit_program = asm_source
+output_path asm_source compile_binary

--- a/self_hosted/casa.casa
+++ b/self_hosted/casa.casa
@@ -1,0 +1,35 @@
+# Self-hosted Casa compiler
+#
+# Compiles Casa source files to x86-64 Linux executables.
+# Usage: ./casa_compiler <input.casa> -o <output>
+
+include "lexer.casa"
+include "parser.casa"
+include "bytecode.casa"
+include "emitter.casa"
+include "compiler.casa"
+
+if 2 argc != 4 argc != && then
+    "usage: casa <input> -o <output>" eprintln
+    1 exit
+fi
+
+1 get_arg = input_path
+"output" = output_path
+
+if 4 argc == then
+    if "-o" 2 get_arg str::eq then
+        3 get_arg = output_path
+    else
+        "usage: casa <input> -o <output>" eprintln
+        1 exit
+    fi
+fi
+
+# Pipeline: lex -> parse -> bytecode -> emit -> compile
+input_path file::read_all = src
+src lex = toks
+toks parse = program_ops
+program_ops compile_bytecode = program_bc
+program_bc emit_program = asm_output
+output_path asm_output compile_binary

--- a/self_hosted/common.casa
+++ b/self_hosted/common.casa
@@ -1,0 +1,44 @@
+# Shared types, enums, and data structures used across the Casa compiler.
+
+include "../lib/std.casa"
+include "../lib/parser.casa"
+
+# ---------------------------------------------------------------------------
+# Token types (matches casa/common.py TokenKind)
+# ---------------------------------------------------------------------------
+
+enum TokenKind { Delimiter Eof Identifier Intrinsic Keyword Literal Operator }
+
+# ---------------------------------------------------------------------------
+# Op types (matches casa/common.py OpKind)
+# ---------------------------------------------------------------------------
+
+enum OpKind { PushInt Add PrintInt }
+
+# ---------------------------------------------------------------------------
+# Instruction types (matches casa/common.py InstKind)
+# ---------------------------------------------------------------------------
+
+enum InstKind { Push Add PrintInt }
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+# Matches casa/common.py Token(value, kind, location)
+struct Token {
+    kind:  TokenKind
+    value: str
+}
+
+# Matches casa/common.py Op(value, kind, location)
+struct Op {
+    kind:  OpKind
+    value: int
+}
+
+# Matches casa/common.py Inst(kind, args)
+struct Inst {
+    kind:  InstKind
+    value: int
+}

--- a/self_hosted/compiler.casa
+++ b/self_hosted/compiler.casa
@@ -1,0 +1,42 @@
+# Assembler and linker integration for producing x86_64 binaries.
+
+include "common.casa"
+
+fn compile_binary asm_source:str output_path:str {
+    f"{output_path}.s" = asm_path
+    f"{output_path}.o" = obj_path
+
+    asm_source asm_path file::write_all = write_ok
+    if write_ok ! then
+        f"failed to write {asm_path}" eprintln
+        1 exit
+    fi
+
+    # Assemble
+    List::new (List[str]) = as_args
+    "/usr/bin/as" as_args .push
+    "-o" as_args .push
+    obj_path as_args .push
+    asm_path as_args .push
+    as_args run_command = as_exit
+    if 0 as_exit != then
+        "assembler failed" eprintln
+        1 exit
+    fi
+
+    # Link
+    List::new (List[str]) = ld_args
+    "/usr/bin/ld" ld_args .push
+    "-o" ld_args .push
+    output_path ld_args .push
+    obj_path ld_args .push
+    ld_args run_command = ld_exit
+    if 0 ld_exit != then
+        "linker failed" eprintln
+        1 exit
+    fi
+
+    # Clean up intermediate files
+    asm_path file::remove drop
+    obj_path file::remove drop
+}

--- a/self_hosted/compiler.casa
+++ b/self_hosted/compiler.casa
@@ -3,12 +3,12 @@
 include "common.casa"
 
 fn compile_binary asm_source:str output_path:str {
-    f"{output_path}.s" = asm_path
-    f"{output_path}.o" = obj_path
+    f"{output_path}.s" = asm_file
+    f"{output_path}.o" = obj_file
 
-    asm_source asm_path file::write_all = write_ok
+    asm_source asm_file file::write_all = write_ok
     if write_ok ! then
-        f"failed to write {asm_path}" eprintln
+        f"failed to write {asm_file}" eprintln
         1 exit
     fi
 
@@ -16,8 +16,8 @@ fn compile_binary asm_source:str output_path:str {
     List::new (List[str]) = as_args
     "/usr/bin/as" as_args .push
     "-o" as_args .push
-    obj_path as_args .push
-    asm_path as_args .push
+    obj_file as_args .push
+    asm_file as_args .push
     as_args run_command = as_exit
     if 0 as_exit != then
         "assembler failed" eprintln
@@ -29,7 +29,7 @@ fn compile_binary asm_source:str output_path:str {
     "/usr/bin/ld" ld_args .push
     "-o" ld_args .push
     output_path ld_args .push
-    obj_path ld_args .push
+    obj_file ld_args .push
     ld_args run_command = ld_exit
     if 0 ld_exit != then
         "linker failed" eprintln
@@ -37,6 +37,6 @@ fn compile_binary asm_source:str output_path:str {
     fi
 
     # Clean up intermediate files
-    asm_path file::remove drop
-    obj_path file::remove drop
+    asm_file file::remove drop
+    obj_file file::remove drop
 }

--- a/self_hosted/emitter.casa
+++ b/self_hosted/emitter.casa
@@ -1,0 +1,192 @@
+# x86-64 GNU assembly emitter for the Casa compiler.
+
+include "common.casa"
+
+struct Emitter {
+    asm:         StringBuilder
+    label_count: int
+}
+
+fn emitter_new -> Emitter {
+    0 StringBuilder::new Emitter
+}
+
+fn next_label emitter:Emitter -> int {
+    emitter.label_count 1 + emitter->label_count
+    emitter.label_count
+}
+
+fn emit_bss emitter:Emitter {
+    ".section .bss\n" emitter.asm.append
+    "return_stack: .skip 65536\n" emitter.asm.append
+    "heap: .skip 67108864\n" emitter.asm.append
+    "heap_ptr: .skip 8\n" emitter.asm.append
+    "__argc: .skip 8\n" emitter.asm.append
+    "__argv: .skip 8\n" emitter.asm.append
+    "print_buf: .skip 32\n" emitter.asm.append
+    "\n" emitter.asm.append
+}
+
+fn emit_data emitter:Emitter {
+    ".section .data\n" emitter.asm.append
+    "bool_true: .ascii \"true\"\n" emitter.asm.append
+    "bool_false: .ascii \"false\"\n" emitter.asm.append
+    "\n" emitter.asm.append
+}
+
+fn emit_print_int_helper emitter:Emitter {
+    "print_int:\n" emitter.asm.append
+    "    movq %rdi, %rax\n" emitter.asm.append
+    "    leaq print_buf+32(%rip), %rsi\n" emitter.asm.append
+    "    testq %rax, %rax\n" emitter.asm.append
+    "    jnz .Lpi_nonzero\n" emitter.asm.append
+    "    decq %rsi\n" emitter.asm.append
+    "    movb $48, (%rsi)\n" emitter.asm.append
+    "    jmp .Lpi_write\n" emitter.asm.append
+    ".Lpi_nonzero:\n" emitter.asm.append
+    "    movq %rax, %r15\n" emitter.asm.append
+    "    jns .Lpi_abs\n" emitter.asm.append
+    "    negq %rax\n" emitter.asm.append
+    ".Lpi_abs:\n" emitter.asm.append
+    "    movq $10, %rcx\n" emitter.asm.append
+    ".Lpi_digit_loop:\n" emitter.asm.append
+    "    decq %rsi\n" emitter.asm.append
+    "    xorq %rdx, %rdx\n" emitter.asm.append
+    "    divq %rcx\n" emitter.asm.append
+    "    addb $48, %dl\n" emitter.asm.append
+    "    movb %dl, (%rsi)\n" emitter.asm.append
+    "    testq %rax, %rax\n" emitter.asm.append
+    "    jnz .Lpi_digit_loop\n" emitter.asm.append
+    "    testq %r15, %r15\n" emitter.asm.append
+    "    jns .Lpi_write\n" emitter.asm.append
+    "    decq %rsi\n" emitter.asm.append
+    "    movb $45, (%rsi)\n" emitter.asm.append
+    ".Lpi_write:\n" emitter.asm.append
+    "    leaq print_buf+32(%rip), %rdx\n" emitter.asm.append
+    "    subq %rsi, %rdx\n" emitter.asm.append
+    "    movq $1, %rax\n" emitter.asm.append
+    "    movq $1, %rdi\n" emitter.asm.append
+    "    syscall\n" emitter.asm.append
+    "    subq $8, %r14\n" emitter.asm.append
+    "    jmpq *(%r14)\n" emitter.asm.append
+    "\n" emitter.asm.append
+}
+
+fn emit_print_str_helper emitter:Emitter {
+    "print_str:\n" emitter.asm.append
+    "    movq (%rdi), %rdx\n" emitter.asm.append
+    "    leaq 8(%rdi), %rsi\n" emitter.asm.append
+    "    movq $1, %rdi\n" emitter.asm.append
+    "    movq $1, %rax\n" emitter.asm.append
+    "    syscall\n" emitter.asm.append
+    "    subq $8, %r14\n" emitter.asm.append
+    "    jmpq *(%r14)\n" emitter.asm.append
+    "\n" emitter.asm.append
+}
+
+fn emit_str_concat_helper emitter:Emitter {
+    "str_concat:\n" emitter.asm.append
+    "    movq %rdi, %r8\n" emitter.asm.append
+    "    movq %rsp, %r9\n" emitter.asm.append
+    "    xorq %r10, %r10\n" emitter.asm.append
+    "    xorq %rcx, %rcx\n" emitter.asm.append
+    ".Lsc_len_loop:\n" emitter.asm.append
+    "    cmpq %r8, %rcx\n" emitter.asm.append
+    "    jge .Lsc_len_done\n" emitter.asm.append
+    "    movq (%r9, %rcx, 8), %rax\n" emitter.asm.append
+    "    addq (%rax), %r10\n" emitter.asm.append
+    "    incq %rcx\n" emitter.asm.append
+    "    jmp .Lsc_len_loop\n" emitter.asm.append
+    ".Lsc_len_done:\n" emitter.asm.append
+    "    leaq heap(%rip), %r11\n" emitter.asm.append
+    "    movq heap_ptr(%rip), %r12\n" emitter.asm.append
+    "    leaq (%r11, %r12), %r13\n" emitter.asm.append
+    "    leaq 9(%r10, %r12), %rax\n" emitter.asm.append
+    "    movq %rax, heap_ptr(%rip)\n" emitter.asm.append
+    "    movq %r10, (%r13)\n" emitter.asm.append
+    "    leaq 8(%r13), %rdi\n" emitter.asm.append
+    "    movq %r8, %rcx\n" emitter.asm.append
+    "    decq %rcx\n" emitter.asm.append
+    ".Lsc_copy_loop:\n" emitter.asm.append
+    "    cmpq $0, %rcx\n" emitter.asm.append
+    "    jl .Lsc_copy_done\n" emitter.asm.append
+    "    movq (%r9, %rcx, 8), %rsi\n" emitter.asm.append
+    "    movq (%rsi), %rdx\n" emitter.asm.append
+    "    addq $8, %rsi\n" emitter.asm.append
+    "    pushq %rcx\n" emitter.asm.append
+    "    movq %rdx, %rcx\n" emitter.asm.append
+    "    rep movsb\n" emitter.asm.append
+    "    popq %rcx\n" emitter.asm.append
+    "    decq %rcx\n" emitter.asm.append
+    "    jmp .Lsc_copy_loop\n" emitter.asm.append
+    ".Lsc_copy_done:\n" emitter.asm.append
+    "    movb $0, (%rdi)\n" emitter.asm.append
+    "    leaq (%r9, %r8, 8), %rsp\n" emitter.asm.append
+    "    pushq %r13\n" emitter.asm.append
+    "    subq $8, %r14\n" emitter.asm.append
+    "    jmpq *(%r14)\n" emitter.asm.append
+    "\n" emitter.asm.append
+}
+
+fn emit_helpers emitter:Emitter {
+    ".section .text\n" emitter.asm.append
+    emitter emit_print_int_helper
+    emitter emit_print_str_helper
+    emitter emit_str_concat_helper
+}
+
+fn emit_inst inst:Inst emitter:Emitter {
+    inst.kind = kind
+
+    if kind InstKind::Push == then
+        f"    pushq ${inst.value .to_str}\n" emitter.asm.append
+    elif kind InstKind::Add == then
+        "    popq %rax\n" emitter.asm.append
+        "    addq %rax, (%rsp)\n" emitter.asm.append
+    elif kind InstKind::PrintInt == then
+        emitter next_label = done_id
+        "    popq %rdi\n" emitter.asm.append
+        f"    leaq .Lprint_done_{done_id .to_str}(%rip), %rax\n" emitter.asm.append
+        "    movq %rax, (%r14)\n" emitter.asm.append
+        "    addq $8, %r14\n" emitter.asm.append
+        "    jmp print_int\n" emitter.asm.append
+        f".Lprint_done_{done_id .to_str}:\n" emitter.asm.append
+    else
+        "unknown instruction kind in emitter" eprintln
+        1 exit
+    fi
+}
+
+fn emit_start emitter:Emitter program_bc:List[Inst] {
+    ".globl _start\n" emitter.asm.append
+    "_start:\n" emitter.asm.append
+    "    leaq return_stack(%rip), %r14\n" emitter.asm.append
+    "    movq (%rsp), %rax\n" emitter.asm.append
+    "    movq %rax, __argc(%rip)\n" emitter.asm.append
+    "    leaq 8(%rsp), %rax\n" emitter.asm.append
+    "    movq %rax, __argv(%rip)\n" emitter.asm.append
+
+    0 = inst_index
+    while inst_index program_bc.length > do
+        emitter inst_index program_bc.get emit_inst
+        1 += inst_index
+    done
+}
+
+fn emit_exit emitter:Emitter {
+    "    movq $60, %rax\n" emitter.asm.append
+    "    xorq %rdi, %rdi\n" emitter.asm.append
+    "    syscall\n" emitter.asm.append
+}
+
+fn emit_program program_bc:List[Inst] -> str {
+    emitter_new = emitter
+
+    emitter emit_bss
+    emitter emit_data
+    emitter emit_helpers
+    program_bc emitter emit_start
+    emitter emit_exit
+
+    emitter.asm.build
+}

--- a/self_hosted/emitter.casa
+++ b/self_hosted/emitter.casa
@@ -144,20 +144,20 @@ fn emit_inst inst:Inst emitter:Emitter {
         "    popq %rax\n" emitter.asm.append
         "    addq %rax, (%rsp)\n" emitter.asm.append
     elif kind InstKind::PrintInt == then
-        emitter next_label = done_id
+        emitter next_label = label_id
         "    popq %rdi\n" emitter.asm.append
-        f"    leaq .Lprint_done_{done_id .to_str}(%rip), %rax\n" emitter.asm.append
+        f"    leaq .Lprint_done_{label_id .to_str}(%rip), %rax\n" emitter.asm.append
         "    movq %rax, (%r14)\n" emitter.asm.append
         "    addq $8, %r14\n" emitter.asm.append
         "    jmp print_int\n" emitter.asm.append
-        f".Lprint_done_{done_id .to_str}:\n" emitter.asm.append
+        f".Lprint_done_{label_id .to_str}:\n" emitter.asm.append
     else
         "unknown instruction kind in emitter" eprintln
         1 exit
     fi
 }
 
-fn emit_start emitter:Emitter program_bc:List[Inst] {
+fn emit_start emitter:Emitter program:List[Inst] {
     ".globl _start\n" emitter.asm.append
     "_start:\n" emitter.asm.append
     "    leaq return_stack(%rip), %r14\n" emitter.asm.append
@@ -167,8 +167,8 @@ fn emit_start emitter:Emitter program_bc:List[Inst] {
     "    movq %rax, __argv(%rip)\n" emitter.asm.append
 
     0 = inst_index
-    while inst_index program_bc.length > do
-        emitter inst_index program_bc.get emit_inst
+    while inst_index program.length > do
+        emitter inst_index program.get emit_inst
         1 += inst_index
     done
 }
@@ -179,13 +179,13 @@ fn emit_exit emitter:Emitter {
     "    syscall\n" emitter.asm.append
 }
 
-fn emit_program program_bc:List[Inst] -> str {
+fn emit_program program:List[Inst] -> str {
     emitter_new = emitter
 
     emitter emit_bss
     emitter emit_data
     emitter emit_helpers
-    program_bc emitter emit_start
+    program emitter emit_start
     emitter emit_exit
 
     emitter.asm.build

--- a/self_hosted/lexer.casa
+++ b/self_hosted/lexer.casa
@@ -1,0 +1,70 @@
+# Tokenizer for the Casa programming language.
+
+include "common.casa"
+
+fn lex_integer_literal cursor:Cursor -> Token {
+    cursor parse_int = result
+    if result.is_error then
+        "invalid number" eprintln
+        1 exit
+    fi
+    result.unwrap .to_str = text
+    text TokenKind::Literal Token
+}
+
+fn lex_word cursor:Cursor -> Token {
+    cursor parse_identifier = result
+    if result.is_error then
+        "unexpected character" eprintln
+        1 exit
+    fi
+    result.unwrap = word
+    if "print" word str::eq then
+        word TokenKind::Intrinsic Token
+    else
+        f"unknown word: {word}" eprintln
+        1 exit
+        # Unreachable: required for consistent stack effect across branches
+        "" TokenKind::Eof Token
+    fi
+}
+
+fn lex source:str -> List[Token] {
+    source Cursor::new = cursor
+    List::new (List[Token]) = tokens
+
+    while cursor.is_eof ! do
+        cursor skip_whitespace
+        if cursor.is_eof then break fi
+
+        cursor.peek.unwrap = ch
+
+        if ch .is_digit then
+            cursor lex_integer_literal tokens .push
+        elif ch '-' == then
+            1 cursor.peek_at = next_ch
+            if next_ch.is_some next_ch.unwrap .is_digit && then
+                cursor lex_integer_literal tokens .push
+            else
+                "unexpected character" eprintln
+                1 exit
+            fi
+        elif ch '+' == then
+            cursor.advance drop
+            "+" TokenKind::Operator Token tokens .push
+        elif ch .is_alpha then
+            cursor lex_word tokens .push
+        elif ch '#' == then
+            while cursor.is_eof ! do
+                cursor.advance.unwrap = comment_ch
+                if comment_ch '\n' == then break fi
+            done
+        else
+            "unexpected character" eprintln
+            1 exit
+        fi
+    done
+
+    "" TokenKind::Eof Token tokens .push
+    tokens
+}

--- a/self_hosted/parser.casa
+++ b/self_hosted/parser.casa
@@ -1,0 +1,39 @@
+# Op tree builder for the Casa compiler.
+
+include "common.casa"
+
+fn parse tokens:List[Token] -> List[Op] {
+    List::new (List[Op]) = ops
+    0 = index
+
+    while index tokens.length > do
+        index tokens.get = token
+        1 += index
+        token.kind = kind
+
+        if kind TokenKind::Literal == then
+            token.value str_to_int OpKind::PushInt Op ops .push
+        elif kind TokenKind::Operator == then
+            if "+" token.value str::eq then
+                0 OpKind::Add Op ops .push
+            else
+                f"unknown operator: {token.value}" eprintln
+                1 exit
+            fi
+        elif kind TokenKind::Intrinsic == then
+            if "print" token.value str::eq then
+                0 OpKind::PrintInt Op ops .push
+            else
+                f"unknown intrinsic: {token.value}" eprintln
+                1 exit
+            fi
+        elif kind TokenKind::Eof == then
+            break
+        else
+            "unexpected token" eprintln
+            1 exit
+        fi
+    done
+
+    ops
+}

--- a/tests/test_self_hosted.sh
+++ b/tests/test_self_hosted.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env sh
+set -eu
+
+ROOT_DIR=$(git rev-parse --show-toplevel)
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+RESET='\033[0m'
+
+pass=0
+fail=0
+
+COMPILER="/tmp/casa_self_hosted_compiler"
+
+# Compile the self-hosted compiler
+python3 "$ROOT_DIR/casa.py" "$ROOT_DIR/self_hosted/casa.casa" -o "$COMPILER"
+
+run_test() {
+    name="$1"
+    source="$2"
+    expected="$3"
+    binary="/tmp/casa_self_hosted_test_$name"
+
+    echo "Running test: $name"
+    "$COMPILER" "$source" -o "$binary" 2>&1
+    output=$("$binary")
+    rm -f "$binary"
+
+    if [ "$output" = "$expected" ]; then
+        echo "${GREEN}[OK]${RESET} Passed: $name"
+        pass=$((pass+1))
+    else
+        echo "${RED}[X]${RESET}  Failed: $name"
+        echo "  Expected: $expected"
+        echo "  Got:      $output"
+        fail=$((fail+1))
+    fi
+}
+
+# Write test source files
+tmp_add="/tmp/casa_sh_add.casa"
+echo '34 35 + print' > "$tmp_add"
+run_test "addition" "$tmp_add" "69"
+
+tmp_neg="/tmp/casa_sh_neg.casa"
+echo '-10 3 + print' > "$tmp_neg"
+run_test "negative_literal" "$tmp_neg" "-7"
+
+tmp_zero="/tmp/casa_sh_zero.casa"
+echo '0 print' > "$tmp_zero"
+run_test "zero" "$tmp_zero" "0"
+
+tmp_single="/tmp/casa_sh_single.casa"
+echo '42 print' > "$tmp_single"
+run_test "single_int" "$tmp_single" "42"
+
+tmp_chain="/tmp/casa_sh_chain.casa"
+echo '1 2 + 3 + print' > "$tmp_chain"
+run_test "chained_addition" "$tmp_chain" "6"
+
+# Clean up
+rm -f "$COMPILER" "$tmp_add" "$tmp_neg" "$tmp_zero" "$tmp_single" "$tmp_chain"
+
+echo
+echo "Summary: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## Summary
- Implements a self-hosted Casa compiler under `self_hosted/` that compiles Casa programs to x86-64 Linux binaries
- Supports integer literals (including negatives), addition, and `print`
- Module structure mirrors the Python compiler: `common.casa`, `lexer.casa`, `parser.casa`, `bytecode.casa`, `emitter.casa`, `compiler.casa`
- Adds test suite (`tests/test_self_hosted.sh`) with 5 tests: addition, negative literals, zero, single int, chained addition

## Test plan
- [x] `tests/test_self_hosted.sh` — all 5 tests pass
- [x] `tests/test_examples.sh` — all 31 existing tests pass (no regressions)