### PR TITLE
feat: add enum inner values, generics, and reimplement Option/Result as enums

### DIFF
--- a/casa/bytecode.py
+++ b/casa/bytecode.py
@@ -4,11 +4,13 @@ from collections.abc import Iterable
 from dataclasses import dataclass, field
 
 from casa.common import (
+    GLOBAL_ENUMS,
     GLOBAL_FUNCTIONS,
     GLOBAL_SCOPE_LABEL,
     GLOBAL_STRUCTS,
     GLOBAL_VARIABLES,
     Bytecode,
+    CasaEnum,
     Cursor,
     EnumVariant,
     Function,
@@ -475,6 +477,12 @@ class Compiler:
 
                 if isinstance(pattern, StructPattern):
                     self._compile_struct_match_arm(pattern, bytecode)
+                elif (
+                    isinstance(pattern, EnumVariant)
+                    and pattern.enum_name
+                    and GLOBAL_ENUMS[pattern.enum_name].has_inner_values
+                ):
+                    self._compile_enum_match_arm(pattern, is_last, next_arm, bytecode)
                 elif is_last:
                     bytecode.append(self.inst(InstKind.DROP))
                 else:
@@ -488,28 +496,95 @@ class Compiler:
                 end_label = op_to_label(op)
                 bytecode.append(self.inst(InstKind.LABEL, args=[end_label]))
 
-    def _compile_tagged_wrapper(self, tag: int, bytecode: list[Inst]) -> None:
-        """Compile a tagged heap wrapper (used by some/ok/error)."""
+    def _compile_enum_variant(
+        self,
+        variant: EnumVariant,
+        casa_enum: "CasaEnum",
+        bytecode: list[Inst],
+    ) -> None:
+        """Compile a data-carrying enum variant construction."""
+        inner_types = casa_enum.variant_types.get(variant.variant_name, [])
+        slot_count = 1 + len(inner_types)  # ordinal + inner values
+
+        # Store inner values from stack into temp locals (reverse order)
+        temp_locals: list[int] = []
+        for _ in inner_types:
+            local_idx = self.locals_count
+            self.locals_count += 1
+            temp_locals.append(local_idx)
+            bytecode.append(self.inst(InstKind.LOCAL_SET, args=[local_idx]))
+
+        # Allocate heap: slot_count * 8 bytes
         local_ptr = self.locals_count
         self.locals_count += 1
-        bytecode.append(self.inst(InstKind.PUSH, args=[16]))
+        bytecode.append(self.inst(InstKind.PUSH, args=[slot_count * 8]))
         bytecode.append(self.inst(InstKind.HEAP_ALLOC))
         bytecode.append(self.inst(InstKind.LOCAL_SET, args=[local_ptr]))
-        # Store value at byte offset 8
-        bytecode.append(self.inst(InstKind.LOCAL_GET, args=[local_ptr]))
-        bytecode.append(self.inst(InstKind.PUSH, args=[8]))
-        bytecode.append(self.inst(InstKind.ADD))
-        bytecode.append(self.inst(InstKind.STORE64))
-        # Store tag at byte offset 0
-        bytecode.append(self.inst(InstKind.PUSH, args=[tag]))
+
+        # Store ordinal at offset 0
+        bytecode.append(self.inst(InstKind.PUSH, args=[variant.ordinal]))
         bytecode.append(self.inst(InstKind.LOCAL_GET, args=[local_ptr]))
         bytecode.append(self.inst(InstKind.STORE64))
+
+        # Store inner values at offsets 8, 16, ...
+        for i, local_idx in enumerate(reversed(temp_locals)):
+            offset = (i + 1) * 8
+            bytecode.append(self.inst(InstKind.LOCAL_GET, args=[local_ptr]))
+            bytecode.append(self.inst(InstKind.PUSH, args=[offset]))
+            bytecode.append(self.inst(InstKind.ADD))
+            bytecode.append(self.inst(InstKind.LOCAL_GET, args=[local_idx]))
+            bytecode.append(self.inst(InstKind.SWAP))
+            bytecode.append(self.inst(InstKind.STORE64))
+
         # Push ptr
         bytecode.append(self.inst(InstKind.LOCAL_GET, args=[local_ptr]))
 
-    def _compile_some(self, bytecode: list[Inst]) -> None:
-        """Compile SOME op -- wraps top of stack in an option."""
-        self._compile_tagged_wrapper(1, bytecode)
+    def _compile_enum_comparison(self, op: Op, bytecode: list[Inst]) -> None:
+        """Compile comparison for data-carrying enums (compare ordinals from heap)."""
+        # Stack: [enum_ptr_a, enum_ptr_b] -> load ordinals and compare
+        local_a = self.locals_count
+        self.locals_count += 1
+        bytecode.append(self.inst(InstKind.LOCAL_SET, args=[local_a]))
+        # Load ordinal from top value (b)
+        bytecode.append(self.inst(InstKind.LOAD64))
+        # Load ordinal from saved value (a)
+        bytecode.append(self.inst(InstKind.LOCAL_GET, args=[local_a]))
+        bytecode.append(self.inst(InstKind.LOAD64))
+        # Compare ordinals
+        inst_kind = InstKind.EQ if op.kind == OpKind.EQ else InstKind.NE
+        bytecode.append(self.inst(inst_kind))
+
+    def _compile_enum_match_arm(
+        self,
+        pattern: EnumVariant,
+        is_last: bool,
+        next_arm: LabelId | None,
+        bytecode: list[Inst],
+    ) -> None:
+        """Compile a data-carrying enum match arm."""
+        assert pattern.enum_name is not None
+        casa_enum = GLOBAL_ENUMS[pattern.enum_name]
+
+        if not is_last and not pattern.is_wildcard:
+            # Compare ordinal: DUP ptr, LOAD64 tag, compare
+            bytecode.append(self.inst(InstKind.DUP))
+            bytecode.append(self.inst(InstKind.LOAD64))
+            bytecode.append(self.inst(InstKind.PUSH, args=[pattern.ordinal]))
+            bytecode.append(self.inst(InstKind.EQ))
+            bytecode.append(self.inst(InstKind.JUMP_NE, args=[next_arm]))
+
+        # Extract bindings from inner values
+        for i, var_name in enumerate(pattern.bindings):
+            offset = (i + 1) * 8
+            bytecode.append(self.inst(InstKind.DUP))
+            bytecode.append(self.inst(InstKind.PUSH, args=[offset]))
+            bytecode.append(self.inst(InstKind.ADD))
+            bytecode.append(self.inst(InstKind.LOAD64))
+            _, set_kind, var_index = self._resolve_variable(var_name)
+            bytecode.append(self.inst(set_kind, args=[var_index]))
+
+        # Drop the enum pointer
+        bytecode.append(self.inst(InstKind.DROP))
 
     def _compile_struct_new(self, op: Op, bytecode: list[Inst]) -> None:
         """Compile STRUCT_NEW op."""
@@ -615,7 +690,7 @@ class Compiler:
     def compile(self) -> Bytecode:
         """Lower all ops to bytecode instructions."""
         assert len(InstKind) == 68, "Exhaustive handling for `InstructionKind"
-        assert len(OpKind) == 89, "Exhaustive handling for `OpKind`"
+        assert len(OpKind) == 85, "Exhaustive handling for `OpKind`"
 
         cursor = Cursor(sequence=self.ops)
         bytecode: list[Inst] = []
@@ -629,6 +704,19 @@ class Compiler:
         while op := cursor.pop():
             self._current_loc = op.location
             if op.kind in DIRECT_OP_TO_INST:
+                # Data-carrying enum comparison: load ordinals from heap
+                if (
+                    op.kind in (OpKind.EQ, OpKind.NE)
+                    and op.type_annotation
+                    and op.type_annotation in GLOBAL_ENUMS
+                ):
+                    self._compile_enum_comparison(op, bytecode)
+                    continue
+                # Data-carrying enum print: load ordinal from heap
+                if op.kind == OpKind.PRINT_INT and op.type_annotation:
+                    bytecode.append(self.inst(InstKind.LOAD64))
+                    bytecode.append(self.inst(InstKind.PRINT_INT))
+                    continue
                 bytecode.append(self.inst(DIRECT_OP_TO_INST[op.kind]))
                 continue
             match op.kind:
@@ -668,7 +756,14 @@ class Compiler:
                 case OpKind.PUSH_ENUM_VARIANT:
                     variant = op.value
                     assert isinstance(variant, EnumVariant)
-                    bytecode.append(self.inst(InstKind.PUSH, args=[variant.ordinal]))
+                    assert variant.enum_name is not None
+                    casa_enum = GLOBAL_ENUMS[variant.enum_name]
+                    if casa_enum.has_inner_values:
+                        self._compile_enum_variant(variant, casa_enum, bytecode)
+                    else:
+                        bytecode.append(
+                            self.inst(InstKind.PUSH, args=[variant.ordinal])
+                        )
                 case OpKind.MATCH_START | OpKind.MATCH_ARM | OpKind.MATCH_END:
                     self._compile_match_block(op, bytecode)
                 case OpKind.METHOD_CALL:
@@ -709,13 +804,6 @@ class Compiler:
                     )
                 case OpKind.PUSH_INT:
                     bytecode.append(self.inst(InstKind.PUSH, args=[op.value]))
-                case OpKind.PUSH_NONE:
-                    bytecode.append(self.inst(InstKind.PUSH, args=[16]))
-                    bytecode.append(self.inst(InstKind.HEAP_ALLOC))
-                    bytecode.append(self.inst(InstKind.DUP))
-                    bytecode.append(self.inst(InstKind.PUSH, args=[0]))
-                    bytecode.append(self.inst(InstKind.SWAP))
-                    bytecode.append(self.inst(InstKind.STORE64))
                 case OpKind.PUSH_STR:
                     string_index = self.intern_string(op.value)
                     bytecode.append(self.inst(InstKind.PUSH_STR, args=[string_index]))
@@ -724,12 +812,6 @@ class Compiler:
                     assert isinstance(variable_name, str), "Valid variable name"
                     get_kind, _, index = self._resolve_variable(variable_name)
                     bytecode.append(self.inst(get_kind, args=[index]))
-                case OpKind.SOME:
-                    self._compile_some(bytecode)
-                case OpKind.OK:
-                    self._compile_tagged_wrapper(1, bytecode)
-                case OpKind.ERROR:
-                    self._compile_tagged_wrapper(0, bytecode)
                 case OpKind.STRUCT_NEW:
                     self._compile_struct_new(op, bytecode)
                 case OpKind.STRUCT_LITERAL:

--- a/casa/common.py
+++ b/casa/common.py
@@ -49,12 +49,6 @@ class Intrinsic(Enum):
     PRINT = auto()
     TYPEOF = auto()
 
-    # Value constructors
-    NONE = auto()
-    SOME = auto()
-    OK = auto()
-    ERROR = auto()
-
     # Functions
     EXEC = auto()
 
@@ -309,11 +303,7 @@ class OpKind(Enum):
     PUSH_BOOL = auto()
     PUSH_CHAR = auto()
     PUSH_INT = auto()
-    PUSH_NONE = auto()
     PUSH_STR = auto()
-    SOME = auto()
-    OK = auto()
-    ERROR = auto()
 
     # Arithmetic
     ADD = auto()
@@ -413,12 +403,9 @@ class Op:
     deferred_return_type: str | None = None
 
     def __post_init__(self):
-        assert len(OpKind) == 89, "Exhaustive handling for `OpKind`"
+        assert len(OpKind) == 85, "Exhaustive handling for `OpKind`"
 
         match self.kind:
-            # Value constructors (no value validation needed)
-            case OpKind.PUSH_NONE | OpKind.SOME | OpKind.OK | OpKind.ERROR:
-                pass
             # Requires `bool`
             case OpKind.PUSH_BOOL:
                 if not isinstance(self.value, bool):
@@ -803,8 +790,6 @@ BUILTIN_TYPES: set[str] = {
     "ptr",
     "array",
     "any",
-    "option",
-    "result",
 }
 
 
@@ -1014,6 +999,7 @@ class EnumVariant:
     enum_name: str | None
     variant_name: str
     ordinal: int
+    bindings: list[str] = field(default_factory=list)
 
     @property
     def is_wildcard(self) -> bool:
@@ -1050,6 +1036,13 @@ class CasaEnum:
     variants: list[str]
     location: Location
     variant_locations: dict[str, Location] | None = None
+    variant_types: dict[str, list[str]] = field(default_factory=dict)
+    type_vars: list[str] = field(default_factory=list)
+
+    @property
+    def has_inner_values(self) -> bool:
+        """Check if any variant carries inner values."""
+        return any(types for types in self.variant_types.values())
 
 
 @dataclass

--- a/casa/parser.py
+++ b/casa/parser.py
@@ -73,10 +73,6 @@ INTRINSIC_TO_OPKIND = {
     Intrinsic.SYSCALL4: OpKind.SYSCALL4,
     Intrinsic.SYSCALL5: OpKind.SYSCALL5,
     Intrinsic.SYSCALL6: OpKind.SYSCALL6,
-    Intrinsic.NONE: OpKind.PUSH_NONE,
-    Intrinsic.SOME: OpKind.SOME,
-    Intrinsic.OK: OpKind.OK,
-    Intrinsic.ERROR: OpKind.ERROR,
     Intrinsic.ARGC: OpKind.ARGC,
     Intrinsic.ARGV: OpKind.ARGV,
 }
@@ -462,6 +458,40 @@ def resolve_identifiers(
                                 function.variables.append(variable)
                         else:
                             GLOBAL_VARIABLES[var_name] = variable
+                elif isinstance(op.value, EnumVariant):
+                    variant = op.value
+                    # Resolve deferred enum variant (ordinal == -1)
+                    if variant.enum_name and variant.ordinal == -1:
+                        casa_enum = GLOBAL_ENUMS.get(variant.enum_name)
+                        if not casa_enum:
+                            errors.append(
+                                CasaError(
+                                    ErrorKind.UNDEFINED_NAME,
+                                    f"Enum `{variant.enum_name}` is not defined",
+                                    op.location,
+                                )
+                            )
+                        elif variant.variant_name not in casa_enum.variants:
+                            errors.append(
+                                CasaError(
+                                    ErrorKind.UNDEFINED_NAME,
+                                    f"Variant `{variant.variant_name}` is not "
+                                    f"defined in enum `{variant.enum_name}`",
+                                    op.location,
+                                )
+                            )
+                        else:
+                            variant.ordinal = casa_enum.variants.index(
+                                variant.variant_name
+                            )
+                    if variant.bindings:
+                        for var_name in variant.bindings:
+                            variable = Variable(var_name)
+                            if function:
+                                if variable not in function.variables:
+                                    function.variables.append(variable)
+                            else:
+                                GLOBAL_VARIABLES[var_name] = variable
             case OpKind.INCLUDE_FILE:
                 included_file = op.value
                 assert isinstance(included_file, Path), "Expected included file path"
@@ -816,9 +846,23 @@ def parse_enum(cursor: Cursor[Token]) -> CasaEnum:
     """Parse an enum definition."""
     expect_token(cursor, value="enum")
     name = expect_token(cursor, kind=TokenKind.IDENTIFIER)
+
+    # Parse optional type parameters: enum Option[T] { ... }
+    type_vars: list[str] = []
+    next_token = cursor.peek()
+    if next_token and next_token.value == "[":
+        type_vars, trait_bounds = parse_type_vars(cursor)
+        if trait_bounds:
+            raise_error(
+                ErrorKind.UNEXPECTED_TOKEN,
+                "Trait bounds are not allowed on enum definitions",
+                name.location,
+            )
+
     expect_token(cursor, value="{")
     variants: list[str] = []
     variant_locations: dict[str, Location] = {}
+    variant_types: dict[str, list[str]] = {}
     while True:
         variant_token = expect_token(cursor)
         if variant_token.value == "}":
@@ -839,13 +883,49 @@ def parse_enum(cursor: Cursor[Token]) -> CasaEnum:
             )
         variants.append(variant_token.value)
         variant_locations[variant_token.value] = variant_token.location
