### PR TITLE
feat: add memory intrinsics, syscalls, and type casts to self-hosted compiler

### DIFF
--- a/self_hosted/bytecode.casa
+++ b/self_hosted/bytecode.casa
@@ -272,9 +272,25 @@ fn op_to_inst op:Op -> Inst {
         OpKind::PrintBool => InstValue::None InstKind::PrintBool Inst
         OpKind::PrintChar => InstValue::None InstKind::PrintChar Inst
         OpKind::PrintCstr => InstValue::None InstKind::PrintCstr Inst
+        OpKind::Alloc     => InstValue::None InstKind::HeapAlloc Inst
         OpKind::HeapAlloc => InstValue::None InstKind::HeapAlloc Inst
+        OpKind::Load8     => InstValue::None InstKind::Load8 Inst
+        OpKind::Load16    => InstValue::None InstKind::Load16 Inst
+        OpKind::Load32    => InstValue::None InstKind::Load32 Inst
         OpKind::Load64    => InstValue::None InstKind::Load64 Inst
+        OpKind::Store8    => InstValue::None InstKind::Store8 Inst
+        OpKind::Store16   => InstValue::None InstKind::Store16 Inst
+        OpKind::Store32   => InstValue::None InstKind::Store32 Inst
         OpKind::Store64   => InstValue::None InstKind::Store64 Inst
+        OpKind::Syscall0  => InstValue::None InstKind::Syscall0 Inst
+        OpKind::Syscall1  => InstValue::None InstKind::Syscall1 Inst
+        OpKind::Syscall2  => InstValue::None InstKind::Syscall2 Inst
+        OpKind::Syscall3  => InstValue::None InstKind::Syscall3 Inst
+        OpKind::Syscall4  => InstValue::None InstKind::Syscall4 Inst
+        OpKind::Syscall5  => InstValue::None InstKind::Syscall5 Inst
+        OpKind::Syscall6  => InstValue::None InstKind::Syscall6 Inst
+        OpKind::Argc      => InstValue::None InstKind::Argc Inst
+        OpKind::Argv      => InstValue::None InstKind::Argv Inst
         _ => {
             "unexpected op in op_to_inst" eprintln
             1 exit
@@ -345,11 +361,13 @@ fn compile_ops ops:List[Op] func_variables:List[str] global_variables:List[str] 
         elif op_kind OpKind::FnReturn == then
             InstValue::None InstKind::FnReturn Inst bytecode.push
 
-        # If blocks
-        # IfStart is a structural marker only; no instructions emitted
-        elif op_kind OpKind::IfStart == then
-            0 drop
+        # No-op: IfStart, MatchStart are structural markers; TypeCast has no runtime effect
+        elif op_kind OpKind::IfStart ==
+             op_kind OpKind::MatchStart == ||
+             op_kind OpKind::TypeCast == ||
+        then
 
+        # If blocks
         elif op_kind OpKind::IfCondition == then
             ops op_index state find_if_branch_target InstValue::Int InstKind::JumpNe Inst bytecode.push
 
@@ -403,9 +421,6 @@ fn compile_ops ops:List[Op] func_variables:List[str] global_variables:List[str] 
             current_op.value op_int_value InstValue::Int InstKind::Push Inst bytecode.push
 
         # Match blocks
-        elif op_kind OpKind::MatchStart == then
-            0 drop
-
         elif op_kind OpKind::MatchArm == then
             current_op.value op_int_value = ordinal
 

--- a/self_hosted/common.casa
+++ b/self_hosted/common.casa
@@ -72,7 +72,9 @@ enum OpKind {
     IfStart IfCondition IfElif IfElse IfEnd
     WhileStart WhileCondition WhileBreak WhileContinue WhileEnd
     FnCall FnReturn
-    HeapAlloc Load64 Store64
+    Alloc HeapAlloc Load8 Load16 Load32 Load64 Store8 Store16 Store32 Store64
+    Syscall0 Syscall1 Syscall2 Syscall3 Syscall4 Syscall5 Syscall6
+    Argc Argv TypeCast
     StructNew PushEnumVariant
     MatchStart MatchArm MatchEnd
 }
@@ -92,7 +94,9 @@ enum InstKind {
     GlobalGet GlobalSet LocalGet LocalSet LocalsInit LocalsUninit
     Label Jump JumpNe
     FnCall FnReturn
-    HeapAlloc Load64 Store64
+    HeapAlloc Load8 Load16 Load32 Load64 Store8 Store16 Store32 Store64
+    Syscall0 Syscall1 Syscall2 Syscall3 Syscall4 Syscall5 Syscall6
+    Argc Argv
 }
 
 # ---------------------------------------------------------------------------

--- a/self_hosted/emitter.casa
+++ b/self_hosted/emitter.casa
@@ -204,11 +204,42 @@ fn sanitize_name name:str -> str {
     result.build
 }
 
+fn emit_load emitter:Emitter mov_inst:str {
+    "    popq %rax\n" emitter.asm.append
+    f"    {mov_inst} (%rax), %eax\n" emitter.asm.append
+    "    pushq %rax\n" emitter.asm.append
+}
+
+fn emit_store emitter:Emitter mov_inst:str {
+    "    popq %rax\n" emitter.asm.append
+    "    popq %rbx\n" emitter.asm.append
+    f"    {mov_inst}\n" emitter.asm.append
+}
+
+fn emit_syscall emitter:Emitter arg_count:int {
+    "    popq %rax\n" emitter.asm.append
+    if 1 arg_count >= then "    popq %rdi\n" emitter.asm.append fi
+    if 2 arg_count >= then "    popq %rsi\n" emitter.asm.append fi
+    if 3 arg_count >= then "    popq %rdx\n" emitter.asm.append fi
+    if 4 arg_count >= then "    popq %r10\n" emitter.asm.append fi
+    if 5 arg_count >= then "    popq %r8\n" emitter.asm.append fi
+    if 6 arg_count >= then "    popq %r9\n" emitter.asm.append fi
+    "    syscall\n" emitter.asm.append
+    "    pushq %rax\n" emitter.asm.append
+}
+
 fn emit_inst inst:Inst emitter:Emitter is_global:bool {
     inst.kind match
         # Push
-        InstKind::Push =>
-            f"    pushq ${inst.value inst_int_value .to_str}\n" emitter.asm.append
+        InstKind::Push => {
+            inst.value inst_int_value = push_val
+            if push_val 2147483647 > push_val 0 2147483648 - < || then
+                f"    movabsq ${push_val .to_str}, %rax\n" emitter.asm.append
+                "    pushq %rax\n" emitter.asm.append
+            else
+                f"    pushq ${push_val .to_str}\n" emitter.asm.append
+            fi
+        }
         # Arithmetic
         InstKind::Add => {
             "    popq %rax\n" emitter.asm.append
@@ -328,15 +359,34 @@ fn emit_inst inst:Inst emitter:Emitter is_global:bool {
             "    addq %rax, %rcx\n" emitter.asm.append
             "    movq %rcx, heap_ptr(%rip)\n" emitter.asm.append
         }
+        InstKind::Load8  => "movzbl" emitter emit_load
+        InstKind::Load16 => "movzwl" emitter emit_load
+        InstKind::Load32 => "movl" emitter emit_load
         InstKind::Load64 => {
             "    popq %rax\n" emitter.asm.append
             "    movq (%rax), %rax\n" emitter.asm.append
             "    pushq %rax\n" emitter.asm.append
         }
-        InstKind::Store64 => {
-            "    popq %rax\n" emitter.asm.append
-            "    popq %rbx\n" emitter.asm.append
-            "    movq %rbx, (%rax)\n" emitter.asm.append
+        InstKind::Store8  => "movb %bl, (%rax)" emitter emit_store
+        InstKind::Store16 => "movw %bx, (%rax)" emitter emit_store
+        InstKind::Store32 => "movl %ebx, (%rax)" emitter emit_store
+        InstKind::Store64 => "movq %rbx, (%rax)" emitter emit_store
+        # Syscalls
+        InstKind::Syscall0 => 0 emitter emit_syscall
+        InstKind::Syscall1 => 1 emitter emit_syscall
+        InstKind::Syscall2 => 2 emitter emit_syscall
+        InstKind::Syscall3 => 3 emitter emit_syscall
+        InstKind::Syscall4 => 4 emitter emit_syscall
+        InstKind::Syscall5 => 5 emitter emit_syscall
+        InstKind::Syscall6 => 6 emitter emit_syscall
+        # Command-line arguments
+        InstKind::Argc => {
+            "    movq __argc(%rip), %rax\n" emitter.asm.append
+            "    pushq %rax\n" emitter.asm.append
+        }
+        InstKind::Argv => {
+            "    movq __argv(%rip), %rax\n" emitter.asm.append
+            "    pushq %rax\n" emitter.asm.append
         }
         # Push string/char
         InstKind::PushStr => {

--- a/self_hosted/lexer.casa
+++ b/self_hosted/lexer.casa
@@ -49,6 +49,24 @@ fn make_intrinsic_set -> Set[str] {
     "swap" intrinsics.add drop
     "over" intrinsics.add drop
     "rot" intrinsics.add drop
+    "alloc" intrinsics.add drop
+    "load8" intrinsics.add drop
+    "load16" intrinsics.add drop
+    "load32" intrinsics.add drop
+    "load64" intrinsics.add drop
+    "store8" intrinsics.add drop
+    "store16" intrinsics.add drop
+    "store32" intrinsics.add drop
+    "store64" intrinsics.add drop
+    "syscall0" intrinsics.add drop
+    "syscall1" intrinsics.add drop
+    "syscall2" intrinsics.add drop
+    "syscall3" intrinsics.add drop
+    "syscall4" intrinsics.add drop
+    "syscall5" intrinsics.add drop
+    "syscall6" intrinsics.add drop
+    "argc" intrinsics.add drop
+    "argv" intrinsics.add drop
     intrinsics
 }
 
@@ -247,6 +265,18 @@ fn lex source:str -> List[Token] {
         elif ch ':' == then
             cursor.advance drop
             ":" TokenKind::Delimiter Token tokens.push
+        elif ch '(' == then
+            cursor.advance drop
+            "(" TokenKind::Delimiter Token tokens.push
+        elif ch ')' == then
+            cursor.advance drop
+            ")" TokenKind::Delimiter Token tokens.push
+        elif ch '[' == then
+            cursor.advance drop
+            "[" TokenKind::Delimiter Token tokens.push
+        elif ch ']' == then
+            cursor.advance drop
+            "]" TokenKind::Delimiter Token tokens.push
         elif ch '+' == ch '*' == || ch '/' == || ch '%' == || ch '&' == || ch '|' == || ch '^' == || ch '~' == || ch '<' == || ch '>' == || ch '=' == || ch '!' == || then
             ch cursor lex_operator tokens.push
         elif ch .is_alpha ch '_' == || then

--- a/self_hosted/parser.casa
+++ b/self_hosted/parser.casa
@@ -47,6 +47,24 @@ fn parse_intrinsic intrinsic_value:str -> OpKind {
         "swap"       => OpKind::Swap
         "over"       => OpKind::Over
         "rot"        => OpKind::Rot
+        "alloc"      => OpKind::Alloc
+        "load8"      => OpKind::Load8
+        "load16"     => OpKind::Load16
+        "load32"     => OpKind::Load32
+        "load64"     => OpKind::Load64
+        "store8"     => OpKind::Store8
+        "store16"    => OpKind::Store16
+        "store32"    => OpKind::Store32
+        "store64"    => OpKind::Store64
+        "syscall0"   => OpKind::Syscall0
+        "syscall1"   => OpKind::Syscall1
+        "syscall2"   => OpKind::Syscall2
+        "syscall3"   => OpKind::Syscall3
+        "syscall4"   => OpKind::Syscall4
+        "syscall5"   => OpKind::Syscall5
+        "syscall6"   => OpKind::Syscall6
+        "argc"       => OpKind::Argc
+        "argv"       => OpKind::Argv
         _ => {
             f"unknown intrinsic: {intrinsic_value}" eprintln
             1 exit
@@ -198,10 +216,31 @@ fn parse_token token:Token index:int ctx:ParseContext ops:List[Op] -> int {
             token.value ctx resolve_identifier ops.push
         fi
     elif kind TokenKind::Delimiter == then
-        f"unexpected delimiter: {token.value}" eprintln
-        1 exit
+        if "(" token.value == then
+            # Type cast: skip tokens until matching )
+            1 = paren_depth
+            while index ctx.tokens.length > 0 paren_depth > && do
+                index ctx.tokens.get .value = paren_val
+                if "(" paren_val == then
+                    1 += paren_depth
+                elif ")" paren_val == then
+                    paren_depth 1 - = paren_depth
+                fi
+                1 += index
+            done
+        elif "[" token.value ==
+             "]" token.value == ||
+             ")" token.value == ||
+        then
+            # Stray brackets/parens from type annotations — skip silently.
+            # This is intentionally permissive: without a type checker,
+            # we cannot distinguish annotation tokens from real errors.
+        else
+            f"unexpected delimiter: {token.value}" eprintln
+            1 exit
+        fi
     elif kind TokenKind::Eof == then
-        0 drop
+        # End of file — nothing to emit
     else
         "unexpected token" eprintln
         1 exit


### PR DESCRIPTION
## Summary
- Add memory intrinsics (`alloc`, `load8/16/32/64`, `store8/16/32/64`), syscalls (`syscall0`-`syscall6`), `argc`/`argv`, and type cast parsing to the self-hosted compiler (Step 8 of the roadmap)
- Add `(`, `)`, `[`, `]` delimiter tokenization for type cast and generic annotation syntax
- Extract `emit_load`, `emit_store`, and `emit_syscall` helpers to reduce emitter match arm duplication

## Test plan
- [x] Compile self-hosted compiler with Python compiler: `python3 casa.py self_hosted/casa.casa -o casa_compiler`
- [x] Compile test program exercising alloc, load/store (8/16/32/64), type casts, argc, argv, and syscall3
- [x] Verify output: correct values for all memory widths, argc=1, argv prints program name, raw syscall writes to stdout