### PR TITLE
feat: reject multiline match arm bodies without braces

### DIFF
--- a/casa/parser.py
+++ b/casa/parser.py
@@ -45,6 +45,7 @@ from casa.error import (
     CasaError,
     CasaErrorCollection,
     ErrorKind,
+    offset_to_line_col,
     raise_error,
 )
 from casa.lexer import is_negative_integer_literal, lex_file, lex_source
@@ -751,6 +752,13 @@ def expect_delimiter(cursor: Cursor[Token], expected: Delimiter) -> Delimiter | 
     return delimiter
 
 
+def _token_line(token: Token) -> int:
+    """Return the 1-based line number of a token."""
+    source = SOURCE_CACHE[token.location.file]
+    line, _, _ = offset_to_line_col(source, token.location.span.offset)
+    return line
+
+
 def parse_block_ops(cursor: Cursor[Token], function_name: str) -> list[Op]:
     """Parse a brace-delimited block of ops."""
     open_brace = cursor.pop()
@@ -1127,6 +1135,7 @@ def _handle_keyword_match(
             ops.extend(parse_block_ops(cursor, function_name))
         else:
             # Single-line arm body: parse until next arm or `end`
+            arm_line: int | None = None
             while not cursor.is_finished():
                 if _is_match_arm_boundary(cursor):
                     break
@@ -1136,6 +1145,14 @@ def _handle_keyword_match(
                 body_token = cursor.pop()
                 if body_token is None:
                     break
+                if arm_line is None:
+                    arm_line = _token_line(body_token)
+                elif _token_line(body_token) != arm_line:
+                    raise_error(
+                        ErrorKind.SYNTAX,
+                        "Multiline match arm body requires `{}` block",
+                        body_token.location,
+                    )
                 if body_token.kind == TokenKind.FSTRING_START:
                     handle_fstring(body_token, cursor, function_name, ops)
                     continue

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -327,6 +327,33 @@ class TestBracedMatchArm:
             parse_string(code)
         assert exc_info.value.errors[0].kind == ErrorKind.UNMATCHED_BLOCK
 
+    def test_multiline_unbraced_arm_raises(self):
+        code = (
+            COLOR_ENUM + "Color::Red match\n"
+            '    Color::Red => "red" print\n'
+            '        "\\n" print\n'
+            "    Color::Green => 2\n"
+            "    Color::Blue => 3\n"
+            "end\n"
+        )
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            parse_string(code)
+        assert exc_info.value.errors[0].kind == ErrorKind.SYNTAX
+        assert "requires" in exc_info.value.errors[0].message
+
+    def test_single_line_arm_body_on_next_line_is_valid(self):
+        code = (
+            COLOR_ENUM + "Color::Red match\n"
+            "    Color::Red =>\n"
+            "        1\n"
+            "    Color::Green => 2\n"
+            "    Color::Blue => 3\n"
+            "end\n"
+        )
+        ops = parse_string(code)
+        arm_ops = find_ops(ops, OpKind.MATCH_ARM)
+        assert len(arm_ops) == 3
+
 
 # ---------------------------------------------------------------------------
 # Identifier resolution: Color::Red -> PUSH_ENUM_VARIANT


### PR DESCRIPTION
## Summary
- Multiline match arm bodies without wrapping `{}` are now a syntax error
- Adds `_token_line` helper to compute line numbers from token byte offsets
- Single-line arm bodies (even on the next line after `=>`) remain valid

## Test plan
- [x] New test: multiline unbraced arm raises `ErrorKind.SYNTAX`
- [x] New test: single-line body on next line after `=>` is valid
- [x] All 1157 unit tests pass
- [x] All 31 example tests pass