### PR TITLE
fix: nested if/elif/else/fi inside elif branches falsely rejected

### DIFF
--- a/casa/bytecode.py
+++ b/casa/bytecode.py
@@ -987,9 +987,8 @@ class Compiler:
                 depth -= direction
 
             if depth < START_DEPTH:
-                is_boundary_op = op.kind in START_KINDS or op.kind in END_KINDS
-                hit_enclosing_end = other_op.kind == end_kind
-                if is_boundary_op or hit_enclosing_end:
+                stop_kind = start_kind if reverse else end_kind
+                if other_op.kind == stop_kind:
                     return None
 
         return None

--- a/tests/test_bytecode.py
+++ b/tests/test_bytecode.py
@@ -3,6 +3,7 @@
 import pytest
 
 from casa.common import InstKind, Program
+from casa.error import CasaErrorCollection
 from tests.conftest import compile_string
 
 
@@ -260,6 +261,27 @@ def test_bytecode_if_control_flow():
     assert len(labels) >= 1
     jumps_ne = find_insts(program, InstKind.JUMP_NE)
     assert len(jumps_ne) >= 1
+
+
+def test_bytecode_nested_elif_in_elif():
+    """Nested if/elif/else/fi inside an elif branch must compile without error."""
+    code = (
+        "1 = x "
+        "if 0 x == then "
+        "    if 0 x == then 10 drop else 20 drop fi "
+        "elif 1 x == then "
+        "    if 0 x == then 30 drop elif 1 x == then 40 drop else 50 drop fi "
+        "fi"
+    )
+    program = compile_string(code)
+    labels = find_insts(program, InstKind.LABEL)
+    assert len(labels) >= 4
+
+
+def test_bytecode_elif_after_else_rejected():
+    """Actual elif after else must still be rejected."""
+    with pytest.raises(CasaErrorCollection):
+        compile_string("if true then 1 drop else 2 drop elif false then 3 drop fi")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `find_matching_label` in `bytecode.py` crossed block boundaries when reverse-searching for `IF_ELSE`, finding unrelated `IF_ELSE` ops from sibling nested blocks
- The depth guard now checks `other_op.kind == start_kind` to only stop at same-type block boundaries
- Added positive test (nested elif compiles) and negative test (actual elif-after-else still rejected)

## Test plan
- [x] All 1191 tests pass (`pytest tests`)
- [x] `tests/test_examples.sh` passes
- [x] New `test_bytecode_nested_elif_in_elif` verifies the fix
- [x] New `test_bytecode_elif_after_else_rejected` guards against regression