### PR TITLE
feat: literal pattern matching and string comparison

### DIFF
--- a/casa/bytecode.py
+++ b/casa/bytecode.py
@@ -17,6 +17,7 @@ from casa.common import (
     Inst,
     InstKind,
     LabelId,
+    LiteralPattern,
     Location,
     Op,
     OpKind,
@@ -450,7 +451,7 @@ class Compiler:
                 pass
             case OpKind.MATCH_ARM:
                 pattern = op.value
-                assert isinstance(pattern, (EnumVariant, StructPattern))
+                assert isinstance(pattern, (EnumVariant, StructPattern, LiteralPattern))
 
                 end_label = self._require_matching_label(
                     op,
@@ -477,6 +478,10 @@ class Compiler:
 
                 if isinstance(pattern, StructPattern):
                     self._compile_struct_match_arm(pattern, bytecode)
+                elif isinstance(pattern, LiteralPattern):
+                    self._compile_literal_match_arm(
+                        pattern, is_last, next_arm, bytecode
+                    )
                 elif (
                     isinstance(pattern, EnumVariant)
                     and pattern.enum_name
@@ -586,6 +591,32 @@ class Compiler:
         # Drop the enum pointer
         bytecode.append(self.inst(InstKind.DROP))
 
+    def _compile_literal_match_arm(
+        self,
+        pattern: LiteralPattern,
+        is_last: bool,
+        next_arm: LabelId | None,
+        bytecode: list[Inst],
+    ) -> None:
+        """Compile a literal value match arm (bool, int, char, str)."""
+        if is_last:
+            bytecode.append(self.inst(InstKind.DROP))
+            return
+        bytecode.append(self.inst(InstKind.DUP))
+        if pattern.typ == "str":
+            assert isinstance(pattern.value, str)
+            string_index = self.intern_string(pattern.value)
+            bytecode.append(self.inst(InstKind.PUSH_STR, args=[string_index]))
+            bytecode.append(self.inst(InstKind.STR_EQ))
+        elif pattern.typ == "char":
+            bytecode.append(self.inst(InstKind.PUSH, args=[pattern.value]))
+            bytecode.append(self.inst(InstKind.EQ))
+        else:
+            bytecode.append(self.inst(InstKind.PUSH, args=[int(pattern.value)]))
+            bytecode.append(self.inst(InstKind.EQ))
+        bytecode.append(self.inst(InstKind.JUMP_NE, args=[next_arm]))
+        bytecode.append(self.inst(InstKind.DROP))
+
     def _compile_struct_new(self, op: Op, bytecode: list[Inst]) -> None:
         """Compile STRUCT_NEW op."""
         struct = op.value
@@ -689,7 +720,7 @@ class Compiler:
 
     def compile(self) -> Bytecode:
         """Lower all ops to bytecode instructions."""
-        assert len(InstKind) == 68, "Exhaustive handling for `InstructionKind"
+        assert len(InstKind) == 69, "Exhaustive handling for `InstructionKind"
         assert len(OpKind) == 85, "Exhaustive handling for `OpKind`"
 
         cursor = Cursor(sequence=self.ops)
@@ -711,6 +742,12 @@ class Compiler:
                     and op.type_annotation in GLOBAL_ENUMS
                 ):
                     self._compile_enum_comparison(op, bytecode)
+                    continue
+                # String content comparison
+                if op.kind in (OpKind.EQ, OpKind.NE) and op.type_annotation == "str":
+                    bytecode.append(self.inst(InstKind.STR_EQ))
+                    if op.kind == OpKind.NE:
+                        bytecode.append(self.inst(InstKind.NOT))
                     continue
                 # Data-carrying enum print: load ordinal from heap
                 if op.kind == OpKind.PRINT_INT and op.type_annotation:

--- a/casa/common.py
+++ b/casa/common.py
@@ -476,12 +476,14 @@ class Op:
                     raise TypeError(
                         f"`{self.kind}` requires value of type `EnumVariant`"
                     )
-            # Requires `EnumVariant` or `StructPattern`
+            # Requires `EnumVariant`, `StructPattern`, or `LiteralPattern`
             case OpKind.MATCH_ARM:
-                if not isinstance(self.value, (EnumVariant, StructPattern)):
+                if not isinstance(
+                    self.value, (EnumVariant, StructPattern, LiteralPattern)
+                ):
                     raise TypeError(
                         f"`{self.kind}` requires value of type"
-                        " `EnumVariant` or `StructPattern`"
+                        " `EnumVariant`, `StructPattern`, or `LiteralPattern`"
                     )
             # Requires `StructLiteral`
             case OpKind.STRUCT_LITERAL:
@@ -631,6 +633,9 @@ class InstKind(Enum):
     CONSTANT_LOAD = auto()
     CONSTANT_STORE = auto()
 
+    # Strings
+    STR_EQ = auto()
+
     # F-strings
     FSTRING_CONCAT = auto()
 
@@ -671,7 +676,7 @@ class Inst:
         return self.args[0]
 
     def __post_init__(self):
-        assert len(InstKind) == 68, "Exhaustive handling for `InstructionKind`"
+        assert len(InstKind) == 69, "Exhaustive handling for `InstructionKind`"
 
         match self.kind:
             # Should not have a parameter
@@ -715,6 +720,7 @@ class Inst:
                 | InstKind.STORE16
                 | InstKind.STORE32
                 | InstKind.STORE64
+                | InstKind.STR_EQ
                 | InstKind.SUB
                 | InstKind.SWAP
                 | InstKind.SYSCALL0
@@ -1025,6 +1031,23 @@ class StructPattern:
     @property
     def is_wildcard(self) -> bool:
         """Struct patterns are never wildcards."""
+        return False
+
+
+LITERAL_MATCH_TYPES = {"bool", "int", "char", "str"}
+
+
+@dataclass
+class LiteralPattern:
+    """A literal value pattern in a match arm (bool, int, char, str)."""
+
+    value: int | bool | str
+    typ: str  # "bool", "int", "char", "str"
+    raw: str  # Source representation for error messages
+
+    @property
+    def is_wildcard(self) -> bool:
+        """Literal patterns are never wildcards."""
         return False
 
 

--- a/casa/emitter.py
+++ b/casa/emitter.py
@@ -532,6 +532,33 @@ class Emitter:
                 self._indent("jmp str_concat")
                 self._line(f".Lconcat_done_{uid}:")
 
+    def _emit_str_eq(self) -> None:
+        """Emit string content equality comparison.
+
+        Stack: [str_a, str_b] -> [bool]
+        Compares lengths, then byte-by-byte content.
+        """
+        uid = self._uid()
+        # Pop both string pointers
+        self._indent("popq %rsi")  # str_b
+        self._indent("popq %rdi")  # str_a
+        # Compare lengths (stored at offset 0)
+        self._indent("movq (%rdi), %rcx")
+        self._indent("cmpq (%rsi), %rcx")
+        self._indent(f"jne .Lstreq_ne_{uid}")
+        # Lengths equal — compare data bytes (at offset 8)
+        self._indent("leaq 8(%rdi), %rdi")
+        self._indent("leaq 8(%rsi), %rsi")
+        self._indent("repe cmpsb")
+        self._indent(f"jne .Lstreq_ne_{uid}")
+        # Equal
+        self._indent("pushq $1")
+        self._indent(f"jmp .Lstreq_done_{uid}")
+        # Not equal
+        self._line(f".Lstreq_ne_{uid}:")
+        self._indent("pushq $0")
+        self._line(f".Lstreq_done_{uid}:")
+
     def _emit_syscall_ops(self, inst: Inst) -> None:
         """Emit syscall instructions."""
         SYSCALL_ARG_COUNTS = {
@@ -546,7 +573,7 @@ class Emitter:
         self._emit_syscall(SYSCALL_ARG_COUNTS[inst.kind])
 
     def _emit_inst(self, inst: Inst, is_global: bool) -> None:
-        assert len(InstKind) == 68, "Exhaustive handling for `InstKind`"
+        assert len(InstKind) == 69, "Exhaustive handling for `InstKind`"
         kind = inst.kind
         match kind:
             case (
@@ -623,6 +650,8 @@ class Emitter:
                 | InstKind.FSTRING_CONCAT
             ):
                 self._emit_io_ops(inst)
+            case InstKind.STR_EQ:
+                self._emit_str_eq()
             case (
                 InstKind.SYSCALL0
                 | InstKind.SYSCALL1

--- a/casa/parser.py
+++ b/casa/parser.py
@@ -20,6 +20,7 @@ from casa.common import (
     Function,
     Intrinsic,
     Keyword,
+    LiteralPattern,
     Location,
     Member,
     Op,
@@ -959,6 +960,8 @@ def _is_match_arm_boundary(cursor: Cursor[Token]) -> bool:
     token = seq[pos]
     if token.value == MATCH_WILDCARD and seq[pos + 1].value == "=>":
         return True
+    if token.kind == TokenKind.LITERAL and seq[pos + 1].value == "=>":
+        return True
     if token.kind != TokenKind.IDENTIFIER:
         return False
     next_value = seq[pos + 1].value
@@ -1027,6 +1030,26 @@ def _parse_struct_match_pattern(
     return StructPattern(name_token.value, bindings)
 
 
+def _parse_literal_match_pattern(token: Token) -> LiteralPattern:
+    """Parse a literal value into a LiteralPattern for a match arm."""
+    value = token.value
+    if value == "true":
+        return LiteralPattern(True, "bool", "true")
+    if value == "false":
+        return LiteralPattern(False, "bool", "false")
+    if value.isdigit() or is_negative_integer_literal(value):
+        return LiteralPattern(int(value), "int", value)
+    if value.startswith("'") and value.endswith("'") and len(value) == 3:
+        return LiteralPattern(ord(value[1]), "char", value)
+    if value.startswith('"') and value.endswith('"'):
+        return LiteralPattern(value[1:-1], "str", value)
+    raise_error(
+        ErrorKind.UNEXPECTED_TOKEN,
+        f"Unsupported literal in match arm: `{value}`",
+        token.location,
+    )
+
+
 def _handle_keyword_match(
     token: Token, cursor: Cursor[Token], function_name: str
 ) -> list[Op]:
@@ -1046,12 +1069,16 @@ def _handle_keyword_match(
             expect_token(cursor, value="=>")
             variant = EnumVariant(None, MATCH_WILDCARD, -1)
             ops.append(Op(variant, OpKind.MATCH_ARM, arm_token.location))
+        elif arm_token.kind == TokenKind.LITERAL:
+            expect_token(cursor, value="=>")
+            literal_pattern = _parse_literal_match_pattern(arm_token)
+            ops.append(Op(literal_pattern, OpKind.MATCH_ARM, arm_token.location))
         elif arm_token.kind != TokenKind.IDENTIFIER:
             raise_error(
                 ErrorKind.UNEXPECTED_TOKEN,
                 "Expected match pattern or `_`",
                 arm_token.location,
-                expected="enum variant, struct pattern, or `_`",
+                expected="enum variant, struct pattern, literal, or `_`",
                 got=f"`{arm_token.value}`",
             )
         elif (next_token := cursor.peek()) and next_token.value == "{":

--- a/casa/typechecker.py
+++ b/casa/typechecker.py
@@ -11,10 +11,12 @@ from casa.common import (
     GLOBAL_STRUCTS,
     GLOBAL_TRAITS,
     GLOBAL_VARIABLES,
+    LITERAL_MATCH_TYPES,
     MATCH_WILDCARD,
     EnumVariant,
     Function,
     Intrinsic,
+    LiteralPattern,
     Location,
     Op,
     OpKind,
@@ -399,6 +401,20 @@ class TypeChecker:
             casa_enum = GLOBAL_ENUMS[t1_enum]
             if casa_enum.has_inner_values:
                 op.type_annotation = t1_enum
+        elif t1 == "str" or t2 == "str":
+            if t1 != t2:
+                raise_error(
+                    ErrorKind.TYPE_MISMATCH,
+                    f"Cannot compare `{t2}` with `{t1}`",
+                    self.current_location,
+                )
+            if op.kind not in (OpKind.EQ, OpKind.NE):
+                raise_error(
+                    ErrorKind.TYPE_MISMATCH,
+                    "Type `str` only supports `==` and `!=` comparison",
+                    self.current_location,
+                )
+            op.type_annotation = "str"
         self.stack_push("bool")
 
     def check_boolean(self, op: Op) -> None:
@@ -979,14 +995,55 @@ class TypeChecker:
                 location,
             )
 
+    @staticmethod
+    def _check_literal_exhaustiveness(
+        typ: str,
+        covered: set[str],
+        has_wildcard: bool,
+        location: Location,
+    ) -> None:
+        """Check exhaustiveness for literal type matches."""
+        if has_wildcard:
+            return
+        if typ == "bool":
+            missing = [v for v in ("true", "false") if v not in covered]
+            if missing:
+                names = ", ".join(f"`{v}`" for v in missing)
+                raise_error(
+                    ErrorKind.TYPE_MISMATCH,
+                    f"Non-exhaustive match, missing arms: {names}",
+                    location,
+                )
+            return
+        # int, char, str have infinite/large domains — wildcard required
+        raise_error(
+            ErrorKind.TYPE_MISMATCH,
+            f"Non-exhaustive match on type `{typ}`." f" A wildcard `_` arm is required",
+            location,
+        )
+
     def _check_match_arm_pattern(
         self,
-        pattern: "EnumVariant | StructPattern",
+        pattern: "EnumVariant | StructPattern | LiteralPattern",
         match_type: str,
         location: Location,
         branched: BranchedStack,
     ) -> str:
         """Validate a match arm pattern and return its covered_key."""
+        if isinstance(pattern, LiteralPattern):
+            if pattern.typ != match_type:
+                raise_error(
+                    ErrorKind.TYPE_MISMATCH,
+                    f"Literal `{pattern.raw}` has type `{pattern.typ}`,"
+                    f" but match subject has type `{match_type}`",
+                    location,
+                )
+            covered_key = f"__covered:{pattern.raw}"
+            self._check_duplicate_arm(
+                covered_key, f"`{pattern.raw}`", location, branched
+            )
+            return covered_key
+
         if isinstance(pattern, StructPattern):
             if pattern.struct_name != match_type:
                 raise_error(
@@ -1007,6 +1064,14 @@ class TypeChecker:
             return f"__covered:{MATCH_WILDCARD}"
 
         base_match_type = self._resolve_match_type(match_type)
+
+        if base_match_type in LITERAL_MATCH_TYPES:
+            raise_error(
+                ErrorKind.TYPE_MISMATCH,
+                f"Expected `{base_match_type}` literal or `_`,"
+                f" got `{variant.variant_name}`",
+                location,
+            )
 
         if variant.enum_name is None:
             # Bare variant name without enum qualifier
@@ -1074,10 +1139,15 @@ class TypeChecker:
             case OpKind.MATCH_START:
                 typ = self.stack_pop()
                 base = self._resolve_match_type(typ)
-                if base not in GLOBAL_ENUMS and base not in GLOBAL_STRUCTS:
+                if (
+                    base not in GLOBAL_ENUMS
+                    and base not in GLOBAL_STRUCTS
+                    and base not in LITERAL_MATCH_TYPES
+                ):
                     raise_error(
                         ErrorKind.TYPE_MISMATCH,
-                        f"Match requires an enum or struct type, got `{typ}`",
+                        f"Match requires an enum, struct, or literal type,"
+                        f" got `{typ}`",
                         op.location,
                     )
                 bs = BranchedStack(self.stack, self.stack_origins)
@@ -1087,7 +1157,7 @@ class TypeChecker:
                 self.branched_stacks.append(bs)
             case OpKind.MATCH_ARM:
                 pattern = op.value
-                assert isinstance(pattern, (EnumVariant, StructPattern))
+                assert isinstance(pattern, (EnumVariant, StructPattern, LiteralPattern))
                 assert self.branched_stacks, "Match block stack state is saved"
                 branched = self.branched_stacks[-1]
 
@@ -1232,6 +1302,10 @@ class TypeChecker:
                             f"Non-exhaustive match on struct `{match_type}`",
                             op.location,
                         )
+                elif base_match_type in LITERAL_MATCH_TYPES:
+                    self._check_literal_exhaustiveness(
+                        base_match_type, covered, has_wildcard, op.location
+                    )
                 else:
                     casa_enum = GLOBAL_ENUMS[base_match_type]
                     if not has_wildcard:

--- a/docs/control-flow.md
+++ b/docs/control-flow.md
@@ -155,21 +155,21 @@ The type checker enforces that loops do not accumulate or consume stack values a
 
 ## Match
 
-Casa has exhaustive pattern matching on enum types using `match`/`end`.
+Casa has exhaustive pattern matching using `match`/`end`. Match works with enum types, struct types, and literal types (`bool`, `int`, `char`, `str`).
 
 ### Syntax
 
 ```
-<enum_value> match
-    EnumName::Variant1 => <body>
-    EnumName::Variant2 => <body>
+<value> match
+    <pattern1> => <body>
+    <pattern2> => <body>
     ...
 end
 ```
 
-The `match` keyword pops an enum value from the stack. Each arm specifies a variant pattern followed by `=>` and a body. The block is closed with `end`.
+The `match` keyword pops a value from the stack. Each arm specifies a pattern followed by `=>` and a body. The block is closed with `end`.
 
-### Basic Example
+### Enum Matching
 
 ```casa
 enum Color { Red Green Blue }
@@ -181,9 +181,46 @@ Color::Green match
 end
 ```
 
+### Literal Matching
+
+Match on `bool`, `int`, `char`, and `str` values using literal patterns:
+
+```casa
+fn describe n:int {
+    n match
+        0 => "zero" print
+        1 => "one" print
+        _ => "other" print
+    end
+}
+
+flag match
+    true => "yes" print
+    false => "no" print
+end
+
+ch match
+    'a' => "letter a" print
+    _ => "something else" print
+end
+
+name match
+    "Alice" => "Hi Alice" print
+    "Bob" => "Hi Bob" print
+    _ => "Hi stranger" print
+end
+```
+
 ### Exhaustiveness
 
-All variants of the enum must be covered. Missing a variant is a compile-time error. Duplicate arms are also rejected. A wildcard `_ =>` arm can be used to match all remaining variants:
+All match blocks must be exhaustive:
+
+- **Enums**: All variants must be covered, or a wildcard `_` arm must be present.
+- **Bool**: Both `true` and `false` must be covered, or a wildcard `_` arm must be present.
+- **Int, char, str**: A wildcard `_` arm is always required (infinite domain).
+- **Structs**: A struct pattern or wildcard `_` arm must be present.
+
+Missing arms are a compile-time error. Duplicate arms are also rejected.
 
 ```casa
 color match

--- a/docs/enums.md
+++ b/docs/enums.md
@@ -106,7 +106,7 @@ Color::Blue print    # 2
 
 ## Match Statement
 
-The `match` keyword provides exhaustive pattern matching on enum values. It consumes the enum value from the stack and executes the matching arm.
+The `match` keyword provides exhaustive pattern matching on enum values. It consumes the enum value from the stack and executes the matching arm. Match also works with literal types (`bool`, `int`, `char`, `str`) — see [Control Flow](control-flow.md#match) for details.
 
 ### Syntax
 

--- a/docs/operators.md
+++ b/docs/operators.md
@@ -89,6 +89,15 @@ All comparison operators consume two values and push a `bool`.
 
 > **Note on stack order:** In `1 0 >`, the value `0` is on top of the stack and `1` is below. The comparison checks whether the top (`0`) is greater than the second (`1`), which is false. To check if 1 > 0, write `0 1 >` or equivalently `1 0 <`.
 
+### String comparison
+
+String `==` and `!=` compare by content (byte-by-byte), not by pointer identity. Other comparison operators (`<`, `<=`, `>`, `>=`) are not supported for strings.
+
+```casa
+"hello" "hello" == print    # true
+"hello" "world" != print    # true
+```
+
 ## Boolean
 
 | Operator | Stack Effect | Description |

--- a/examples/enum.casa
+++ b/examples/enum.casa
@@ -92,3 +92,53 @@ pt match
     Shape::Rectangle(width height) => width height * print "\n" print
     Shape::Point => "point\n" print
 end
+
+# Match on literal types (bool, int, char, str)
+
+# Bool match - exhaustive with both arms
+fn is_active flag:bool -> str {
+    flag match
+        true => "active"
+        false => "inactive"
+    end
+}
+true is_active print "\n" print
+false is_active print "\n" print
+
+# Int match - wildcard required for exhaustiveness
+fn describe_number n:int -> str {
+    n match
+        0 => "zero"
+        1 => "one"
+        -1 => "negative one"
+        _ => "other"
+    end
+}
+0 describe_number print "\n" print
+1 describe_number print "\n" print
+-1 describe_number print "\n" print
+42 describe_number print "\n" print
+
+# Char match
+fn classify_char ch:char -> str {
+    ch match
+        'y' => "yes"
+        'n' => "no"
+        _ => "unknown"
+    end
+}
+'y' classify_char print "\n" print
+'n' classify_char print "\n" print
+'x' classify_char print "\n" print
+
+# String match
+fn greet name:str -> str {
+    name match
+        "Alice" => "Hi Alice"
+        "Bob" => "Hi Bob"
+        _ => "Hello"
+    end
+}
+"Alice" greet print "\n" print
+"Bob" greet print "\n" print
+"Charlie" greet print "\n" print

--- a/examples/outputs/enum.out
+++ b/examples/outputs/enum.out
@@ -14,3 +14,15 @@ it is red
 10
 12
 point
+active
+inactive
+zero
+one
+negative one
+other
+yes
+no
+unknown
+Hi Alice
+Hi Bob
+Hello

--- a/examples/outputs/string_operations.out
+++ b/examples/outputs/string_operations.out
@@ -11,6 +11,7 @@ A
 true
 false
 true
+true
 === concat ===
 hello world
 test

--- a/examples/string_operations.casa
+++ b/examples/string_operations.casa
@@ -18,11 +18,12 @@ include "../lib/std.casa"
 'A' print "\n" print
 '\n' (int) print "\n" print
 
-# String equality
+# String equality (== and != compare by content)
 "=== eq ===" print "\n" print
-"hello" "hello" str::eq print "\n" print
-"hello" "world" str::eq print "\n" print
-"" "" str::eq print "\n" print
+"hello" "hello" == print "\n" print
+"hello" "world" == print "\n" print
+"" "" == print "\n" print
+"hello" "world" != print "\n" print
 
 # String concatenation
 "=== concat ===" print "\n" print

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -10,6 +10,7 @@ from casa.common import (
     CasaEnum,
     EnumVariant,
     InstKind,
+    LiteralPattern,
     OpKind,
     Program,
 )
@@ -151,9 +152,9 @@ class TestEnumParsing:
 # Match arm: bare variant hint
 # ---------------------------------------------------------------------------
 class TestMatchBareVariantHint:
-    def test_non_identifier_token_rejected_by_parser(self):
+    def test_literal_in_enum_match_rejected_by_typechecker(self):
         with pytest.raises(CasaErrorCollection) as exc_info:
-            parse_string(
+            typecheck_string(
                 "enum Color { Red Green Blue }\n"
                 "Color::Red match\n"
                 "    42 => 1\n"
@@ -161,7 +162,7 @@ class TestMatchBareVariantHint:
                 "end\n"
             )
         error = exc_info.value.errors[0]
-        assert error.kind == ErrorKind.UNEXPECTED_TOKEN
+        assert error.kind == ErrorKind.TYPE_MISMATCH
 
     def test_bare_identifier_parsed_as_match_arm(self):
         """Bare identifiers are parsed as match arms and deferred to type checker."""
@@ -556,9 +557,7 @@ class TestEnumInnerValuesTypeChecking:
             )
 
     def test_data_enum_comparison(self):
-        sig = typecheck_string(
-            SHAPE_ENUM + "Shape::Point Shape::Point =="
-        )
+        sig = typecheck_string(SHAPE_ENUM + "Shape::Point Shape::Point ==")
         assert sig.return_types == ["bool"]
 
     def test_generic_enum_in_function_return(self):
@@ -885,15 +884,381 @@ class TestEnumEndToEnd:
         assert output == "other"
 
     def test_data_enum_eq(self, run_casa):
-        output = run_casa(
-            SHAPE_ENUM
-            + "Shape::Point Shape::Point == print\n"
-        )
+        output = run_casa(SHAPE_ENUM + "Shape::Point Shape::Point == print\n")
         assert output == "true"
 
     def test_data_enum_ne(self, run_casa):
-        output = run_casa(
-            SHAPE_ENUM
-            + "10 Shape::Circle Shape::Point != print\n"
-        )
+        output = run_casa(SHAPE_ENUM + "10 Shape::Circle Shape::Point != print\n")
         assert output == "true"
+
+
+# ---------------------------------------------------------------------------
+# Literal pattern matching — parsing
+# ---------------------------------------------------------------------------
+class TestLiteralMatchParsing:
+    def test_bool_literal_parsed_as_literal_pattern(self):
+        ops = parse_string("true match\n" "    true => 1\n" "    false => 0\n" "end\n")
+        arms = [op for op in ops if op.kind == OpKind.MATCH_ARM]
+        assert len(arms) == 2
+        assert isinstance(arms[0].value, LiteralPattern)
+        assert arms[0].value.typ == "bool"
+        assert arms[0].value.value is True
+        assert isinstance(arms[1].value, LiteralPattern)
+        assert arms[1].value.value is False
+
+    def test_int_literal_parsed_as_literal_pattern(self):
+        ops = parse_string("42 match\n" "    0 => 1\n" "    _ => 2\n" "end\n")
+        arms = [op for op in ops if op.kind == OpKind.MATCH_ARM]
+        assert len(arms) == 2
+        assert isinstance(arms[0].value, LiteralPattern)
+        assert arms[0].value.typ == "int"
+        assert arms[0].value.value == 0
+
+    def test_char_literal_parsed_as_literal_pattern(self):
+        ops = parse_string("'a' match\n" "    'a' => 1\n" "    _ => 2\n" "end\n")
+        arms = [op for op in ops if op.kind == OpKind.MATCH_ARM]
+        assert isinstance(arms[0].value, LiteralPattern)
+        assert arms[0].value.typ == "char"
+        assert arms[0].value.value == ord("a")
+
+    def test_str_literal_parsed_as_literal_pattern(self):
+        ops = parse_string(
+            '"hello" match\n' '    "hello" => 1\n' "    _ => 2\n" "end\n"
+        )
+        arms = [op for op in ops if op.kind == OpKind.MATCH_ARM]
+        assert isinstance(arms[0].value, LiteralPattern)
+        assert arms[0].value.typ == "str"
+        assert arms[0].value.value == "hello"
+
+    def test_negative_int_literal_parsed(self):
+        ops = parse_string("42 match\n" "    -1 => 1\n" "    _ => 2\n" "end\n")
+        arms = [op for op in ops if op.kind == OpKind.MATCH_ARM]
+        assert isinstance(arms[0].value, LiteralPattern)
+        assert arms[0].value.value == -1
+
+
+# ---------------------------------------------------------------------------
+# Literal pattern matching — type checking
+# ---------------------------------------------------------------------------
+class TestLiteralMatchTypecheck:
+    def test_bool_exhaustive_passes(self):
+        sig = typecheck_string(
+            "true match\n" "    true => 1\n" "    false => 0\n" "end\n"
+        )
+        assert sig.return_types == ["int"]
+
+    def test_bool_with_wildcard_passes(self):
+        sig = typecheck_string("true match\n" "    true => 1\n" "    _ => 0\n" "end\n")
+        assert sig.return_types == ["int"]
+
+    def test_bool_missing_arm_raises(self):
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            typecheck_string("true match\n" "    true => 1\n" "end\n")
+        error = exc_info.value.errors[0]
+        assert error.kind == ErrorKind.TYPE_MISMATCH
+        assert "false" in error.message
+
+    def test_int_with_wildcard_passes(self):
+        sig = typecheck_string(
+            "42 match\n" "    0 => 1\n" "    1 => 2\n" "    _ => 3\n" "end\n"
+        )
+        assert sig.return_types == ["int"]
+
+    def test_int_without_wildcard_raises(self):
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            typecheck_string("42 match\n" "    0 => 1\n" "    1 => 2\n" "end\n")
+        error = exc_info.value.errors[0]
+        assert error.kind == ErrorKind.TYPE_MISMATCH
+        assert "wildcard" in error.message
+
+    def test_char_with_wildcard_passes(self):
+        sig = typecheck_string("'a' match\n" "    'a' => 1\n" "    _ => 0\n" "end\n")
+        assert sig.return_types == ["int"]
+
+    def test_char_without_wildcard_raises(self):
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            typecheck_string("'a' match\n" "    'a' => 1\n" "end\n")
+        error = exc_info.value.errors[0]
+        assert error.kind == ErrorKind.TYPE_MISMATCH
+
+    def test_str_with_wildcard_passes(self):
+        sig = typecheck_string(
+            '"hello" match\n' '    "hello" => 1\n' "    _ => 0\n" "end\n"
+        )
+        assert sig.return_types == ["int"]
+
+    def test_str_without_wildcard_raises(self):
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            typecheck_string('"hello" match\n' '    "hello" => 1\n' "end\n")
+        error = exc_info.value.errors[0]
+        assert error.kind == ErrorKind.TYPE_MISMATCH
+
+    def test_type_mismatch_int_literal_in_bool_match(self):
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            typecheck_string("true match\n" "    42 => 1\n" "    _ => 0\n" "end\n")
+        error = exc_info.value.errors[0]
+        assert error.kind == ErrorKind.TYPE_MISMATCH
+
+    def test_type_mismatch_bool_literal_in_int_match(self):
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            typecheck_string("42 match\n" "    true => 1\n" "    _ => 0\n" "end\n")
+        error = exc_info.value.errors[0]
+        assert error.kind == ErrorKind.TYPE_MISMATCH
+
+    def test_duplicate_literal_arm_raises(self):
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            typecheck_string(
+                "42 match\n" "    0 => 1\n" "    0 => 2\n" "    _ => 3\n" "end\n"
+            )
+        error = exc_info.value.errors[0]
+        assert error.kind == ErrorKind.DUPLICATE_NAME
+
+    def test_literal_arms_after_wildcard_raises(self):
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            typecheck_string("42 match\n" "    _ => 1\n" "    0 => 2\n" "end\n")
+        error = exc_info.value.errors[0]
+        assert error.kind == ErrorKind.SYNTAX
+
+    def test_enum_variant_in_int_match_raises(self):
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            typecheck_string(
+                COLOR_ENUM + "42 match\n" "    Color::Red => 1\n" "    _ => 2\n" "end\n"
+            )
+        error = exc_info.value.errors[0]
+        assert error.kind == ErrorKind.TYPE_MISMATCH
+
+    def test_literal_in_enum_match_raises(self):
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            typecheck_string(
+                COLOR_ENUM + "Color::Red match\n" "    42 => 1\n" "    _ => 2\n" "end\n"
+            )
+        error = exc_info.value.errors[0]
+        assert error.kind == ErrorKind.TYPE_MISMATCH
+
+    def test_bare_identifier_in_literal_match_raises(self):
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            typecheck_string("42 match\n" "    foo => 1\n" "    _ => 2\n" "end\n")
+        error = exc_info.value.errors[0]
+        assert error.kind == ErrorKind.TYPE_MISMATCH
+
+
+# ---------------------------------------------------------------------------
+# Literal pattern matching — bytecode
+# ---------------------------------------------------------------------------
+class TestLiteralMatchBytecode:
+    def test_int_match_compiles_dup_push_eq_pattern(self):
+        program = compile_string("42 match\n" "    0 => 1\n" "    _ => 2\n" "end\n")
+        kinds = [i.kind for i in program.bytecode]
+        assert InstKind.DUP in kinds
+        assert InstKind.EQ in kinds
+
+    def test_bool_match_compiles(self):
+        program = compile_string(
+            "true match\n" "    true => 1\n" "    false => 0\n" "end\n"
+        )
+        kinds = [i.kind for i in program.bytecode]
+        assert InstKind.DUP in kinds
+        assert InstKind.EQ in kinds
+
+    def test_str_match_compiles_str_eq(self):
+        program = compile_string(
+            '"hello" match\n' '    "hello" => 1\n' "    _ => 2\n" "end\n"
+        )
+        kinds = [i.kind for i in program.bytecode]
+        assert InstKind.STR_EQ in kinds
+
+    def test_str_eq_compiles_str_eq_inst(self):
+        program = compile_string('"hello" "world" ==\n')
+        kinds = [i.kind for i in program.bytecode]
+        assert InstKind.STR_EQ in kinds
+
+    def test_str_ne_compiles_str_eq_and_not(self):
+        program = compile_string('"hello" "world" !=\n')
+        kinds = [i.kind for i in program.bytecode]
+        assert InstKind.STR_EQ in kinds
+        assert InstKind.NOT in kinds
+
+
+# ---------------------------------------------------------------------------
+# Literal pattern matching — end-to-end
+# ---------------------------------------------------------------------------
+class TestLiteralMatchEndToEnd:
+    @pytest.fixture
+    def run_casa(self, tmp_path):
+        def _run(code: str) -> str:
+            src = tmp_path / "test.casa"
+            src.write_text(code)
+            binary = tmp_path / "test"
+            result = subprocess.run(
+                ["python3", "casa.py", str(src), "-o", str(binary)],
+                capture_output=True,
+                text=True,
+                cwd=CASA_ROOT,
+                timeout=30,
+            )
+            if result.returncode != 0:
+                pytest.fail(
+                    f"Compilation failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+                )
+            run_result = subprocess.run(
+                [str(binary)],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            return run_result.stdout
+
+        return _run
+
+    def test_bool_match(self, run_casa):
+        output = run_casa(
+            "fn check flag:bool {\n"
+            "    flag match\n"
+            '        true => "yes" print\n'
+            '        false => "no" print\n'
+            "    end\n"
+            "}\n"
+            "true check\n"
+            "false check\n"
+        )
+        assert output == "yesno"
+
+    def test_int_match(self, run_casa):
+        output = run_casa(
+            "fn describe n:int {\n"
+            "    n match\n"
+            '        0 => "zero" print\n'
+            '        1 => "one" print\n'
+            '        _ => "other" print\n'
+            "    end\n"
+            "}\n"
+            "0 describe\n"
+            "1 describe\n"
+            "99 describe\n"
+        )
+        assert output == "zerooneother"
+
+    def test_char_match(self, run_casa):
+        output = run_casa(
+            "fn check ch:char {\n"
+            "    ch match\n"
+            "        'y' => \"yes\" print\n"
+            "        'n' => \"no\" print\n"
+            '        _ => "unknown" print\n'
+            "    end\n"
+            "}\n"
+            "'y' check\n"
+            "'n' check\n"
+            "'x' check\n"
+        )
+        assert output == "yesnounknown"
+
+    def test_str_match(self, run_casa):
+        output = run_casa(
+            "fn greet name:str {\n"
+            "    name match\n"
+            '        "Alice" => "Hi Alice" print\n'
+            '        "Bob" => "Hi Bob" print\n'
+            '        _ => "Hi stranger" print\n'
+            "    end\n"
+            "}\n"
+            '"Alice" greet\n'
+            '"Bob" greet\n'
+            '"Charlie" greet\n'
+        )
+        assert output == "Hi AliceHi BobHi stranger"
+
+    def test_int_match_negative(self, run_casa):
+        output = run_casa(
+            "fn check n:int {\n"
+            "    n match\n"
+            '        -1 => "neg" print\n'
+            '        0 => "zero" print\n'
+            '        _ => "pos" print\n'
+            "    end\n"
+            "}\n"
+            "-1 check\n"
+            "0 check\n"
+            "5 check\n"
+        )
+        assert output == "negzeropos"
+
+    def test_bool_match_wildcard_only(self, run_casa):
+        output = run_casa("true match\n" '    _ => "matched" print\n' "end\n")
+        assert output == "matched"
+
+    def test_int_match_single_arm_with_wildcard(self, run_casa):
+        output = run_casa("42 match\n" '    _ => "any" print\n' "end\n")
+        assert output == "any"
+
+
+# ---------------------------------------------------------------------------
+# String equality comparison — end-to-end
+# ---------------------------------------------------------------------------
+class TestStrComparisonEndToEnd:
+    @pytest.fixture
+    def run_casa(self, tmp_path):
+        def _run(code: str) -> str:
+            src = tmp_path / "test.casa"
+            src.write_text(code)
+            binary = tmp_path / "test"
+            result = subprocess.run(
+                ["python3", "casa.py", str(src), "-o", str(binary)],
+                capture_output=True,
+                text=True,
+                cwd=CASA_ROOT,
+                timeout=30,
+            )
+            if result.returncode != 0:
+                pytest.fail(
+                    f"Compilation failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+                )
+            run_result = subprocess.run(
+                [str(binary)],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            return run_result.stdout
+
+        return _run
+
+    def test_str_eq_same_literal(self, run_casa):
+        output = run_casa('"hello" "hello" == print\n')
+        assert output == "true"
+
+    def test_str_eq_different_literal(self, run_casa):
+        output = run_casa('"hello" "world" == print\n')
+        assert output == "false"
+
+    def test_str_ne_different(self, run_casa):
+        output = run_casa('"hello" "world" != print\n')
+        assert output == "true"
+
+    def test_str_ne_same(self, run_casa):
+        output = run_casa('"hello" "hello" != print\n')
+        assert output == "false"
+
+    def test_str_eq_empty_strings(self, run_casa):
+        output = run_casa('"" "" == print\n')
+        assert output == "true"
+
+    def test_str_eq_empty_vs_nonempty(self, run_casa):
+        output = run_casa('"" "a" == print\n')
+        assert output == "false"
+
+    def test_str_eq_in_conditional(self, run_casa):
+        output = run_casa(
+            '"Alice" = name\n' 'if name "Alice" == then\n' '    "yes" print\n' "fi\n"
+        )
+        assert output == "yes"
+
+    def test_str_eq_variable_comparison(self, run_casa):
+        output = run_casa(
+            "fn check a:str b:str -> bool {\n"
+            "    a b ==\n"
+            "}\n"
+            '"hello" "hello" check print\n'
+            '"hello" "world" check print\n'
+        )
+        assert output == "truefalse"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -606,8 +606,7 @@ def test_parse_fn_type_two_generic_vars():
 def test_parse_option_type_in_fn_signature():
     """Option[int] parses correctly as a parameter type."""
     parse_string(
-        "enum Option[T] { None Some(T) }"
-        " fn unwrap opt:Option[int] -> int { 0 }"
+        "enum Option[T] { None Some(T) }" " fn unwrap opt:Option[int] -> int { 0 }"
     )
     fn = GLOBAL_FUNCTIONS["unwrap"]
     assert fn.signature is not None

--- a/tests/test_struct_literal.py
+++ b/tests/test_struct_literal.py
@@ -272,10 +272,10 @@ p match
 end""")
         assert exc_info.value.errors[0].kind == ErrorKind.DUPLICATE_NAME
 
-    def test_match_on_non_enum_non_struct_error(self):
+    def test_match_on_unsupported_type_error(self):
         with pytest.raises(CasaErrorCollection) as exc_info:
             typecheck_string("""\
-42 match
+42 (ptr) match
     _ => 0
 end""")
         assert exc_info.value.errors[0].kind == ErrorKind.TYPE_MISMATCH

--- a/tests/test_typechecker.py
+++ b/tests/test_typechecker.py
@@ -1239,7 +1239,10 @@ def test_typecheck_option_some_if_none_else():
 
 def test_typecheck_option_mixed_elif():
     """Multiple elif branches mixing Option::None and Option::Some are compatible."""
-    code = OPTION_ENUM + "if true then Option::None elif false then 42 Option::Some else 99 Option::Some fi"
+    code = (
+        OPTION_ENUM
+        + "if true then Option::None elif false then 42 Option::Some else 99 Option::Some fi"
+    )
     sig = typecheck_string(code)
     assert sig.return_types == ["Option[int]"]
 
@@ -1296,6 +1299,67 @@ def test_typecheck_char_comparison_gt():
     """Char > comparison returns bool."""
     sig = typecheck_string("'z' 'a' >")
     assert sig.return_types == ["bool"]
+
+
+def test_typecheck_str_eq():
+    """String == comparison returns bool."""
+    sig = typecheck_string('"hello" "world" ==')
+    assert sig.return_types == ["bool"]
+
+
+def test_typecheck_str_ne():
+    """String != comparison returns bool."""
+    sig = typecheck_string('"hello" "world" !=')
+    assert sig.return_types == ["bool"]
+
+
+def test_typecheck_str_lt_raises():
+    """String < comparison is not supported."""
+    with pytest.raises(CasaErrorCollection) as exc_info:
+        typecheck_string('"hello" "world" <')
+    error = exc_info.value.errors[0]
+    assert error.kind == ErrorKind.TYPE_MISMATCH
+    assert "str" in error.message
+
+
+def test_typecheck_str_gt_raises():
+    """String > comparison is not supported."""
+    with pytest.raises(CasaErrorCollection) as exc_info:
+        typecheck_string('"hello" "world" >')
+    error = exc_info.value.errors[0]
+    assert error.kind == ErrorKind.TYPE_MISMATCH
+
+
+def test_typecheck_str_le_raises():
+    """String <= comparison is not supported."""
+    with pytest.raises(CasaErrorCollection) as exc_info:
+        typecheck_string('"hello" "world" <=')
+    error = exc_info.value.errors[0]
+    assert error.kind == ErrorKind.TYPE_MISMATCH
+
+
+def test_typecheck_str_ge_raises():
+    """String >= comparison is not supported."""
+    with pytest.raises(CasaErrorCollection) as exc_info:
+        typecheck_string('"hello" "world" >=')
+    error = exc_info.value.errors[0]
+    assert error.kind == ErrorKind.TYPE_MISMATCH
+
+
+def test_typecheck_str_eq_int_raises():
+    """Comparing str with int is a type error."""
+    with pytest.raises(CasaErrorCollection) as exc_info:
+        typecheck_string('"hello" 42 ==')
+    error = exc_info.value.errors[0]
+    assert error.kind == ErrorKind.TYPE_MISMATCH
+
+
+def test_typecheck_int_eq_str_raises():
+    """Comparing int with str is a type error."""
+    with pytest.raises(CasaErrorCollection) as exc_info:
+        typecheck_string('42 "hello" ==')
+    error = exc_info.value.errors[0]
+    assert error.kind == ErrorKind.TYPE_MISMATCH
 
 
 def test_typecheck_print_resolves_to_print_char():
@@ -1484,7 +1548,7 @@ def test_typecheck_deferred_method_different_return_types_error():
 
 def test_typecheck_deferred_method_nonexistent():
     """Lambda with nonexistent method produces error."""
-    code = '{ .nonexistent_method } = f'
+    code = "{ .nonexistent_method } = f"
     with pytest.raises(CasaErrorCollection) as exc_info:
         typecheck_string(code)
     assert exc_info.value.errors[0].kind == ErrorKind.UNDEFINED_NAME


### PR DESCRIPTION
## Summary
- Extend `match` blocks to support `bool`, `int`, `char`, and `str` literal patterns with exhaustiveness checking (bool requires both arms; int/char/str require wildcard `_`)
- Add `STR_EQ` instruction for byte-by-byte string content comparison using x86-64 `repe cmpsb`
- Implement `==` and `!=` operators for `str` type; mixed-type string comparisons are a compile error

## Test plan
- [x] 1147 unit tests pass (`pytest tests/`)
- [x] 31 example tests pass (`tests/test_examples.sh`)
- [x] `black`, `mypy`, `pylint` clean
- [x] Literal match: bool exhaustive, int/char/str with wildcard, duplicate arm detection, type mismatch errors
- [x] String comparison: equal/not-equal for literals and variables, empty strings, conditional usage