### PR TITLE
feat: add is keyword for enum variant checking

### DIFF
--- a/casa/bytecode.py
+++ b/casa/bytecode.py
@@ -559,6 +559,58 @@ class Compiler:
         inst_kind = InstKind.EQ if op.kind == OpKind.EQ else InstKind.NE
         bytecode.append(self.inst(inst_kind))
 
+    def _compile_is_check(self, op: Op, bytecode: list[Inst]) -> None:
+        """Compile IS_CHECK: variant check that pushes bool, optionally extracts bindings."""
+        variant = op.value
+        assert isinstance(variant, EnumVariant)
+        assert variant.enum_name is not None
+        casa_enum = GLOBAL_ENUMS[variant.enum_name]
+
+        if not casa_enum.has_inner_values:
+            # Plain enum: stack has ordinal, compare directly
+            bytecode.append(self.inst(InstKind.PUSH, args=[variant.ordinal]))
+            bytecode.append(self.inst(InstKind.EQ))
+            return
+
+        if not variant.bindings:
+            # Data-carrying enum, no bindings: load ordinal and compare
+            bytecode.append(self.inst(InstKind.LOAD64))
+            bytecode.append(self.inst(InstKind.PUSH, args=[variant.ordinal]))
+            bytecode.append(self.inst(InstKind.EQ))
+            return
+
+        # Data-carrying enum with bindings: save ptr, check ordinal,
+        # conditionally extract bindings
+        temp_ptr = self.locals_count
+        self.locals_count += 1
+
+        skip_bindings = new_label()
+
+        # Save the enum pointer
+        bytecode.append(self.inst(InstKind.LOCAL_SET, args=[temp_ptr]))
+
+        # Load ordinal and compare
+        bytecode.append(self.inst(InstKind.LOCAL_GET, args=[temp_ptr]))
+        bytecode.append(self.inst(InstKind.LOAD64))
+        bytecode.append(self.inst(InstKind.PUSH, args=[variant.ordinal]))
+        bytecode.append(self.inst(InstKind.EQ))
+
+        # Duplicate bool: one for binding extraction check, one stays on stack
+        bytecode.append(self.inst(InstKind.DUP))
+        bytecode.append(self.inst(InstKind.JUMP_NE, args=[skip_bindings]))
+
+        # Extract bindings from inner values
+        for i, var_name in enumerate(variant.bindings):
+            offset = (i + 1) * 8
+            bytecode.append(self.inst(InstKind.LOCAL_GET, args=[temp_ptr]))
+            bytecode.append(self.inst(InstKind.PUSH, args=[offset]))
+            bytecode.append(self.inst(InstKind.ADD))
+            bytecode.append(self.inst(InstKind.LOAD64))
+            _, set_kind, var_index = self._resolve_variable(var_name)
+            bytecode.append(self.inst(set_kind, args=[var_index]))
+
+        bytecode.append(self.inst(InstKind.LABEL, args=[skip_bindings]))
+
     def _compile_enum_match_arm(
         self,
         pattern: EnumVariant,
@@ -721,7 +773,7 @@ class Compiler:
     def compile(self) -> Bytecode:
         """Lower all ops to bytecode instructions."""
         assert len(InstKind) == 69, "Exhaustive handling for `InstructionKind"
-        assert len(OpKind) == 85, "Exhaustive handling for `OpKind`"
+        assert len(OpKind) == 86, "Exhaustive handling for `OpKind`"
 
         cursor = Cursor(sequence=self.ops)
         bytecode: list[Inst] = []
@@ -801,6 +853,8 @@ class Compiler:
                         bytecode.append(
                             self.inst(InstKind.PUSH, args=[variant.ordinal])
                         )
+                case OpKind.IS_CHECK:
+                    self._compile_is_check(op, bytecode)
                 case OpKind.MATCH_START | OpKind.MATCH_ARM | OpKind.MATCH_END:
                     self._compile_match_block(op, bytecode)
                 case OpKind.METHOD_CALL:

--- a/casa/common.py
+++ b/casa/common.py
@@ -104,6 +104,9 @@ class Keyword(Enum):
     END = auto()
     MATCH = auto()
 
+    # Variant check
+    IS = auto()
+
     # Include files
     INCLUDE = auto()
 
@@ -365,6 +368,7 @@ class OpKind(Enum):
 
     # Enums
     PUSH_ENUM_VARIANT = auto()
+    IS_CHECK = auto()
 
     # Match
     MATCH_START = auto()
@@ -403,7 +407,7 @@ class Op:
     deferred_return_type: str | None = None
 
     def __post_init__(self):
-        assert len(OpKind) == 85, "Exhaustive handling for `OpKind`"
+        assert len(OpKind) == 86, "Exhaustive handling for `OpKind`"
 
         match self.kind:
             # Requires `bool`
@@ -471,7 +475,7 @@ class Op:
                 if not isinstance(self.value, Intrinsic):
                     raise TypeError(f"`{self.kind}` requires value of type `Intrinsic`")
             # Requires `EnumVariant`
-            case OpKind.PUSH_ENUM_VARIANT:
+            case OpKind.PUSH_ENUM_VARIANT | OpKind.IS_CHECK:
                 if not isinstance(self.value, EnumVariant):
                     raise TypeError(
                         f"`{self.kind}` requires value of type `EnumVariant`"

--- a/casa/parser.py
+++ b/casa/parser.py
@@ -332,6 +332,44 @@ def _resolve_trait_ref(
     return None
 
 
+def _resolve_enum_variant(
+    variant: EnumVariant,
+    op: Op,
+    function: "Function | None",
+    errors: list[CasaError],
+) -> None:
+    """Resolve a deferred enum variant ordinal and register its bindings as variables."""
+    if variant.enum_name and variant.ordinal == -1:
+        casa_enum = GLOBAL_ENUMS.get(variant.enum_name)
+        if not casa_enum:
+            errors.append(
+                CasaError(
+                    ErrorKind.UNDEFINED_NAME,
+                    f"Enum `{variant.enum_name}` is not defined",
+                    op.location,
+                )
+            )
+        elif variant.variant_name not in casa_enum.variants:
+            errors.append(
+                CasaError(
+                    ErrorKind.UNDEFINED_NAME,
+                    f"Variant `{variant.variant_name}` is not "
+                    f"defined in enum `{variant.enum_name}`",
+                    op.location,
+                )
+            )
+        else:
+            variant.ordinal = casa_enum.variants.index(variant.variant_name)
+    if variant.bindings:
+        for var_name in variant.bindings:
+            variable = Variable(var_name)
+            if function:
+                if variable not in function.variables:
+                    function.variables.append(variable)
+            else:
+                GLOBAL_VARIABLES[var_name] = variable
+
+
 def resolve_identifiers(
     ops: list[Op],
     function: Function | None = None,
@@ -461,39 +499,10 @@ def resolve_identifiers(
                         else:
                             GLOBAL_VARIABLES[var_name] = variable
                 elif isinstance(op.value, EnumVariant):
-                    variant = op.value
-                    # Resolve deferred enum variant (ordinal == -1)
-                    if variant.enum_name and variant.ordinal == -1:
-                        casa_enum = GLOBAL_ENUMS.get(variant.enum_name)
-                        if not casa_enum:
-                            errors.append(
-                                CasaError(
-                                    ErrorKind.UNDEFINED_NAME,
-                                    f"Enum `{variant.enum_name}` is not defined",
-                                    op.location,
-                                )
-                            )
-                        elif variant.variant_name not in casa_enum.variants:
-                            errors.append(
-                                CasaError(
-                                    ErrorKind.UNDEFINED_NAME,
-                                    f"Variant `{variant.variant_name}` is not "
-                                    f"defined in enum `{variant.enum_name}`",
-                                    op.location,
-                                )
-                            )
-                        else:
-                            variant.ordinal = casa_enum.variants.index(
-                                variant.variant_name
-                            )
-                    if variant.bindings:
-                        for var_name in variant.bindings:
-                            variable = Variable(var_name)
-                            if function:
-                                if variable not in function.variables:
-                                    function.variables.append(variable)
-                            else:
-                                GLOBAL_VARIABLES[var_name] = variable
+                    _resolve_enum_variant(op.value, op, function, errors)
+            case OpKind.IS_CHECK:
+                assert isinstance(op.value, EnumVariant)
+                _resolve_enum_variant(op.value, op, function, errors)
             case OpKind.INCLUDE_FILE:
                 included_file = op.value
                 assert isinstance(included_file, Path), "Expected included file path"
@@ -675,6 +684,10 @@ def token_to_op(
                 struct = GLOBAL_STRUCTS.get(token.value)
                 if struct:
                     return _parse_struct_literal(token, struct, cursor, function_name)
+            if "::" in token.value:
+                is_op = _try_parse_is_check(token, cursor)
+                if is_op:
+                    return is_op
             return Op(token.value, OpKind.IDENTIFIER, token.location)
         case TokenKind.LITERAL:
             return get_op_literal(token)
@@ -959,6 +972,55 @@ def _handle_keyword_enum(
     GLOBAL_ENUMS[casa_enum.name] = casa_enum
 
 
+def _try_parse_is_check(token: Token, cursor: Cursor[Token]) -> Op | None:
+    """Try to parse an `is` check: `Enum::Variant is` or `Enum::Variant(bindings) is`.
+
+    Returns an IS_CHECK op if `is` follows, otherwise returns None without consuming tokens.
+    """
+    saved_position = cursor.position
+    peeked = cursor.peek()
+    if not peeked:
+        return None
+
+    bindings: list[str] = []
+
+    if peeked.value == "(":
+        # Parse potential bindings: Enum::Variant(a b) is
+        cursor.pop()  # consume (
+        while True:
+            inner_tok = cursor.peek()
+            if not inner_tok:
+                # Unexpected end — not an is-check, restore
+                cursor.position = saved_position
+                return None
+            if inner_tok.value == ")":
+                cursor.pop()  # consume )
+                if not bindings:
+                    # Empty parens: Enum::Variant() — not an is-check
+                    cursor.position = saved_position
+                    return None
+                break
+            if inner_tok.kind != TokenKind.IDENTIFIER:
+                # Not bindings — restore and let normal parsing handle it
+                cursor.position = saved_position
+                return None
+            cursor.pop()
+            bindings.append(inner_tok.value)
+
+    # Check if next token is `is`
+    next_tok = cursor.peek()
+    if not next_tok or next_tok.value != "is":
+        cursor.position = saved_position
+        return None
+
+    cursor.pop()  # consume `is`
+
+    parts = token.value.split("::", 1)
+    enum_name, variant_name = parts[0], parts[1]
+    variant = EnumVariant(enum_name, variant_name, -1, bindings)
+    return Op(variant, OpKind.IS_CHECK, token.location)
+
+
 def _is_match_arm_boundary(cursor: Cursor[Token]) -> bool:
     """Check if current position looks like a match arm pattern (Ident => or _ =>)."""
     pos = cursor.position
@@ -1235,7 +1297,7 @@ def get_op_keyword(
     function_name: str,
 ) -> Op | list[Op] | None:
     """Convert a keyword token into its op, parsing any nested blocks."""
-    assert len(Keyword) == 19, "Exhaustive handling for `Keyword"
+    assert len(Keyword) == 20, "Exhaustive handling for `Keyword"
 
     keyword = Keyword.from_lowercase(token.value)
     assert keyword, f"Token `{token.value}` is not a keyword"
@@ -1265,6 +1327,12 @@ def get_op_keyword(
             return None
         case Keyword.INCLUDE:
             return _handle_keyword_include(token, cursor)
+        case Keyword.IS:
+            raise_error(
+                ErrorKind.SYNTAX,
+                "`is` requires a preceding enum variant (e.g. `value Enum::Variant is`)",
+                token.location,
+            )
         case Keyword.MATCH:
             return _handle_keyword_match(token, cursor, function_name)
         case Keyword.STRUCT:

--- a/casa/typechecker.py
+++ b/casa/typechecker.py
@@ -109,6 +109,8 @@ class TypeChecker:
     deferred_lambda_vars: dict[str, str] = field(default_factory=dict)
     # Tracks the last pushed deferred lambda name for assignment tracking
     last_deferred_lambda: str | None = None
+    # True when processing ops between IF_START/IF_ELIF and IF_CONDITION (then)
+    in_branch_condition: bool = False
 
     def stack_push(self, typ: Type, origin: Location | None = None):
         """Push a type onto the symbolic stack."""
@@ -650,7 +652,9 @@ class TypeChecker:
                 bs = BranchedStack(self.stack, self.stack_origins)
                 bs.if_location = op.location
                 self.branched_stacks.append(bs)
+                self.in_branch_condition = True
             case OpKind.IF_CONDITION:
+                self.in_branch_condition = False
                 self.expect_type("bool")
 
                 assert len(self.branched_stacks) > 0, "If block stack state is saved"
@@ -691,8 +695,10 @@ class TypeChecker:
                 if op.kind is OpKind.IF_ELSE:
                     branched.default_present = True
                     branched.current_branch_label = "else"
+                    self.in_branch_condition = False
                 else:
                     branched.current_branch_label = "elif"
+                    self.in_branch_condition = True
                 branched.current_branch_location = op.location
 
                 if self.stack == before == after:
@@ -972,6 +978,68 @@ class TypeChecker:
             type_vars=set(casa_enum.type_vars),
         )
         self.apply_signature(sig, f"{variant.enum_name}::{variant.variant_name}")
+
+    def check_is(self, op: Op, function: "Function | None" = None) -> None:
+        """Handle IS_CHECK: pop enum, push bool, optionally bind inner values."""
+        variant = op.value
+        assert isinstance(variant, EnumVariant)
+        assert variant.enum_name is not None
+
+        # Pop the enum value
+        typ = self.stack_pop()
+        base_type = self._resolve_match_type(typ)
+
+        # Validate the variant belongs to the correct enum
+        if base_type not in GLOBAL_ENUMS:
+            raise_error(
+                ErrorKind.TYPE_MISMATCH,
+                f"`is` requires an enum type, got `{typ}`",
+                op.location,
+            )
+
+        casa_enum = GLOBAL_ENUMS[base_type]
+        if variant.enum_name != casa_enum.name:
+            raise_error(
+                ErrorKind.TYPE_MISMATCH,
+                f"Cannot check `{variant.enum_name}::{variant.variant_name}`"
+                f" on value of type `{typ}`",
+                op.location,
+            )
+
+        if variant.bindings:
+            # Bindings only allowed in if/elif conditions
+            if not self.in_branch_condition:
+                raise_error(
+                    ErrorKind.SYNTAX,
+                    "`is` with bindings is only allowed in `if`/`elif` conditions",
+                    op.location,
+                )
+
+            inner_types = casa_enum.variant_types.get(variant.variant_name, [])
+            if len(variant.bindings) != len(inner_types):
+                raise_error(
+                    ErrorKind.TYPE_MISMATCH,
+                    f"Variant `{variant.enum_name}::{variant.variant_name}`"
+                    f" has {len(inner_types)} inner value(s),"
+                    f" but {len(variant.bindings)} binding(s) provided",
+                    op.location,
+                )
+
+            # Resolve generic type vars from the concrete enum type
+            type_bindings: dict[str, str] = {}
+            if casa_enum.type_vars:
+                params = extract_generic_params(typ)
+                if params:
+                    for tvar, concrete in zip(
+                        casa_enum.type_vars, params, strict=False
+                    ):
+                        type_bindings[tvar] = concrete
+
+            for var_name, inner_type in zip(variant.bindings, inner_types, strict=True):
+                resolved_type = type_bindings.get(inner_type, inner_type)
+                self._set_struct_binding_type(var_name, resolved_type, function)
+
+        self.stack_push("bool")
 
     @staticmethod
     def _check_duplicate_arm(
@@ -2122,7 +2190,7 @@ def type_satisfies_trait(
 
 def type_check_ops(ops: list[Op], function: Function | None = None) -> Signature:
     """Type-check a list of ops and return the inferred signature."""
-    assert len(OpKind) == 85, "Exhaustive handling for `OpKind`"
+    assert len(OpKind) == 86, "Exhaustive handling for `OpKind`"
 
     tc = TypeChecker(ops=ops)
     op_index = 0
@@ -2222,6 +2290,8 @@ def type_check_ops(ops: list[Op], function: Function | None = None) -> Signature
                 tc.stack_push("ptr")
             case OpKind.PUSH_ENUM_VARIANT:
                 tc.check_enum_variant(op)
+            case OpKind.IS_CHECK:
+                tc.check_is(op, function)
             case OpKind.MATCH_START | OpKind.MATCH_ARM | OpKind.MATCH_END:
                 tc.check_match(op, function)
             case OpKind.STRUCT_NEW:

--- a/docs/control-flow.md
+++ b/docs/control-flow.md
@@ -82,6 +82,28 @@ The same applies to bare `array` and `array[T]`, and to `any` with any concrete 
 
 If there is no `else` branch, the `if`/`elif` branches must not change the stack at all (since the "no match" path leaves the stack unchanged).
 
+### Variant Checking with `is`
+
+The `is` keyword can be used in `if`/`elif` conditions to check and destructure enum variants. See [Enums — Variant Checking with `is`](enums.md#variant-checking-with-is) for details.
+
+```casa
+enum Shape {
+    Circle(int)
+    Rectangle(int int)
+    Point
+}
+
+10 Shape::Circle = shape
+
+if shape Shape::Circle(radius) is then
+    "radius=" print
+    radius print
+elif shape Shape::Rectangle(w h) is then
+    "area=" print
+    w h * print
+fi
+```
+
 ## Loops
 
 Casa has `while`/`do`/`done` loops with `break` and `continue`.

--- a/docs/enums.md
+++ b/docs/enums.md
@@ -94,6 +94,62 @@ Color::Red Direction::North ==
 
 Comparing an enum value with a non-enum type (e.g. `int`) is also a compile-time error.
 
+## Variant Checking with `is`
+
+The `is` keyword checks whether an enum value is a specific variant. It consumes the enum value and pushes a `bool`.
+
+**Stack effect:** `EnumName -> bool`
+
+```casa
+Color::Red = color
+color Color::Red is print     # true
+color Color::Blue is print    # false
+```
+
+### Destructuring with `is`
+
+Inside `if`/`elif` conditions, `is` can destructure inner values into bindings. The bindings are available in the corresponding `then`-block.
+
+```casa
+enum Shape {
+    Circle(int)
+    Rectangle(int int)
+    Point
+}
+
+10 Shape::Circle = shape
+
+if shape Shape::Circle(radius) is then
+    radius print
+fi
+```
+
+Use `elif` to check multiple variants:
+
+```casa
+if shape Shape::Circle(r) is then
+    r print
+elif shape Shape::Rectangle(w h) is then
+    w h * print
+fi
+```
+
+For generic enums, binding types are inferred from the concrete enum type:
+
+```casa
+42 Option::Some = maybe
+if maybe Option::Some(value) is then
+    value print    # value has type int
+fi
+```
+
+Using `is` with bindings outside of `if`/`elif` conditions is a compile-time error:
+
+```casa
+# ERROR: `is` with bindings is only allowed in `if`/`elif` conditions
+shape Shape::Circle(r) is
+```
+
 ## Printing
 
 Printing an enum value outputs its ordinal (0-based index in the declaration order).

--- a/examples/enum.casa
+++ b/examples/enum.casa
@@ -157,3 +157,22 @@ fn greet name:str -> str {
 "Alice" greet print "\n" print
 "Bob" greet print "\n" print
 "Charlie" greet print "\n" print
+
+# Variant checking with `is`
+color Color::Green is print "\n" print
+color Color::Red is print "\n" print
+
+# `is` with destructuring in if/elif
+if circle Shape::Circle(r) is then
+    "circle r=" print
+    r print
+    "\n" print
+fi
+
+if rect Shape::Circle(r) is then
+    "circle\n" print
+elif rect Shape::Rectangle(w h) is then
+    "rect area=" print
+    w h * print
+    "\n" print
+fi

--- a/examples/outputs/enum.out
+++ b/examples/outputs/enum.out
@@ -27,3 +27,7 @@ unknown
 Hi Alice
 Hi Bob
 Hello
+true
+false
+circle r=10
+rect area=12

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -1410,3 +1410,284 @@ class TestStrComparisonEndToEnd:
             '"hello" "world" check print\n'
         )
         assert output == "truefalse"
+
+
+# ---------------------------------------------------------------------------
+# `is` keyword - parsing
+# ---------------------------------------------------------------------------
+class TestIsCheckParsing:
+    def test_plain_enum_is_check(self):
+        ops = resolve_string(COLOR_ENUM + "Color::Red = c\nc Color::Red is\n")
+        is_ops = find_ops(ops, OpKind.IS_CHECK)
+        assert len(is_ops) == 1
+        variant = is_ops[0].value
+        assert isinstance(variant, EnumVariant)
+        assert variant.enum_name == "Color"
+        assert variant.variant_name == "Red"
+        assert variant.bindings == []
+
+    def test_is_check_with_bindings(self):
+        ops = resolve_string(
+            SHAPE_ENUM
+            + "10 Shape::Circle = s\n"
+            + "if s Shape::Circle(r) is then\nr print\nfi\n"
+        )
+        is_ops = find_ops(ops, OpKind.IS_CHECK)
+        assert len(is_ops) == 1
+        variant = is_ops[0].value
+        assert variant.bindings == ["r"]
+
+    def test_is_check_multiple_bindings(self):
+        ops = resolve_string(
+            SHAPE_ENUM
+            + "3 4 Shape::Rectangle = s\n"
+            + "if s Shape::Rectangle(w h) is then\nw print\nfi\n"
+        )
+        is_ops = find_ops(ops, OpKind.IS_CHECK)
+        assert len(is_ops) == 1
+        assert is_ops[0].value.bindings == ["w", "h"]
+
+    def test_is_check_resolves_ordinal(self):
+        ops = resolve_string(COLOR_ENUM + "Color::Blue = c\nc Color::Blue is\n")
+        is_ops = find_ops(ops, OpKind.IS_CHECK)
+        assert is_ops[0].value.ordinal == 2
+
+    def test_bare_is_keyword_error(self):
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            resolve_string(COLOR_ENUM + "Color::Red = c\nc is\n")
+        assert exc_info.value.errors[0].kind == ErrorKind.SYNTAX
+
+
+# ---------------------------------------------------------------------------
+# `is` keyword - type checking
+# ---------------------------------------------------------------------------
+class TestIsCheckTypeChecking:
+    def test_is_pushes_bool(self):
+        sig = typecheck_string(COLOR_ENUM + "Color::Red = c\nc Color::Red is\n")
+        assert sig.return_types == ["bool"]
+
+    def test_is_type_mismatch(self):
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            typecheck_string(
+                COLOR_ENUM + DIRECTION_ENUM + "Color::Red = c\nc Direction::North is\n"
+            )
+        assert exc_info.value.errors[0].kind == ErrorKind.TYPE_MISMATCH
+
+    def test_is_non_enum_type(self):
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            typecheck_string(COLOR_ENUM + "42 = n\nn Color::Red is\n")
+        assert exc_info.value.errors[0].kind == ErrorKind.TYPE_MISMATCH
+
+    def test_is_bindings_outside_if_error(self):
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            typecheck_string(
+                SHAPE_ENUM + "10 Shape::Circle = s\ns Shape::Circle(r) is\n"
+            )
+        assert exc_info.value.errors[0].kind == ErrorKind.SYNTAX
+
+    def test_is_wrong_binding_count(self):
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            typecheck_string(
+                SHAPE_ENUM
+                + "10 Shape::Circle = s\n"
+                + "if s Shape::Circle(a b) is then\na print\nfi\n"
+            )
+        assert exc_info.value.errors[0].kind == ErrorKind.TYPE_MISMATCH
+
+    def test_is_bindings_on_plain_variant(self):
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            typecheck_string(
+                COLOR_ENUM
+                + "Color::Red = c\n"
+                + "if c Color::Red(x) is then\nx print\nfi\n"
+            )
+        assert exc_info.value.errors[0].kind == ErrorKind.TYPE_MISMATCH
+
+    def test_is_bindings_in_while_condition_error(self):
+        with pytest.raises(CasaErrorCollection) as exc_info:
+            typecheck_string(
+                SHAPE_ENUM
+                + "10 Shape::Circle = s\n"
+                + "while s Shape::Circle(r) is do\nr print\ndone\n"
+            )
+        assert exc_info.value.errors[0].kind == ErrorKind.SYNTAX
+
+    def test_is_generic_enum(self):
+        sig = typecheck_string(OPTION_ENUM + "42 Option::Some = m\nm Option::Some is\n")
+        assert sig.return_types == ["bool"]
+
+    def test_is_generic_with_bindings(self):
+        typecheck_string(
+            OPTION_ENUM
+            + "42 Option::Some = m\n"
+            + "if m Option::Some(v) is then\nv print\nfi\n"
+        )
+
+
+# ---------------------------------------------------------------------------
+# `is` keyword - bytecode
+# ---------------------------------------------------------------------------
+class TestIsCheckBytecode:
+    def test_plain_enum_bytecode(self):
+        program = compile_string(COLOR_ENUM + "Color::Red = c\nc Color::Red is\n")
+        inst_kinds = [i.kind for i in program.bytecode]
+        # Should contain PUSH (ordinal) + EQ for plain enum
+        assert InstKind.EQ in inst_kinds
+
+    def test_data_carrying_no_bindings_bytecode(self):
+        program = compile_string(
+            SHAPE_ENUM + "10 Shape::Circle = s\ns Shape::Circle is\n"
+        )
+        inst_kinds = [i.kind for i in program.bytecode]
+        # Should contain LOAD64 (read ordinal from heap) + PUSH + EQ
+        assert InstKind.LOAD64 in inst_kinds
+        assert InstKind.EQ in inst_kinds
+
+
+# ---------------------------------------------------------------------------
+# `is` keyword - end to end
+# ---------------------------------------------------------------------------
+class TestIsCheckEndToEnd:
+    @pytest.fixture
+    def run_casa(self, tmp_path):
+        def _run(code: str) -> str:
+            src = tmp_path / "test.casa"
+            src.write_text(code)
+            binary = tmp_path / "test"
+            result = subprocess.run(
+                ["python3", "casa.py", str(src), "-o", str(binary)],
+                capture_output=True,
+                text=True,
+                cwd=CASA_ROOT,
+                timeout=30,
+            )
+            if result.returncode != 0:
+                pytest.fail(
+                    f"Compilation failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+                )
+            run_result = subprocess.run(
+                [str(binary)],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            return run_result.stdout
+
+        return _run
+
+    def test_plain_enum_is_true(self, run_casa):
+        output = run_casa(COLOR_ENUM + "Color::Red = c\nc Color::Red is print\n")
+        assert output == "true"
+
+    def test_plain_enum_is_false(self, run_casa):
+        output = run_casa(COLOR_ENUM + "Color::Red = c\nc Color::Blue is print\n")
+        assert output == "false"
+
+    def test_data_carrying_is_true(self, run_casa):
+        output = run_casa(
+            SHAPE_ENUM + "10 Shape::Circle = s\ns Shape::Circle is print\n"
+        )
+        assert output == "true"
+
+    def test_data_carrying_is_false(self, run_casa):
+        output = run_casa(
+            SHAPE_ENUM + "10 Shape::Circle = s\ns Shape::Rectangle is print\n"
+        )
+        assert output == "false"
+
+    def test_is_with_bindings_if(self, run_casa):
+        output = run_casa(
+            SHAPE_ENUM
+            + "10 Shape::Circle = s\n"
+            + "if s Shape::Circle(r) is then\n"
+            + "    r print\n"
+            + "fi\n"
+        )
+        assert output == "10"
+
+    def test_is_with_bindings_elif(self, run_casa):
+        output = run_casa(
+            SHAPE_ENUM
+            + "3 4 Shape::Rectangle = s\n"
+            + "if s Shape::Circle(r) is then\n"
+            + '    "circle" print\n'
+            + "elif s Shape::Rectangle(w h) is then\n"
+            + "    w h * print\n"
+            + "fi\n"
+        )
+        assert output == "12"
+
+    def test_is_with_bindings_no_match(self, run_casa):
+        output = run_casa(
+            SHAPE_ENUM
+            + "Shape::Point = s\n"
+            + "if s Shape::Circle(r) is then\n"
+            + '    "circle" print\n'
+            + "else\n"
+            + '    "other" print\n'
+            + "fi\n"
+        )
+        assert output == "other"
+
+    def test_is_generic_enum(self, run_casa):
+        output = run_casa(
+            OPTION_ENUM
+            + "42 Option::Some = m\n"
+            + "if m Option::Some(v) is then\n"
+            + "    v print\n"
+            + "fi\n"
+        )
+        assert output == "42"
+
+    def test_is_generic_none(self, run_casa):
+        output = run_casa(
+            OPTION_ENUM + "Option::None = m\n" + "m Option::Some is print\n"
+        )
+        assert output == "false"
+
+    def test_is_in_function(self, run_casa):
+        output = run_casa(
+            SHAPE_ENUM
+            + "fn get_radius s:Shape -> int {\n"
+            + "    if s Shape::Circle(r) is then\n"
+            + "        r return\n"
+            + "    fi\n"
+            + "    0\n"
+            + "}\n"
+            + "10 Shape::Circle get_radius print\n"
+            + "Shape::Point get_radius print\n"
+        )
+        assert output == "100"
+
+    def test_is_multiple_bindings(self, run_casa):
+        output = run_casa(
+            SHAPE_ENUM
+            + "3 4 Shape::Rectangle = s\n"
+            + "if s Shape::Rectangle(w h) is then\n"
+            + '    w print " " print h print\n'
+            + "fi\n"
+        )
+        assert output == "3 4"
+
+    def test_is_no_data_variant_on_data_enum_true(self, run_casa):
+        output = run_casa(SHAPE_ENUM + "Shape::Point = p\np Shape::Point is print\n")
+        assert output == "true"
+
+    def test_is_no_data_variant_on_data_enum_false(self, run_casa):
+        output = run_casa(
+            SHAPE_ENUM + "10 Shape::Circle = s\ns Shape::Point is print\n"
+        )
+        assert output == "false"
+
+    def test_is_without_bindings_in_function(self, run_casa):
+        output = run_casa(
+            OPTION_ENUM
+            + "fn is_some o:Option[int] -> bool { o Option::Some is }\n"
+            + "42 Option::Some is_some print\n"
+            + "Option::None is_some print\n"
+        )
+        assert output == "truefalse"
+
+    def test_is_plain_enum_without_bindings_in_while(self, run_casa):
+        output = run_casa(COLOR_ENUM + "Color::Red = c\n" + "c Color::Red is print\n")
+        assert output == "true"

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -28,6 +28,7 @@ ALL_KEYWORDS = [
     "struct",
     "trait",
     "match",
+    "is",
     "include",
 ]
 assert len(ALL_KEYWORDS) == len(Keyword)


### PR DESCRIPTION
## Summary

- Add `is` keyword for checking enum variant and optionally destructuring inner values
- `value Enum::Variant is` consumes the enum value and pushes a `bool`
- `is` with bindings (`Enum::Variant(x) is`) is allowed only in `if`/`elif` conditions, scoping bindings to the then-block
- Works with plain enums, data-carrying enums, and generic enums

## Test plan

- [x] 31 new tests: parsing (5), type checking (9), bytecode (2), end-to-end (15)
- [x] All 1189 tests pass
- [x] All 31 example tests pass
- [x] black, pylint, mypy clean