### PR TITLE
refactor: use if/is for enum variant destructuring

### DIFF
--- a/self_hosted/bytecode.casa
+++ b/self_hosted/bytecode.casa
@@ -148,12 +148,12 @@ fn find_variable variables:List[str] name:str -> Option[int] {
 # Checks function locals first, then globals.
 fn resolve_variable name:str func_variables:List[str] global_variables:List[str] -> InstKind InstKind int {
     name func_variables find_variable = local_result
-    if local_result.is_some then
-        InstKind::LocalGet InstKind::LocalSet local_result.unwrap return
+    if local_result Option::Some(index) is then
+        InstKind::LocalGet InstKind::LocalSet index return
     fi
     name global_variables find_variable = global_result
-    if global_result.is_some then
-        InstKind::GlobalGet InstKind::GlobalSet global_result.unwrap return
+    if global_result Option::Some(index) is then
+        InstKind::GlobalGet InstKind::GlobalSet index return
     fi
     f"undefined variable: {name}" eprintln
     1 exit

--- a/self_hosted/common.casa
+++ b/self_hosted/common.casa
@@ -17,47 +17,43 @@ enum OpValue { None Int(int) Str(str) }
 enum InstValue { None Int(int) Str(str) }
 
 fn op_int_value op_value:OpValue -> int {
-    op_value match
-        OpValue::Int(value) => value
-        _ => {
-            "error: expected OpValue::Int\n" print
-            1 exit
-            0
-        }
-    end
+    if op_value OpValue::Int(value) is then
+        value
+    else
+        "error: expected OpValue::Int\n" print
+        1 exit
+        0
+    fi
 }
 
 fn op_str_value op_value:OpValue -> str {
-    op_value match
-        OpValue::Str(value) => value
-        _ => {
-            "error: expected OpValue::Str\n" print
-            1 exit
-            ""
-        }
-    end
+    if op_value OpValue::Str(value) is then
+        value
+    else
+        "error: expected OpValue::Str\n" print
+        1 exit
+        ""
+    fi
 }
 
 fn inst_int_value inst_value:InstValue -> int {
-    inst_value match
-        InstValue::Int(value) => value
-        _ => {
-            "error: expected InstValue::Int\n" print
-            1 exit
-            0
-        }
-    end
+    if inst_value InstValue::Int(value) is then
+        value
+    else
+        "error: expected InstValue::Int\n" print
+        1 exit
+        0
+    fi
 }
 
 fn inst_str_value inst_value:InstValue -> str {
-    inst_value match
-        InstValue::Str(value) => value
-        _ => {
-            "error: expected InstValue::Str\n" print
-            1 exit
-            ""
-        }
-    end
+    if inst_value InstValue::Str(value) is then
+        value
+    else
+        "error: expected InstValue::Str\n" print
+        1 exit
+        ""
+    fi
 }
 
 # ---------------------------------------------------------------------------

--- a/self_hosted/lexer.casa
+++ b/self_hosted/lexer.casa
@@ -3,13 +3,14 @@
 include "common.casa"
 
 fn lex_integer_literal cursor:Cursor -> Token {
-    cursor parse_int = result
-    if result.is_error then
+    if cursor parse_int Result::Ok(number) is then
+        number .to_str = text
+        text TokenKind::Literal Token
+    else
         "invalid number" eprintln
         1 exit
+        "" TokenKind::Literal Token
     fi
-    result.unwrap .to_str = text
-    text TokenKind::Literal Token
 }
 
 fn make_keyword_set -> Set[str] {
@@ -47,29 +48,49 @@ fn make_intrinsic_set -> Set[str] {
 }
 
 fn lex_word cursor:Cursor keywords:Set[str] intrinsics:Set[str] -> Token {
-    cursor parse_identifier = result
-    if result.is_error then
+    if cursor parse_identifier Result::Ok(word) is then
+        if word keywords.has then
+            word TokenKind::Keyword Token
+        elif word intrinsics.has then
+            word TokenKind::Intrinsic Token
+        else
+            word TokenKind::Identifier Token
+        fi
+    else
         "unexpected character" eprintln
         1 exit
-    fi
-    result.unwrap = word
-    if word keywords.has then
-        word TokenKind::Keyword Token
-    elif word intrinsics.has then
-        word TokenKind::Intrinsic Token
-    else
-        word TokenKind::Identifier Token
+        "" TokenKind::Identifier Token
     fi
 }
 
 fn lex_two_char_op cursor:Cursor second:char op:str -> Token {
     0 cursor.peek_at = next_ch
-    if next_ch.is_some next_ch.unwrap second == && then
-        cursor.advance drop
-        op TokenKind::Operator Token
-    else
-        "" TokenKind::Eof Token
+    if next_ch Option::Some(ch) is then
+        if ch second == then
+            cursor.advance drop
+            op TokenKind::Operator Token return
+        fi
     fi
+    "" TokenKind::Eof Token
+}
+
+fn lex_minus cursor:Cursor tokens:List[Token] {
+    1 cursor.peek_at = next_ch
+    if next_ch Option::Some(next_char) is then
+        if next_char .is_digit then
+            cursor lex_integer_literal tokens.push return
+        elif next_char '=' == then
+            cursor.advance drop
+            cursor.advance drop
+            "-=" TokenKind::Operator Token tokens.push return
+        elif next_char '>' == then
+            cursor.advance drop
+            cursor.advance drop
+            "->" TokenKind::Delimiter Token tokens.push return
+        fi
+    fi
+    cursor.advance drop
+    "-" TokenKind::Operator Token tokens.push
 }
 
 fn lex_operator cursor:Cursor ch:char -> Token {
@@ -155,38 +176,24 @@ fn lex source:str -> List[Token] {
         # to distinguish them from integer literals in the parser:
         # strings start with ", chars start with ' followed by ordinal.
         if ch '"' == then
-            cursor parse_quoted_string = str_result
-            if str_result.is_error then
+            if cursor parse_quoted_string Result::Ok(str_value) is then
+                f"\"{str_value}" TokenKind::Literal Token tokens.push
+            else
                 "invalid string literal" eprintln
                 1 exit
             fi
-            f"\"{str_result.unwrap}" TokenKind::Literal Token tokens.push
         elif ch '\'' == then
-            cursor parse_char_literal = char_result
-            if char_result.is_error then
+            if cursor parse_char_literal Result::Ok(char_value) is then
+                f"'{char_value (int) .to_str}" TokenKind::Literal Token tokens.push
+            else
                 "invalid char literal" eprintln
                 1 exit
             fi
-            f"'{char_result.unwrap (int) .to_str}" TokenKind::Literal Token tokens.push
         elif ch .is_digit then
             cursor lex_integer_literal tokens.push
         # Minus handled separately: needs lookahead for negative literals, -=, and ->
         elif ch '-' == then
-            1 cursor.peek_at = next_ch
-            if next_ch.is_some next_ch.unwrap .is_digit && then
-                cursor lex_integer_literal tokens.push
-            elif next_ch.is_some next_ch.unwrap '=' == && then
-                cursor.advance drop
-                cursor.advance drop
-                "-=" TokenKind::Operator Token tokens.push
-            elif next_ch.is_some next_ch.unwrap '>' == && then
-                cursor.advance drop
-                cursor.advance drop
-                "->" TokenKind::Delimiter Token tokens.push
-            else
-                cursor.advance drop
-                "-" TokenKind::Operator Token tokens.push
-            fi
+            tokens cursor lex_minus
         elif ch '{' == then
             cursor.advance drop
             "{" TokenKind::Delimiter Token tokens.push


### PR DESCRIPTION
## Summary
- Replace `match`/`_` blocks with `if`/`is` destructuring in value extractor functions (`op_int_value`, `op_str_value`, `inst_int_value`, `inst_str_value`)
- Replace `.is_some` + `.unwrap` patterns with `Option::Some(binding) is` in `resolve_variable`
- Replace `.is_error` + `.unwrap` patterns with `Result::Ok(binding) is` in lexer functions
- Replace `.is_some` + `.unwrap` compound conditions with `Option::Some(binding) is` in `lex_two_char_op` and minus handling
- Extract `lex_minus` helper to keep nesting within 3 levels

## Test plan
- [x] Self-hosted compiler builds successfully
- [x] Compiled test programs produce correct output
- [x] All 31 example tests pass