### PR TITLE
feat: add f-string support to self-hosted compiler

### DIFF
--- a/self_hosted/bytecode.casa
+++ b/self_hosted/bytecode.casa
@@ -291,7 +291,8 @@ fn op_to_inst op:Op -> Inst {
         OpKind::Syscall6  => InstValue::None InstKind::Syscall6 Inst
         OpKind::Argc      => InstValue::None InstKind::Argc Inst
         OpKind::Argv      => InstValue::None InstKind::Argv Inst
-        OpKind::FnExec    => InstValue::None InstKind::FnExec Inst
+        OpKind::FnExec         => InstValue::None InstKind::FnExec Inst
+        OpKind::FstringConcat  => op.value op_int_value InstValue::Int InstKind::FstringConcat Inst
         _ => {
             "unexpected op in op_to_inst" eprintln
             1 exit

--- a/self_hosted/common.casa
+++ b/self_hosted/common.casa
@@ -78,6 +78,7 @@ enum OpKind {
     StructNew PushEnumVariant
     MatchStart MatchArm MatchEnd
     FnExec
+    FstringConcat
 }
 
 # ---------------------------------------------------------------------------
@@ -99,6 +100,7 @@ enum InstKind {
     Syscall0 Syscall1 Syscall2 Syscall3 Syscall4 Syscall5 Syscall6
     Argc Argv
     FnExec
+    FstringConcat
 }
 
 # ---------------------------------------------------------------------------

--- a/self_hosted/emitter.casa
+++ b/self_hosted/emitter.casa
@@ -515,6 +515,16 @@ fn emit_inst inst:Inst emitter:Emitter is_global:bool {
             f"    jmp fn_{fn_label}\n" emitter.asm.append
             f".Lret_{ret_label .to_str}:\n" emitter.asm.append
         }
+        InstKind::FstringConcat => {
+            inst.value inst_int_value = concat_count
+            emitter next_label = concat_label
+            f"    movq ${concat_count .to_str}, %rdi\n" emitter.asm.append
+            f"    leaq .Lconcat_done_{concat_label .to_str}(%rip), %rax\n" emitter.asm.append
+            "    movq %rax, (%r14)\n" emitter.asm.append
+            "    addq $8, %r14\n" emitter.asm.append
+            "    jmp str_concat\n" emitter.asm.append
+            f".Lconcat_done_{concat_label .to_str}:\n" emitter.asm.append
+        }
         InstKind::FnReturn => {
             if is_global then
                 "    movq $60, %rax\n" emitter.asm.append

--- a/self_hosted/lexer.casa
+++ b/self_hosted/lexer.casa
@@ -275,7 +275,7 @@ fn lex_fstring cursor:Cursor tokens:List[Token] keywords:Set[str] intrinsics:Set
             cursor.advance drop
             # Lex expression tokens until matching }
             1 = fstr_brace_depth
-            while cursor.is_eof ! fstr_brace_depth 0 > && do
+            while cursor.is_eof ! 0 fstr_brace_depth > && do
                 cursor skip_whitespace
                 if cursor.is_eof then break fi
                 cursor.peek.unwrap = expr_ch
@@ -288,6 +288,10 @@ fn lex_fstring cursor:Cursor tokens:List[Token] keywords:Set[str] intrinsics:Set
                 elif expr_ch '"' == then
                     if cursor parse_quoted_string Result::Ok(expr_str) is then
                         f"\"{expr_str}" TokenKind::Literal Token tokens.push
+                    fi
+                elif expr_ch '\'' == then
+                    if cursor parse_char_literal Result::Ok(char_value) is then
+                        f"'{char_value (int) .to_str}" TokenKind::Literal Token tokens.push
                     fi
                 elif expr_ch .is_digit then
                     cursor lex_integer_literal tokens.push
@@ -310,21 +314,12 @@ fn lex_fstring cursor:Cursor tokens:List[Token] keywords:Set[str] intrinsics:Set
                     expr_ch cursor lex_operator tokens.push
                 fi
             done
-            # Emit .to_str to convert expression result to string
-            "." TokenKind::Delimiter Token tokens.push
-            "to_str" TokenKind::Identifier Token tokens.push
-            if 0 fstr_part_count > then
-                "str::concat" TokenKind::Identifier Token tokens.push
-            fi
             1 += fstr_part_count
         else
             # Text segment
             cursor lex_fstring_text = fstr_text
             if 0 fstr_text.length > then
                 f"\"{fstr_text}" TokenKind::Literal Token tokens.push
-                if 0 fstr_part_count > then
-                    "str::concat" TokenKind::Identifier Token tokens.push
-                fi
                 1 += fstr_part_count
             fi
         fi
@@ -333,6 +328,10 @@ fn lex_fstring cursor:Cursor tokens:List[Token] keywords:Set[str] intrinsics:Set
     # If no parts were emitted, push empty string
     if 0 fstr_part_count == then
         "\"" TokenKind::Literal Token tokens.push
+    elif 1 fstr_part_count > then
+        # Emit part count and fstring_concat intrinsic
+        fstr_part_count .to_str TokenKind::Literal Token tokens.push
+        "fstring_concat" TokenKind::Intrinsic Token tokens.push
     fi
 }
 

--- a/self_hosted/parser.casa
+++ b/self_hosted/parser.casa
@@ -247,11 +247,25 @@ fn parse_token token:Token index:int ctx:ParseContext ops:List[Op] -> int {
         fi
     elif kind TokenKind::Intrinsic == then
         if "print" token.value == then
-            OpValue::None ops dispatch_print Op ops.push
+            if "str" ctx.expression_type == then
+                OpValue::None OpKind::PrintStr Op ops.push
+            elif "char" ctx.expression_type == then
+                OpValue::None OpKind::PrintChar Op ops.push
+            elif "bool" ctx.expression_type == then
+                OpValue::None OpKind::PrintBool Op ops.push
+            else
+                OpValue::None ops dispatch_print Op ops.push
+            fi
+        elif "fstring_concat" token.value == then
+            # Pop the part count (pushed as PushInt just before this token)
+            ops.length 1 - ops.get .value op_int_value = fstr_count
+            ops.pop drop
+            fstr_count OpValue::Int OpKind::FstringConcat Op ops.push
+            "str" ctx->expression_type
         else
             OpValue::None token.value parse_intrinsic Op ops.push
+            "" ctx->expression_type
         fi
-        "" ctx->expression_type
     elif kind TokenKind::Identifier == then
         if token.value ctx.functions.has then
             token.value OpValue::Str OpKind::FnCall Op ops.push


### PR DESCRIPTION
## Summary
- Add `FstringConcat` to `OpKind` and `InstKind` enums across all compiler phases
- F-strings are desugared at lex time: text segments become string literals, expressions are lexed inline, and a `FstringConcat(N)` instruction concatenates all N parts via the existing `str_concat` assembly helper
- No dependency on the standard library — expressions must already produce `str` type
- Fix pre-existing bug where reversed comparison operand order (`fstr_brace_depth 0 >` → `0 fstr_brace_depth >`) prevented the f-string expression loop from executing
- Improve `print` dispatch to use expression type tracking for `str`/`char`/`bool` types
- Add char literal support inside f-string expressions

## Test plan
- [x] `examples/fstring.casa` produces identical output with both Python and self-hosted compilers
- [x] All 31 example tests pass (`tests/test_examples.sh`)