### PR TITLE
Add arithmetic, bitwise, comparison, boolean operators and stack intrinsics

### DIFF
--- a/self_hosted/bytecode.casa
+++ b/self_hosted/bytecode.casa
@@ -2,25 +2,44 @@
 
 include "common.casa"
 
+fn op_to_inst op:Op -> Inst {
+    op.kind match
+        OpKind::PushInt => op.value InstKind::Push Inst
+        OpKind::Add => 0 InstKind::Add Inst
+        OpKind::Sub => 0 InstKind::Sub Inst
+        OpKind::Mul => 0 InstKind::Mul Inst
+        OpKind::Div => 0 InstKind::Div Inst
+        OpKind::Mod => 0 InstKind::Mod Inst
+        OpKind::BitAnd => 0 InstKind::BitAnd Inst
+        OpKind::BitOr => 0 InstKind::BitOr Inst
+        OpKind::BitXor => 0 InstKind::BitXor Inst
+        OpKind::BitNot => 0 InstKind::BitNot Inst
+        OpKind::Shl => 0 InstKind::Shl Inst
+        OpKind::Shr => 0 InstKind::Shr Inst
+        OpKind::Eq => 0 InstKind::Eq Inst
+        OpKind::Ne => 0 InstKind::Ne Inst
+        OpKind::Lt => 0 InstKind::Lt Inst
+        OpKind::Gt => 0 InstKind::Gt Inst
+        OpKind::Le => 0 InstKind::Le Inst
+        OpKind::Ge => 0 InstKind::Ge Inst
+        OpKind::And => 0 InstKind::And Inst
+        OpKind::Or => 0 InstKind::Or Inst
+        OpKind::Not => 0 InstKind::Not Inst
+        OpKind::Drop => 0 InstKind::Drop Inst
+        OpKind::Dup => 0 InstKind::Dup Inst
+        OpKind::Swap => 0 InstKind::Swap Inst
+        OpKind::Over => 0 InstKind::Over Inst
+        OpKind::Rot => 0 InstKind::Rot Inst
+        OpKind::PrintInt => 0 InstKind::PrintInt Inst
+    end
+}
+
 fn compile_bytecode ops:List[Op] -> List[Inst] {
     List::new (List[Inst]) = bytecode
     0 = op_index
 
     while op_index ops.length > do
-        op_index ops.get = op
-        op.kind = kind
-
-        if kind OpKind::PushInt == then
-            op.value InstKind::Push Inst bytecode .push
-        elif kind OpKind::Add == then
-            0 InstKind::Add Inst bytecode .push
-        elif kind OpKind::PrintInt == then
-            0 InstKind::PrintInt Inst bytecode .push
-        else
-            "unknown op kind in bytecode compiler" eprintln
-            1 exit
-        fi
-
+        op_index ops.get op_to_inst bytecode .push
         1 += op_index
     done
 

--- a/self_hosted/common.casa
+++ b/self_hosted/common.casa
@@ -13,13 +13,27 @@ enum TokenKind { Delimiter Eof Identifier Intrinsic Keyword Literal Operator }
 # Op types (matches casa/common.py OpKind)
 # ---------------------------------------------------------------------------
 
-enum OpKind { PushInt Add PrintInt }
+enum OpKind {
+    PushInt Add Sub Mul Div Mod
+    BitAnd BitOr BitXor BitNot Shl Shr
+    Eq Ne Lt Gt Le Ge
+    And Or Not
+    Drop Dup Swap Over Rot
+    PrintInt
+}
 
 # ---------------------------------------------------------------------------
 # Instruction types (matches casa/common.py InstKind)
 # ---------------------------------------------------------------------------
 
-enum InstKind { Push Add PrintInt }
+enum InstKind {
+    Push Add Sub Mul Div Mod
+    BitAnd BitOr BitXor BitNot Shl Shr
+    Eq Ne Lt Gt Le Ge
+    And Or Not
+    Drop Dup Swap Over Rot
+    PrintInt
+}
 
 # ---------------------------------------------------------------------------
 # Data structures

--- a/self_hosted/emitter.casa
+++ b/self_hosted/emitter.casa
@@ -135,14 +135,114 @@ fn emit_helpers emitter:Emitter {
     emitter emit_str_concat_helper
 }
 
+fn emit_comparison emitter:Emitter setcc:str {
+    "    popq %rax\n" emitter.asm.append
+    "    cmpq %rax, (%rsp)\n" emitter.asm.append
+    f"    {setcc} %al\n" emitter.asm.append
+    "    movzbq %al, %rax\n" emitter.asm.append
+    "    movq %rax, (%rsp)\n" emitter.asm.append
+}
+
 fn emit_inst inst:Inst emitter:Emitter {
     inst.kind = kind
 
     if kind InstKind::Push == then
         f"    pushq ${inst.value .to_str}\n" emitter.asm.append
+    # Arithmetic
     elif kind InstKind::Add == then
         "    popq %rax\n" emitter.asm.append
         "    addq %rax, (%rsp)\n" emitter.asm.append
+    elif kind InstKind::Sub == then
+        "    popq %rax\n" emitter.asm.append
+        "    subq %rax, (%rsp)\n" emitter.asm.append
+    elif kind InstKind::Mul == then
+        "    popq %rax\n" emitter.asm.append
+        "    imulq (%rsp), %rax\n" emitter.asm.append
+        "    movq %rax, (%rsp)\n" emitter.asm.append
+    elif kind InstKind::Div == then
+        "    popq %rbx\n" emitter.asm.append
+        "    popq %rax\n" emitter.asm.append
+        "    cqto\n" emitter.asm.append
+        "    idivq %rbx\n" emitter.asm.append
+        "    pushq %rax\n" emitter.asm.append
+    elif kind InstKind::Mod == then
+        "    popq %rbx\n" emitter.asm.append
+        "    popq %rax\n" emitter.asm.append
+        "    cqto\n" emitter.asm.append
+        "    idivq %rbx\n" emitter.asm.append
+        "    pushq %rdx\n" emitter.asm.append
+    # Bitwise
+    elif kind InstKind::BitAnd == then
+        "    popq %rax\n" emitter.asm.append
+        "    andq %rax, (%rsp)\n" emitter.asm.append
+    elif kind InstKind::BitOr == then
+        "    popq %rax\n" emitter.asm.append
+        "    orq %rax, (%rsp)\n" emitter.asm.append
+    elif kind InstKind::BitXor == then
+        "    popq %rax\n" emitter.asm.append
+        "    xorq %rax, (%rsp)\n" emitter.asm.append
+    elif kind InstKind::BitNot == then
+        "    notq (%rsp)\n" emitter.asm.append
+    elif kind InstKind::Shl == then
+        "    popq %rcx\n" emitter.asm.append
+        "    shlq %cl, (%rsp)\n" emitter.asm.append
+    elif kind InstKind::Shr == then
+        "    popq %rcx\n" emitter.asm.append
+        "    sarq %cl, (%rsp)\n" emitter.asm.append
+    # Comparison
+    elif kind InstKind::Eq == then
+        "sete" emitter emit_comparison
+    elif kind InstKind::Ne == then
+        "setne" emitter emit_comparison
+    elif kind InstKind::Lt == then
+        "setl" emitter emit_comparison
+    elif kind InstKind::Le == then
+        "setle" emitter emit_comparison
+    elif kind InstKind::Gt == then
+        "setg" emitter emit_comparison
+    elif kind InstKind::Ge == then
+        "setge" emitter emit_comparison
+    # Boolean
+    elif kind InstKind::And == then
+        "    popq %rax\n" emitter.asm.append
+        "    testq %rax, %rax\n" emitter.asm.append
+        "    setne %al\n" emitter.asm.append
+        "    cmpq $0, (%rsp)\n" emitter.asm.append
+        "    setne %cl\n" emitter.asm.append
+        "    andb %cl, %al\n" emitter.asm.append
+        "    movzbq %al, %rax\n" emitter.asm.append
+        "    movq %rax, (%rsp)\n" emitter.asm.append
+    elif kind InstKind::Or == then
+        "    popq %rax\n" emitter.asm.append
+        "    orq %rax, (%rsp)\n" emitter.asm.append
+        "    setne %al\n" emitter.asm.append
+        "    movzbq %al, %rax\n" emitter.asm.append
+        "    movq %rax, (%rsp)\n" emitter.asm.append
+    elif kind InstKind::Not == then
+        "    cmpq $0, (%rsp)\n" emitter.asm.append
+        "    sete %al\n" emitter.asm.append
+        "    movzbq %al, %rax\n" emitter.asm.append
+        "    movq %rax, (%rsp)\n" emitter.asm.append
+    # Stack
+    elif kind InstKind::Drop == then
+        "    addq $8, %rsp\n" emitter.asm.append
+    elif kind InstKind::Dup == then
+        "    pushq (%rsp)\n" emitter.asm.append
+    elif kind InstKind::Swap == then
+        "    popq %rax\n" emitter.asm.append
+        "    popq %rbx\n" emitter.asm.append
+        "    pushq %rax\n" emitter.asm.append
+        "    pushq %rbx\n" emitter.asm.append
+    elif kind InstKind::Over == then
+        "    pushq 8(%rsp)\n" emitter.asm.append
+    elif kind InstKind::Rot == then
+        "    popq %rax\n" emitter.asm.append
+        "    popq %rbx\n" emitter.asm.append
+        "    popq %rcx\n" emitter.asm.append
+        "    pushq %rbx\n" emitter.asm.append
+        "    pushq %rax\n" emitter.asm.append
+        "    pushq %rcx\n" emitter.asm.append
+    # Print
     elif kind InstKind::PrintInt == then
         emitter next_label = label_id
         "    popq %rdi\n" emitter.asm.append

--- a/self_hosted/lexer.casa
+++ b/self_hosted/lexer.casa
@@ -12,6 +12,15 @@ fn lex_integer_literal cursor:Cursor -> Token {
     text TokenKind::Literal Token
 }
 
+fn is_intrinsic word:str -> bool {
+    "print" word str::eq
+    "drop" word str::eq ||
+    "dup" word str::eq ||
+    "swap" word str::eq ||
+    "over" word str::eq ||
+    "rot" word str::eq ||
+}
+
 fn lex_word cursor:Cursor -> Token {
     cursor parse_identifier = result
     if result.is_error then
@@ -19,13 +28,78 @@ fn lex_word cursor:Cursor -> Token {
         1 exit
     fi
     result.unwrap = word
-    if "print" word str::eq then
+    if word is_intrinsic then
         word TokenKind::Intrinsic Token
     else
         f"unknown word: {word}" eprintln
         1 exit
         # Unreachable: required for consistent stack effect across branches
         "" TokenKind::Eof Token
+    fi
+}
+
+fn lex_two_char_op cursor:Cursor second:char op:str -> Token {
+    0 cursor.peek_at = next_ch
+    if next_ch.is_some next_ch.unwrap second == && then
+        cursor.advance drop
+        op TokenKind::Operator Token
+    else
+        "" TokenKind::Eof Token
+    fi
+}
+
+fn lex_operator cursor:Cursor ch:char -> Token {
+    cursor.advance drop
+    if ch '<' == then
+        "<<" '<' cursor lex_two_char_op = result
+        if result.kind TokenKind::Eof != then result
+        else
+            "<=" '=' cursor lex_two_char_op = result
+            if result.kind TokenKind::Eof != then result
+            else "<" TokenKind::Operator Token
+            fi
+        fi
+    elif ch '>' == then
+        ">>" '>' cursor lex_two_char_op = result
+        if result.kind TokenKind::Eof != then result
+        else
+            ">=" '=' cursor lex_two_char_op = result
+            if result.kind TokenKind::Eof != then result
+            else ">" TokenKind::Operator Token
+            fi
+        fi
+    elif ch '=' == then
+        "==" '=' cursor lex_two_char_op = result
+        if result.kind TokenKind::Eof != then result
+        else "=" TokenKind::Operator Token
+        fi
+    elif ch '!' == then
+        "!=" '=' cursor lex_two_char_op = result
+        if result.kind TokenKind::Eof != then result
+        else "!" TokenKind::Operator Token
+        fi
+    elif ch '&' == then
+        "&&" '&' cursor lex_two_char_op = result
+        if result.kind TokenKind::Eof != then result
+        else "&" TokenKind::Operator Token
+        fi
+    elif ch '|' == then
+        "||" '|' cursor lex_two_char_op = result
+        if result.kind TokenKind::Eof != then result
+        else "|" TokenKind::Operator Token
+        fi
+    elif ch '*' == then
+        "*" TokenKind::Operator Token
+    elif ch '/' == then
+        "/" TokenKind::Operator Token
+    elif ch '%' == then
+        "%" TokenKind::Operator Token
+    elif ch '^' == then
+        "^" TokenKind::Operator Token
+    elif ch '~' == then
+        "~" TokenKind::Operator Token
+    else
+        "+" TokenKind::Operator Token
     fi
 }
 
@@ -46,12 +120,11 @@ fn lex source:str -> List[Token] {
             if next_ch.is_some next_ch.unwrap .is_digit && then
                 cursor lex_integer_literal tokens .push
             else
-                "unexpected character" eprintln
-                1 exit
+                cursor.advance drop
+                "-" TokenKind::Operator Token tokens .push
             fi
-        elif ch '+' == then
-            cursor.advance drop
-            "+" TokenKind::Operator Token tokens .push
+        elif ch '+' == ch '*' == || ch '/' == || ch '%' == || ch '&' == || ch '|' == || ch '^' == || ch '~' == || ch '<' == || ch '>' == || ch '=' == || ch '!' == || then
+            ch cursor lex_operator tokens .push
         elif ch .is_alpha then
             cursor lex_word tokens .push
         elif ch '#' == then

--- a/self_hosted/parser.casa
+++ b/self_hosted/parser.casa
@@ -2,6 +2,50 @@
 
 include "common.casa"
 
+fn parse_operator op_value:str -> OpKind {
+    if "+" op_value str::eq then OpKind::Add
+    elif "-" op_value str::eq then OpKind::Sub
+    elif "*" op_value str::eq then OpKind::Mul
+    elif "/" op_value str::eq then OpKind::Div
+    elif "%" op_value str::eq then OpKind::Mod
+    elif "&" op_value str::eq then OpKind::BitAnd
+    elif "|" op_value str::eq then OpKind::BitOr
+    elif "^" op_value str::eq then OpKind::BitXor
+    elif "~" op_value str::eq then OpKind::BitNot
+    elif "<<" op_value str::eq then OpKind::Shl
+    elif ">>" op_value str::eq then OpKind::Shr
+    elif "==" op_value str::eq then OpKind::Eq
+    elif "!=" op_value str::eq then OpKind::Ne
+    elif "<" op_value str::eq then OpKind::Lt
+    elif ">" op_value str::eq then OpKind::Gt
+    elif "<=" op_value str::eq then OpKind::Le
+    elif ">=" op_value str::eq then OpKind::Ge
+    elif "&&" op_value str::eq then OpKind::And
+    elif "||" op_value str::eq then OpKind::Or
+    elif "!" op_value str::eq then OpKind::Not
+    else
+        f"unknown operator: {op_value}" eprintln
+        1 exit
+        # Unreachable
+        OpKind::Add
+    fi
+}
+
+fn parse_intrinsic intrinsic_value:str -> OpKind {
+    if "print" intrinsic_value str::eq then OpKind::PrintInt
+    elif "drop" intrinsic_value str::eq then OpKind::Drop
+    elif "dup" intrinsic_value str::eq then OpKind::Dup
+    elif "swap" intrinsic_value str::eq then OpKind::Swap
+    elif "over" intrinsic_value str::eq then OpKind::Over
+    elif "rot" intrinsic_value str::eq then OpKind::Rot
+    else
+        f"unknown intrinsic: {intrinsic_value}" eprintln
+        1 exit
+        # Unreachable
+        OpKind::Drop
+    fi
+}
+
 fn parse tokens:List[Token] -> List[Op] {
     List::new (List[Op]) = ops
     0 = index
@@ -14,19 +58,9 @@ fn parse tokens:List[Token] -> List[Op] {
         if kind TokenKind::Literal == then
             token.value str_to_int OpKind::PushInt Op ops .push
         elif kind TokenKind::Operator == then
-            if "+" token.value str::eq then
-                0 OpKind::Add Op ops .push
-            else
-                f"unknown operator: {token.value}" eprintln
-                1 exit
-            fi
+            0 token.value parse_operator Op ops .push
         elif kind TokenKind::Intrinsic == then
-            if "print" token.value str::eq then
-                0 OpKind::PrintInt Op ops .push
-            else
-                f"unknown intrinsic: {token.value}" eprintln
-                1 exit
-            fi
+            0 token.value parse_intrinsic Op ops .push
         elif kind TokenKind::Eof == then
             break
         else

--- a/tests/test_self_hosted.sh
+++ b/tests/test_self_hosted.sh
@@ -58,8 +58,140 @@ tmp_chain="/tmp/casa_sh_chain.casa"
 echo '1 2 + 3 + print' > "$tmp_chain"
 run_test "chained_addition" "$tmp_chain" "6"
 
+# Subtraction
+tmp_sub="/tmp/casa_sh_sub.casa"
+echo '10 3 - print' > "$tmp_sub"
+run_test "subtraction" "$tmp_sub" "7"
+
+# Multiplication
+tmp_mul="/tmp/casa_sh_mul.casa"
+echo '6 7 * print' > "$tmp_mul"
+run_test "multiplication" "$tmp_mul" "42"
+
+# Division
+tmp_div="/tmp/casa_sh_div.casa"
+echo '20 4 / print' > "$tmp_div"
+run_test "division" "$tmp_div" "5"
+
+# Modulo
+tmp_mod="/tmp/casa_sh_mod.casa"
+echo '17 5 % print' > "$tmp_mod"
+run_test "modulo" "$tmp_mod" "2"
+
+# Combined arithmetic
+tmp_arith="/tmp/casa_sh_arith.casa"
+echo '3 4 * 2 + print' > "$tmp_arith"
+run_test "combined_arithmetic" "$tmp_arith" "14"
+
+# Bitwise AND
+tmp_band="/tmp/casa_sh_band.casa"
+echo '12 10 & print' > "$tmp_band"
+run_test "bitwise_and" "$tmp_band" "8"
+
+# Bitwise OR
+tmp_bor="/tmp/casa_sh_bor.casa"
+echo '12 10 | print' > "$tmp_bor"
+run_test "bitwise_or" "$tmp_bor" "14"
+
+# Bitwise XOR
+tmp_bxor="/tmp/casa_sh_bxor.casa"
+echo '12 10 ^ print' > "$tmp_bxor"
+run_test "bitwise_xor" "$tmp_bxor" "6"
+
+# Bitwise NOT
+tmp_bnot="/tmp/casa_sh_bnot.casa"
+echo '0 ~ print' > "$tmp_bnot"
+run_test "bitwise_not" "$tmp_bnot" "-1"
+
+# Shift left
+tmp_shl="/tmp/casa_sh_shl.casa"
+echo '1 4 << print' > "$tmp_shl"
+run_test "shift_left" "$tmp_shl" "16"
+
+# Shift right
+tmp_shr="/tmp/casa_sh_shr.casa"
+echo '16 2 >> print' > "$tmp_shr"
+run_test "shift_right" "$tmp_shr" "4"
+
+# Comparisons
+tmp_eq="/tmp/casa_sh_eq.casa"
+echo '5 5 == print' > "$tmp_eq"
+run_test "equal_true" "$tmp_eq" "1"
+
+tmp_eq2="/tmp/casa_sh_eq2.casa"
+echo '5 3 == print' > "$tmp_eq2"
+run_test "equal_false" "$tmp_eq2" "0"
+
+tmp_ne="/tmp/casa_sh_ne.casa"
+echo '5 3 != print' > "$tmp_ne"
+run_test "not_equal_true" "$tmp_ne" "1"
+
+tmp_lt="/tmp/casa_sh_lt.casa"
+echo '3 5 < print' > "$tmp_lt"
+run_test "less_than_true" "$tmp_lt" "1"
+
+tmp_gt="/tmp/casa_sh_gt.casa"
+echo '5 3 > print' > "$tmp_gt"
+run_test "greater_than_true" "$tmp_gt" "1"
+
+tmp_le="/tmp/casa_sh_le.casa"
+echo '5 5 <= print' > "$tmp_le"
+run_test "less_equal_true" "$tmp_le" "1"
+
+tmp_ge="/tmp/casa_sh_ge.casa"
+echo '5 5 >= print' > "$tmp_ge"
+run_test "greater_equal_true" "$tmp_ge" "1"
+
+# Boolean
+tmp_and="/tmp/casa_sh_and.casa"
+echo '1 1 && print' > "$tmp_and"
+run_test "boolean_and_true" "$tmp_and" "1"
+
+tmp_and2="/tmp/casa_sh_and2.casa"
+echo '1 0 && print' > "$tmp_and2"
+run_test "boolean_and_false" "$tmp_and2" "0"
+
+tmp_or="/tmp/casa_sh_or.casa"
+echo '0 1 || print' > "$tmp_or"
+run_test "boolean_or_true" "$tmp_or" "1"
+
+tmp_not="/tmp/casa_sh_not.casa"
+echo '0 ! print' > "$tmp_not"
+run_test "boolean_not_true" "$tmp_not" "1"
+
+tmp_not2="/tmp/casa_sh_not2.casa"
+echo '1 ! print' > "$tmp_not2"
+run_test "boolean_not_false" "$tmp_not2" "0"
+
+# Stack intrinsics
+tmp_drop="/tmp/casa_sh_drop.casa"
+echo '1 2 drop print' > "$tmp_drop"
+run_test "drop" "$tmp_drop" "1"
+
+tmp_dup="/tmp/casa_sh_dup.casa"
+echo '42 dup + print' > "$tmp_dup"
+run_test "dup" "$tmp_dup" "84"
+
+tmp_swap="/tmp/casa_sh_swap.casa"
+echo '1 2 swap - print' > "$tmp_swap"
+run_test "swap" "$tmp_swap" "1"
+
+tmp_over="/tmp/casa_sh_over.casa"
+echo '1 2 over + print' > "$tmp_over"
+run_test "over" "$tmp_over" "3"
+
+tmp_rot="/tmp/casa_sh_rot.casa"
+echo '1 2 3 rot print drop drop' > "$tmp_rot"
+run_test "rot" "$tmp_rot" "1"
+
 # Clean up
-rm -f "$COMPILER" "$tmp_add" "$tmp_neg" "$tmp_zero" "$tmp_single" "$tmp_chain"
+rm -f "$COMPILER"
+rm -f "$tmp_add" "$tmp_neg" "$tmp_zero" "$tmp_single" "$tmp_chain"
+rm -f "$tmp_sub" "$tmp_mul" "$tmp_div" "$tmp_mod" "$tmp_arith"
+rm -f "$tmp_band" "$tmp_bor" "$tmp_bxor" "$tmp_bnot" "$tmp_shl" "$tmp_shr"
+rm -f "$tmp_eq" "$tmp_eq2" "$tmp_ne" "$tmp_lt" "$tmp_gt" "$tmp_le" "$tmp_ge"
+rm -f "$tmp_and" "$tmp_and2" "$tmp_or" "$tmp_not" "$tmp_not2"
+rm -f "$tmp_drop" "$tmp_dup" "$tmp_swap" "$tmp_over" "$tmp_rot"
 
 echo
 echo "Summary: $pass passed, $fail failed"


### PR DESCRIPTION
## Summary
- Add all arithmetic (`-`, `*`, `/`, `%`), bitwise (`&`, `|`, `^`, `~`, `<<`, `>>`), comparison (`==`, `!=`, `<`, `>`, `<=`, `>=`), and boolean (`&&`, `||`, `!`) operators
- Add stack intrinsics: `drop`, `dup`, `swap`, `over`, `rot`
- Refactor bytecode compiler to use `match` for exhaustive enum dispatch
- Extract `parse_operator` and `parse_intrinsic` helpers in the parser
- Add `emit_comparison` helper for shared comparison assembly pattern

## Test plan
- [x] All 33 self-hosted compiler tests pass (`tests/test_self_hosted.sh`)
- [x] All 31 Python compiler example tests pass (`tests/test_examples.sh`)