### PR TITLE
feat: add struct literal construction and struct match destructuring

### DIFF
--- a/casa/bytecode.py
+++ b/casa/bytecode.py
@@ -2,10 +2,11 @@
 
 from collections.abc import Iterable
 from dataclasses import dataclass, field
-from typing import assert_never
+
 from casa.common import (
     GLOBAL_FUNCTIONS,
     GLOBAL_SCOPE_LABEL,
+    GLOBAL_STRUCTS,
     GLOBAL_VARIABLES,
     Bytecode,
     Cursor,
@@ -19,6 +20,8 @@ from casa.common import (
     OpKind,
     Program,
     Struct,
+    StructLiteral,
+    StructPattern,
     Variable,
 )
 from casa.error import ErrorKind, raise_error
@@ -444,8 +447,8 @@ class Compiler:
             case OpKind.MATCH_START:
                 pass
             case OpKind.MATCH_ARM:
-                variant = op.value
-                assert isinstance(variant, EnumVariant)
+                pattern = op.value
+                assert isinstance(pattern, (EnumVariant, StructPattern))
 
                 end_label = self._require_matching_label(
                     op,
@@ -469,11 +472,14 @@ class Compiler:
                     target_kinds=[OpKind.MATCH_ARM],
                 )
                 is_last = next_arm is None
-                if is_last:
+
+                if isinstance(pattern, StructPattern):
+                    self._compile_struct_match_arm(pattern, bytecode)
+                elif is_last:
                     bytecode.append(self.inst(InstKind.DROP))
                 else:
                     bytecode.append(self.inst(InstKind.DUP))
-                    bytecode.append(self.inst(InstKind.PUSH, args=[variant.ordinal]))
+                    bytecode.append(self.inst(InstKind.PUSH, args=[pattern.ordinal]))
                     bytecode.append(self.inst(InstKind.EQ))
                     bytecode.append(self.inst(InstKind.JUMP_NE, args=[next_arm]))
                     bytecode.append(self.inst(InstKind.DROP))
@@ -520,6 +526,64 @@ class Compiler:
                 bytecode.append(self.inst(InstKind.ADD))
             bytecode.append(self.inst(InstKind.STORE64))
 
+    def _compile_struct_match_arm(
+        self,
+        pattern: StructPattern,
+        bytecode: list[Inst],
+    ) -> None:
+        """Compile a struct destructuring match arm."""
+        struct = GLOBAL_STRUCTS[pattern.struct_name]
+        field_offsets = {m.name: i * 8 for i, m in enumerate(struct.members)}
+
+        # Extract bound fields from the struct pointer
+        for field_name, var_name in pattern.bindings.items():
+            offset = field_offsets[field_name]
+            bytecode.append(self.inst(InstKind.DUP))
+            if offset > 0:
+                bytecode.append(self.inst(InstKind.PUSH, args=[offset]))
+                bytecode.append(self.inst(InstKind.ADD))
+            bytecode.append(self.inst(InstKind.LOAD64))
+            _, set_kind, var_index = self._resolve_variable(var_name)
+            bytecode.append(self.inst(set_kind, args=[var_index]))
+
+        # Drop the struct pointer
+        bytecode.append(self.inst(InstKind.DROP))
+
+    def _compile_struct_literal(self, op: Op, bytecode: list[Inst]) -> None:
+        """Compile STRUCT_LITERAL op with named fields."""
+        literal = op.value
+        assert isinstance(literal, StructLiteral)
+        struct = literal.struct
+        member_count = len(struct.members)
+
+        # Map field names to their declaration index
+        decl_index_by_name = {m.name: i for i, m in enumerate(struct.members)}
+
+        # Store all field values into temp locals (top of stack = last in field_order)
+        temp_locals: dict[str, int] = {}
+        for field_name in reversed(literal.field_order):
+            local_idx = self.locals_count
+            self.locals_count += 1
+            temp_locals[field_name] = local_idx
+            bytecode.append(self.inst(InstKind.LOCAL_SET, args=[local_idx]))
+
+        # Allocate struct on heap
+        bytecode.append(self.inst(InstKind.PUSH, args=[member_count * 8]))
+        bytecode.append(self.inst(InstKind.HEAP_ALLOC))
+
+        # Store each field at its correct offset
+        for member in struct.members:
+            offset = decl_index_by_name[member.name] * 8
+            bytecode.append(self.inst(InstKind.DUP))
+            if offset > 0:
+                bytecode.append(self.inst(InstKind.PUSH, args=[offset]))
+                bytecode.append(self.inst(InstKind.ADD))
+            bytecode.append(
+                self.inst(InstKind.LOCAL_GET, args=[temp_locals[member.name]])
+            )
+            bytecode.append(self.inst(InstKind.SWAP))
+            bytecode.append(self.inst(InstKind.STORE64))
+
     def _compile_function(self, function: Function, op: Op) -> None:
         """Compile a function if not already compiled."""
         if function.bytecode is not None:
@@ -551,7 +615,7 @@ class Compiler:
     def compile(self) -> Bytecode:
         """Lower all ops to bytecode instructions."""
         assert len(InstKind) == 68, "Exhaustive handling for `InstructionKind"
-        assert len(OpKind) == 88, "Exhaustive handling for `OpKind`"
+        assert len(OpKind) == 89, "Exhaustive handling for `OpKind`"
 
         cursor = Cursor(sequence=self.ops)
         bytecode: list[Inst] = []
@@ -668,6 +732,8 @@ class Compiler:
                     self._compile_tagged_wrapper(0, bytecode)
                 case OpKind.STRUCT_NEW:
                     self._compile_struct_new(op, bytecode)
+                case OpKind.STRUCT_LITERAL:
+                    self._compile_struct_literal(op, bytecode)
                 case (
                     OpKind.WHILE_BREAK
                     | OpKind.WHILE_CONDITION
@@ -677,7 +743,7 @@ class Compiler:
                 ):
                     self._compile_while_block(op, bytecode)
                 case _:
-                    assert_never(op.kind)
+                    raise AssertionError(f"Unhandled OpKind: {op.kind}")
 
         if self.locals_count > 0:
             bytecode.insert(0, Inst(InstKind.LOCALS_INIT, args=[self.locals_count]))

--- a/casa/common.py
+++ b/casa/common.py
@@ -383,6 +383,7 @@ class OpKind(Enum):
 
     # Structs
     STRUCT_NEW = auto()
+    STRUCT_LITERAL = auto()
 
     # Types
     TYPE_CAST = auto()
@@ -412,7 +413,7 @@ class Op:
     deferred_return_type: str | None = None
 
     def __post_init__(self):
-        assert len(OpKind) == 88, "Exhaustive handling for `OpKind`"
+        assert len(OpKind) == 89, "Exhaustive handling for `OpKind`"
 
         match self.kind:
             # Value constructors (no value validation needed)
@@ -483,10 +484,23 @@ class Op:
                 if not isinstance(self.value, Intrinsic):
                     raise TypeError(f"`{self.kind}` requires value of type `Intrinsic`")
             # Requires `EnumVariant`
-            case OpKind.PUSH_ENUM_VARIANT | OpKind.MATCH_ARM:
+            case OpKind.PUSH_ENUM_VARIANT:
                 if not isinstance(self.value, EnumVariant):
                     raise TypeError(
                         f"`{self.kind}` requires value of type `EnumVariant`"
+                    )
+            # Requires `EnumVariant` or `StructPattern`
+            case OpKind.MATCH_ARM:
+                if not isinstance(self.value, (EnumVariant, StructPattern)):
+                    raise TypeError(
+                        f"`{self.kind}` requires value of type"
+                        " `EnumVariant` or `StructPattern`"
+                    )
+            # Requires `StructLiteral`
+            case OpKind.STRUCT_LITERAL:
+                if not isinstance(self.value, StructLiteral):
+                    raise TypeError(
+                        f"`{self.kind}` requires value of type `StructLiteral`"
                     )
             # Requires `Keyword`
             case (
@@ -1005,6 +1019,27 @@ class EnumVariant:
     def is_wildcard(self) -> bool:
         """Check if this variant is a wildcard pattern."""
         return self.variant_name == MATCH_WILDCARD
+
+
+@dataclass
+class StructLiteral:
+    """A struct construction with named fields."""
+
+    struct: "Struct"
+    field_order: list[str]
+
+
+@dataclass
+class StructPattern:
+    """A struct destructuring pattern in a match arm."""
+
+    struct_name: str
+    bindings: dict[str, str]  # field_name -> variable_name
+
+    @property
+    def is_wildcard(self) -> bool:
+        """Struct patterns are never wildcards."""
+        return False
 
 
 @dataclass

--- a/casa/parser.py
+++ b/casa/parser.py
@@ -29,6 +29,8 @@ from casa.common import (
     Signature,
     Span,
     Struct,
+    StructLiteral,
+    StructPattern,
     Token,
     TokenKind,
     Trait,
@@ -451,6 +453,15 @@ def resolve_identifiers(
                         op.location,
                     )
                 )
+            case OpKind.MATCH_ARM:
+                if isinstance(op.value, StructPattern):
+                    for var_name in op.value.bindings.values():
+                        variable = Variable(var_name)
+                        if function:
+                            if variable not in function.variables:
+                                function.variables.append(variable)
+                        else:
+                            GLOBAL_VARIABLES[var_name] = variable
             case OpKind.INCLUDE_FILE:
                 included_file = op.value
                 assert isinstance(included_file, Path), "Expected included file path"
@@ -471,6 +482,126 @@ def resolve_identifiers(
         raise CasaErrorCollection(errors)
 
     return ops
+
+
+def _is_struct_field_boundary(cursor: Cursor[Token], member_names: set[str]) -> bool:
+    """Check if current position is a struct field like `field_name:`."""
+    pos = cursor.position
+    seq = cursor.sequence
+    if pos + 1 >= len(seq):
+        return False
+    token = seq[pos]
+    if token.kind != TokenKind.IDENTIFIER:
+        return False
+    if token.value not in member_names:
+        return False
+    return seq[pos + 1].value == ":"
+
+
+def _parse_struct_field_value(
+    cursor: Cursor[Token],
+    struct: Struct,
+    member_names: set[str],
+    function_name: str,
+    all_ops: list[Op],
+) -> None:
+    """Parse a single field's value expression in a struct literal."""
+    while not cursor.is_finished():
+        peek = cursor.peek()
+        if not peek or peek.value == "}":
+            break
+        if _is_struct_field_boundary(cursor, member_names):
+            break
+        # Check for unknown field name (identifier followed by `:`)
+        if (
+            peek.kind == TokenKind.IDENTIFIER
+            and peek.value not in member_names
+            and cursor.position + 1 < len(cursor.sequence)
+            and cursor.sequence[cursor.position + 1].value == ":"
+        ):
+            raise_error(
+                ErrorKind.UNDEFINED_NAME,
+                f"Struct `{struct.name}` has no field `{peek.value}`",
+                peek.location,
+            )
+        value_token = cursor.pop()
+        assert value_token is not None
+        if value_token.kind == TokenKind.FSTRING_START:
+            handle_fstring(value_token, cursor, function_name, all_ops)
+            continue
+        _append_op_result(all_ops, token_to_op(value_token, cursor, function_name))
+
+
+def _parse_struct_literal(
+    name_token: Token,
+    struct: Struct,
+    cursor: Cursor[Token],
+    function_name: str,
+) -> list[Op]:
+    """Parse a struct literal: StructName { field: value ... }."""
+    expect_token(cursor, value="{")
+    member_names = {m.name for m in struct.members}
+    field_order: list[str] = []
+    all_ops: list[Op] = []
+    seen_fields: set[str] = set()
+
+    while True:
+        next_tok = cursor.peek()
+        if not next_tok:
+            raise_error(
+                ErrorKind.UNEXPECTED_TOKEN,
+                "Unexpected end of input in struct literal",
+                name_token.location,
+                expected="`}`",
+                got="end of input",
+            )
+        if next_tok.value == "}":
+            cursor.pop()
+            break
+
+        # Parse field name
+        field_token = expect_token(cursor, kind=TokenKind.IDENTIFIER)
+        if field_token.value not in member_names:
+            raise_error(
+                ErrorKind.UNDEFINED_NAME,
+                f"Struct `{struct.name}` has no field `{field_token.value}`",
+                field_token.location,
+            )
+        if field_token.value in seen_fields:
+            raise_error(
+                ErrorKind.DUPLICATE_NAME,
+                f"Duplicate field `{field_token.value}` in struct literal",
+                field_token.location,
+            )
+        seen_fields.add(field_token.value)
+        field_order.append(field_token.value)
+
+        # Expect colon separator
+        expect_token(cursor, value=":")
+
+        # Parse value expression until next field boundary or `}`
+        value_start = len(all_ops)
+        _parse_struct_field_value(cursor, struct, member_names, function_name, all_ops)
+        if len(all_ops) == value_start:
+            raise_error(
+                ErrorKind.SYNTAX,
+                f"Missing value for field `{field_token.value}`" f" in struct literal",
+                field_token.location,
+            )
+
+    # Validate all fields are specified
+    missing = member_names - seen_fields
+    if missing:
+        names = ", ".join(f"`{n}`" for n in sorted(missing))
+        raise_error(
+            ErrorKind.TYPE_MISMATCH,
+            f"Missing fields in struct literal: {names}",
+            name_token.location,
+        )
+
+    literal = StructLiteral(struct, field_order)
+    all_ops.append(Op(literal, OpKind.STRUCT_LITERAL, name_token.location))
+    return all_ops
 
 
 def _append_op_result(ops: list[Op], result: "Op | list[Op] | None") -> None:
@@ -507,6 +638,11 @@ def token_to_op(
                 f"F-string token `{token.kind}` should be handled by handle_fstring"
             )
         case TokenKind.IDENTIFIER:
+            next_tok = cursor.peek()
+            if next_tok and next_tok.value == "{":
+                struct = GLOBAL_STRUCTS.get(token.value)
+                if struct:
+                    return _parse_struct_literal(token, struct, cursor, function_name)
             return Op(token.value, OpKind.IDENTIFIER, token.location)
         case TokenKind.LITERAL:
             return get_op_literal(token)
@@ -745,7 +881,63 @@ def _is_match_arm_boundary(cursor: Cursor[Token]) -> bool:
         return True
     if token.kind != TokenKind.IDENTIFIER:
         return False
-    return seq[pos + 1].value == "=>"
+    next_value = seq[pos + 1].value
+    if next_value == "=>":
+        return True
+    if next_value == "{" and token.value in GLOBAL_STRUCTS:
+        return True
+    return False
+
+
+def _parse_struct_match_pattern(
+    name_token: Token, cursor: Cursor[Token]
+) -> StructPattern:
+    """Parse a struct destructuring pattern: StructName { field: var ... } =>."""
+    expect_token(cursor, value="{")
+    struct = GLOBAL_STRUCTS.get(name_token.value)
+    if not struct:
+        raise_error(
+            ErrorKind.UNDEFINED_NAME,
+            f"Struct `{name_token.value}` is not defined",
+            name_token.location,
+        )
+    member_names = {m.name for m in struct.members}
+    bindings: dict[str, str] = {}
+
+    while True:
+        next_tok = cursor.peek()
+        if not next_tok:
+            raise_error(
+                ErrorKind.UNEXPECTED_TOKEN,
+                "Unexpected end of input in struct pattern",
+                name_token.location,
+                expected="`}`",
+                got="end of input",
+            )
+        if next_tok.value == "}":
+            cursor.pop()
+            break
+
+        field_token = expect_token(cursor, kind=TokenKind.IDENTIFIER)
+        if field_token.value not in member_names:
+            raise_error(
+                ErrorKind.UNDEFINED_NAME,
+                f"Struct `{struct.name}` has no field `{field_token.value}`",
+                field_token.location,
+            )
+        if field_token.value in bindings:
+            raise_error(
+                ErrorKind.DUPLICATE_NAME,
+                f"Duplicate field `{field_token.value}` in struct pattern",
+                field_token.location,
+            )
+
+        expect_token(cursor, value=":")
+        var_token = expect_token(cursor, kind=TokenKind.IDENTIFIER)
+        bindings[field_token.value] = var_token.value
+
+    expect_token(cursor, value="=>")
+    return StructPattern(name_token.value, bindings)
 
 
 def _handle_keyword_match(
@@ -770,11 +962,15 @@ def _handle_keyword_match(
         elif arm_token.kind != TokenKind.IDENTIFIER:
             raise_error(
                 ErrorKind.UNEXPECTED_TOKEN,
-                "Expected enum variant pattern (e.g. `Enum::Variant`) or `_`",
+                "Expected match pattern or `_`",
                 arm_token.location,
-                expected="enum variant or `_`",
+                expected="enum variant, struct pattern, or `_`",
                 got=f"`{arm_token.value}`",
             )
+        elif (next_token := cursor.peek()) and next_token.value == "{":
+            # Struct pattern: StructName { field: var ... } =>
+            pattern = _parse_struct_match_pattern(arm_token, cursor)
+            ops.append(Op(pattern, OpKind.MATCH_ARM, arm_token.location))
         elif "::" not in arm_token.value:
             # Bare identifier, defer validation to the type checker
             expect_token(cursor, value="=>")
@@ -935,7 +1131,7 @@ def get_op_keyword(
             _handle_keyword_trait(token, cursor, function_name)
             return None
         case _:
-            assert_never(keyword)
+            raise AssertionError(f"Unhandled keyword: {keyword}")
 
 
 def parse_type(cursor: Cursor[Token]) -> Type:

--- a/casa/typechecker.py
+++ b/casa/typechecker.py
@@ -8,6 +8,7 @@ from casa.common import (
     ANY_TYPE,
     GLOBAL_ENUMS,
     GLOBAL_FUNCTIONS,
+    GLOBAL_STRUCTS,
     GLOBAL_TRAITS,
     GLOBAL_VARIABLES,
     MATCH_WILDCARD,
@@ -20,6 +21,8 @@ from casa.common import (
     Parameter,
     Signature,
     Struct,
+    StructLiteral,
+    StructPattern,
     Type,
     Variable,
     extract_fn_signature_str,
@@ -56,7 +59,7 @@ class BranchedStack:
     current_branch_label: str | None
     current_branch_location: Location | None
     if_location: Location | None
-    if_location_enum_name: str | None
+    if_location_match_type: str | None
 
     def __init__(
         self,
@@ -77,7 +80,7 @@ class BranchedStack:
         self.current_branch_label = None
         self.current_branch_location = None
         self.if_location = None
-        self.if_location_enum_name = None
+        self.if_location_match_type = None
 
 
 @dataclass
@@ -904,30 +907,129 @@ class TypeChecker:
         assert variant.enum_name is not None
         self.stack_push(variant.enum_name)
 
-    def check_match(self, op: Op) -> None:
+    @staticmethod
+    def _check_duplicate_arm(
+        covered_key: str,
+        display_name: str,
+        location: Location,
+        branched: BranchedStack,
+    ) -> None:
+        """Raise an error if a match arm has already been covered."""
+        for label, _, _ in branched.branch_records:
+            if label == covered_key:
+                raise_error(
+                    ErrorKind.DUPLICATE_NAME,
+                    f"Duplicate match arm for {display_name}",
+                    location,
+                )
+        if branched.current_branch_label == covered_key:
+            raise_error(
+                ErrorKind.DUPLICATE_NAME,
+                f"Duplicate match arm for {display_name}",
+                location,
+            )
+
+    def _check_match_arm_pattern(
+        self,
+        pattern: "EnumVariant | StructPattern",
+        match_type: str,
+        location: Location,
+        branched: BranchedStack,
+    ) -> str:
+        """Validate a match arm pattern and return its covered_key."""
+        if isinstance(pattern, StructPattern):
+            if pattern.struct_name != match_type:
+                raise_error(
+                    ErrorKind.TYPE_MISMATCH,
+                    f"Struct pattern `{pattern.struct_name}`"
+                    f" does not match type `{match_type}`",
+                    location,
+                )
+            covered_key = f"__covered:{pattern.struct_name}"
+            self._check_duplicate_arm(
+                covered_key, f"`{pattern.struct_name}`", location, branched
+            )
+            return covered_key
+
+        # EnumVariant pattern
+        variant = pattern
+        if variant.is_wildcard:
+            return f"__covered:{MATCH_WILDCARD}"
+
+        if variant.enum_name is None:
+            # Bare variant name without enum qualifier
+            casa_enum = GLOBAL_ENUMS[match_type]
+            assert casa_enum.variants
+            if variant.variant_name in casa_enum.variants:
+                raise_error(
+                    ErrorKind.TYPE_MISMATCH,
+                    f"Unqualified enum variant `{variant.variant_name}`."
+                    f" Did you mean `{match_type}::{variant.variant_name}`?",
+                    location,
+                )
+            raise_error(
+                ErrorKind.TYPE_MISMATCH,
+                f"Expected qualified enum variant"
+                f" (e.g. `{match_type}::{casa_enum.variants[0]}`) or `_`,"
+                f" got `{variant.variant_name}`",
+                location,
+            )
+
+        if variant.enum_name != match_type:
+            raise_error(
+                ErrorKind.TYPE_MISMATCH,
+                f"Match arm variant `{variant.enum_name}::{variant.variant_name}`"
+                f" does not belong to enum `{match_type}`",
+                location,
+            )
+
+        covered_key = f"__covered:{variant.variant_name}"
+        self._check_duplicate_arm(
+            covered_key,
+            f"`{variant.enum_name}::{variant.variant_name}`",
+            location,
+            branched,
+        )
+        return covered_key
+
+    @staticmethod
+    def _set_struct_binding_type(
+        var_name: str, field_type: Type, function: "Function | None"
+    ) -> None:
+        """Set the type on a variable bound in a struct match pattern."""
+        if function:
+            for variable in function.variables:
+                if variable.name == var_name:
+                    variable.typ = field_type
+                    return
+        global_var = GLOBAL_VARIABLES.get(var_name)
+        if global_var:
+            global_var.typ = field_type
+
+    def check_match(self, op: Op, function: "Function | None" = None) -> None:
         """Handle MATCH_START, MATCH_ARM, MATCH_END."""
         match op.kind:
             case OpKind.MATCH_START:
                 typ = self.stack_pop()
-                if typ not in GLOBAL_ENUMS:
+                if typ not in GLOBAL_ENUMS and typ not in GLOBAL_STRUCTS:
                     raise_error(
                         ErrorKind.TYPE_MISMATCH,
-                        f"Match requires an enum type, got `{typ}`",
+                        f"Match requires an enum or struct type, got `{typ}`",
                         op.location,
                     )
                 bs = BranchedStack(self.stack, self.stack_origins)
                 bs.if_location = op.location
-                bs.if_location_enum_name = typ
+                bs.if_location_match_type = typ
                 bs.default_present = True
                 self.branched_stacks.append(bs)
             case OpKind.MATCH_ARM:
-                variant = op.value
-                assert isinstance(variant, EnumVariant)
+                pattern = op.value
+                assert isinstance(pattern, (EnumVariant, StructPattern))
                 assert self.branched_stacks, "Match block stack state is saved"
                 branched = self.branched_stacks[-1]
 
-                enum_name = branched.if_location_enum_name
-                assert enum_name is not None
+                match_type = branched.if_location_match_type
+                assert match_type is not None
 
                 # Check for arms after wildcard
                 wildcard_key = f"__covered:{MATCH_WILDCARD}"
@@ -945,51 +1047,12 @@ class TypeChecker:
                         op.location,
                     )
 
-                if variant.is_wildcard:
-                    covered_key = wildcard_key
-                elif variant.enum_name is None:
-                    # Bare variant name without enum qualifier
-                    casa_enum = GLOBAL_ENUMS[enum_name]
-                    assert casa_enum.variants
-                    if variant.variant_name in casa_enum.variants:
-                        raise_error(
-                            ErrorKind.TYPE_MISMATCH,
-                            f"Unqualified enum variant `{variant.variant_name}`."
-                            f" Did you mean `{enum_name}::{variant.variant_name}`?",
-                            op.location,
-                        )
-                    raise_error(
-                        ErrorKind.TYPE_MISMATCH,
-                        f"Expected qualified enum variant"
-                        f" (e.g. `{enum_name}::{casa_enum.variants[0]}`) or `_`,"
-                        f" got `{variant.variant_name}`",
-                        op.location,
-                    )
-                else:
-                    if variant.enum_name != enum_name:
-                        raise_error(
-                            ErrorKind.TYPE_MISMATCH,
-                            f"Match arm variant `{variant.enum_name}::{variant.variant_name}`"
-                            f" does not belong to enum `{enum_name}`",
-                            op.location,
-                        )
-
-                    covered_key = f"__covered:{variant.variant_name}"
-                    # Check for duplicate: in branch_records or the current label
-                    for label, _, _ in branched.branch_records:
-                        if label == covered_key:
-                            raise_error(
-                                ErrorKind.DUPLICATE_NAME,
-                                f"Duplicate match arm for"
-                                f" `{variant.enum_name}::{variant.variant_name}`",
-                                op.location,
-                            )
-                    if branched.current_branch_label == covered_key:
-                        raise_error(
-                            ErrorKind.DUPLICATE_NAME,
-                            f"Duplicate match arm for `{variant.enum_name}::{variant.variant_name}`",
-                            op.location,
-                        )
+                covered_key = self._check_match_arm_pattern(
+                    pattern,
+                    match_type,
+                    op.location,
+                    branched,
+                )
 
                 # Handle branch state like elif
                 if branched.condition_present:
@@ -1029,6 +1092,14 @@ class TypeChecker:
                     branched.after = branched.before
                     branched.after_origins = branched.before_origins
 
+                # For struct patterns, set types on bound variables
+                if isinstance(pattern, StructPattern):
+                    struct = GLOBAL_STRUCTS[pattern.struct_name]
+                    member_type_by_name = {m.name: m.typ for m in struct.members}
+                    for field_name, var_name in pattern.bindings.items():
+                        field_type = member_type_by_name[field_name]
+                        self._set_struct_binding_type(var_name, field_type, function)
+
                 branched.current_branch_label = covered_key
                 branched.current_branch_location = op.location
 
@@ -1050,25 +1121,35 @@ class TypeChecker:
                         )
                     )
 
-                # Extract enum name from if_location metadata
-                enum_name = branched.if_location_enum_name
-                assert enum_name is not None
-                casa_enum = GLOBAL_ENUMS[enum_name]
+                # Extract matched type from if_location metadata
+                match_type = branched.if_location_match_type
+                assert match_type is not None
                 covered = {
                     label.split(":", 1)[1]
                     for label, _, _ in branched.branch_records
                     if label.startswith("__covered:")
                 }
                 has_wildcard = MATCH_WILDCARD in covered
-                if not has_wildcard:
-                    missing = [v for v in casa_enum.variants if v not in covered]
-                    if missing:
-                        names = ", ".join(f"`{enum_name}::{v}`" for v in missing)
+
+                if match_type in GLOBAL_STRUCTS:
+                    # Struct match: one struct arm or wildcard is exhaustive
+                    if not has_wildcard and match_type not in covered:
                         raise_error(
                             ErrorKind.TYPE_MISMATCH,
-                            f"Non-exhaustive match, missing arms: {names}",
+                            f"Non-exhaustive match on struct `{match_type}`",
                             op.location,
                         )
+                else:
+                    casa_enum = GLOBAL_ENUMS[match_type]
+                    if not has_wildcard:
+                        missing = [v for v in casa_enum.variants if v not in covered]
+                        if missing:
+                            names = ", ".join(f"`{match_type}::{v}`" for v in missing)
+                            raise_error(
+                                ErrorKind.TYPE_MISMATCH,
+                                f"Non-exhaustive match, missing arms: {names}",
+                                op.location,
+                            )
 
                 # Apply final stack state
                 # Identity check: after is the same object as before when only
@@ -1112,6 +1193,37 @@ class TypeChecker:
         # Generic struct: bind type vars from actual stack types
         param_struct_type = f"{struct.name}[{' '.join(struct.type_vars)}]"
         params = [Parameter(m.typ) for m in struct.members]
+        sig = Signature(
+            params,
+            [param_struct_type],
+            type_vars=set(struct.type_vars),
+        )
+        self.apply_signature(sig, struct.name)
+
+    def check_struct_literal(self, op: Op) -> None:
+        """Handle STRUCT_LITERAL."""
+        literal = op.value
+        assert isinstance(literal, StructLiteral)
+        struct = literal.struct
+
+        if not struct.type_vars:
+            member_types = " ".join(m.typ for m in struct.members)
+            self.current_op_context = (
+                f"`{struct.name}` ({member_types} -> {struct.name})"
+            )
+            # Pop field values in reverse parse order (last pushed is on top)
+            member_type_by_name = {m.name: m.typ for m in struct.members}
+            for field_name in reversed(literal.field_order):
+                self.current_expect_context = f"field `{field_name}` of `{struct.name}`"
+                self.expect_type(member_type_by_name[field_name])
+            self.current_expect_context = None
+            self.stack_push(struct.name)
+            return
+
+        # Generic struct: build a signature with fields in parse order
+        member_type_by_name = {m.name: m.typ for m in struct.members}
+        params = [Parameter(member_type_by_name[name]) for name in literal.field_order]
+        param_struct_type = f"{struct.name}[{' '.join(struct.type_vars)}]"
         sig = Signature(
             params,
             [param_struct_type],
@@ -1565,7 +1677,7 @@ def _try_specialize_deferred_exec(
         existing = clone
 
     # Verify the clone's parameter type matches the concrete argument type
-    if existing.signature.parameters:
+    if existing.signature and existing.signature.parameters:
         expected_param = existing.signature.parameters[0].typ
         if (
             expected_param != concrete_type
@@ -1574,7 +1686,7 @@ def _try_specialize_deferred_exec(
         ):
             raise_error(
                 ErrorKind.TYPE_MISMATCH,
-                f"Type mismatch in deferred method call",
+                "Type mismatch in deferred method call",
                 exec_op.location,
                 expected=f"`{expected_param}`",
                 got=f"`{concrete_type}`",
@@ -1835,7 +1947,7 @@ def type_satisfies_trait(
 
 def type_check_ops(ops: list[Op], function: Function | None = None) -> Signature:
     """Type-check a list of ops and return the inferred signature."""
-    assert len(OpKind) == 88, "Exhaustive handling for `OpKind`"
+    assert len(OpKind) == 89, "Exhaustive handling for `OpKind`"
 
     tc = TypeChecker(ops=ops)
     op_index = 0
@@ -1940,9 +2052,11 @@ def type_check_ops(ops: list[Op], function: Function | None = None) -> Signature
             case OpKind.PUSH_ENUM_VARIANT:
                 tc.check_enum_variant(op)
             case OpKind.MATCH_START | OpKind.MATCH_ARM | OpKind.MATCH_END:
-                tc.check_match(op)
+                tc.check_match(op, function)
             case OpKind.STRUCT_NEW:
                 tc.check_struct_new(op)
+            case OpKind.STRUCT_LITERAL:
+                tc.check_struct_literal(op)
             case OpKind.METHOD_CALL:
                 op_index = tc.check_method_call(op, ops, op_index, function)
             case OpKind.TYPE_CAST:

--- a/docs/structs-and-methods.md
+++ b/docs/structs-and-methods.md
@@ -11,9 +11,29 @@ struct Person {
 }
 ```
 
-## Instantiation
+## Struct Literals
 
-Push fields onto the stack in reverse declaration order (last declared field deepest, first declared field on top), then call the struct name. Fields are popped from the top in declaration order.
+Construct a struct with named fields inside braces. Fields can appear in any order. All fields must be specified.
+
+```casa
+Person { name: "John Doe" age: 18 } = person
+```
+
+Field order does not matter:
+
+```casa
+Person { age: 18 name: "John Doe" } = person
+```
+
+Each field value is an arbitrary expression:
+
+```casa
+Person { name: first_name " " str::concat last_name str::concat age: birth_year current_year swap - } = person
+```
+
+## Stack-Based Instantiation
+
+Alternatively, push fields onto the stack in reverse declaration order (last declared field deepest, first declared field on top), then call the struct name.
 
 **Stack effect:** `fieldN ... field2 field1 -> StructName`
 
@@ -21,7 +41,7 @@ Push fields onto the stack in reverse declaration order (last declared field dee
 18 "John Doe" Person = person
 ```
 
-Here `18` (`age`, last declared) is pushed first and sits deepest. `"John Doe"` (`name`, first declared) is pushed second and sits on top. The struct constructor pops fields in declaration order: `name` first (from top), then `age`.
+Here `18` (`age`, last declared) is pushed first and sits deepest. `"John Doe"` (`name`, first declared) is pushed second and sits on top.
 
 ## Auto-Generated Accessors
 
@@ -222,7 +242,7 @@ impl Person {
 }
 
 # Instantiate
-18 "John Doe" Person = person
+Person { name: "John Doe" age: 18 } = person
 
 # Getters
 person.name print       # John Doe
@@ -238,6 +258,32 @@ person.age print        # 19
 ```
 
 See [`examples/struct.casa`](../examples/struct.casa).
+
+## Struct Destructuring in Match
+
+Structs can be destructured in `match` expressions. Each arm binds struct fields to local variables.
+
+```casa
+person match
+    Person { name: n age: a } => n print a print
+end
+```
+
+Partial destructuring is allowed — you do not need to bind every field:
+
+```casa
+person match
+    Person { name: n } => n print
+end
+```
+
+A single struct pattern arm is exhaustive (structs have one shape). A wildcard `_` arm is also valid:
+
+```casa
+person match
+    _ => "any person" print
+end
+```
 
 ## Traits
 

--- a/examples/outputs/struct.out
+++ b/examples/outputs/struct.out
@@ -2,3 +2,4 @@ John Doe
 18
 Jane Doe
 19
+Jane Doe is 19

--- a/examples/struct.casa
+++ b/examples/struct.casa
@@ -9,8 +9,8 @@ impl Person {
     }
 }
 
-# Struct is instantiated using struct's name
-18 "John Doe" Person = person
+# Struct literal construction with named fields
+Person { name: "John Doe" age: 18 } = person
 
 # Getters:
 #   Person::name
@@ -29,3 +29,8 @@ person Person::name print "\n" print
 #   person->age <==> person Person::set_age
 person.celebrate_birthday
 person.age print "\n" print
+
+# Struct destructuring in match
+person match
+    Person { name: n age: a } => n print " is " print a print "\n" print
+end

--- a/tests/test_struct_literal.py
+++ b/tests/test_struct_literal.py
@@ -1,0 +1,335 @@
+"""Tests for struct literal construction and struct match destructuring."""
+
+import pytest
+
+from casa.common import (
+    Op,
+    OpKind,
+    StructLiteral,
+    StructPattern,
+)
+from casa.error import CasaErrorCollection, ErrorKind
+from tests.conftest import (
+    emit_string,
+    parse_string,
+    typecheck_string,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def find_ops(ops: list[Op], kind: OpKind) -> list[Op]:
+    return [op for op in ops if op.kind == kind]
+
+
+# ---------------------------------------------------------------------------
+# Parser — struct literal construction
+# ---------------------------------------------------------------------------
+class TestParseStructLiteral:
+    def test_basic_struct_literal(self):
+        ops = parse_string("""\
+struct Point { x: int y: int }
+Point { x: 1 y: 2 }""")
+        literals = find_ops(ops, OpKind.STRUCT_LITERAL)
+        assert len(literals) == 1
+        literal = literals[0].value
+        assert isinstance(literal, StructLiteral)
+        assert literal.struct.name == "Point"
+        assert literal.field_order == ["x", "y"]
+
+    def test_reverse_field_order(self):
+        ops = parse_string("""\
+struct Point { x: int y: int }
+Point { y: 2 x: 1 }""")
+        literal = find_ops(ops, OpKind.STRUCT_LITERAL)[0].value
+        assert literal.field_order == ["y", "x"]
+
+    def test_missing_field_error(self):
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            parse_string("""\
+struct Point { x: int y: int }
+Point { x: 1 }""")
+        assert exc_info.value.errors[0].kind == ErrorKind.TYPE_MISMATCH
+
+    def test_unknown_field_error(self):
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            parse_string("""\
+struct Point { x: int y: int }
+Point { z: 1 y: 2 }""")
+        assert exc_info.value.errors[0].kind == ErrorKind.UNDEFINED_NAME
+
+    def test_unknown_field_mid_literal_error(self):
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            parse_string("""\
+struct Point { x: int y: int }
+Point { x: 1 z: 2 }""")
+        assert exc_info.value.errors[0].kind == ErrorKind.UNDEFINED_NAME
+
+    def test_duplicate_field_error(self):
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            parse_string("""\
+struct Point { x: int y: int }
+Point { x: 1 x: 2 y: 3 }""")
+        assert exc_info.value.errors[0].kind == ErrorKind.DUPLICATE_NAME
+
+    def test_empty_literal_error(self):
+        with pytest.raises(CasaErrorCollection):
+            parse_string("""\
+struct Point { x: int y: int }
+Point { }""")
+
+    def test_field_value_with_expression(self):
+        ops = parse_string("""\
+struct Point { x: int y: int }
+Point { x: 1 2 + y: 3 }""")
+        literals = find_ops(ops, OpKind.STRUCT_LITERAL)
+        assert len(literals) == 1
+
+    def test_missing_value_error(self):
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            parse_string("""\
+struct Point { x: int y: int }
+Point { x: y: 1 }""")
+        assert exc_info.value.errors[0].kind == ErrorKind.SYNTAX
+
+
+# ---------------------------------------------------------------------------
+# Parser — struct match pattern
+# ---------------------------------------------------------------------------
+class TestParseStructMatchPattern:
+    def test_basic_struct_pattern(self):
+        ops = parse_string("""\
+struct Point { x: int y: int }
+1 2 Point = p
+p match
+    Point { x: px y: py } => px py +
+end""")
+        arms = find_ops(ops, OpKind.MATCH_ARM)
+        assert len(arms) == 1
+        pattern = arms[0].value
+        assert isinstance(pattern, StructPattern)
+        assert pattern.struct_name == "Point"
+        assert pattern.bindings == {"x": "px", "y": "py"}
+
+    def test_partial_binding(self):
+        ops = parse_string("""\
+struct Point { x: int y: int }
+1 2 Point = p
+p match
+    Point { x: px } => px
+end""")
+        pattern = find_ops(ops, OpKind.MATCH_ARM)[0].value
+        assert isinstance(pattern, StructPattern)
+        assert pattern.bindings == {"x": "px"}
+
+    def test_wildcard_arm(self):
+        ops = parse_string("""\
+struct Point { x: int y: int }
+1 2 Point = p
+p match
+    _ => 0
+end""")
+        arms = find_ops(ops, OpKind.MATCH_ARM)
+        assert len(arms) == 1
+        assert arms[0].value.is_wildcard
+
+    def test_unknown_struct_in_pattern_error(self):
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            parse_string("""\
+struct Point { x: int y: int }
+1 2 Point = p
+p match
+    Rect { x: px } => px
+end""")
+        assert exc_info.value.errors[0].kind == ErrorKind.UNDEFINED_NAME
+
+    def test_unknown_field_in_pattern_error(self):
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            parse_string("""\
+struct Point { x: int y: int }
+1 2 Point = p
+p match
+    Point { z: pz } => pz
+end""")
+        assert exc_info.value.errors[0].kind == ErrorKind.UNDEFINED_NAME
+
+    def test_duplicate_field_in_pattern_error(self):
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            parse_string("""\
+struct Point { x: int y: int }
+1 2 Point = p
+p match
+    Point { x: a x: b } => a
+end""")
+        assert exc_info.value.errors[0].kind == ErrorKind.DUPLICATE_NAME
+
+
+# ---------------------------------------------------------------------------
+# Type checker — struct literal
+# ---------------------------------------------------------------------------
+class TestTypecheckStructLiteral:
+    def test_basic_type(self):
+        sig = typecheck_string("""\
+struct Point { x: int y: int }
+Point { x: 1 y: 2 }""")
+        assert sig.return_types == ["Point"]
+
+    def test_reverse_order_type(self):
+        sig = typecheck_string("""\
+struct Point { x: int y: int }
+Point { y: 2 x: 1 }""")
+        assert sig.return_types == ["Point"]
+
+    def test_wrong_field_type_error(self):
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            typecheck_string("""\
+struct Point { x: int y: int }
+Point { x: "hello" y: 2 }""")
+        assert exc_info.value.errors[0].kind == ErrorKind.TYPE_MISMATCH
+
+    def test_generic_struct_literal(self):
+        sig = typecheck_string("""\
+struct Box[T] { value: T }
+Box { value: 42 }""")
+        assert sig.return_types == ["Box[int]"]
+
+    def test_generic_struct_literal_str(self):
+        sig = typecheck_string("""\
+struct Box[T] { value: T }
+Box { value: "hello" }""")
+        assert sig.return_types == ["Box[str]"]
+
+
+# ---------------------------------------------------------------------------
+# Type checker — struct match
+# ---------------------------------------------------------------------------
+class TestTypecheckStructMatch:
+    def test_struct_match_exhaustive(self):
+        typecheck_string("""\
+struct Point { x: int y: int }
+1 2 Point = p
+p match
+    Point { x: px y: py } => px py +
+end
+drop""")
+
+    def test_struct_match_wildcard_exhaustive(self):
+        typecheck_string("""\
+struct Point { x: int y: int }
+1 2 Point = p
+p match
+    _ => 0
+end
+drop""")
+
+    def test_struct_match_non_exhaustive_error(self):
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            typecheck_string("""\
+struct Point { x: int y: int }
+1 2 Point = p
+p match
+end""")
+        assert exc_info.value.errors[0].kind == ErrorKind.TYPE_MISMATCH
+
+    def test_struct_match_wrong_struct_error(self):
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            typecheck_string("""\
+struct Point { x: int y: int }
+struct Rect { w: int h: int }
+1 2 Point = p
+p match
+    Rect { w: rw } => rw
+end""")
+        assert exc_info.value.errors[0].kind == ErrorKind.TYPE_MISMATCH
+
+    def test_struct_match_binding_types(self):
+        sig = typecheck_string("""\
+struct Person { name: str age: int }
+18 "Alice" Person = p
+p match
+    Person { name: n age: a } => n a
+end""")
+        assert sig.return_types == ["str", "int"]
+
+    def test_struct_match_partial_binding(self):
+        sig = typecheck_string("""\
+struct Point { x: int y: int }
+1 2 Point = p
+p match
+    Point { x: px } => px
+end""")
+        assert sig.return_types == ["int"]
+
+    def test_struct_match_duplicate_arm_error(self):
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            typecheck_string("""\
+struct Point { x: int y: int }
+1 2 Point = p
+p match
+    Point { x: px } => px
+    Point { y: py } => py
+end""")
+        assert exc_info.value.errors[0].kind == ErrorKind.DUPLICATE_NAME
+
+    def test_match_on_non_enum_non_struct_error(self):
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            typecheck_string("""\
+42 match
+    _ => 0
+end""")
+        assert exc_info.value.errors[0].kind == ErrorKind.TYPE_MISMATCH
+
+
+# ---------------------------------------------------------------------------
+# Bytecode / integration — struct literal
+# ---------------------------------------------------------------------------
+class TestCompileStructLiteral:
+    def test_compile_struct_literal(self):
+        emit_string("""\
+struct Point { x: int y: int }
+Point { x: 1 y: 2 } = p
+p.x drop""")
+
+    def test_compile_struct_literal_reverse_order(self):
+        emit_string("""\
+struct Point { x: int y: int }
+Point { y: 99 x: 42 } = p
+p.x drop""")
+
+    def test_compile_struct_match(self):
+        emit_string("""\
+struct Point { x: int y: int }
+1 2 Point = p
+p match
+    Point { x: px y: py } => px py +
+end
+drop""")
+
+    def test_compile_struct_match_as_expression(self):
+        emit_string("""\
+struct Point { x: int y: int }
+1 2 Point = p
+p match
+    Point { x: px } => px
+end
+drop""")
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility
+# ---------------------------------------------------------------------------
+class TestBackwardCompatibility:
+    def test_stack_based_construction_still_works(self):
+        sig = typecheck_string("""\
+struct Point { x: int y: int }
+1 2 Point""")
+        assert sig.return_types == ["Point"]
+
+    def test_stack_based_and_literal_coexist(self):
+        sig = typecheck_string("""\
+struct Point { x: int y: int }
+1 2 Point = p1
+Point { x: 3 y: 4 } = p2
+p1.x p2.x +""")
+        assert sig.return_types == ["int"]


### PR DESCRIPTION
## Summary
- Add named-field struct construction syntax: `Person { name: "John" age: 18 }`
- Add struct destructuring in match expressions: `Person { name: n age: a } => ...`
- Fix pre-existing mypy errors in bytecode.py, parser.py, and typechecker.py

## Test plan
- [x] 34 new unit tests in `tests/test_struct_literal.py` covering parser, type checker, bytecode, and backward compatibility
- [x] Updated `examples/struct.casa` with both new syntax forms
- [x] All 979 pytest tests pass
- [x] All 31 example integration tests pass
- [x] mypy: 0 errors
- [x] black: no reformatting needed