### PR TITLE
feat: support {} block syntax for multiline match arm bodies

### DIFF
--- a/casa/parser.py
+++ b/casa/parser.py
@@ -1120,20 +1120,26 @@ def _handle_keyword_match(
             variant = EnumVariant(enum_name, variant_name, -1, bindings)
             ops.append(Op(variant, OpKind.MATCH_ARM, arm_token.location))
 
-        # Parse arm body until next arm or `end`
-        while not cursor.is_finished():
-            if _is_match_arm_boundary(cursor):
-                break
-            next_token = cursor.peek()
-            if next_token and next_token.value == "end":
-                break
-            body_token = cursor.pop()
-            if body_token is None:
-                break
-            if body_token.kind == TokenKind.FSTRING_START:
-                handle_fstring(body_token, cursor, function_name, ops)
-                continue
-            _append_op_result(ops, token_to_op(body_token, cursor, function_name))
+        # Parse arm body
+        peeked = cursor.peek()
+        if peeked and peeked.value == "{":
+            # Brace-delimited arm body for multiline arms
+            ops.extend(parse_block_ops(cursor, function_name))
+        else:
+            # Single-line arm body: parse until next arm or `end`
+            while not cursor.is_finished():
+                if _is_match_arm_boundary(cursor):
+                    break
+                next_token = cursor.peek()
+                if next_token and next_token.value == "end":
+                    break
+                body_token = cursor.pop()
+                if body_token is None:
+                    break
+                if body_token.kind == TokenKind.FSTRING_START:
+                    handle_fstring(body_token, cursor, function_name, ops)
+                    continue
+                _append_op_result(ops, token_to_op(body_token, cursor, function_name))
 
     return ops
 

--- a/docs/control-flow.md
+++ b/docs/control-flow.md
@@ -169,6 +169,27 @@ end
 
 The `match` keyword pops a value from the stack. Each arm specifies a pattern followed by `=>` and a body. The block is closed with `end`.
 
+### Block Arm Bodies
+
+When an arm body contains multiple statements, wrap it in `{}`:
+
+```casa
+circle match
+    Shape::Circle(radius) => {
+        "Circle with radius: " print
+        radius print
+        "\n" print
+    }
+    Shape::Rectangle(width height) => {
+        width height * print
+        "\n" print
+    }
+    Shape::Point => "point\n" print
+end
+```
+
+Single-expression arms do not need braces. Braced and unbraced arms can be mixed freely.
+
 ### Enum Matching
 
 ```casa

--- a/docs/control-flow.md
+++ b/docs/control-flow.md
@@ -171,7 +171,7 @@ The `match` keyword pops a value from the stack. Each arm specifies a pattern fo
 
 ### Block Arm Bodies
 
-When an arm body contains multiple statements, wrap it in `{}`:
+Multiline arm bodies require `{}`:
 
 ```casa
 circle match
@@ -188,7 +188,7 @@ circle match
 end
 ```
 
-Single-expression arms do not need braces. Braced and unbraced arms can be mixed freely.
+Single-line arms do not need braces. Braced and unbraced arms can be mixed freely.
 
 ### Enum Matching
 

--- a/examples/enum.casa
+++ b/examples/enum.casa
@@ -93,6 +93,21 @@ pt match
     Shape::Point => "point\n" print
 end
 
+# Match with block arm bodies
+circle match
+    Shape::Circle(radius) => {
+        "radius=" print
+        radius print
+        "\n" print
+    }
+    Shape::Rectangle(width height) => {
+        "area=" print
+        width height * print
+        "\n" print
+    }
+    Shape::Point => "point\n" print
+end
+
 # Match on literal types (bool, int, char, str)
 
 # Bool match - exhaustive with both arms

--- a/examples/outputs/enum.out
+++ b/examples/outputs/enum.out
@@ -14,6 +14,7 @@ it is red
 10
 12
 point
+radius=10
 active
 inactive
 zero

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -224,6 +224,111 @@ class TestMatchParsing:
 
 
 # ---------------------------------------------------------------------------
+# Braced match arm bodies
+# ---------------------------------------------------------------------------
+class TestBracedMatchArm:
+    def test_braced_arm_produces_correct_ops(self):
+        code = (
+            COLOR_ENUM + "Color::Red match\n"
+            "    Color::Red => { 1 }\n"
+            "    Color::Green => { 2 }\n"
+            "    Color::Blue => { 3 }\n"
+            "end\n"
+        )
+        ops = parse_string(code)
+        arm_ops = find_ops(ops, OpKind.MATCH_ARM)
+        assert len(arm_ops) == 3
+
+    def test_braced_arm_multiline_body(self):
+        code = (
+            COLOR_ENUM + "Color::Red match\n"
+            "    Color::Red => {\n"
+            '        "red" print\n'
+            '        "\\n" print\n'
+            "    }\n"
+            '    Color::Green => "green"\n'
+            '    Color::Blue => "blue"\n'
+            "end\n"
+        )
+        ops = parse_string(code)
+        arm_ops = find_ops(ops, OpKind.MATCH_ARM)
+        assert len(arm_ops) == 3
+        push_str_ops = find_ops(ops, OpKind.PUSH_STR)
+        assert any(op.value == "red" for op in push_str_ops)
+
+    def test_mixed_braced_and_unbraced_arms(self):
+        code = (
+            COLOR_ENUM + "Color::Green match\n"
+            "    Color::Red => 0\n"
+            "    Color::Green => {\n"
+            "        1\n"
+            "    }\n"
+            "    Color::Blue => 2\n"
+            "end\n"
+        )
+        ops = parse_string(code)
+        push_int_ops = find_ops(ops, OpKind.PUSH_INT)
+        values = [op.value for op in push_int_ops]
+        assert 0 in values
+        assert 1 in values
+        assert 2 in values
+
+    def test_braced_arm_as_expression(self):
+        code = (
+            COLOR_ENUM + "fn color_code c:Color -> int {\n"
+            "    c match\n"
+            "        Color::Red => { 0 }\n"
+            "        Color::Green => { 1 }\n"
+            "        Color::Blue => { 2 }\n"
+            "    end\n"
+            "}\n"
+        )
+        typecheck_string(code)
+
+    def test_braced_arm_with_destructuring(self):
+        code = (
+            SHAPE_ENUM + "10 Shape::Circle match\n"
+            "    Shape::Circle(radius) => {\n"
+            '        "r=" print\n'
+            "        radius print\n"
+            "    }\n"
+            "    Shape::Rectangle(width height) => {\n"
+            "        width height * print\n"
+            "    }\n"
+            '    Shape::Point => "point" print\n'
+            "end\n"
+        )
+        ops = parse_string(code)
+        arm_ops = find_ops(ops, OpKind.MATCH_ARM)
+        assert len(arm_ops) == 3
+
+    def test_empty_braced_arm_body(self):
+        code = (
+            COLOR_ENUM + "Color::Red match\n"
+            "    Color::Red => {}\n"
+            "    Color::Green => {}\n"
+            "    Color::Blue => {}\n"
+            "end\n"
+        )
+        ops = parse_string(code)
+        arm_ops = find_ops(ops, OpKind.MATCH_ARM)
+        assert len(arm_ops) == 3
+
+    def test_unclosed_brace_in_arm_raises(self):
+        code = (
+            COLOR_ENUM + "Color::Red match\n"
+            "    Color::Red => {\n"
+            "        1\n"
+            "    Color::Green => 2\n"
+            "    Color::Blue => 3\n"
+            "end\n"
+        )
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            parse_string(code)
+        assert exc_info.value.errors[0].kind == ErrorKind.UNMATCHED_BLOCK
+
+
+# ---------------------------------------------------------------------------
 # Identifier resolution: Color::Red -> PUSH_ENUM_VARIANT
 # ---------------------------------------------------------------------------
 class TestEnumResolution:
@@ -832,6 +937,22 @@ class TestEnumEndToEnd:
             + "end\n"
         )
         assert output == "point"
+
+    def test_braced_arm_end_to_end(self, run_casa):
+        output = run_casa(
+            SHAPE_ENUM
+            + "10 Shape::Circle match\n"
+            + "    Shape::Circle(radius) => {\n"
+            + '        "r=" print\n'
+            + "        radius print\n"
+            + "    }\n"
+            + "    Shape::Rectangle(width height) => {\n"
+            + "        width height * print\n"
+            + "    }\n"
+            + '    Shape::Point => "point" print\n'
+            + "end\n"
+        )
+        assert output == "r=10"
 
     def test_generic_enum_some(self, run_casa):
         output = run_casa(


### PR DESCRIPTION
## Summary
- Add `{}` block syntax for multiline match arm bodies, reusing the existing `parse_block_ops` parser function
- Single-expression arms remain unchanged; braced and unbraced arms can be mixed freely
- Empty braced arms `=> {}` are valid (no stack effect)

## Test plan
- [x] Unit tests for parsing braced arms (correct ops, multiline, mixed, destructuring, empty body)
- [x] Error test for unclosed brace
- [x] Typecheck test for braced arms as expressions
- [x] End-to-end compile-and-run test with destructuring
- [x] `pytest tests` — 1155 passed
- [x] `bash tests/test_examples.sh` — 31 passed