+
+        # Parse optional inner types: Variant(type1 type2 ...)
+        inner_types: list[str] = []
+        peeked = cursor.peek()
+        if peeked and peeked.value == "(":
+            cursor.pop()  # consume (
+            while True:
+                inner_tok = cursor.peek()
+                if not inner_tok:
+                    raise_error(
+                        ErrorKind.UNEXPECTED_TOKEN,
+                        "Unexpected end of input in variant inner types",
+                        variant_token.location,
+                        expected="`)`",
+                        got="end of input",
+                    )
+                if inner_tok.value == ")":
+                    cursor.pop()  # consume )
+                    break
+                inner_types.append(parse_type(cursor))
+            if not inner_types:
+                raise_error(
+                    ErrorKind.SYNTAX,
+                    "Variant inner types cannot be empty."
+                    " Remove the parentheses for a variant without inner values",
+                    variant_token.location,
+                )
+        variant_types[variant_token.value] = inner_types
+
     if not variants:
         raise_error(
             ErrorKind.SYNTAX,
             "Enum must have at least one variant",
             name.location,
         )
-    return CasaEnum(name.value, variants, name.location, variant_locations)
+    return CasaEnum(
+        name.value,
+        variants,
+        name.location,
+        variant_locations,
+        variant_types=variant_types,
+        type_vars=type_vars,
+    )
 
 
 def _handle_keyword_enum(
@@ -886,6 +966,13 @@ def _is_match_arm_boundary(cursor: Cursor[Token]) -> bool:
         return True
     if next_value == "{" and token.value in GLOBAL_STRUCTS:
         return True
+    # EnumName::Variant(bindings) => pattern
+    if next_value == "(" and "::" in token.value:
+        scan = pos + 2
+        while scan < len(seq) and seq[scan].value != ")":
+            scan += 1
+        if scan + 1 < len(seq) and seq[scan + 1].value == "=>":
+            return True
     return False
 
 
@@ -977,27 +1064,33 @@ def _handle_keyword_match(
             variant = EnumVariant(None, arm_token.value, -1)
             ops.append(Op(variant, OpKind.MATCH_ARM, arm_token.location))
         else:
-            # Parse the => delimiter
-            expect_token(cursor, value="=>")
-
-            # Resolve the variant
+            # Store raw enum::variant, defer resolution to resolve_identifiers
             parts = arm_token.value.split("::", 1)
             enum_name, variant_name = parts[0], parts[1]
-            casa_enum = GLOBAL_ENUMS.get(enum_name)
-            if not casa_enum:
-                raise_error(
-                    ErrorKind.UNDEFINED_NAME,
-                    f"Enum `{enum_name}` is not defined",
-                    arm_token.location,
-                )
-            if variant_name not in casa_enum.variants:
-                raise_error(
-                    ErrorKind.UNDEFINED_NAME,
-                    f"Variant `{variant_name}` is not defined in enum `{enum_name}`",
-                    arm_token.location,
-                )
-            ordinal = casa_enum.variants.index(variant_name)
-            variant = EnumVariant(enum_name, variant_name, ordinal)
+
+            # Parse optional bindings: EnumName::Variant(binding1 binding2) =>
+            bindings: list[str] = []
+            peeked = cursor.peek()
+            if peeked and peeked.value == "(":
+                cursor.pop()  # consume (
+                while True:
+                    inner_tok = cursor.peek()
+                    if not inner_tok:
+                        raise_error(
+                            ErrorKind.UNEXPECTED_TOKEN,
+                            "Unexpected end of input in match arm bindings",
+                            arm_token.location,
+                            expected="`)`",
+                            got="end of input",
+                        )
+                    if inner_tok.value == ")":
+                        cursor.pop()  # consume )
+                        break
+                    binding_tok = expect_token(cursor, kind=TokenKind.IDENTIFIER)
+                    bindings.append(binding_tok.value)
+
+            expect_token(cursor, value="=>")
+            variant = EnumVariant(enum_name, variant_name, -1, bindings)
             ops.append(Op(variant, OpKind.MATCH_ARM, arm_token.location))
 
         # Parse arm body until next arm or `end`
@@ -1201,7 +1294,7 @@ def parse_impl_block(cursor: Cursor[Token]):
     expect_token(cursor, value="impl")
 
     # Parse optional type parameters: impl[K: Hashable] Set[K] { ... }
-    impl_type_vars: set[str] = set()
+    impl_type_vars: list[str] = []
     impl_trait_bounds: dict[str, str] = {}
     next_token = cursor.peek()
     if next_token and next_token.value == "[":
@@ -1215,7 +1308,7 @@ def parse_impl_block(cursor: Cursor[Token]):
     while (fn := cursor.peek()) and fn.value == "fn":
         function = parse_function(
             cursor,
-            inherited_type_vars=impl_type_vars or None,
+            inherited_type_vars=set(impl_type_vars) if impl_type_vars else None,
             inherited_trait_bounds=impl_trait_bounds or None,
         )
         function.name = f"{impl_base_type}::{function.name}"
@@ -1240,7 +1333,7 @@ def parse_struct(cursor: Cursor[Token]) -> Struct:
     type_vars: list[str] = []
     next_token = cursor.peek()
     if next_token and next_token.value == "[":
-        type_vars_set, trait_bounds = parse_type_vars(cursor)
+        type_vars, trait_bounds = parse_type_vars(cursor)
         if trait_bounds:
             raise_error(
                 ErrorKind.UNEXPECTED_TOKEN,
@@ -1248,7 +1341,6 @@ def parse_struct(cursor: Cursor[Token]) -> Struct:
                 "Use `impl[K: Bound] StructName[K]` instead",
                 struct_name.location,
             )
-        type_vars = sorted(type_vars_set)
 
     members: list[Member] = []
     expect_token(cursor, value="{")
@@ -1372,10 +1464,11 @@ def parse_trait_method_signature(cursor: Cursor[Token]) -> Signature:
 
 def parse_type_vars(
     cursor: Cursor[Token],
-) -> tuple[set[str], dict[str, str]]:
+) -> tuple[list[str], dict[str, str]]:
     """Parse bracketed type variables and optional trait bounds."""
     expect_token(cursor, value="[")
-    type_vars: set[str] = set()
+    type_vars: list[str] = []
+    seen_vars: set[str] = set()
     trait_bounds: dict[str, str] = {}
     while token := cursor.pop():
         if token.value == "]":
@@ -1405,7 +1498,14 @@ def parse_type_vars(
                     f"Type variable `{token.value}` shadows enum type `{token.value}`",
                     token.location,
                 )
-            type_vars.add(token.value)
+            if token.value in seen_vars:
+                raise_error(
+                    ErrorKind.DUPLICATE_NAME,
+                    f"Duplicate type variable `{token.value}`",
+                    token.location,
+                )
+            type_vars.append(token.value)
+            seen_vars.add(token.value)
             # Check for trait bound: K: Hashable
             next_tok = cursor.peek()
             if next_tok and next_tok.value == ":":
@@ -1441,7 +1541,7 @@ def parse_function(
     name = expect_token(cursor, kind=TokenKind.IDENTIFIER)
 
     # Parse optional type parameters: fn name[T1 T2] or fn name[K: Hashable, V]
-    type_vars: set[str] = set()
+    type_vars: list[str] = []
     trait_bounds: dict[str, str] = {}
     next_token = cursor.peek()
     if next_token and next_token.value == "[":
@@ -1449,12 +1549,14 @@ def parse_function(
 
     # Merge inherited type vars/bounds from impl block
     if inherited_type_vars:
-        type_vars |= inherited_type_vars
+        for tv in inherited_type_vars:
+            if tv not in type_vars:
+                type_vars.append(tv)
     if inherited_trait_bounds:
         trait_bounds = {**inherited_trait_bounds, **trait_bounds}
 
     signature = parse_signature(cursor)
-    signature.type_vars = type_vars
+    signature.type_vars = set(type_vars)
     signature.trait_bounds = trait_bounds
 
     ops: list[Op] = []

--- a/casa/typechecker.py
+++ b/casa/typechecker.py
@@ -152,16 +152,21 @@ class TypeChecker:
             return expected
         if typ == expected:
             return typ
-        # Match parameterized generics with any wildcard, e.g. option[any] with option[int]
+        # Match parameterized generics with any/type-var wildcard
         exp_base = extract_generic_base(expected)
         act_base = extract_generic_base(typ)
         if exp_base is not None and exp_base == act_base:
             exp_params = extract_generic_params(expected)
             act_params = extract_generic_params(typ)
+            type_vars: set[str] = set()
+            if exp_base in GLOBAL_ENUMS:
+                type_vars = set(GLOBAL_ENUMS[exp_base].type_vars)
             if exp_params and act_params and len(exp_params) == len(act_params):
                 if all(
                     expected_param == ANY_TYPE
                     or actual_param == ANY_TYPE
+                    or expected_param in type_vars
+                    or actual_param in type_vars
                     or expected_param == actual_param
                     for expected_param, actual_param in zip(exp_params, act_params)
                 ):
@@ -218,9 +223,14 @@ class TypeChecker:
             return
 
         bound = bindings[type_var]
-        if bound == ANY_TYPE and actual != ANY_TYPE:
+        if (bound == ANY_TYPE or _is_enum_type_var(bound)) and actual != ANY_TYPE:
             bindings[type_var] = actual
-        elif actual != bound and actual != ANY_TYPE and bound != ANY_TYPE:
+        elif (
+            actual != bound
+            and actual != ANY_TYPE
+            and bound != ANY_TYPE
+            and not _is_enum_type_var(actual)
+        ):
             raise_error(
                 ErrorKind.TYPE_MISMATCH,
                 f"Type variable `{type_var}` bound to `{bound}` but got `{actual}`",
@@ -367,9 +377,11 @@ class TypeChecker:
         """Handle EQ, NE, LT, LE, GT, GE."""
         t1 = self.stack_pop()
         t2 = self.stack_pop()
-        t1_is_enum = t1 in GLOBAL_ENUMS
-        t2_is_enum = t2 in GLOBAL_ENUMS
-        if t1_is_enum or t2_is_enum:
+        t1_base = self._resolve_match_type(t1)
+        t1_enum = t1_base if t1_base in GLOBAL_ENUMS else None
+        t2_base = self._resolve_match_type(t2)
+        t2_enum = t2_base if t2_base in GLOBAL_ENUMS else None
+        if t1_enum or t2_enum:
             if t1 != t2:
                 raise_error(
                     ErrorKind.TYPE_MISMATCH,
@@ -382,6 +394,11 @@ class TypeChecker:
                     f"Enum type `{t1}` only supports `==` and `!=` comparison",
                     self.current_location,
                 )
+            # Annotate for bytecode: data-carrying enums need heap tag comparison
+            assert t1_enum is not None
+            casa_enum = GLOBAL_ENUMS[t1_enum]
+            if casa_enum.has_inner_values:
+                op.type_annotation = t1_enum
         self.stack_push("bool")
 
     def check_boolean(self, op: Op) -> None:
@@ -835,17 +852,6 @@ class TypeChecker:
                 self.stack_push("bool")
             case OpKind.PUSH_CHAR:
                 self.stack_push("char")
-            case OpKind.PUSH_NONE:
-                self.stack_push("option")
-            case OpKind.SOME:
-                t1 = self.stack_pop()
-                self.stack_push(f"option[{t1}]")
-            case OpKind.OK:
-                t1 = self.stack_pop()
-                self.stack_push(f"result[{t1} any]")
-            case OpKind.ERROR:
-                t1 = self.stack_pop()
-                self.stack_push(f"result[any {t1}]")
             case OpKind.PUSH_ARRAY:
                 items = op.value
                 assert isinstance(items, list)
@@ -883,8 +889,16 @@ class TypeChecker:
         elif typ == "cstr":
             op.kind = OpKind.PRINT_CSTR
         elif typ in GLOBAL_ENUMS:
+            casa_enum = GLOBAL_ENUMS[typ]
+            if casa_enum.has_inner_values:
+                op.type_annotation = typ
             op.kind = OpKind.PRINT_INT
         else:
+            enum_base = extract_generic_base(typ)
+            if enum_base and enum_base in GLOBAL_ENUMS:
+                casa_enum = GLOBAL_ENUMS[enum_base]
+                if casa_enum.has_inner_values:
+                    op.type_annotation = enum_base
             op.kind = OpKind.PRINT_INT
 
     def check_typeof(self, op: Op) -> None:
@@ -905,7 +919,43 @@ class TypeChecker:
         variant = op.value
         assert isinstance(variant, EnumVariant)
         assert variant.enum_name is not None
-        self.stack_push(variant.enum_name)
+        casa_enum = GLOBAL_ENUMS[variant.enum_name]
+        inner_types = casa_enum.variant_types.get(variant.variant_name, [])
+
+        if not inner_types:
+            # No inner values — just push enum type
+            if casa_enum.type_vars:
+                # Generic enum variant without data (e.g., Option::None)
+                param_type = f"{casa_enum.name}[{' '.join(casa_enum.type_vars)}]"
+                self.stack_push(param_type)
+            else:
+                self.stack_push(variant.enum_name)
+            return
+
+        # Data-carrying variant: pop inner values and push enum type
+        if not casa_enum.type_vars:
+            self.current_op_context = (
+                f"`{variant.enum_name}::{variant.variant_name}`"
+                f" ({' '.join(inner_types)} -> {variant.enum_name})"
+            )
+            for inner_type in inner_types:
+                self.current_expect_context = (
+                    f"inner value of `{variant.enum_name}::{variant.variant_name}`"
+                )
+                self.expect_type(inner_type)
+            self.current_expect_context = None
+            self.stack_push(variant.enum_name)
+            return
+
+        # Generic data-carrying variant: use apply_signature to bind type vars
+        param_enum_type = f"{casa_enum.name}[{' '.join(casa_enum.type_vars)}]"
+        params = [Parameter(t) for t in inner_types]
+        sig = Signature(
+            params,
+            [param_enum_type],
+            type_vars=set(casa_enum.type_vars),
+        )
+        self.apply_signature(sig, f"{variant.enum_name}::{variant.variant_name}")
 
     @staticmethod
     def _check_duplicate_arm(
@@ -956,30 +1006,32 @@ class TypeChecker:
         if variant.is_wildcard:
             return f"__covered:{MATCH_WILDCARD}"
 
+        base_match_type = self._resolve_match_type(match_type)
+
         if variant.enum_name is None:
             # Bare variant name without enum qualifier
-            casa_enum = GLOBAL_ENUMS[match_type]
+            casa_enum = GLOBAL_ENUMS[base_match_type]
             assert casa_enum.variants
             if variant.variant_name in casa_enum.variants:
                 raise_error(
                     ErrorKind.TYPE_MISMATCH,
                     f"Unqualified enum variant `{variant.variant_name}`."
-                    f" Did you mean `{match_type}::{variant.variant_name}`?",
+                    f" Did you mean `{base_match_type}::{variant.variant_name}`?",
                     location,
                 )
             raise_error(
                 ErrorKind.TYPE_MISMATCH,
                 f"Expected qualified enum variant"
-                f" (e.g. `{match_type}::{casa_enum.variants[0]}`) or `_`,"
+                f" (e.g. `{base_match_type}::{casa_enum.variants[0]}`) or `_`,"
                 f" got `{variant.variant_name}`",
                 location,
             )
 
-        if variant.enum_name != match_type:
+        if variant.enum_name != base_match_type:
             raise_error(
                 ErrorKind.TYPE_MISMATCH,
                 f"Match arm variant `{variant.enum_name}::{variant.variant_name}`"
-                f" does not belong to enum `{match_type}`",
+                f" does not belong to enum `{base_match_type}`",
                 location,
             )
 
@@ -1006,12 +1058,23 @@ class TypeChecker:
         if global_var:
             global_var.typ = field_type
 
+    @staticmethod
+    def _resolve_match_type(typ: str) -> str:
+        """Resolve a match type to the base enum/struct name for lookups."""
+        if typ in GLOBAL_ENUMS or typ in GLOBAL_STRUCTS:
+            return typ
+        base = extract_generic_base(typ)
+        if base and base in GLOBAL_ENUMS:
+            return base
+        return typ
+
     def check_match(self, op: Op, function: "Function | None" = None) -> None:
         """Handle MATCH_START, MATCH_ARM, MATCH_END."""
         match op.kind:
             case OpKind.MATCH_START:
                 typ = self.stack_pop()
-                if typ not in GLOBAL_ENUMS and typ not in GLOBAL_STRUCTS:
+                base = self._resolve_match_type(typ)
+                if base not in GLOBAL_ENUMS and base not in GLOBAL_STRUCTS:
                     raise_error(
                         ErrorKind.TYPE_MISMATCH,
                         f"Match requires an enum or struct type, got `{typ}`",
@@ -1100,6 +1163,34 @@ class TypeChecker:
                         field_type = member_type_by_name[field_name]
                         self._set_struct_binding_type(var_name, field_type, function)
 
+                # For enum variant patterns with bindings, set types
+                if isinstance(pattern, EnumVariant) and pattern.bindings:
+                    base_type = self._resolve_match_type(match_type)
+                    casa_enum = GLOBAL_ENUMS[base_type]
+                    inner_types = casa_enum.variant_types.get(pattern.variant_name, [])
+                    if len(pattern.bindings) != len(inner_types):
+                        raise_error(
+                            ErrorKind.TYPE_MISMATCH,
+                            f"Variant `{pattern.enum_name}::{pattern.variant_name}`"
+                            f" has {len(inner_types)} inner value(s),"
+                            f" but {len(pattern.bindings)} binding(s) provided",
+                            op.location,
+                        )
+                    # Resolve generic type vars from match subject type
+                    type_bindings: dict[str, str] = {}
+                    if casa_enum.type_vars:
+                        params = extract_generic_params(match_type)
+                        if params:
+                            for tvar, concrete in zip(
+                                casa_enum.type_vars, params, strict=False
+                            ):
+                                type_bindings[tvar] = concrete
+                    for var_name, inner_type in zip(
+                        pattern.bindings, inner_types, strict=True
+                    ):
+                        resolved_type = type_bindings.get(inner_type, inner_type)
+                        self._set_struct_binding_type(var_name, resolved_type, function)
+
                 branched.current_branch_label = covered_key
                 branched.current_branch_location = op.location
 
@@ -1131,20 +1222,24 @@ class TypeChecker:
                 }
                 has_wildcard = MATCH_WILDCARD in covered
 
-                if match_type in GLOBAL_STRUCTS:
+                base_match_type = self._resolve_match_type(match_type)
+
+                if base_match_type in GLOBAL_STRUCTS:
                     # Struct match: one struct arm or wildcard is exhaustive
-                    if not has_wildcard and match_type not in covered:
+                    if not has_wildcard and base_match_type not in covered:
                         raise_error(
                             ErrorKind.TYPE_MISMATCH,
                             f"Non-exhaustive match on struct `{match_type}`",
                             op.location,
                         )
                 else:
-                    casa_enum = GLOBAL_ENUMS[match_type]
+                    casa_enum = GLOBAL_ENUMS[base_match_type]
                     if not has_wildcard:
                         missing = [v for v in casa_enum.variants if v not in covered]
                         if missing:
-                            names = ", ".join(f"`{match_type}::{v}`" for v in missing)
+                            names = ", ".join(
+                                f"`{base_match_type}::{v}`" for v in missing
+                            )
                             raise_error(
                                 ErrorKind.TYPE_MISMATCH,
                                 f"Non-exhaustive match, missing arms: {names}",
@@ -1441,9 +1536,6 @@ OP_STACK_EFFECTS: dict[OpKind, tuple[str, str]] = {
     OpKind.PRINT_BOOL: ("print", "any -> None"),
     OpKind.PRINT_CHAR: ("print", "any -> None"),
     OpKind.PRINT_CSTR: ("print", "any -> None"),
-    OpKind.SOME: ("some", "any -> option[any]"),
-    OpKind.OK: ("ok", "any -> result[any any]"),
-    OpKind.ERROR: ("error", "any -> result[any any]"),
     OpKind.FN_EXEC: ("exec", "fn[sig] -> ..."),
     OpKind.TYPEOF: ("typeof", "any -> str"),
     OpKind.ASSIGN_DECREMENT: ("-=", "int -> None"),
@@ -1478,10 +1570,6 @@ def _infer_literal_type(op: Op, function: Function | None = None) -> str:
             return "char"
         case OpKind.PUSH_INT:
             return "int"
-        case OpKind.PUSH_NONE:
-            return "option"
-        case OpKind.OK | OpKind.ERROR:
-            return "result"
         case OpKind.PUSH_STR:
             return "str"
         case OpKind.PUSH_BOOL:
@@ -1521,6 +1609,19 @@ def _format_branch_signature(before: list[Type], after: list[Type]) -> str:
     return f"`{before_str} -> {after_str}`"
 
 
+def _is_enum_type_var(typ: Type) -> bool:
+    """Check if a type is an unresolved enum type variable (e.g. T, E).
+
+    Only matches type variables that don't shadow a concrete type (struct/enum).
+    """
+    if typ in GLOBAL_STRUCTS or typ in GLOBAL_ENUMS:
+        return False
+    for casa_enum in GLOBAL_ENUMS.values():
+        if typ in casa_enum.type_vars:
+            return True
+    return False
+
+
 def _unify_type(a: Type, b: Type) -> Type | None:
     """Resolve two compatible types to the more specific one.
 
@@ -1528,9 +1629,9 @@ def _unify_type(a: Type, b: Type) -> Type | None:
     """
     if a == b:
         return a
-    if a == ANY_TYPE:
+    if a == ANY_TYPE or _is_enum_type_var(a):
         return b
-    if b == ANY_TYPE:
+    if b == ANY_TYPE or _is_enum_type_var(b):
         return a
     base_a = extract_generic_base(a)
     base_b = extract_generic_base(b)
@@ -1947,7 +2048,7 @@ def type_satisfies_trait(
 
 def type_check_ops(ops: list[Op], function: Function | None = None) -> Signature:
     """Type-check a list of ops and return the inferred signature."""
-    assert len(OpKind) == 89, "Exhaustive handling for `OpKind`"
+    assert len(OpKind) == 85, "Exhaustive handling for `OpKind`"
 
     tc = TypeChecker(ops=ops)
     op_index = 0
@@ -2023,10 +2124,6 @@ def type_check_ops(ops: list[Op], function: Function | None = None) -> Signature
                 | OpKind.PUSH_STR
                 | OpKind.PUSH_BOOL
                 | OpKind.PUSH_CHAR
-                | OpKind.PUSH_NONE
-                | OpKind.SOME
-                | OpKind.OK
-                | OpKind.ERROR
                 | OpKind.PUSH_ARRAY
                 | OpKind.FSTRING_CONCAT
             ):

--- a/casa_ls.py
+++ b/casa_ls.py
@@ -679,10 +679,6 @@ OP_TOKEN_TYPE: dict[OpKind, int] = {
     OpKind.PUSH_CHAR: 3,
     # keyword (4)
     OpKind.PUSH_BOOL: 4,
-    OpKind.PUSH_NONE: 4,
-    OpKind.SOME: 4,
-    OpKind.OK: 4,
-    OpKind.ERROR: 4,
     OpKind.FN_EXEC: 4,
     OpKind.IF_START: 4,
     OpKind.IF_CONDITION: 4,

--- a/docs/control-flow.md
+++ b/docs/control-flow.md
@@ -67,15 +67,15 @@ fi
 
 The first branch pushes an `int`, the second pushes a `str` — the type checker rejects this.
 
-Compatible types are allowed across branches. For example, `none` (bare `option`) and `some` (`option[T]`) can appear in different branches. The type checker unifies them to the more specific type:
+Compatible types are allowed across branches. For example, `Option::None` (bare `Option`) and `Option::Some` (`Option[T]`) can appear in different branches. The type checker unifies them to the more specific type:
 
 ```casa
 if condition then
-    none           # option
+    Option::None           # Option
 else
-    42 some        # option[int]
+    42 Option::Some        # Option[int]
 fi
-# result type: option[int]
+# result type: Option[int]
 ```
 
 The same applies to bare `array` and `array[T]`, and to `any` with any concrete type.

--- a/docs/enums.md
+++ b/docs/enums.md
@@ -13,26 +13,70 @@ enum Direction { North South East West }
 
 Each variant is a distinct value of the enum type. An enum must have at least one variant. Variant names must be unique within the enum.
 
+## Variants with Inner Values
+
+Variants can carry inner values by specifying types in parentheses.
+
+```casa
+enum Shape {
+    Circle(int)
+    Rectangle(int int)
+    Point
+}
+```
+
+An enum can mix variants with and without inner values. When any variant has inner values, all variants are heap-allocated at runtime.
+
+## Generic Enums
+
+Enums can have type parameters, written in brackets after the name.
+
+```casa
+enum Option[T] { None Some(T) }
+enum Result[T E] { Error(E) Ok(T) }
+```
+
+The type parameters are resolved when constructing or matching on the enum.
+
 ## Variant Constructors
 
 Access variants using the `EnumName::VariantName` syntax.
 
-**Stack effect:** `-> EnumName`
+**Stack effect (plain):** `-> EnumName`
 
 ```casa
 Color::Red        # pushes a Color value
 Direction::North  # pushes a Direction value
 ```
 
+For variants with inner values, push the inner values onto the stack first.
+
+**Stack effect (with inner values):** `inner_values -> EnumName`
+
+```casa
+10 Shape::Circle           # pushes Shape with radius 10
+3 4 Shape::Rectangle       # pushes Shape with width 3, height 4
+Shape::Point               # pushes Shape with no inner values
+```
+
+For generic enums, the type parameters are inferred from the inner values.
+
+```casa
+42 Option::Some            # pushes Option[int]
+Option::None               # pushes Option[T] (generic)
+"hello" Option::Some       # pushes Option[str]
+```
+
 Variants can be assigned to variables:
 
 ```casa
 Color::Blue = my_color
+42 Option::Some = maybe_int
 ```
 
 ## Comparison
 
-Enum values of the same type can be compared with `==` and `!=`.
+Enum values of the same type can be compared with `==` and `!=`. For data-carrying enums, comparison checks the variant tag only (not inner values).
 
 **Stack effect:** `EnumName EnumName -> bool`
 
@@ -87,6 +131,34 @@ Color::Green match
     Color::Blue => "blue" print
 end
 # prints: green
+```
+
+### Match with Destructuring
+
+For variants with inner values, use `(bindings)` after the variant name to bind the inner values to variables.
+
+```casa
+enum Shape {
+    Circle(int)
+    Rectangle(int int)
+    Point
+}
+
+10 Shape::Circle match
+    Shape::Circle(radius) => radius print
+    Shape::Rectangle(width height) => width height * print
+    Shape::Point => "point" print
+end
+# prints: 10
+```
+
+For generic enums, the binding types are inferred from the match subject type.
+
+```casa
+42 Option::Some match
+    Option::Some(value) => value print    # value has type int
+    Option::None => "nothing" print
+end
 ```
 
 ### Exhaustiveness

--- a/docs/functions-and-lambdas.md
+++ b/docs/functions-and-lambdas.md
@@ -166,7 +166,7 @@ impl Box {
 Type variables can have trait bounds that restrict which types are accepted. Use `K: TraitName` syntax:
 
 ```casa
-fn get[K: Hashable, V] self:Map[K V] key:K -> option[V] {
+fn get[K: Hashable, V] self:Map[K V] key:K -> Option[V] {
     key K::hash self.capacity % = idx
     ...
 }
@@ -232,11 +232,11 @@ A variable's type is set on first assignment and cannot change:
 "hi" = x     # ERROR: cannot assign str to int variable
 ```
 
-The `= name:type` form annotates the variable type explicitly. The type checker verifies the stack value is compatible and uses the annotated type for the variable. This is useful for narrowing `any` or bare `option` to a concrete type:
+The `= name:type` form annotates the variable type explicitly. The type checker verifies the stack value is compatible and uses the annotated type for the variable. This is useful for narrowing `any` or bare `Option` to a concrete type:
 
 ```casa
 42 (any) = x:int            # narrow any to int
-none = empty:option[int]    # narrow bare option to option[int]
+Option::None = empty:Option[int]    # narrow bare Option to Option[int]
 ```
 
 ## Lambdas

--- a/docs/language-server.md
+++ b/docs/language-server.md
@@ -147,7 +147,7 @@ The server provides full semantic token highlighting. Each token is classified i
 | `variable` | Variable reads, captures, assignments |
 | `string` | String literals |
 | `number` | Integer and character literals |
-| `keyword` | `fn`, `if`, `while`, `match`, `true`, `false`, `none`, `some`, `ok`, `error`, `exec`, `return`, `break`, `continue` |
+| `keyword` | `fn`, `if`, `while`, `match`, `true`, `false`, `exec`, `return`, `break`, `continue` |
 | `operator` | Arithmetic, comparison, boolean, and bitwise operators |
 | `type` | Type casts `(TypeName)` |
 | `enumMember` | Enum variant references |

--- a/docs/operators.md
+++ b/docs/operators.md
@@ -126,7 +126,7 @@ The `= name:type` form lets you annotate the type of a variable at assignment ti
 
 ```casa
 42 = x:int                  # explicit int annotation
-none = empty:option[int]    # narrow bare option to option[int]
+Option::None = empty:Option[int]    # narrow bare Option to Option[int]
 42 (any) = val:int          # narrow any to int
 ```
 

--- a/docs/parser.md
+++ b/docs/parser.md
@@ -60,11 +60,11 @@ Returns `true` if the cursor is at or past the end of the source string.
 
 ### `Cursor::peek`
 
-Returns the current character without advancing the cursor. Returns `none` at EOF.
+Returns the current character without advancing the cursor. Returns `Option::None` at EOF.
 
-**Signature:** `Cursor::peek self:Cursor -> option[char]`
+**Signature:** `Cursor::peek self:Cursor -> Option[char]`
 
-**Stack effect:** `Cursor -> option[char]`
+**Stack effect:** `Cursor -> Option[char]`
 
 ```casa
 "hello" Cursor::new .peek .unwrap print    # h
@@ -72,11 +72,11 @@ Returns the current character without advancing the cursor. Returns `none` at EO
 
 ### `Cursor::peek_at`
 
-Returns the character at `pos + offset` without advancing the cursor. Returns `none` if out of bounds.
+Returns the character at `pos + offset` without advancing the cursor. Returns `Option::None` if out of bounds.
 
-**Signature:** `Cursor::peek_at self:Cursor offset:int -> option[char]`
+**Signature:** `Cursor::peek_at self:Cursor offset:int -> Option[char]`
 
-**Stack effect:** `Cursor int -> option[char]`
+**Stack effect:** `Cursor int -> Option[char]`
 
 ```casa
 2 "hello" Cursor::new .peek_at .unwrap print    # l
@@ -84,11 +84,11 @@ Returns the character at `pos + offset` without advancing the cursor. Returns `n
 
 ### `Cursor::advance`
 
-Returns the current character and advances the cursor by one. Returns `none` at EOF.
+Returns the current character and advances the cursor by one. Returns `Option::None` at EOF.
 
-**Signature:** `Cursor::advance self:Cursor -> option[char]`
+**Signature:** `Cursor::advance self:Cursor -> Option[char]`
 
-**Stack effect:** `Cursor -> option[char]`
+**Stack effect:** `Cursor -> Option[char]`
 
 ```casa
 "hello" Cursor::new = cursor
@@ -112,11 +112,11 @@ Checks if the remaining input (from the current position) starts with the given 
 
 ### `Cursor::expect_char`
 
-Consumes the next character if it matches `expected`. Returns `ok` with the character on success, or `error` with a `ParseError` on mismatch or EOF.
+Consumes the next character if it matches `expected`. Returns `Result::Ok` with the character on success, or `Result::Error` with a `ParseError` on mismatch or EOF.
 
-**Signature:** `Cursor::expect_char self:Cursor expected:char -> result[char ParseError]`
+**Signature:** `Cursor::expect_char self:Cursor expected:char -> Result[char ParseError]`
 
-**Stack effect:** `Cursor char -> result[char ParseError]`
+**Stack effect:** `Cursor char -> Result[char ParseError]`
 
 ```casa
 "abc" Cursor::new = cursor
@@ -139,11 +139,11 @@ cursor.peek .unwrap print    # l
 
 ### `Cursor::take_string`
 
-Consumes the exact target string if the remaining input starts with it. Returns `ok` with the matched string on success, or `error` with a `ParseError` on mismatch.
+Consumes the exact target string if the remaining input starts with it. Returns `Result::Ok` with the matched string on success, or `Result::Error` with a `ParseError` on mismatch.
 
-**Signature:** `Cursor::take_string self:Cursor target:str -> result[str ParseError]`
+**Signature:** `Cursor::take_string self:Cursor target:str -> Result[str ParseError]`
 
-**Stack effect:** `Cursor str -> result[str ParseError]`
+**Stack effect:** `Cursor str -> Result[str ParseError]`
 
 ```casa
 "hello world" Cursor::new = cursor
@@ -260,11 +260,11 @@ cursor.pos print    # 3
 
 ### `parse_int`
 
-Parses an integer with optional leading `-`. Returns `error` if no digits are found. Restores cursor position on failure.
+Parses an integer with optional leading `-`. Returns `Result::Error` if no digits are found. Restores cursor position on failure.
 
-**Signature:** `parse_int cursor:Cursor -> result[int ParseError]`
+**Signature:** `parse_int cursor:Cursor -> Result[int ParseError]`
 
-**Stack effect:** `Cursor -> result[int ParseError]`
+**Stack effect:** `Cursor -> Result[int ParseError]`
 
 ```casa
 "42" Cursor::new parse_int .unwrap print      # 42
@@ -274,11 +274,11 @@ Parses an integer with optional leading `-`. Returns `error` if no digits are fo
 
 ### `parse_identifier`
 
-Parses an identifier matching `[a-zA-Z_][a-zA-Z0-9_]*`. Returns `error` if the current character is not a valid identifier start. Restores cursor position on failure.
+Parses an identifier matching `[a-zA-Z_][a-zA-Z0-9_]*`. Returns `Result::Error` if the current character is not a valid identifier start. Restores cursor position on failure.
 
-**Signature:** `parse_identifier cursor:Cursor -> result[str ParseError]`
+**Signature:** `parse_identifier cursor:Cursor -> Result[str ParseError]`
 
-**Stack effect:** `Cursor -> result[str ParseError]`
+**Stack effect:** `Cursor -> Result[str ParseError]`
 
 ```casa
 "my_var" Cursor::new parse_identifier .unwrap print    # my_var
@@ -288,25 +288,25 @@ Parses an identifier matching `[a-zA-Z_][a-zA-Z0-9_]*`. Returns `error` if the c
 
 Parses an escape sequence after the `\` has been consumed. Recognizes: `\n`, `\t`, `\\`, `\"`, `\'`, `\0`, `\r`, `\{`, `\}`.
 
-**Signature:** `parse_escape cursor:Cursor -> result[char ParseError]`
+**Signature:** `parse_escape cursor:Cursor -> Result[char ParseError]`
 
-**Stack effect:** `Cursor -> result[char ParseError]`
+**Stack effect:** `Cursor -> Result[char ParseError]`
 
 ### `parse_quoted_string`
 
 Parses a double-quoted string with escape sequences. Consumes the opening and closing `"` characters. Returns the string contents (with escapes processed).
 
-**Signature:** `parse_quoted_string cursor:Cursor -> result[str ParseError]`
+**Signature:** `parse_quoted_string cursor:Cursor -> Result[str ParseError]`
 
-**Stack effect:** `Cursor -> result[str ParseError]`
+**Stack effect:** `Cursor -> Result[str ParseError]`
 
 ### `parse_char_literal`
 
 Parses a single-quoted character literal with escape sequences. Consumes the opening and closing `'` characters. Returns the character value.
 
-**Signature:** `parse_char_literal cursor:Cursor -> result[char ParseError]`
+**Signature:** `parse_char_literal cursor:Cursor -> Result[char ParseError]`
 
-**Stack effect:** `Cursor -> result[char ParseError]`
+**Stack effect:** `Cursor -> Result[char ParseError]`
 
 ## Complete Example
 

--- a/docs/standard-library.md
+++ b/docs/standard-library.md
@@ -118,127 +118,161 @@ The accumulator type and the array element type can differ.
 
 ## Option
 
-Methods for working with `option[T]` values. Method calls on any `option[T]` receiver are resolved to `option::method`.
+`Option[T]` is an enum representing a value that may or may not exist. It is defined as:
 
-### `option::is_some`
+```casa
+enum Option[T] { None Some(T) }
+```
+
+Methods are resolved via `Option::method`.
+
+### `Option::is_some`
 
 Returns `true` if the option contains a value.
 
-**Signature:** `option::is_some self:option -> bool`
+**Signature:** `Option::is_some self:Option -> bool`
 
-**Stack effect:** `option -> bool`
+**Stack effect:** `Option -> bool`
 
 ```casa
-42 some .is_some print    # 1
-none .is_some print       # 0
+42 Option::Some .is_some print       # 1
+Option::None .is_some print          # 0
 ```
 
-### `option::is_none`
+### `Option::is_none`
 
 Returns `true` if the option is empty.
 
-**Signature:** `option::is_none self:option -> bool`
+**Signature:** `Option::is_none self:Option -> bool`
 
-**Stack effect:** `option -> bool`
-
-```casa
-42 some .is_none print    # 0
-none .is_none print       # 1
-```
-
-### `option::unwrap`
-
-Extracts the contained value. Prints an error and exits with code 60 if called on `none`.
-
-**Signature:** `option::unwrap[T] self:option[T] -> T`
-
-**Stack effect:** `option[T] -> T`
+**Stack effect:** `Option -> bool`
 
 ```casa
-42 some .unwrap print     # 42
-none .unwrap              # error: called unwrap on None
+42 Option::Some .is_none print       # 0
+Option::None .is_none print          # 1
 ```
 
-### `option::unwrap_or`
+### `Option::unwrap`
+
+Extracts the contained value. Prints an error and exits with code 60 if called on `None`.
+
+**Signature:** `Option::unwrap[T] self:Option[T] -> T`
+
+**Stack effect:** `Option[T] -> T`
+
+```casa
+42 Option::Some .unwrap print        # 42
+Option::None .unwrap                 # error: called unwrap on None
+```
+
+### `Option::unwrap_or`
 
 Returns the contained value, or a default if the option is empty.
 
-**Signature:** `option::unwrap_or[T] self:option[T] default:T -> T`
+**Signature:** `Option::unwrap_or[T] self:Option[T] default:T -> T`
 
-**Stack effect:** `option[T] T -> T`
+**Stack effect:** `Option[T] T -> T`
 
 ```casa
-0 42 some .unwrap_or print    # 42
-0 none .unwrap_or print       # 0
+0 42 Option::Some .unwrap_or print   # 42
+0 Option::None .unwrap_or print      # 0
+```
+
+### Match on Option
+
+Use `match` with destructuring to handle Option values:
+
+```casa
+42 Option::Some match
+    Option::Some(value) => value print
+    Option::None => "nothing" print
+end
 ```
 
 ## Result
 
-Methods for working with `result[T E]` values. Method calls on any `result[T E]` receiver are resolved to `result::method`.
+`Result[T E]` is an enum representing success or failure. It is defined as:
 
-### `result::is_ok`
+```casa
+enum Result[T E] { Error(E) Ok(T) }
+```
+
+Methods are resolved via `Result::method`.
+
+### `Result::is_ok`
 
 Returns `true` if the result contains a success value.
 
-**Signature:** `result::is_ok self:result -> bool`
+**Signature:** `Result::is_ok self:Result -> bool`
 
-**Stack effect:** `result -> bool`
+**Stack effect:** `Result -> bool`
 
 ```casa
-42 ok .is_ok print           # 1
-"error" error .is_ok print   # 0
+42 Result::Ok .is_ok print                  # 1
+"error" Result::Error .is_ok print          # 0
 ```
 
-### `result::is_error`
+### `Result::is_error`
 
 Returns `true` if the result contains an error value.
 
-**Signature:** `result::is_error self:result -> bool`
+**Signature:** `Result::is_error self:Result -> bool`
 
-**Stack effect:** `result -> bool`
-
-```casa
-42 ok .is_error print          # 0
-"error" error .is_error print  # 1
-```
-
-### `result::unwrap`
-
-Extracts the success value. Prints an error and exits with code 60 if called on an `error` result.
-
-**Signature:** `result::unwrap[T E] self:result[T E] -> T`
-
-**Stack effect:** `result[T E] -> T`
+**Stack effect:** `Result -> bool`
 
 ```casa
-42 ok .unwrap print          # 42
-"error" error .unwrap        # error: called unwrap on error
+42 Result::Ok .is_error print               # 0
+"error" Result::Error .is_error print       # 1
 ```
 
-### `result::unwrap_error`
+### `Result::unwrap`
 
-Extracts the error value. Prints an error and exits with code 60 if called on an `ok` result.
+Extracts the success value. Prints an error and exits with code 60 if called on an `Error` result.
 
-**Signature:** `result::unwrap_error[T E] self:result[T E] -> E`
+**Signature:** `Result::unwrap[T E] self:Result[T E] -> T`
 
-**Stack effect:** `result[T E] -> E`
+**Stack effect:** `Result[T E] -> T`
 
 ```casa
-"error" error .unwrap_error print   # error
-42 ok .unwrap_error                 # error: called unwrap_error on ok
+42 Result::Ok .unwrap print                 # 42
+"error" Result::Error .unwrap               # error: called unwrap on error
 ```
 
-### `result::unwrap_or`
+### `Result::unwrap_error`
+
+Extracts the error value. Prints an error and exits with code 60 if called on an `Ok` result.
+
+**Signature:** `Result::unwrap_error[T E] self:Result[T E] -> E`
+
+**Stack effect:** `Result[T E] -> E`
+
+```casa
+"error" Result::Error .unwrap_error print   # error
+42 Result::Ok .unwrap_error                 # error: called unwrap_error on ok
+```
+
+### `Result::unwrap_or`
 
 Returns the success value, or a default if the result is an error.
 
-**Signature:** `result::unwrap_or[T E] self:result[T E] default:T -> T`
+**Signature:** `Result::unwrap_or[T E] self:Result[T E] default:T -> T`
 
-**Stack effect:** `result[T E] T -> T`
+**Stack effect:** `Result[T E] T -> T`
 
 ```casa
-0 42 ok .unwrap_or print              # 42
-0 "error" error .unwrap_or print      # 0
+0 42 Result::Ok .unwrap_or print            # 42
+0 "error" Result::Error .unwrap_or print    # 0
+```
+
+### Match on Result
+
+Use `match` with destructuring to handle Result values:
+
+```casa
+42 Result::Ok match
+    Result::Ok(value) => value print
+    Result::Error(err) => err print
+end
 ```
 
 ## `List[T]`
@@ -873,11 +907,11 @@ m.length print    # 0
 
 ### `Map::get`
 
-Looks up a key and returns `option[V]`. Returns `some` with the value if found, `none` otherwise.
+Looks up a key and returns `Option[V]`. Returns `Option::Some` with the value if found, `Option::None` otherwise.
 
-**Signature:** `Map::get self:Map[K V] key:K -> option[V]`
+**Signature:** `Map::get self:Map[K V] key:K -> Option[V]`
 
-**Stack effect:** `Map[K V] K -> option[V]`
+**Stack effect:** `Map[K V] K -> Option[V]`
 
 ```casa
 "hello" m.get .unwrap print    # prints the value for "hello"

--- a/docs/traits.md
+++ b/docs/traits.md
@@ -81,7 +81,7 @@ fn identity[T] x:T -> T { x }
 
 ```casa
 impl[K: Hashable, V] Map[K V] {
-    fn get self:Map[K V] key:K -> option[V] {
+    fn get self:Map[K V] key:K -> Option[V] {
         key K::hash self.capacity % = idx
         ...
     }

--- a/docs/types-and-literals.md
+++ b/docs/types-and-literals.md
@@ -243,22 +243,26 @@ fn apply f:fn[int -> int] x:int -> int {
 
 See [Functions and Lambdas](functions-and-lambdas.md#lambdas) for details.
 
-### `option[T]`
+### `Option[T]`
 
-Optional type representing a value that may or may not be present. Built with the `some` and `none` constructors.
-
-`none` pushes an empty option with bare type `option`. It is compatible with any `option[T]`.
-
-**Stack effect:** `-> option`
-
-`some` wraps the top-of-stack value into an option. The resulting type is `option[T]` where `T` is the type of the wrapped value.
-
-**Stack effect:** `T -> option[T]`
+Optional type representing a value that may or may not be present. `Option` is an enum defined in `lib/std.casa`:
 
 ```casa
-42 some          # type: option[int]
-"hello" some     # type: option[str]
-none             # type: option (compatible with any option[T])
+enum Option[T] { None Some(T) }
+```
+
+`Option::None` pushes an empty option with bare type `Option`. It is compatible with any `Option[T]`.
+
+**Stack effect:** `-> Option`
+
+`Option::Some` wraps the top-of-stack value into an option. The resulting type is `Option[T]` where `T` is the type of the wrapped value.
+
+**Stack effect:** `T -> Option[T]`
+
+```casa
+42 Option::Some          # type: Option[int]
+"hello" Option::Some     # type: Option[str]
+Option::None             # type: Option (compatible with any Option[T])
 ```
 
 At runtime, an option is heap-allocated as 16 bytes: `[tag, value]` where each field is 8 bytes. The tag is `1` for `Some` and `0` for `None`.
@@ -266,78 +270,82 @@ At runtime, an option is heap-allocated as 16 bytes: `[tag, value]` where each f
 Options stored in variables retain their type:
 
 ```casa
-42 some = x      # x has type option[int]
-none = y         # y has type option (bare)
+42 Option::Some = x      # x has type Option[int]
+Option::None = y         # y has type Option (bare)
 ```
 
-A bare `option` type matches any `option[T]` in function signatures, similar to how bare `array` matches any `array[T]`:
+A bare `Option` type matches any `Option[T]` in function signatures, similar to how bare `array` matches any `array[T]`:
 
 ```casa
-fn check opt:option -> bool { true }
-42 some check    # works: option[int] matches bare option
+fn check opt:Option -> bool { true }
+42 Option::Some check    # works: Option[int] matches bare Option
 ```
 
-`none` and `some` can appear in different branches of a conditional. The type checker unifies them to the more specific `option[T]`:
+`Option::None` and `Option::Some` can appear in different branches of a conditional. The type checker unifies them to the more specific `Option[T]`:
 
 ```casa
-fn safe_head arr:array[int] -> option[int] {
+fn safe_head arr:array[int] -> Option[int] {
     if 0 arr .length > then
-        0 arr array::nth some
+        0 arr array::nth Option::Some
     else
-        none
+        Option::None
     fi
 }
 ```
 
 See [Standard Library -- Option](standard-library.md#option) for `is_some`, `is_none`, `unwrap`, and `unwrap_or`.
 
-### `result[T E]`
+### `Result[T E]`
 
-Result type representing either a success value (`ok`) or an error value (`error`). Built with the `ok` and `error` constructors.
-
-`ok` wraps the top-of-stack value into a result. The resulting type is `result[T any]` where `T` is the type of the wrapped value.
-
-**Stack effect:** `T -> result[T any]`
-
-`error` wraps the top-of-stack value into an error result. The resulting type is `result[any E]` where `E` is the type of the error value.
-
-**Stack effect:** `E -> result[any E]`
+Result type representing either a success value (`Result::Ok`) or an error value (`Result::Error`). `Result` is an enum defined in `lib/std.casa`:
 
 ```casa
-42 ok            # type: result[int any]
-"not found" error # type: result[any str]
+enum Result[T E] { Error(E) Ok(T) }
 ```
 
-At runtime, a result is heap-allocated as 16 bytes: `[tag, value]` where each field is 8 bytes. The tag is `1` for `ok` and `0` for `error`.
+`Result::Ok` wraps the top-of-stack value into a result. The resulting type is `Result[T any]` where `T` is the type of the wrapped value.
+
+**Stack effect:** `T -> Result[T any]`
+
+`Result::Error` wraps the top-of-stack value into an error result. The resulting type is `Result[any E]` where `E` is the type of the error value.
+
+**Stack effect:** `E -> Result[any E]`
+
+```casa
+42 Result::Ok            # type: Result[int any]
+"not found" Result::Error # type: Result[any str]
+```
+
+At runtime, a result is heap-allocated as 16 bytes: `[tag, value]` where each field is 8 bytes. The tag is `1` for `Ok` and `0` for `Error`.
 
 Results stored in variables retain their type:
 
 ```casa
-42 ok = x                    # x has type result[int any]
-"not found" error = y        # y has type result[any str]
+42 Result::Ok = x                    # x has type Result[int any]
+"not found" Result::Error = y        # y has type Result[any str]
 ```
 
 Type annotations can narrow the type to specify both type parameters:
 
 ```casa
-42 ok = x:result[int str]    # x has type result[int str]
+42 Result::Ok = x:Result[int str]    # x has type Result[int str]
 ```
 
-A bare `result` type matches any `result[T E]` in function signatures, similar to how bare `option` matches any `option[T]`:
+A bare `Result` type matches any `Result[T E]` in function signatures, similar to how bare `Option` matches any `Option[T]`:
 
 ```casa
-fn check res:result -> bool { true }
-42 ok check    # works: result[int any] matches bare result
+fn check res:Result -> bool { true }
+42 Result::Ok check    # works: Result[int any] matches bare Result
 ```
 
-`ok` and `error` can appear in different branches of a conditional. The type checker unifies them to the more specific `result[T E]`:
+`Result::Ok` and `Result::Error` can appear in different branches of a conditional. The type checker unifies them to the more specific `Result[T E]`:
 
 ```casa
-fn divide dividend:int divisor:int -> result[int str] {
+fn divide dividend:int divisor:int -> Result[int str] {
     if 0 divisor == then
-        "division by zero" error
+        "division by zero" Result::Error
     else
-        dividend divisor / ok
+        dividend divisor / Result::Ok
     fi
 }
 ```

--- a/examples/enum.casa
+++ b/examples/enum.casa
@@ -62,3 +62,33 @@ Color::Red = my_color
 if my_color Color::Red == then
     "it is red\n" print
 fi
+
+# Enum variants with inner values
+enum Shape {
+    Circle(int)
+    Rectangle(int int)
+    Point
+}
+
+10 Shape::Circle = circle
+3 4 Shape::Rectangle = rect
+Shape::Point = pt
+
+# Match with destructuring
+circle match
+    Shape::Circle(radius) => radius print "\n" print
+    Shape::Rectangle(width height) => width height * print "\n" print
+    Shape::Point => "point\n" print
+end
+
+rect match
+    Shape::Circle(radius) => radius print "\n" print
+    Shape::Rectangle(width height) => width height * print "\n" print
+    Shape::Point => "point\n" print
+end
+
+pt match
+    Shape::Circle(radius) => radius print "\n" print
+    Shape::Rectangle(width height) => width height * print "\n" print
+    Shape::Point => "point\n" print
+end

--- a/examples/option.casa
+++ b/examples/option.casa
@@ -1,14 +1,14 @@
 # Option type - representing values that may or may not exist
 #
-# some wraps a value into option[T], none creates an empty option.
+# Option::Some wraps a value into Option[T], Option::None creates an empty option.
 # Methods: is_some, is_none, unwrap, unwrap_or
 
 include "../lib/std.casa"
 
 # Creating options
-42 some = maybe_int       # option[int]
-"hello" some = maybe_str  # option[str]
-none = empty              # option (compatible with any option[T])
+42 Option::Some = maybe_int       # Option[int]
+"hello" Option::Some = maybe_str  # Option[str]
+Option::None = empty              # Option[T] (compatible with any Option[T])
 
 # Checking presence
 if maybe_int.is_some then
@@ -30,16 +30,22 @@ maybe_str.unwrap print "\n" print     # hello
 
 # Using options with generic functions
 fn id[T] T -> T { }
-42 some id .unwrap print "\n" print    # 42
+42 Option::Some id .unwrap print "\n" print    # 42
 
-# Branching with option types — none and some in different branches
-fn safe_head arr:array[int] -> option[int] {
+# Branching with option types
+fn safe_head arr:array[int] -> Option[int] {
     if 0 arr .length > then
-        0 arr array::nth some
+        0 arr array::nth Option::Some
     else
-        none
+        Option::None
     fi
 }
 
 [1, 2, 3] safe_head .unwrap print "\n" print  # 1
 [] (array[int]) safe_head .is_none print "\n" print  # 1 (true)
+
+# Match on option
+42 Option::Some match
+    Option::Some(value) => value print "\n" print
+    Option::None => "nothing\n" print
+end

--- a/examples/outputs/enum.out
+++ b/examples/outputs/enum.out
@@ -11,3 +11,6 @@ not up
 3
 4
 it is red
+10
+12
+point

--- a/examples/outputs/option.out
+++ b/examples/outputs/option.out
@@ -7,3 +7,4 @@ hello
 42
 1
 true
+42

--- a/examples/outputs/result.out
+++ b/examples/outputs/result.out
@@ -6,3 +6,4 @@ not found
 42
 5
 division by zero
+5

--- a/examples/result.casa
+++ b/examples/result.casa
@@ -1,13 +1,13 @@
 # Result type - representing success or failure with typed errors
 #
-# ok wraps a value into result[T any], error wraps an error into result[any E].
+# Result::Ok wraps a value into Result[T E], Result::Error wraps an error.
 # Methods: is_ok, is_error, unwrap, unwrap_error, unwrap_or
 
 include "../lib/std.casa"
 
 # Creating results
-42 ok = success          # result[int any]
-"not found" error = failure  # result[any str]
+42 Result::Ok = success            # Result[int E]
+"not found" Result::Error = failure  # Result[T str]
 
 # Checking status
 if success.is_ok then
@@ -28,11 +28,11 @@ failure.unwrap_error print "\n" print    # not found
 0 success.unwrap_or print "\n" print   # 42 (has a value, default ignored)
 
 # Function returning a result
-fn divide dividend:int divisor:int -> result[int str] {
+fn divide dividend:int divisor:int -> Result[int str] {
     if 0 divisor == then
-        "division by zero" error
+        "division by zero" Result::Error
     else
-        dividend divisor / ok
+        dividend divisor / Result::Ok
     fi
 }
 
@@ -46,3 +46,9 @@ fi
 if zero_div.is_error then
     zero_div.unwrap_error print "\n" print
 fi
+
+# Match on result
+5 Result::Ok match
+    Result::Ok(value) => value print "\n" print
+    Result::Error(err) => err print "\n" print
+end

--- a/examples/type_annotations.casa
+++ b/examples/type_annotations.casa
@@ -16,8 +16,8 @@ greeting print "\n" print
 flag print "\n" print
 
 # Type annotations with option types
-42 some = maybe_val:option[int]
-none = empty_val:option[int]
+42 Option::Some = maybe_val:Option[int]
+Option::None = empty_val:Option[int]
 
 # Check option values
 if maybe_val.is_some then

--- a/lib/parser.casa
+++ b/lib/parser.casa
@@ -33,28 +33,28 @@ impl Cursor {
         self.source.length self.pos >=
     }
 
-    fn peek self:Cursor -> option[char] {
+    fn peek self:Cursor -> Option[char] {
         if self.is_eof then
-            none (option[char])
+            Option::None (Option[char])
         else
-            self.pos self.source.at some
+            self.pos self.source.at Option::Some
         fi
     }
 
-    fn peek_at self:Cursor offset:int -> option[char] {
+    fn peek_at self:Cursor offset:int -> Option[char] {
         self.pos offset + = pa_idx
         if self.source.length pa_idx >= then
-            none (option[char])
+            Option::None (Option[char])
         else
-            pa_idx self.source.at some
+            pa_idx self.source.at Option::Some
         fi
     }
 
-    fn advance self:Cursor -> option[char] {
+    fn advance self:Cursor -> Option[char] {
         if self.is_eof then
-            none (option[char])
+            Option::None (Option[char])
         else
-            self.pos self.source.at some
+            self.pos self.source.at Option::Some
             self.pos 1 + self->pos
         fi
     }
@@ -77,16 +77,16 @@ impl Cursor {
         fi
     }
 
-    fn expect_char self:Cursor expected:char -> result[char ParseError] {
+    fn expect_char self:Cursor expected:char -> Result[char ParseError] {
         if self.is_eof then
-            self.pos "unexpected EOF" ParseError error
+            self.pos "unexpected EOF" ParseError Result::Error
         else
             self.pos self.source.at = ec_ch
             if ec_ch expected == then
                 self.pos 1 + self->pos
-                ec_ch ok
+                ec_ch Result::Ok
             else
-                self.pos "unexpected character" ParseError error
+                self.pos "unexpected character" ParseError Result::Error
             fi
         fi
     }
@@ -95,12 +95,12 @@ impl Cursor {
         self.pos n + self->pos
     }
 
-    fn take_string self:Cursor target:str -> result[str ParseError] {
+    fn take_string self:Cursor target:str -> Result[str ParseError] {
         if target self.starts_with then
             target.length self.skip
-            target ok
+            target Result::Ok
         else
-            self.pos "expected string not found" ParseError error
+            self.pos "expected string not found" ParseError Result::Error
         fi
     }
 
@@ -166,7 +166,7 @@ fn skip_whitespace cursor:Cursor {
     { .is_space } cursor.skip_while
 }
 
-fn parse_int cursor:Cursor -> result[int ParseError] {
+fn parse_int cursor:Cursor -> Result[int ParseError] {
     cursor.save = pi_start
     false = pi_neg
     if cursor.is_eof ! then
@@ -178,51 +178,51 @@ fn parse_int cursor:Cursor -> result[int ParseError] {
     { .is_digit } cursor.take_while = pi_digits
     if pi_digits.length 0 == then
         pi_start cursor.restore
-        pi_start "expected integer" ParseError error
+        pi_start "expected integer" ParseError Result::Error
     else
         pi_digits str_to_int = pi_val
-        if pi_neg then 0 pi_val - else pi_val fi ok
+        if pi_neg then 0 pi_val - else pi_val fi Result::Ok
     fi
 }
 
-fn parse_identifier cursor:Cursor -> result[str ParseError] {
+fn parse_identifier cursor:Cursor -> Result[str ParseError] {
     cursor.save = pid_start
     if cursor.is_eof then
-        pid_start "expected identifier" ParseError error
+        pid_start "expected identifier" ParseError Result::Error
     elif cursor.peek.unwrap is_ident_start ! then
-        pid_start "expected identifier" ParseError error
+        pid_start "expected identifier" ParseError Result::Error
     else
-        &is_ident_char cursor.take_while ok
+        &is_ident_char cursor.take_while Result::Ok
     fi
 }
 
-fn parse_escape cursor:Cursor -> result[char ParseError] {
+fn parse_escape cursor:Cursor -> Result[char ParseError] {
     cursor.advance = pe_opt
     if pe_opt.is_none then
-        cursor.pos "unexpected EOF in escape" ParseError error
+        cursor.pos "unexpected EOF in escape" ParseError Result::Error
         return
     fi
     pe_opt.unwrap = pe_ch
-    if pe_ch 'n' == then '\n' ok
-    elif pe_ch 't' == then '\t' ok
-    elif pe_ch '\\' == then '\\' ok
-    elif pe_ch '"' == then '"' ok
-    elif pe_ch '\'' == then '\'' ok
-    elif pe_ch '0' == then '\0' ok
-    elif pe_ch 'r' == then '\r' ok
-    elif pe_ch '{' == then '{' ok
-    elif pe_ch '}' == then '}' ok
+    if pe_ch 'n' == then '\n' Result::Ok
+    elif pe_ch 't' == then '\t' Result::Ok
+    elif pe_ch '\\' == then '\\' Result::Ok
+    elif pe_ch '"' == then '"' Result::Ok
+    elif pe_ch '\'' == then '\'' Result::Ok
+    elif pe_ch '0' == then '\0' Result::Ok
+    elif pe_ch 'r' == then '\r' Result::Ok
+    elif pe_ch '{' == then '{' Result::Ok
+    elif pe_ch '}' == then '}' Result::Ok
     else
-        cursor.pos "unknown escape sequence" ParseError error
+        cursor.pos "unknown escape sequence" ParseError Result::Error
     fi
 }
 
-fn parse_quoted_string cursor:Cursor -> result[str ParseError] {
+fn parse_quoted_string cursor:Cursor -> Result[str ParseError] {
     cursor.save = pqs_start
     '"' cursor.expect_char = pqs_open
     if pqs_open.is_error then
         pqs_start cursor.restore
-        pqs_open.unwrap_error error
+        pqs_open.unwrap_error Result::Error
         return
     fi
     pqs_open drop
@@ -231,14 +231,14 @@ fn parse_quoted_string cursor:Cursor -> result[str ParseError] {
         cursor.peek.unwrap = pqs_ch
         if pqs_ch '"' == then
             cursor.advance drop
-            pqs_chars chars_to_str ok
+            pqs_chars chars_to_str Result::Ok
             return
         elif pqs_ch '\\' == then
             cursor.advance drop
             cursor parse_escape = pqs_esc
             if pqs_esc.is_error then
                 pqs_start cursor.restore
-                pqs_esc.unwrap_error error
+                pqs_esc.unwrap_error Result::Error
                 return
             fi
             pqs_esc.unwrap pqs_chars.push
@@ -248,22 +248,22 @@ fn parse_quoted_string cursor:Cursor -> result[str ParseError] {
         fi
     done
     pqs_start cursor.restore
-    pqs_start "unterminated string" ParseError error
+    pqs_start "unterminated string" ParseError Result::Error
 }
 
-fn parse_char_literal cursor:Cursor -> result[char ParseError] {
+fn parse_char_literal cursor:Cursor -> Result[char ParseError] {
     cursor.save = pcl_start
     '\'' cursor.expect_char = pcl_open
     if pcl_open.is_error then
         pcl_start cursor.restore
-        pcl_open.unwrap_error error
+        pcl_open.unwrap_error Result::Error
         return
     fi
     pcl_open drop
     cursor.advance = pcl_opt
     if pcl_opt.is_none then
         pcl_start cursor.restore
-        pcl_start "unterminated char literal" ParseError error
+        pcl_start "unterminated char literal" ParseError Result::Error
         return
     fi
     pcl_opt.unwrap = pcl_ch
@@ -271,7 +271,7 @@ fn parse_char_literal cursor:Cursor -> result[char ParseError] {
         cursor parse_escape = pcl_esc
         if pcl_esc.is_error then
             pcl_start cursor.restore
-            pcl_esc.unwrap_error error
+            pcl_esc.unwrap_error Result::Error
             return
         fi
         pcl_esc.unwrap = pcl_ch
@@ -279,9 +279,9 @@ fn parse_char_literal cursor:Cursor -> result[char ParseError] {
     '\'' cursor.expect_char = pcl_close
     if pcl_close.is_error then
         pcl_start cursor.restore
-        pcl_close.unwrap_error error
+        pcl_close.unwrap_error Result::Error
         return
     fi
     pcl_close drop
-    pcl_ch ok
+    pcl_ch Result::Ok
 }

--- a/lib/std.casa
+++ b/lib/std.casa
@@ -401,21 +401,30 @@ impl ptr {
     fn to_str p:ptr -> str { p (int) .to_str }
 }
 
-impl option {
-    fn is_some self:option -> bool {
+# ---------------------------------------------------------------------------
+# Option and Result enums
+# ---------------------------------------------------------------------------
+# None=0, Some=1 so is_some checks ordinal==1
+enum Option[T] { None Some(T) }
+
+# Error=0, Ok=1 so is_ok checks ordinal==1
+enum Result[T E] { Error(E) Ok(T) }
+
+impl Option {
+    fn is_some self:Option -> bool {
         self (ptr) load64 1 ==
     }
-    fn is_none self:option -> bool {
+    fn is_none self:Option -> bool {
         self (ptr) load64 0 ==
     }
-    fn unwrap[T] self:option[T] -> T {
+    fn unwrap[T] self:Option[T] -> T {
         if self.is_none then
             "error: called unwrap on None\n" print
             60 exit
         fi
         self (ptr) 8 + load64 (T)
     }
-    fn unwrap_or[T] self:option[T] default:T -> T {
+    fn unwrap_or[T] self:Option[T] default:T -> T {
         if self.is_some then
             self.unwrap
         else
@@ -424,28 +433,28 @@ impl option {
     }
 }
 
-impl result {
-    fn is_ok self:result -> bool {
+impl Result {
+    fn is_ok self:Result -> bool {
         self (ptr) load64 1 ==
     }
-    fn is_error self:result -> bool {
+    fn is_error self:Result -> bool {
         self (ptr) load64 0 ==
     }
-    fn unwrap[T E] self:result[T E] -> T {
+    fn unwrap[T E] self:Result[T E] -> T {
         if self.is_error then
             "error: called unwrap on error\n" print
             60 exit
         fi
         self (ptr) 8 + load64 (T)
     }
-    fn unwrap_error[T E] self:result[T E] -> E {
+    fn unwrap_error[T E] self:Result[T E] -> E {
         if self.is_ok then
             "error: called unwrap_error on ok\n" print
             60 exit
         fi
         self (ptr) 8 + load64 (E)
     }
-    fn unwrap_or[T E] self:result[T E] default:T -> T {
+    fn unwrap_or[T E] self:Result[T E] default:T -> T {
         if self.is_ok then
             self.unwrap
         else
@@ -517,18 +526,18 @@ impl[K: Hashable, V] Map[K V] {
         self.size
     }
 
-    fn get self:Map[K V] key:K -> option[V] {
+    fn get self:Map[K V] key:K -> Option[V] {
         key K::hash self.capacity % = mg_idx
         self.buckets mg_idx 8 * + load64 = mg_entry
         while 0 mg_entry != do
             mg_entry (ptr) load64 (K) = mg_nk
             if key mg_nk K::eq then
-                mg_entry (ptr) 8 + load64 (V) some
+                mg_entry (ptr) 8 + load64 (V) Option::Some
                 return
             fi
             mg_entry (ptr) 16 + load64 = mg_entry
         done
-        none (option[V])
+        Option::None (Option[V])
     }
 
     fn has self:Map[K V] key:K -> bool {

--- a/tests/test_bytecode.py
+++ b/tests/test_bytecode.py
@@ -288,39 +288,6 @@ def test_bytecode_string_interning():
 
 
 # ---------------------------------------------------------------------------
-# Option[T] (none / some)
-# ---------------------------------------------------------------------------
-def test_bytecode_none():
-    """none generates HEAP_ALLOC and STORE64 instructions (tag 0)."""
-    program = compile_string("none")
-    kinds = [i.kind for i in program.bytecode]
-    assert InstKind.HEAP_ALLOC in kinds
-    assert InstKind.STORE64 in kinds
-
-
-def test_bytecode_some():
-    """42 some generates HEAP_ALLOC and STORE64 instructions (tag 1, value)."""
-    program = compile_string("42 some")
-    kinds = [i.kind for i in program.bytecode]
-    assert InstKind.HEAP_ALLOC in kinds
-    assert InstKind.STORE64 in kinds
-
-
-def test_bytecode_none_push_tag_zero():
-    """none pushes tag 0 for the none variant."""
-    program = compile_string("none")
-    pushes = find_insts(program, InstKind.PUSH)
-    assert any(i.args == [0] for i in pushes)
-
-
-def test_bytecode_some_push_tag_one():
-    """some pushes tag 1 for the some variant."""
-    program = compile_string("42 some")
-    pushes = find_insts(program, InstKind.PUSH)
-    assert any(i.args == [1] for i in pushes)
-
-
-# ---------------------------------------------------------------------------
 # Sized load/store variants
 # ---------------------------------------------------------------------------
 @pytest.mark.parametrize(

--- a/tests/test_emitter.py
+++ b/tests/test_emitter.py
@@ -467,42 +467,42 @@ def test_emit_to_str_in_fstring():
 
 
 # ---------------------------------------------------------------------------
-# option[T] (none / some)
+# Option[T] (Option::None / Option::Some)
 # ---------------------------------------------------------------------------
-def test_emit_none():
-    """none generates assembly with heap_ptr reference."""
-    asm = emit_string("none")
+def test_emit_option_some():
+    """Option::Some generates assembly with heap allocation."""
+    asm = emit_string(STD_INCLUDE + "42 Option::Some")
     assert "heap_ptr" in asm
 
 
-def test_emit_some():
-    """42 some generates assembly with heap allocation."""
-    asm = emit_string("42 some")
+def test_emit_option_none():
+    """Option::None generates assembly with heap_ptr reference."""
+    asm = emit_string(STD_INCLUDE + "Option::None")
     assert "heap_ptr" in asm
 
 
 def test_emit_option_is_some():
-    """option::is_some emits correct function label."""
-    asm = emit_string(STD_INCLUDE + "42 some .is_some")
-    assert "fn_option__is_some" in asm
+    """Option::is_some emits correct function label."""
+    asm = emit_string(STD_INCLUDE + "42 Option::Some .is_some")
+    assert "fn_Option__is_some" in asm
 
 
 def test_emit_option_is_none():
-    """option::is_none emits correct function label."""
-    asm = emit_string(STD_INCLUDE + "42 some .is_none")
-    assert "fn_option__is_none" in asm
+    """Option::is_none emits correct function label."""
+    asm = emit_string(STD_INCLUDE + "42 Option::Some .is_none")
+    assert "fn_Option__is_none" in asm
 
 
 def test_emit_option_unwrap():
-    """option::unwrap emits correct function label."""
-    asm = emit_string(STD_INCLUDE + "42 some .unwrap")
-    assert "fn_option__unwrap" in asm
+    """Option::unwrap emits correct function label."""
+    asm = emit_string(STD_INCLUDE + "42 Option::Some .unwrap")
+    assert "fn_Option__unwrap" in asm
 
 
 def test_emit_option_unwrap_or():
-    """option::unwrap_or emits correct function label."""
-    asm = emit_string(STD_INCLUDE + "0 42 some .unwrap_or")
-    assert "fn_option__unwrap_or" in asm
+    """Option::unwrap_or emits correct function label."""
+    asm = emit_string(STD_INCLUDE + "0 42 Option::Some .unwrap_or")
+    assert "fn_Option__unwrap_or" in asm
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -24,6 +24,9 @@ from tests.conftest import (
 CASA_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 COLOR_ENUM = "enum Color { Red Green Blue }\n"
 DIRECTION_ENUM = "enum Direction { North South East West }\n"
+SHAPE_ENUM = "enum Shape { Circle(int) Rectangle(int int) Point }\n"
+OPTION_ENUM = "enum Option[T] { None Some(T) }\n"
+RESULT_ENUM = "enum Result[T E] { Error(E) Ok(T) }\n"
 
 
 # ---------------------------------------------------------------------------
@@ -93,6 +96,55 @@ class TestEnumParsing:
     def test_parse_enum_unclosed_block_raises(self):
         with pytest.raises(CasaErrorCollection):
             parse_string("enum Color { Red Green Blue")
+
+    def test_parse_enum_with_inner_types(self):
+        parse_string(SHAPE_ENUM)
+        shape = GLOBAL_ENUMS["Shape"]
+        assert shape.variant_types["Circle"] == ["int"]
+        assert shape.variant_types["Rectangle"] == ["int", "int"]
+        assert shape.variant_types["Point"] == []
+
+    def test_parse_enum_has_inner_values(self):
+        parse_string(SHAPE_ENUM)
+        assert GLOBAL_ENUMS["Shape"].has_inner_values is True
+
+    def test_parse_plain_enum_no_inner_values(self):
+        parse_string(COLOR_ENUM)
+        assert GLOBAL_ENUMS["Color"].has_inner_values is False
+
+    def test_parse_generic_enum_type_vars(self):
+        parse_string(OPTION_ENUM)
+        assert GLOBAL_ENUMS["Option"].type_vars == ["T"]
+
+    def test_parse_generic_enum_two_type_vars(self):
+        parse_string(RESULT_ENUM)
+        assert GLOBAL_ENUMS["Result"].type_vars == ["T", "E"]
+
+    def test_parse_generic_enum_type_var_order_preserved(self):
+        parse_string("enum Pair[A B] { Left(A) Right(B) }\n")
+        assert GLOBAL_ENUMS["Pair"].type_vars == ["A", "B"]
+
+    def test_parse_empty_inner_types_raises(self):
+        with pytest.raises(CasaErrorCollection):
+            parse_string("enum Bad { Variant() }\n")
+
+    def test_parse_duplicate_type_var_raises(self):
+        with pytest.raises(CasaErrorCollection):
+            parse_string("enum Bad[T T] { A(T) }\n")
+
+    def test_parse_match_destructuring_bindings(self):
+        ops = resolve_string(
+            SHAPE_ENUM
+            + "10 Shape::Circle match\n"
+            + "    Shape::Circle(radius) => radius\n"
+            + "    Shape::Rectangle(width height) => width\n"
+            + "    Shape::Point => 0\n"
+            + "end\n"
+        )
+        arm_ops = find_ops(ops, OpKind.MATCH_ARM)
+        assert arm_ops[0].value.bindings == ["radius"]
+        assert arm_ops[1].value.bindings == ["width", "height"]
+        assert arm_ops[2].value.bindings == []
 
 
 # ---------------------------------------------------------------------------
@@ -443,6 +495,82 @@ class TestMatchInFunction:
 
 
 # ---------------------------------------------------------------------------
+# Type checking: inner values and generics
+# ---------------------------------------------------------------------------
+class TestEnumInnerValuesTypeChecking:
+    def test_data_variant_pops_inner_and_pushes_enum(self):
+        sig = typecheck_string(SHAPE_ENUM + "10 Shape::Circle")
+        assert sig.return_types == ["Shape"]
+
+    def test_data_variant_two_inner_values(self):
+        sig = typecheck_string(SHAPE_ENUM + "3 4 Shape::Rectangle")
+        assert sig.return_types == ["Shape"]
+
+    def test_no_data_variant_in_data_enum(self):
+        sig = typecheck_string(SHAPE_ENUM + "Shape::Point")
+        assert sig.return_types == ["Shape"]
+
+    def test_generic_some_pushes_option_int(self):
+        sig = typecheck_string(OPTION_ENUM + "42 Option::Some")
+        assert sig.return_types == ["Option[int]"]
+
+    def test_generic_some_pushes_option_str(self):
+        sig = typecheck_string(OPTION_ENUM + '"hello" Option::Some')
+        assert sig.return_types == ["Option[str]"]
+
+    def test_generic_none_pushes_option_t(self):
+        sig = typecheck_string(OPTION_ENUM + "Option::None")
+        assert sig.return_types == ["Option[T]"]
+
+    def test_result_ok_pushes_result(self):
+        sig = typecheck_string(RESULT_ENUM + "42 Result::Ok")
+        assert sig.return_types == ["Result[int E]"]
+
+    def test_result_error_pushes_result(self):
+        sig = typecheck_string(RESULT_ENUM + '"oops" Result::Error')
+        assert sig.return_types == ["Result[T str]"]
+
+    def test_data_enum_wrong_inner_type_raises(self):
+        with pytest.raises(CasaErrorCollection):
+            typecheck_string(SHAPE_ENUM + '"hello" Shape::Circle')
+
+    def test_match_destructuring_binding_types(self):
+        sig = typecheck_string(
+            OPTION_ENUM
+            + "42 Option::Some match\n"
+            + "    Option::Some(value) => value\n"
+            + "    Option::None => 0\n"
+            + "end\n"
+        )
+        assert sig.return_types == ["int"]
+
+    def test_match_destructuring_wrong_binding_count_raises(self):
+        with pytest.raises(CasaErrorCollection):
+            typecheck_string(
+                SHAPE_ENUM
+                + "10 Shape::Circle match\n"
+                + "    Shape::Circle(a b) => a\n"
+                + "    Shape::Rectangle(w h) => w\n"
+                + "    Shape::Point => 0\n"
+                + "end\n"
+            )
+
+    def test_data_enum_comparison(self):
+        sig = typecheck_string(
+            SHAPE_ENUM + "Shape::Point Shape::Point =="
+        )
+        assert sig.return_types == ["bool"]
+
+    def test_generic_enum_in_function_return(self):
+        sig = typecheck_string(
+            OPTION_ENUM
+            + "fn wrap x:int -> Option[int] { x Option::Some }\n"
+            + "42 wrap\n"
+        )
+        assert sig.return_types == ["Option[int]"]
+
+
+# ---------------------------------------------------------------------------
 # Bytecode: PUSH_ENUM_VARIANT compiles to PUSH(ordinal)
 # ---------------------------------------------------------------------------
 def find_insts(program: Program, kind: InstKind, in_functions: bool = False):
@@ -488,6 +616,25 @@ class TestEnumBytecode:
     def test_enum_print_compiles_to_print_int(self):
         program = compile_string(COLOR_ENUM + "Color::Red print\n")
         assert len(find_insts(program, InstKind.PRINT_INT)) >= 1
+
+    def test_data_enum_variant_compiles_to_heap_alloc(self):
+        program = compile_string(SHAPE_ENUM + "10 Shape::Circle\n")
+        assert len(find_insts(program, InstKind.HEAP_ALLOC)) >= 1
+
+    def test_data_enum_stores_ordinal(self):
+        program = compile_string(SHAPE_ENUM + "10 Shape::Circle\n")
+        assert len(find_insts(program, InstKind.STORE64)) >= 1
+
+    def test_data_enum_match_loads_ordinal(self):
+        program = compile_string(
+            SHAPE_ENUM
+            + "10 Shape::Circle match\n"
+            + "    Shape::Circle(r) => r drop\n"
+            + "    Shape::Rectangle(w h) => w drop\n"
+            + "    Shape::Point => 0 drop\n"
+            + "end\n"
+        )
+        assert len(find_insts(program, InstKind.LOAD64)) >= 1
 
 
 # ---------------------------------------------------------------------------
@@ -653,3 +800,100 @@ class TestEnumEndToEnd:
             + "Direction::West print\n"
         )
         assert output == "03"
+
+    def test_data_enum_match_destructure(self, run_casa):
+        output = run_casa(
+            SHAPE_ENUM
+            + "10 Shape::Circle match\n"
+            + "    Shape::Circle(radius) => radius print\n"
+            + "    Shape::Rectangle(width height) => width height * print\n"
+            + '    Shape::Point => "point" print\n'
+            + "end\n"
+        )
+        assert output == "10"
+
+    def test_data_enum_match_second_arm(self, run_casa):
+        output = run_casa(
+            SHAPE_ENUM
+            + "3 4 Shape::Rectangle match\n"
+            + "    Shape::Circle(radius) => radius print\n"
+            + "    Shape::Rectangle(width height) => width height * print\n"
+            + '    Shape::Point => "point" print\n'
+            + "end\n"
+        )
+        assert output == "12"
+
+    def test_data_enum_match_no_data_arm(self, run_casa):
+        output = run_casa(
+            SHAPE_ENUM
+            + "Shape::Point match\n"
+            + "    Shape::Circle(radius) => radius print\n"
+            + "    Shape::Rectangle(width height) => width height * print\n"
+            + '    Shape::Point => "point" print\n'
+            + "end\n"
+        )
+        assert output == "point"
+
+    def test_generic_enum_some(self, run_casa):
+        output = run_casa(
+            OPTION_ENUM
+            + "42 Option::Some match\n"
+            + "    Option::Some(value) => value print\n"
+            + '    Option::None => "none" print\n'
+            + "end\n"
+        )
+        assert output == "42"
+
+    def test_generic_enum_none(self, run_casa):
+        output = run_casa(
+            OPTION_ENUM
+            + "Option::None match\n"
+            + '    Option::Some(value) => "some" print\n'
+            + '    Option::None => "none" print\n'
+            + "end\n"
+        )
+        assert output == "none"
+
+    def test_result_ok_destructure(self, run_casa):
+        output = run_casa(
+            RESULT_ENUM
+            + "5 Result::Ok match\n"
+            + "    Result::Error(err) => err print\n"
+            + "    Result::Ok(val) => val print\n"
+            + "end\n"
+        )
+        assert output == "5"
+
+    def test_result_error_destructure(self, run_casa):
+        output = run_casa(
+            RESULT_ENUM
+            + '"oops" Result::Error match\n'
+            + "    Result::Error(err) => err print\n"
+            + '    Result::Ok(val) => "ok" print\n'
+            + "end\n"
+        )
+        assert output == "oops"
+
+    def test_data_enum_wildcard(self, run_casa):
+        output = run_casa(
+            SHAPE_ENUM
+            + "Shape::Point match\n"
+            + "    Shape::Circle(radius) => radius print\n"
+            + '    _ => "other" print\n'
+            + "end\n"
+        )
+        assert output == "other"
+
+    def test_data_enum_eq(self, run_casa):
+        output = run_casa(
+            SHAPE_ENUM
+            + "Shape::Point Shape::Point == print\n"
+        )
+        assert output == "true"
+
+    def test_data_enum_ne(self, run_casa):
+        output = run_casa(
+            SHAPE_ENUM
+            + "10 Shape::Circle Shape::Point != print\n"
+        )
+        assert output == "true"

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -69,10 +69,6 @@ ALL_INTRINSICS = [
     "syscall4",
     "syscall5",
     "syscall6",
-    "none",
-    "some",
-    "ok",
-    "error",
     "argc",
     "argv",
 ]
@@ -891,65 +887,20 @@ def test_lex_multiple_comment_lines():
 
 
 # ---------------------------------------------------------------------------
-# Option[T] literals (none / some)
+# none / some are identifiers (no longer intrinsics)
 # ---------------------------------------------------------------------------
-def test_lex_none_intrinsic():
-    """none is recognized as an INTRINSIC token."""
+def test_lex_none_is_identifier():
+    """none is lexed as an IDENTIFIER token."""
     tokens = lex_string("none")
-    assert tokens[0].kind == TokenKind.INTRINSIC
+    assert tokens[0].kind == TokenKind.IDENTIFIER
     assert tokens[0].value == "none"
 
 
-def test_lex_some_intrinsic():
-    """some is recognized as an INTRINSIC token."""
+def test_lex_some_is_identifier():
+    """some is lexed as an IDENTIFIER token."""
     tokens = lex_string("some")
-    assert tokens[0].kind == TokenKind.INTRINSIC
+    assert tokens[0].kind == TokenKind.IDENTIFIER
     assert tokens[0].value == "some"
-
-
-def test_lex_none_is_not_keyword():
-    """none should not be lexed as a keyword."""
-    tokens = lex_string("none")
-    assert tokens[0].kind != TokenKind.KEYWORD
-
-
-def test_lex_some_is_not_keyword():
-    """some should not be lexed as a keyword."""
-    tokens = lex_string("some")
-    assert tokens[0].kind != TokenKind.KEYWORD
-
-
-def test_lex_none_is_not_identifier():
-    """none should not be lexed as an identifier."""
-    tokens = lex_string("none")
-    assert tokens[0].kind != TokenKind.IDENTIFIER
-
-
-def test_lex_some_is_not_identifier():
-    """some should not be lexed as an identifier."""
-    tokens = lex_string("some")
-    assert tokens[0].kind != TokenKind.IDENTIFIER
-
-
-def test_lex_none_in_expression():
-    """none in an expression context lexes correctly."""
-    tokens = lex_string("none print")
-    non_eof = [t for t in tokens if t.kind != TokenKind.EOF]
-    assert len(non_eof) == 2
-    assert non_eof[0].kind == TokenKind.INTRINSIC
-    assert non_eof[0].value == "none"
-    assert non_eof[1].kind == TokenKind.INTRINSIC
-
-
-def test_lex_some_in_expression():
-    """some after a value lexes correctly."""
-    tokens = lex_string("42 some")
-    non_eof = [t for t in tokens if t.kind != TokenKind.EOF]
-    assert len(non_eof) == 2
-    assert non_eof[0].kind == TokenKind.LITERAL
-    assert non_eof[0].value == "42"
-    assert non_eof[1].kind == TokenKind.INTRINSIC
-    assert non_eof[1].value == "some"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_lsp.py
+++ b/tests/test_lsp.py
@@ -929,20 +929,6 @@ class TestHoverStackEffects:
         assert result is not None
         assert "print: any -> None" in result.contents.value
 
-    def test_some_hover(self, tmp_path):
-        """Hover over some shows its stack effect."""
-        source_file = tmp_path / "hover_some.casa"
-        source = "42 some drop"
-        source_file.write_text(source)
-
-        state, _ = run_pipeline(source_file)
-        uri = f"file://{source_file}"
-        document_states[uri] = state
-
-        result = text_document_hover(_make_hover_params(uri, 0, 3))
-        assert result is not None
-        assert "some: any -> option[any]" in result.contents.value
-
     def test_exec_hover(self, tmp_path):
         """Hover over exec shows its stack effect."""
         source_file = tmp_path / "hover_exec.casa"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -601,71 +601,26 @@ def test_parse_fn_type_two_generic_vars():
 
 
 # ---------------------------------------------------------------------------
-# Option[T] literals (none / some)
+# Option[T] / Result[T E] enum variants
 # ---------------------------------------------------------------------------
-def test_parse_push_none():
-    """none produces OpKind.PUSH_NONE op."""
-    ops = parse_string("none")
-    assert len(ops) == 1
-    assert ops[0].kind == OpKind.PUSH_NONE
-
-
-def test_parse_some():
-    """some produces OpKind.SOME op."""
-    ops = parse_string("42 some")
-    some_ops = find_ops(ops, OpKind.SOME)
-    assert len(some_ops) == 1
-
-
-def test_parse_none_value():
-    """PUSH_NONE op has Intrinsic.NONE as value."""
-    ops = parse_string("none")
-    assert ops[0].value == Intrinsic.NONE
-
-
-def test_parse_some_value():
-    """SOME op has Intrinsic.SOME as value."""
-    ops = parse_string("42 some")
-    some_ops = find_ops(ops, OpKind.SOME)
-    assert some_ops[0].value == Intrinsic.SOME
-
-
-def test_parse_none_in_function():
-    """none can appear inside function body."""
-    parse_string("fn get_none -> { none }")
-    fn = GLOBAL_FUNCTIONS["get_none"]
-    none_ops = find_ops(fn.ops, OpKind.PUSH_NONE)
-    assert len(none_ops) == 1
-
-
-def test_parse_some_in_function():
-    """some can appear inside function body."""
-    parse_string("fn wrap a:int -> { a some }")
-    fn = GLOBAL_FUNCTIONS["wrap"]
-    some_ops = find_ops(fn.ops, OpKind.SOME)
-    assert len(some_ops) == 1
-
-
 def test_parse_option_type_in_fn_signature():
-    """option[int] parses correctly as a parameter type."""
-    parse_string("fn unwrap opt:option[int] -> int { 0 }")
+    """Option[int] parses correctly as a parameter type."""
+    parse_string(
+        "enum Option[T] { None Some(T) }"
+        " fn unwrap opt:Option[int] -> int { 0 }"
+    )
     fn = GLOBAL_FUNCTIONS["unwrap"]
     assert fn.signature is not None
-    assert [p.typ for p in fn.signature.parameters] == ["option[int]"]
+    assert [p.typ for p in fn.signature.parameters] == ["Option[int]"]
     assert fn.signature.return_types == ["int"]
 
 
-def test_parse_bare_option_type_in_fn_signature():
-    """Bare option parses correctly as a parameter type."""
-    parse_string("fn check opt:option -> bool { true }")
-    fn = GLOBAL_FUNCTIONS["check"]
-    assert fn.signature is not None
-    assert [p.typ for p in fn.signature.parameters] == ["option"]
-
-
 def test_parse_option_type_in_return_type():
-    """option[int] can appear as a return type."""
-    parse_string("fn wrap x:int -> option[int] { x some }")
+    """Option[int] can appear as a return type."""
+    parse_string(
+        "enum Option[T] { None Some(T) }"
+        " fn wrap x:int -> Option[int] { x Option::Some }"
+    )
     fn = GLOBAL_FUNCTIONS["wrap"]
     assert fn.signature is not None
-    assert fn.signature.return_types == ["option[int]"]
+    assert fn.signature.return_types == ["Option[int]"]

--- a/tests/test_type_annotations.py
+++ b/tests/test_type_annotations.py
@@ -46,16 +46,16 @@ class TestParserTypeAnnotation:
         assert assign_ops[0].type_annotation == "bool"
 
     def test_annotation_option_int(self):
-        """= x:option[int] produces Op with type_annotation='option[int]'."""
-        ops = parse_string("42 some = x:option[int]")
+        """= x:Option[int] produces Op with type_annotation='Option[int]'."""
+        ops = parse_string("0 = x:Option[int]")
         assign_ops = find_ops(ops, OpKind.ASSIGN_VARIABLE)
-        assert assign_ops[0].type_annotation == "option[int]"
+        assert assign_ops[0].type_annotation == "Option[int]"
 
     def test_annotation_bare_option(self):
-        """= x:option produces Op with type_annotation='option'."""
-        ops = parse_string("none = x:option")
+        """= x:Option produces Op with type_annotation='Option'."""
+        ops = parse_string("0 = x:Option")
         assign_ops = find_ops(ops, OpKind.ASSIGN_VARIABLE)
-        assert assign_ops[0].type_annotation == "option"
+        assert assign_ops[0].type_annotation == "Option"
 
     def test_annotation_generic_list(self):
         """= x:List[int] produces Op with type_annotation='List[int]'."""
@@ -155,10 +155,12 @@ class TestTypecheckerTypeAnnotation:
         sig = typecheck_string('"hello" (any) = x:str x')
         assert sig.return_types == ["str"]
 
-    def test_narrow_bare_option_to_option_int(self):
-        """Type annotation narrows bare 'option' to 'option[int]'."""
-        sig = typecheck_string("none = x:option[int] x")
-        assert sig.return_types == ["option[int]"]
+    def test_narrow_any_to_option(self):
+        """Type annotation narrows 'any' to 'Option[T]'."""
+        sig = typecheck_string(
+            "enum Option[T] { None Some(T) } Option::None (any) = x:Option[T] x"
+        )
+        assert sig.return_types == ["Option[T]"]
 
     def test_type_mismatch_raises(self):
         """Annotating str value as int raises TYPE_MISMATCH."""
@@ -194,9 +196,11 @@ class TestTypecheckerTypeAnnotation:
         assert sig.return_types == ["int"]
 
     def test_annotation_option_int_with_some(self):
-        """42 some = x:option[int] assigns x with type option[int]."""
-        sig = typecheck_string("42 some = x:option[int] x")
-        assert sig.return_types == ["option[int]"]
+        """Option::Some = x:Option[int] assigns x with type Option[int]."""
+        sig = typecheck_string(
+            "enum Option[T] { None Some(T) } 42 Option::Some = x:Option[int] x"
+        )
+        assert sig.return_types == ["Option[int]"]
 
     def test_without_annotation_still_works(self):
         """Assignment without annotation still infers type normally."""
@@ -230,12 +234,14 @@ class TestTypecheckerTypeAnnotationWarnings:
         assert "any" in WARNINGS[0].message
 
     def test_warn_bare_option_retains_type(self):
-        """Annotating option[int] as bare option warns and retains original type."""
-        sig = typecheck_string("42 some = x:option x")
+        """Annotating Option[int] as bare Option warns and retains original type."""
+        sig = typecheck_string(
+            "enum Option[T] { None Some(T) } 42 Option::Some = x:Option x"
+        )
         assert len(WARNINGS) == 1
         assert WARNINGS[0].kind == WarningKind.LOSSY_TYPE_ANNOTATION
-        assert "option" in WARNINGS[0].message
-        assert sig.return_types == ["option[int]"]
+        assert "Option" in WARNINGS[0].message
+        assert sig.return_types == ["Option[int]"]
 
     def test_warn_bare_array_retains_type(self):
         """Annotating array[int] as bare array warns and retains original type."""
@@ -250,9 +256,11 @@ class TestTypecheckerTypeAnnotationWarnings:
         typecheck_string("42 = x:int")
         assert len(WARNINGS) == 0
 
-    def test_no_warn_narrowing_option(self):
-        """No warning when narrowing bare option to option[int]."""
-        typecheck_string("none = x:option[int]")
+    def test_no_warn_matching_option(self):
+        """No warning when annotation matches Option type."""
+        typecheck_string(
+            "enum Option[T] { None Some(T) } 42 Option::Some = x:Option[int]"
+        )
         assert len(WARNINGS) == 0
 
     def test_no_warn_narrowing_any(self):

--- a/tests/test_typechecker.py
+++ b/tests/test_typechecker.py
@@ -1049,170 +1049,174 @@ def test_typecheck_map_str_array():
 # ---------------------------------------------------------------------------
 # Option[T] type
 # ---------------------------------------------------------------------------
+OPTION_ENUM = "enum Option[T] { None Some(T) } "
+RESULT_ENUM = "enum Result[T E] { Error(E) Ok(T) } "
+
+
 def test_typecheck_none_pushes_option():
-    """none pushes bare option onto the stack."""
-    sig = typecheck_string("none")
-    assert sig.return_types == ["option"]
+    """Option::None pushes Option[T] onto the stack."""
+    sig = typecheck_string(OPTION_ENUM + "Option::None")
+    assert sig.return_types == ["Option[T]"]
 
 
 def test_typecheck_some_int():
-    """42 some pushes option[int] onto the stack."""
-    sig = typecheck_string("42 some")
-    assert sig.return_types == ["option[int]"]
+    """42 Option::Some pushes Option[int] onto the stack."""
+    sig = typecheck_string(OPTION_ENUM + "42 Option::Some")
+    assert sig.return_types == ["Option[int]"]
 
 
 def test_typecheck_some_str():
-    """'hello' some pushes option[str] onto the stack."""
-    sig = typecheck_string('"hello" some')
-    assert sig.return_types == ["option[str]"]
+    """'hello' Option::Some pushes Option[str] onto the stack."""
+    sig = typecheck_string(OPTION_ENUM + '"hello" Option::Some')
+    assert sig.return_types == ["Option[str]"]
 
 
 def test_typecheck_some_bool():
-    """true some pushes option[bool] onto the stack."""
-    sig = typecheck_string("true some")
-    assert sig.return_types == ["option[bool]"]
+    """true Option::Some pushes Option[bool] onto the stack."""
+    sig = typecheck_string(OPTION_ENUM + "true Option::Some")
+    assert sig.return_types == ["Option[bool]"]
 
 
 def test_typecheck_none_compat_with_option_int():
-    """none is compatible with option[int] in function signatures."""
-    code = """
-    fn take_opt opt:option[int] -> int { 0 }
-    none take_opt
+    """Option::None is compatible with Option[int] in function signatures."""
+    code = OPTION_ENUM + """
+    fn take_opt opt:Option[int] -> int { 0 }
+    Option::None take_opt
     """
     sig = typecheck_string(code)
     assert sig.return_types == ["int"]
 
 
 def test_typecheck_option_in_variable():
-    """option[int] stored in variable retains its type."""
-    code = "42 some = x x"
+    """Option[int] stored in variable retains its type."""
+    code = OPTION_ENUM + "42 Option::Some = x x"
     sig = typecheck_string(code)
-    assert sig.return_types == ["option[int]"]
+    assert sig.return_types == ["Option[int]"]
 
 
 def test_typecheck_none_in_variable():
-    """none stored in variable retains bare option type."""
-    code = "none = x x"
+    """Option::None stored in variable retains Option[T] type."""
+    code = OPTION_ENUM + "Option::None = x x"
     sig = typecheck_string(code)
-    assert sig.return_types == ["option"]
+    assert sig.return_types == ["Option[T]"]
 
 
 def test_typecheck_option_dup():
-    """dup on option[int] preserves the element type."""
-    sig = typecheck_string("42 some dup")
-    assert sig.return_types == ["option[int]", "option[int]"]
+    """dup on Option[int] preserves the element type."""
+    sig = typecheck_string(OPTION_ENUM + "42 Option::Some dup")
+    assert sig.return_types == ["Option[int]", "Option[int]"]
 
 
 def test_typecheck_bare_option_matches_typed_option():
-    """A function expecting bare option accepts option[int] (like bare array)."""
-    code = """
-    fn check opt:option -> bool { true }
-    42 some check
+    """A function expecting bare Option accepts Option[int] (like bare array)."""
+    code = OPTION_ENUM + """
+    fn check opt:Option -> bool { true }
+    42 Option::Some check
     """
     sig = typecheck_string(code)
     assert sig.return_types == ["bool"]
 
 
 def test_typecheck_typed_option_matches_bare_option():
-    """A function expecting option[int] accepts bare option (like typed array)."""
-    code = """
-    fn check opt:option[int] -> bool { true }
+    """A function expecting Option[int] accepts bare Option (like typed array)."""
+    code = OPTION_ENUM + """
+    fn check opt:Option[int] -> bool { true }
     """
     typecheck_string(code)
     fn = GLOBAL_FUNCTIONS["check"]
     assert fn.signature is not None
-    assert [p.typ for p in fn.signature.parameters] == ["option[int]"]
+    assert [p.typ for p in fn.signature.parameters] == ["Option[int]"]
 
 
 def test_typecheck_signature_matches_bare_and_typed_option():
-    """Signature.matches() treats bare option as compatible with option[int]."""
-    sig_bare = Signature([Parameter("option")], ["int"])
-    sig_typed = Signature([Parameter("option[int]")], ["int"])
+    """Signature.matches() treats bare Option as compatible with Option[int]."""
+    sig_bare = Signature([Parameter("Option")], ["int"])
+    sig_typed = Signature([Parameter("Option[int]")], ["int"])
     assert sig_bare.matches(sig_typed)
     assert sig_typed.matches(sig_bare)
 
 
 def test_typecheck_signature_matches_different_typed_options():
-    """Signature.matches() rejects option[int] vs option[str]."""
-    sig_int = Signature([Parameter("option[int]")], ["int"])
-    sig_str = Signature([Parameter("option[str]")], ["int"])
+    """Signature.matches() rejects Option[int] vs Option[str]."""
+    sig_int = Signature([Parameter("Option[int]")], ["int"])
+    sig_str = Signature([Parameter("Option[str]")], ["int"])
     assert not sig_int.matches(sig_str)
     assert not sig_str.matches(sig_int)
 
 
 def test_typecheck_option_is_some():
-    """is_some on option[int] returns bool."""
-    code = STD_INCLUDE + "42 some .is_some"
+    """is_some on Option[int] returns bool."""
+    code = STD_INCLUDE + "42 Option::Some .is_some"
     sig = typecheck_string(code)
     assert sig.return_types == ["bool"]
 
 
 def test_typecheck_option_is_none():
-    """is_none on option[int] returns bool."""
-    code = STD_INCLUDE + "42 some .is_none"
+    """is_none on Option[int] returns bool."""
+    code = STD_INCLUDE + "42 Option::Some .is_none"
     sig = typecheck_string(code)
     assert sig.return_types == ["bool"]
 
 
 def test_typecheck_none_is_some():
-    """is_some on none returns bool."""
-    code = STD_INCLUDE + "none .is_some"
+    """is_some on Option::None returns bool."""
+    code = STD_INCLUDE + "Option::None .is_some"
     sig = typecheck_string(code)
     assert sig.return_types == ["bool"]
 
 
 def test_typecheck_none_is_none():
-    """is_none on none returns bool."""
-    code = STD_INCLUDE + "none .is_none"
+    """is_none on Option::None returns bool."""
+    code = STD_INCLUDE + "Option::None .is_none"
     sig = typecheck_string(code)
     assert sig.return_types == ["bool"]
 
 
 def test_typecheck_option_unwrap():
-    """unwrap on option[int] returns int."""
-    code = STD_INCLUDE + "42 some .unwrap"
+    """unwrap on Option[int] returns int."""
+    code = STD_INCLUDE + "42 Option::Some .unwrap"
     sig = typecheck_string(code)
     assert sig.return_types == ["int"]
 
 
 def test_typecheck_option_unwrap_or():
-    """unwrap_or on option[int] with int default returns int."""
-    code = STD_INCLUDE + "0 42 some .unwrap_or"
+    """unwrap_or on Option[int] with int default returns int."""
+    code = STD_INCLUDE + "0 42 Option::Some .unwrap_or"
     sig = typecheck_string(code)
     assert sig.return_types == ["int"]
 
 
 def test_typecheck_option_in_generic_function():
-    """Generic function accepting option[T] parameter."""
-    code = """
+    """Generic function accepting Option[T] parameter."""
+    code = OPTION_ENUM + """
     fn id[T] T -> T { }
-    42 some id
+    42 Option::Some id
     """
     sig = typecheck_string(code)
-    assert sig.return_types == ["option[int]"]
+    assert sig.return_types == ["Option[int]"]
 
 
 def test_typecheck_option_type_in_fn_signature():
-    """Parser handles option[int] in function signatures."""
-    code = """
-    fn wrap x:int -> option[int] { x some }
+    """Parser handles Option[int] in function signatures."""
+    code = OPTION_ENUM + """
+    fn wrap x:int -> Option[int] { x Option::Some }
     42 wrap
     """
     sig = typecheck_string(code)
-    assert sig.return_types == ["option[int]"]
+    assert sig.return_types == ["Option[int]"]
 
 
 def test_typecheck_option_type_cast():
-    """Type cast (option[int]) works."""
-    code = "none (option[int])"
+    """Type cast (Option[int]) works."""
+    code = OPTION_ENUM + "Option::None (Option[int])"
     sig = typecheck_string(code)
-    assert sig.return_types == ["option[int]"]
+    assert sig.return_types == ["Option[int]"]
 
 
 def test_typecheck_signature_from_str_option_type():
-    """Signature.from_str handles option[int] as a parameter type."""
-    sig = Signature.from_str("option[int] -> int")
-    assert [p.typ for p in sig.parameters] == ["option[int]"]
+    """Signature.from_str handles Option[int] as a parameter type."""
+    sig = Signature.from_str("Option[int] -> int")
+    assert [p.typ for p in sig.parameters] == ["Option[int]"]
     assert sig.return_types == ["int"]
 
 
@@ -1220,39 +1224,39 @@ def test_typecheck_signature_from_str_option_type():
 # Option[T] branch compatibility
 # ---------------------------------------------------------------------------
 def test_typecheck_option_none_if_some_else():
-    """none in if branch and some in else branch are compatible."""
-    code = "if true then none else 42 some fi"
+    """Option::None in if branch and Option::Some in else branch are compatible."""
+    code = OPTION_ENUM + "if true then Option::None else 42 Option::Some fi"
     sig = typecheck_string(code)
-    assert sig.return_types == ["option[int]"]
+    assert sig.return_types == ["Option[int]"]
 
 
 def test_typecheck_option_some_if_none_else():
-    """some in if branch and none in else branch are compatible."""
-    code = "if true then 42 some else none fi"
+    """Option::Some in if branch and Option::None in else branch are compatible."""
+    code = OPTION_ENUM + "if true then 42 Option::Some else Option::None fi"
     sig = typecheck_string(code)
-    assert sig.return_types == ["option[int]"]
+    assert sig.return_types == ["Option[int]"]
 
 
 def test_typecheck_option_mixed_elif():
-    """Multiple elif branches mixing none and some are compatible."""
-    code = "if true then none elif false then 42 some else 99 some fi"
+    """Multiple elif branches mixing Option::None and Option::Some are compatible."""
+    code = OPTION_ENUM + "if true then Option::None elif false then 42 Option::Some else 99 Option::Some fi"
     sig = typecheck_string(code)
-    assert sig.return_types == ["option[int]"]
+    assert sig.return_types == ["Option[int]"]
 
 
 def test_typecheck_option_different_some_types_rejected():
-    """option[int] and option[bool] in different branches are incompatible."""
-    code = "if true then 42 some else true some fi"
+    """Option[int] and Option[bool] in different branches are incompatible."""
+    code = OPTION_ENUM + "if true then 42 Option::Some else true Option::Some fi"
     with pytest.raises(CasaErrorCollection) as exc_info:
         typecheck_string(code)
     assert exc_info.value.errors[0].kind == ErrorKind.STACK_MISMATCH
 
 
 def test_typecheck_option_none_if_no_else_no_change():
-    """none in if-without-else that doesn't change the stack is fine."""
-    code = "none if true then drop none fi"
+    """Option::None in if-without-else that doesn't change the stack is fine."""
+    code = OPTION_ENUM + "Option::None if true then drop Option::None fi"
     sig = typecheck_string(code)
-    assert sig.return_types == ["option"]
+    assert sig.return_types == ["Option[T]"]
 
 
 # ---------------------------------------------------------------------------
@@ -1389,41 +1393,41 @@ def test_typecheck_str_concat():
 # Return type unification
 # ---------------------------------------------------------------------------
 def test_typecheck_return_type_unification_ok_and_error():
-    """Return types with ok (result[T any]) and error (result[any E]) unify."""
-    code = """
+    """Return types with Result::Ok and Result::Error unify."""
+    code = RESULT_ENUM + """
     struct MyErr { msg: str }
-    fn try_it x:int -> result[int MyErr] {
+    fn try_it x:int -> Result[int MyErr] {
         if 0 x == then
-            "zero" MyErr error
+            "zero" MyErr Result::Error
             return
         fi
-        x ok
+        x Result::Ok
     }
     5 try_it
     """
     sig = typecheck_string(code)
-    assert sig.return_types == ["result[int MyErr]"]
+    assert sig.return_types == ["Result[int MyErr]"]
 
 
 def test_typecheck_return_type_unification_multiple_returns():
     """Multiple return statements with different any positions unify."""
-    code = """
+    code = RESULT_ENUM + """
     struct ParseErr { msg: str pos: int }
-    fn parse x:int -> result[str ParseErr] {
+    fn parse x:int -> Result[str ParseErr] {
         if 0 x == then
-            x "bad" ParseErr error
+            x "bad" ParseErr Result::Error
             return
         fi
         if 10 x > then
-            x "too big" ParseErr error
+            x "too big" ParseErr Result::Error
             return
         fi
-        "good" ok
+        "good" Result::Ok
     }
     5 parse
     """
     sig = typecheck_string(code)
-    assert sig.return_types == ["result[str ParseErr]"]
+    assert sig.return_types == ["Result[str ParseErr]"]
 
 
 def test_typecheck_return_type_unification_mismatch():


### PR DESCRIPTION
## Summary

- Add inner value support to enum variants: `enum Shape { Circle(int) Rectangle(int int) Point }`
- Add generic enum support: `enum Option[T] { Some(T) None }`
- Reimplement Option and Result as enum types defined in `lib/std.casa`, removing the built-in `some`/`none`/`ok`/`error` intrinsics entirely
- Enable match destructuring on data-carrying variants: `Option::Some(value) => value`
- Data-carrying enums are heap-allocated as `[ordinal, value1, value2, ...]`; plain enums remain stack ordinals

## Test plan

- [x] All 1099 unit tests pass (`pytest tests`)
- [x] All 31 example tests pass (`tests/test_examples.sh`)
- [x] 35 new tests added for enum inner values (parsing, type checking, bytecode, e2e)
- [x] Existing option/result tests updated to new syntax
- [x] `black`, `mypy`, `pylint` all pass
- [x] Code review passed with no must-fix or should-fix items