### PR TITLE
feat: add string, char, and boolean literal support

### DIFF
--- a/self_hosted/bytecode.casa
+++ b/self_hosted/bytecode.casa
@@ -135,6 +135,9 @@ fn find_while_start state:LabelState from_index:int ops:List[Op] -> int {
 fn op_to_inst op:Op -> Inst {
     op.kind match
         OpKind::PushInt => op.value InstKind::Push Inst
+        OpKind::PushStr => op.value InstKind::PushStr Inst
+        OpKind::PushChar => op.value InstKind::PushChar Inst
+        OpKind::PushBool => op.value InstKind::Push Inst
         OpKind::Add => 0 InstKind::Add Inst
         OpKind::Sub => 0 InstKind::Sub Inst
         OpKind::Mul => 0 InstKind::Mul Inst
@@ -161,6 +164,10 @@ fn op_to_inst op:Op -> Inst {
         OpKind::Over => 0 InstKind::Over Inst
         OpKind::Rot => 0 InstKind::Rot Inst
         OpKind::PrintInt => 0 InstKind::PrintInt Inst
+        OpKind::PrintStr => 0 InstKind::PrintStr Inst
+        OpKind::PrintBool => 0 InstKind::PrintBool Inst
+        OpKind::PrintChar => 0 InstKind::PrintChar Inst
+        OpKind::PrintCstr => 0 InstKind::PrintCstr Inst
         OpKind::AssignVariable => op.value InstKind::GlobalSet Inst
         OpKind::PushVariable => op.value InstKind::GlobalGet Inst
         _ => {

--- a/self_hosted/casa.casa
+++ b/self_hosted/casa.casa
@@ -9,27 +9,36 @@ include "bytecode.casa"
 include "emitter.casa"
 include "compiler.casa"
 
-if 2 argc != 4 argc != && then
-    "usage: casa <input> -o <output>" eprintln
+if argc 2 > then
+    "usage: casa <input> [-o <output>] [--keep-asm]" eprintln
     1 exit
 fi
 
 1 get_arg = input_path
 "output" = output_path
+false = keep_asm
 
-if 4 argc == then
-    if "-o" 2 get_arg str::eq then
-        3 get_arg = output_path
-    else
-        "usage: casa <input> -o <output>" eprintln
-        1 exit
+2 = arg_index
+while arg_index argc > do
+    arg_index get_arg = current_arg
+    if "-o" current_arg str::eq then
+        arg_index 1 + = arg_index
+        if arg_index argc > ! then
+            "missing value for -o" eprintln
+            1 exit
+        fi
+        arg_index get_arg = output_path
+    elif "--keep-asm" current_arg str::eq then
+        true = keep_asm
     fi
-fi
+    1 += arg_index
+done
 
 # Pipeline: lex -> parse -> bytecode -> emit -> compile
 input_path file::read_all = source
 source lex = token_list
-token_list parse = globals_count = parsed_ops
+List::new (List[str]) = string_table
+string_table token_list parse = globals_count = parsed_ops
 parsed_ops compile_bytecode = label_count = instructions
-label_count globals_count instructions emit_program = asm_source
-output_path asm_source compile_binary
+string_table label_count globals_count instructions emit_program = asm_source
+keep_asm output_path asm_source compile_binary

--- a/self_hosted/common.casa
+++ b/self_hosted/common.casa
@@ -14,12 +14,13 @@ enum TokenKind { Delimiter Eof Identifier Intrinsic Keyword Literal Operator }
 # ---------------------------------------------------------------------------
 
 enum OpKind {
-    PushInt Add Sub Mul Div Mod
+    PushInt PushStr PushChar PushBool
+    Add Sub Mul Div Mod
     BitAnd BitOr BitXor BitNot Shl Shr
     Eq Ne Lt Gt Le Ge
     And Or Not
     Drop Dup Swap Over Rot
-    PrintInt
+    PrintInt PrintStr PrintBool PrintChar PrintCstr
     AssignVariable AssignIncrement AssignDecrement PushVariable
     IfStart IfCondition IfElif IfElse IfEnd
     WhileStart WhileCondition WhileBreak WhileContinue WhileEnd
@@ -30,12 +31,13 @@ enum OpKind {
 # ---------------------------------------------------------------------------
 
 enum InstKind {
-    Push Add Sub Mul Div Mod
+    Push PushStr PushChar
+    Add Sub Mul Div Mod
     BitAnd BitOr BitXor BitNot Shl Shr
     Eq Ne Lt Gt Le Ge
     And Or Not
     Drop Dup Swap Over Rot
-    PrintInt
+    PrintInt PrintStr PrintBool PrintChar PrintCstr
     GlobalGet GlobalSet
     Label Jump JumpNe
 }

--- a/self_hosted/compiler.casa
+++ b/self_hosted/compiler.casa
@@ -2,7 +2,7 @@
 
 include "common.casa"
 
-fn compile_binary asm_source:str output_path:str {
+fn compile_binary asm_source:str output_path:str keep_asm:bool {
     f"{output_path}.s" = asm_file
     f"{output_path}.o" = obj_file
 
@@ -37,6 +37,8 @@ fn compile_binary asm_source:str output_path:str {
     fi
 
     # Clean up intermediate files
-    asm_file file::remove drop
+    if keep_asm ! then
+        asm_file file::remove drop
+    fi
     obj_file file::remove drop
 }

--- a/self_hosted/emitter.casa
+++ b/self_hosted/emitter.casa
@@ -30,8 +30,42 @@ fn emit_bss emitter:Emitter globals_count:int {
     "\n" emitter.asm.append
 }
 
-fn emit_data emitter:Emitter {
+fn escape_for_asm value:str -> str {
+    StringBuilder::new = result
+    0 = efa_index
+    while efa_index value.length > do
+        efa_index value.at = efa_ch
+        if efa_ch '\\' == then
+            "\\\\" result.append
+        elif efa_ch '"' == then
+            "\\\"" result.append
+        elif efa_ch '\n' == then
+            "\\n" result.append
+        elif efa_ch '\t' == then
+            "\\t" result.append
+        elif efa_ch '\0' == then
+            "\\0" result.append
+        elif efa_ch '\r' == then
+            "\\r" result.append
+        else
+            efa_ch result.append_char
+        fi
+        1 += efa_index
+    done
+    result.build
+}
+
+fn emit_data emitter:Emitter string_table:List[str] {
     ".section .data\n" emitter.asm.append
+    0 = str_index
+    while str_index string_table.length > do
+        str_index string_table.get = str_value
+        ".align 8\n" emitter.asm.append
+        f"str_{str_index .to_str}:\n" emitter.asm.append
+        f".quad {str_value.length .to_str}\n" emitter.asm.append
+        f".asciz \"{str_value escape_for_asm}\"\n" emitter.asm.append
+        1 += str_index
+    done
     "bool_true: .ascii \"true\"\n" emitter.asm.append
     "bool_false: .ascii \"false\"\n" emitter.asm.append
     "\n" emitter.asm.append
@@ -260,6 +294,13 @@ fn emit_inst inst:Inst emitter:Emitter {
             "    pushq %rax\n" emitter.asm.append
             "    pushq %rcx\n" emitter.asm.append
         }
+        # Push string/char
+        InstKind::PushStr => {
+            f"    leaq str_{inst.value .to_str}(%rip), %rax\n" emitter.asm.append
+            "    pushq %rax\n" emitter.asm.append
+        }
+        InstKind::PushChar =>
+            f"    pushq ${inst.value .to_str}\n" emitter.asm.append
         # Print
         InstKind::PrintInt => {
             emitter next_label = label_id
@@ -269,6 +310,57 @@ fn emit_inst inst:Inst emitter:Emitter {
             "    addq $8, %r14\n" emitter.asm.append
             "    jmp print_int\n" emitter.asm.append
             f".Lprint_done_{label_id .to_str}:\n" emitter.asm.append
+        }
+        InstKind::PrintStr => {
+            emitter next_label = label_id
+            "    popq %rdi\n" emitter.asm.append
+            f"    leaq .Lprint_done_{label_id .to_str}(%rip), %rax\n" emitter.asm.append
+            "    movq %rax, (%r14)\n" emitter.asm.append
+            "    addq $8, %r14\n" emitter.asm.append
+            "    jmp print_str\n" emitter.asm.append
+            f".Lprint_done_{label_id .to_str}:\n" emitter.asm.append
+        }
+        InstKind::PrintBool => {
+            emitter next_label = label_id
+            "    popq %rax\n" emitter.asm.append
+            "    testq %rax, %rax\n" emitter.asm.append
+            f"    jz .Lpb_false_{label_id .to_str}\n" emitter.asm.append
+            "    leaq bool_true(%rip), %rsi\n" emitter.asm.append
+            "    movq $4, %rdx\n" emitter.asm.append
+            f"    jmp .Lpb_write_{label_id .to_str}\n" emitter.asm.append
+            f".Lpb_false_{label_id .to_str}:\n" emitter.asm.append
+            "    leaq bool_false(%rip), %rsi\n" emitter.asm.append
+            "    movq $5, %rdx\n" emitter.asm.append
+            f".Lpb_write_{label_id .to_str}:\n" emitter.asm.append
+            "    movq $1, %rdi\n" emitter.asm.append
+            "    movq $1, %rax\n" emitter.asm.append
+            "    syscall\n" emitter.asm.append
+        }
+        InstKind::PrintChar => {
+            "    popq %rax\n" emitter.asm.append
+            "    movb %al, -1(%rsp)\n" emitter.asm.append
+            "    leaq -1(%rsp), %rsi\n" emitter.asm.append
+            "    movq $1, %rdx\n" emitter.asm.append
+            "    movq $1, %rdi\n" emitter.asm.append
+            "    movq $1, %rax\n" emitter.asm.append
+            "    syscall\n" emitter.asm.append
+        }
+        InstKind::PrintCstr => {
+            emitter next_label = label_id
+            "    popq %rsi\n" emitter.asm.append
+            "    movq %rsi, %rdi\n" emitter.asm.append
+            f".Lpc_scan_{label_id .to_str}:\n" emitter.asm.append
+            "    cmpb $0, (%rsi)\n" emitter.asm.append
+            f"    je .Lpc_done_{label_id .to_str}\n" emitter.asm.append
+            "    incq %rsi\n" emitter.asm.append
+            f"    jmp .Lpc_scan_{label_id .to_str}\n" emitter.asm.append
+            f".Lpc_done_{label_id .to_str}:\n" emitter.asm.append
+            "    movq %rsi, %rdx\n" emitter.asm.append
+            "    subq %rdi, %rdx\n" emitter.asm.append
+            "    movq %rdi, %rsi\n" emitter.asm.append
+            "    movq $1, %rdi\n" emitter.asm.append
+            "    movq $1, %rax\n" emitter.asm.append
+            "    syscall\n" emitter.asm.append
         }
         # Control flow
         InstKind::Label =>
@@ -314,12 +406,12 @@ fn emit_exit emitter:Emitter {
     "    syscall\n" emitter.asm.append
 }
 
-fn emit_program program:List[Inst] globals_count:int label_count:int -> str {
+fn emit_program program:List[Inst] globals_count:int label_count:int string_table:List[str] -> str {
     emitter_new = emitter
     label_count emitter->label_count
 
     globals_count emitter emit_bss
-    emitter emit_data
+    string_table emitter emit_data
     emitter emit_helpers
     program emitter emit_start
     emitter emit_exit

--- a/self_hosted/lexer.casa
+++ b/self_hosted/lexer.casa
@@ -24,12 +24,18 @@ fn make_keyword_set -> Set[str] {
     "done" keywords.add drop
     "break" keywords.add drop
     "continue" keywords.add drop
+    "true" keywords.add drop
+    "false" keywords.add drop
     keywords
 }
 
 fn make_intrinsic_set -> Set[str] {
     Set::new (Set[str]) = intrinsics
     "print" intrinsics.add drop
+    "print_str" intrinsics.add drop
+    "print_bool" intrinsics.add drop
+    "print_char" intrinsics.add drop
+    "print_cstr" intrinsics.add drop
     "drop" intrinsics.add drop
     "dup" intrinsics.add drop
     "swap" intrinsics.add drop
@@ -143,7 +149,24 @@ fn lex source:str -> List[Token] {
 
         cursor.peek.unwrap = ch
 
-        if ch .is_digit then
+        # String and char literals use a prefix in the token value
+        # to distinguish them from integer literals in the parser:
+        # strings start with ", chars start with ' followed by ordinal.
+        if ch '"' == then
+            cursor parse_quoted_string = str_result
+            if str_result.is_error then
+                "invalid string literal" eprintln
+                1 exit
+            fi
+            f"\"{str_result.unwrap}" TokenKind::Literal Token tokens.push
+        elif ch '\'' == then
+            cursor parse_char_literal = char_result
+            if char_result.is_error then
+                "invalid char literal" eprintln
+                1 exit
+            fi
+            f"'{char_result.unwrap (int) .to_str}" TokenKind::Literal Token tokens.push
+        elif ch .is_digit then
             cursor lex_integer_literal tokens.push
         # Minus handled separately: needs lookahead for negative literals and -=
         elif ch '-' == then
@@ -160,7 +183,7 @@ fn lex source:str -> List[Token] {
             fi
         elif ch '+' == ch '*' == || ch '/' == || ch '%' == || ch '&' == || ch '|' == || ch '^' == || ch '~' == || ch '<' == || ch '>' == || ch '=' == || ch '!' == || then
             ch cursor lex_operator tokens.push
-        elif ch .is_alpha then
+        elif ch .is_alpha ch '_' == || then
             intrinsics keywords cursor lex_word tokens.push
         elif ch '#' == then
             while cursor.is_eof ! do

--- a/self_hosted/parser.casa
+++ b/self_hosted/parser.casa
@@ -49,12 +49,15 @@ fn parse_operator op_value:str -> OpKind {
 
 fn parse_intrinsic intrinsic_value:str -> OpKind {
     intrinsic_value match
-        "print" => OpKind::PrintInt
-        "drop"  => OpKind::Drop
-        "dup"   => OpKind::Dup
-        "swap"  => OpKind::Swap
-        "over"  => OpKind::Over
-        "rot"   => OpKind::Rot
+        "print_str"  => OpKind::PrintStr
+        "print_bool" => OpKind::PrintBool
+        "print_char" => OpKind::PrintChar
+        "print_cstr" => OpKind::PrintCstr
+        "drop"       => OpKind::Drop
+        "dup"        => OpKind::Dup
+        "swap"       => OpKind::Swap
+        "over"       => OpKind::Over
+        "rot"        => OpKind::Rot
         _ => {
             f"unknown intrinsic: {intrinsic_value}" eprintln
             1 exit
@@ -62,6 +65,18 @@ fn parse_intrinsic intrinsic_value:str -> OpKind {
             OpKind::Drop
         }
     end
+}
+
+fn parse_bool_or_keyword token_value:str -> Op {
+    if "true" token_value str::eq then
+        1 OpKind::PushBool Op
+    else
+        if "false" token_value str::eq then
+            0 OpKind::PushBool Op
+        else
+            0 token_value parse_keyword Op
+        fi
+    fi
 }
 
 fn parse_keyword keyword_value:str -> OpKind {
@@ -85,6 +100,18 @@ fn parse_keyword keyword_value:str -> OpKind {
     end
 }
 
+fn intern_string string_table:List[str] value:str -> int {
+    0 = intern_index
+    while intern_index string_table.length > do
+        if value intern_index string_table.get str::eq then
+            intern_index return
+        fi
+        1 += intern_index
+    done
+    value string_table.push
+    string_table.length 1 -
+}
+
 fn resolve_variable variables:List[str] name:str op_kind:OpKind -> int {
     name variables find_variable = result
     if result.is_some then
@@ -100,7 +127,25 @@ fn resolve_variable variables:List[str] name:str op_kind:OpKind -> int {
     fi
 }
 
-fn parse tokens:List[Token] -> List[Op] int {
+# Infer print variant from the previous op's type.
+# Only works when print immediately follows a literal push.
+# Use explicit print_str/print_char/print_bool/print_cstr otherwise.
+fn dispatch_print ops:List[Op] -> OpKind {
+    if 0 ops.length > then
+        ops.length 1 - ops.get = prev_op
+        prev_op.kind = prev_kind
+        if prev_kind OpKind::PushStr == then
+            OpKind::PrintStr return
+        elif prev_kind OpKind::PushChar == then
+            OpKind::PrintChar return
+        elif prev_kind OpKind::PushBool == then
+            OpKind::PrintBool return
+        fi
+    fi
+    OpKind::PrintInt
+}
+
+fn parse tokens:List[Token] string_table:List[str] -> List[Op] int {
     List::new (List[Op]) = ops
     List::new (List[str]) = variables
     0 = index
@@ -111,7 +156,14 @@ fn parse tokens:List[Token] -> List[Op] int {
         token.kind = kind
 
         if kind TokenKind::Literal == then
-            token.value str_to_int OpKind::PushInt Op ops.push
+            0 token.value str::at = first_ch
+            if first_ch '"' == then
+                token.value 1 token.value.length 1 - str::substring string_table intern_string OpKind::PushStr Op ops.push
+            elif first_ch '\'' == then
+                token.value 1 token.value.length 1 - str::substring str_to_int OpKind::PushChar Op ops.push
+            else
+                token.value str_to_int OpKind::PushInt Op ops.push
+            fi
         elif kind TokenKind::Operator == then
             token.value parse_operator = op_kind
             if op_kind OpKind::AssignVariable == op_kind OpKind::AssignIncrement == || op_kind OpKind::AssignDecrement == || then
@@ -126,9 +178,13 @@ fn parse tokens:List[Token] -> List[Op] int {
                 0 op_kind Op ops.push
             fi
         elif kind TokenKind::Keyword == then
-            0 token.value parse_keyword Op ops.push
+            token.value parse_bool_or_keyword ops.push
         elif kind TokenKind::Intrinsic == then
-            0 token.value parse_intrinsic Op ops.push
+            if "print" token.value str::eq then
+                0 ops dispatch_print Op ops.push
+            else
+                0 token.value parse_intrinsic Op ops.push
+            fi
         elif kind TokenKind::Identifier == then
             token.value variables find_variable = result
             if result.is_none then


### PR DESCRIPTION
## Summary
- Add string literal lexing/parsing with escape sequences (`\n`, `\t`, `\\`, `\"`, `\0`, `\r`)
- Add char literal lexing/parsing with ordinal conversion
- Add boolean literal support (`true`/`false` as keywords)
- Add print variants: `print_str`, `print_bool`, `print_char`, `print_cstr`
- Add `print` dispatch heuristic that infers type from previous op
- Add string table with interning in `.data` section
- Add `--keep-asm` flag for debugging generated assembly
- Improve argument parsing with proper validation

## Test plan
- [x] `"Hello, world!" print` outputs string correctly
- [x] `'A' print` outputs character correctly
- [x] `true print` / `false print` outputs boolean correctly
- [x] Escape sequences (`\n`, `\t`) work in strings and chars
- [x] Explicit print variants (`print_str`, `print_char`, `print_bool`) work
- [x] String interning deduplicates identical strings
- [x] `--keep-asm` preserves `.s` file
- [x] Argument validation: no args, `-o` without value
- [x] Existing integer/variable/control-flow programs still work
- [x] FizzBuzz with string output works end-to-end