### PR TITLE
feat: add native StrEq instruction for inline string comparison

### DIFF
--- a/self_hosted/bytecode.casa
+++ b/self_hosted/bytecode.casa
@@ -559,7 +559,7 @@ fn compile_ops ops:List[Op] func_variables:List[str] global_variables:List[str] 
                 else
                     InstValue::None InstKind::Dup Inst bytecode.push
                     lit_str_index InstValue::Int InstKind::PushStr Inst bytecode.push
-                    "str::eq" InstValue::Str InstKind::FnCall Inst bytecode.push
+                    InstValue::None InstKind::StrEq Inst bytecode.push
                     ops op_index state find_next_match_arm InstValue::Int InstKind::JumpNe Inst bytecode.push
                     InstValue::None InstKind::Drop Inst bytecode.push
                 fi

--- a/self_hosted/common.casa
+++ b/self_hosted/common.casa
@@ -106,6 +106,7 @@ enum InstKind {
     FnPush
     ConstantLoad
     ConstantStore
+    StrEq
     FstringConcat
 }
 

--- a/self_hosted/emitter.casa
+++ b/self_hosted/emitter.casa
@@ -541,6 +541,23 @@ fn emit_inst inst:Inst emitter:Emitter is_global:bool {
             "    jmp str_concat\n" emitter.asm.append
             f".Lconcat_done_{concat_label .to_str}:\n" emitter.asm.append
         }
+        InstKind::StrEq => {
+            emitter next_label = streq_uid
+            "    popq %rsi\n" emitter.asm.append
+            "    popq %rdi\n" emitter.asm.append
+            "    movq (%rdi), %rcx\n" emitter.asm.append
+            "    cmpq (%rsi), %rcx\n" emitter.asm.append
+            f"    jne .Lstreq_ne_{streq_uid .to_str}\n" emitter.asm.append
+            "    leaq 8(%rdi), %rdi\n" emitter.asm.append
+            "    leaq 8(%rsi), %rsi\n" emitter.asm.append
+            "    repe cmpsb\n" emitter.asm.append
+            f"    jne .Lstreq_ne_{streq_uid .to_str}\n" emitter.asm.append
+            "    pushq $1\n" emitter.asm.append
+            f"    jmp .Lstreq_done_{streq_uid .to_str}\n" emitter.asm.append
+            f".Lstreq_ne_{streq_uid .to_str}:\n" emitter.asm.append
+            "    pushq $0\n" emitter.asm.append
+            f".Lstreq_done_{streq_uid .to_str}:\n" emitter.asm.append
+        }
         InstKind::FnReturn => {
             if is_global then
                 "    movq $60, %rax\n" emitter.asm.append


### PR DESCRIPTION
## Summary
- Add `StrEq` variant to `InstKind` enum in the self-hosted compiler to match the Python compiler's `STR_EQ` instruction
- Implement inline assembly emission for byte-by-byte string comparison (compare lengths, then `repe cmpsb`)
- Replace `str::eq` function call with native `StrEq` instruction in string match arm compilation

## Test plan
- [x] Self-hosted compiler compiles successfully with the Python compiler
- [x] All 31 example tests pass (`tests/test_examples.sh`)
- [x] Parser example (uses string operations) works correctly with self-hosted compiler
- [x] Code review found no issues