### PR TITLE
Add unit test suite for self-hosted compiler

### DIFF
--- a/lib/test.casa
+++ b/lib/test.casa
@@ -1,0 +1,58 @@
+# Test assertion library for Casa unit tests.
+#
+# Provides assertion functions and test result tracking.
+# Include this file in test programs to use assertions.
+#
+# Usage:
+#   "test_name" test_start
+#   condition "message" assert_true
+#   actual expected "message" assert_eq
+#   test_summary
+
+include "std.casa"
+
+0 = test_pass_count
+0 = test_fail_count
+"" = test_current_name
+
+fn test_start name:str {
+    name = test_current_name
+}
+
+fn assert_true condition:bool msg:str {
+    if condition then
+        1 += test_pass_count
+    else
+        f"[FAIL] {test_current_name}: {msg}\n" eprint
+        1 += test_fail_count
+    fi
+}
+
+fn assert_false condition:bool msg:str {
+    msg condition ! assert_true
+}
+
+fn assert_eq actual:int expected:int msg:str {
+    if expected actual == then
+        1 += test_pass_count
+    else
+        f"[FAIL] {test_current_name}: {msg} (expected {expected .to_str}, got {actual .to_str})\n" eprint
+        1 += test_fail_count
+    fi
+}
+
+fn assert_str_eq actual:str expected:str msg:str {
+    if expected actual == then
+        1 += test_pass_count
+    else
+        f"[FAIL] {test_current_name}: {msg} (expected '{expected}', got '{actual}')\n" eprint
+        1 += test_fail_count
+    fi
+}
+
+fn test_summary {
+    f"{test_pass_count .to_str} passed, {test_fail_count .to_str} failed\n" print
+    if 0 test_fail_count > then
+        1 exit
+    fi
+}

--- a/self_hosted/emitter.casa
+++ b/self_hosted/emitter.casa
@@ -236,7 +236,10 @@ fn emit_inst inst:Inst emitter:Emitter is_global:bool {
         # Push
         InstKind::Push => {
             inst.value inst_int_value = push_val
-            if push_val 2147483647 > push_val 0 2147483648 - < || then
+            if
+                push_val 2147483647 <
+                push_val 0 2147483648 - > ||
+            then
                 f"    movabsq ${push_val .to_str}, %rax\n" emitter.asm.append
                 "    pushq %rax\n" emitter.asm.append
             else

--- a/self_hosted/lexer.casa
+++ b/self_hosted/lexer.casa
@@ -37,6 +37,7 @@ fn make_keyword_set -> Set[str] {
     "include" keywords.add drop
     "impl" keywords.add drop
     "trait" keywords.add drop
+    "is" keywords.add drop
     keywords
 }
 
@@ -99,7 +100,13 @@ fn try_lex_coloncolon_suffix cursor:Cursor word:str -> bool str {
     cursor.advance drop
     cursor.advance drop
     if cursor parse_identifier Result::Ok(suffix) is then
-        true f"{word}::{suffix}" return
+        f"{word}::{suffix}" = combined
+        # Check for further :: chains (e.g. A::B::c)
+        combined cursor try_lex_coloncolon_suffix = chained = chained_found
+        if chained_found then
+            true chained return
+        fi
+        true combined return
     fi
     false ""
 }

--- a/tests/self_hosted/test_bytecode.casa
+++ b/tests/self_hosted/test_bytecode.casa
@@ -1,0 +1,514 @@
+# Unit tests for the self-hosted bytecode compiler.
+
+include "../../self_hosted/lexer.casa"
+include "../../self_hosted/parser.casa"
+include "../../self_hosted/bytecode.casa"
+include "../../lib/test.casa"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+fn instkind_to_str kind:InstKind -> str {
+    kind match
+        InstKind::Push          => "Push"
+        InstKind::PushStr       => "PushStr"
+        InstKind::PushChar      => "PushChar"
+        InstKind::Add           => "Add"
+        InstKind::Sub           => "Sub"
+        InstKind::Mul           => "Mul"
+        InstKind::Div           => "Div"
+        InstKind::Mod           => "Mod"
+        InstKind::BitAnd        => "BitAnd"
+        InstKind::BitOr         => "BitOr"
+        InstKind::BitXor        => "BitXor"
+        InstKind::BitNot        => "BitNot"
+        InstKind::Shl           => "Shl"
+        InstKind::Shr           => "Shr"
+        InstKind::Eq            => "Eq"
+        InstKind::Ne            => "Ne"
+        InstKind::Lt            => "Lt"
+        InstKind::Gt            => "Gt"
+        InstKind::Le            => "Le"
+        InstKind::Ge            => "Ge"
+        InstKind::And           => "And"
+        InstKind::Or            => "Or"
+        InstKind::Not           => "Not"
+        InstKind::Drop          => "Drop"
+        InstKind::Dup           => "Dup"
+        InstKind::Swap          => "Swap"
+        InstKind::Over          => "Over"
+        InstKind::Rot           => "Rot"
+        InstKind::PrintInt      => "PrintInt"
+        InstKind::PrintStr      => "PrintStr"
+        InstKind::PrintBool     => "PrintBool"
+        InstKind::PrintChar     => "PrintChar"
+        InstKind::PrintCstr     => "PrintCstr"
+        InstKind::GlobalGet     => "GlobalGet"
+        InstKind::GlobalSet     => "GlobalSet"
+        InstKind::LocalGet      => "LocalGet"
+        InstKind::LocalSet      => "LocalSet"
+        InstKind::LocalsInit    => "LocalsInit"
+        InstKind::LocalsUninit  => "LocalsUninit"
+        InstKind::Label         => "Label"
+        InstKind::Jump          => "Jump"
+        InstKind::JumpNe        => "JumpNe"
+        InstKind::FnCall        => "FnCall"
+        InstKind::FnReturn      => "FnReturn"
+        InstKind::HeapAlloc     => "HeapAlloc"
+        InstKind::Load8         => "Load8"
+        InstKind::Load16        => "Load16"
+        InstKind::Load32        => "Load32"
+        InstKind::Load64        => "Load64"
+        InstKind::Store8        => "Store8"
+        InstKind::Store16       => "Store16"
+        InstKind::Store32       => "Store32"
+        InstKind::Store64       => "Store64"
+        InstKind::Syscall0      => "Syscall0"
+        InstKind::Syscall1      => "Syscall1"
+        InstKind::Syscall2      => "Syscall2"
+        InstKind::Syscall3      => "Syscall3"
+        InstKind::Syscall4      => "Syscall4"
+        InstKind::Syscall5      => "Syscall5"
+        InstKind::Syscall6      => "Syscall6"
+        InstKind::Argc          => "Argc"
+        InstKind::Argv          => "Argv"
+        InstKind::FnExec        => "FnExec"
+        InstKind::FnPush        => "FnPush"
+        InstKind::ConstantLoad  => "ConstantLoad"
+        InstKind::ConstantStore => "ConstantStore"
+        InstKind::StrEq         => "StrEq"
+        InstKind::FstringConcat => "FstringConcat"
+    end
+}
+
+fn assert_instkind actual:InstKind expected:InstKind msg:str {
+    if expected actual == then
+        1 += test_pass_count
+    else
+        f"[FAIL] {test_current_name}: {msg} (expected {expected instkind_to_str}, got {actual instkind_to_str})\n" eprint
+        1 += test_fail_count
+    fi
+}
+
+# Compile source string through the full pipeline: lex -> parse -> bytecode
+fn compile_source source:str -> Program {
+    source lex = tokens
+    List::new (List[str]) = string_table
+    Map::new (Map[str Function]) = functions
+    Map::new (Map[str StructDef]) = structs
+    Map::new (Map[str EnumDef]) = enums
+    Map::new (Map[str str]) "" 0 "__global__" "" Map::new (Map[str str]) enums structs functions string_table tokens ParseContext = ctx
+    ctx parse = ops
+    ctx.functions ctx.string_table ops compile_bytecode
+}
+
+# Check if any instruction in main bytecode has the given kind
+fn has_inst program:Program kind:InstKind -> bool {
+    0 = index
+    while index program.bytecode.length > do
+        if kind index program.bytecode.get .kind == then
+            true return
+        fi
+        1 += index
+    done
+    false
+}
+
+# Check if any instruction in any function bytecode has the given kind
+fn has_inst_in_functions program:Program kind:InstKind -> bool {
+    program.functions.keys = func_names
+    0 = func_index
+    while func_index func_names.length > do
+        func_index func_names.get = func_name
+        func_name program.functions.get .unwrap = func_insts
+        0 = inst_index
+        while inst_index func_insts.length > do
+            if kind inst_index func_insts.get .kind == then
+                true return
+            fi
+            1 += inst_index
+        done
+        1 += func_index
+    done
+    false
+}
+
+# Find the int value of a Push instruction with the given value
+fn has_push_value program:Program value:int -> bool {
+    0 = index
+    while index program.bytecode.length > do
+        index program.bytecode.get = inst
+        if inst.kind InstKind::Push == ! then
+            1 += index
+            continue
+        fi
+        if inst.value InstValue::Int(pushed_value) is then
+            if pushed_value value == then true return fi
+        fi
+        1 += index
+    done
+    false
+}
+
+# ---------------------------------------------------------------------------
+# Simple ops (1:1 mapping from OpKind to InstKind)
+# ---------------------------------------------------------------------------
+
+fn test_bytecode_simple_ops {
+    "bytecode_simple_ops" test_start
+
+    "1 2 +" compile_source = program
+    "Add" InstKind::Add program has_inst assert_true
+
+    "1 2 -" compile_source = program
+    "Sub" InstKind::Sub program has_inst assert_true
+
+    "1 2 *" compile_source = program
+    "Mul" InstKind::Mul program has_inst assert_true
+
+    "1 2 /" compile_source = program
+    "Div" InstKind::Div program has_inst assert_true
+
+    "1 2 %" compile_source = program
+    "Mod" InstKind::Mod program has_inst assert_true
+
+    "1 2 <<" compile_source = program
+    "Shl" InstKind::Shl program has_inst assert_true
+
+    "1 2 >>" compile_source = program
+    "Shr" InstKind::Shr program has_inst assert_true
+
+    "1 2 &&" compile_source = program
+    "And" InstKind::And program has_inst assert_true
+
+    "1 2 ||" compile_source = program
+    "Or" InstKind::Or program has_inst assert_true
+
+    "1 !" compile_source = program
+    "Not" InstKind::Not program has_inst assert_true
+
+    "1 2 ==" compile_source = program
+    "Eq" InstKind::Eq program has_inst assert_true
+
+    "1 2 !=" compile_source = program
+    "Ne" InstKind::Ne program has_inst assert_true
+
+    "1 2 >" compile_source = program
+    "Gt" InstKind::Gt program has_inst assert_true
+
+    "1 2 >=" compile_source = program
+    "Ge" InstKind::Ge program has_inst assert_true
+
+    "1 2 <" compile_source = program
+    "Lt" InstKind::Lt program has_inst assert_true
+
+    "1 2 <=" compile_source = program
+    "Le" InstKind::Le program has_inst assert_true
+
+    "1 drop" compile_source = program
+    "Drop" InstKind::Drop program has_inst assert_true
+
+    "1 dup" compile_source = program
+    "Dup" InstKind::Dup program has_inst assert_true
+
+    "1 2 swap" compile_source = program
+    "Swap" InstKind::Swap program has_inst assert_true
+
+    "1 2 over" compile_source = program
+    "Over" InstKind::Over program has_inst assert_true
+
+    "1 2 3 rot" compile_source = program
+    "Rot" InstKind::Rot program has_inst assert_true
+
+    "3 5 &" compile_source = program
+    "BitAnd" InstKind::BitAnd program has_inst assert_true
+
+    "3 5 |" compile_source = program
+    "BitOr" InstKind::BitOr program has_inst assert_true
+
+    "3 5 ^" compile_source = program
+    "BitXor" InstKind::BitXor program has_inst assert_true
+
+    "5 ~" compile_source = program
+    "BitNot" InstKind::BitNot program has_inst assert_true
+}
+
+fn test_bytecode_syscalls {
+    "bytecode_syscalls" test_start
+
+    "60 syscall0" compile_source = program
+    "Syscall0" InstKind::Syscall0 program has_inst assert_true
+
+    "0 60 syscall1" compile_source = program
+    "Syscall1" InstKind::Syscall1 program has_inst assert_true
+
+    "0 0 60 syscall2" compile_source = program
+    "Syscall2" InstKind::Syscall2 program has_inst assert_true
+
+    "0 0 0 60 syscall3" compile_source = program
+    "Syscall3" InstKind::Syscall3 program has_inst assert_true
+
+    "0 0 0 0 60 syscall4" compile_source = program
+    "Syscall4" InstKind::Syscall4 program has_inst assert_true
+
+    "0 0 0 0 0 60 syscall5" compile_source = program
+    "Syscall5" InstKind::Syscall5 program has_inst assert_true
+
+    "0 0 0 0 0 0 60 syscall6" compile_source = program
+    "Syscall6" InstKind::Syscall6 program has_inst assert_true
+}
+
+# ---------------------------------------------------------------------------
+# Push instructions
+# ---------------------------------------------------------------------------
+
+fn test_bytecode_push_int {
+    "bytecode_push_int" test_start
+
+    "42" compile_source = program
+    "Push" InstKind::Push program has_inst assert_true
+    "value 42" 42 program has_push_value assert_true
+}
+
+fn test_bytecode_push_bool {
+    "bytecode_push_bool" test_start
+
+    "true" compile_source = program
+    "true value" 1 program has_push_value assert_true
+
+    "false" compile_source = program
+    "false value" 0 program has_push_value assert_true
+}
+
+fn test_bytecode_push_str {
+    "bytecode_push_str" test_start
+
+    "\"hello\"" compile_source = program
+    "PushStr" InstKind::PushStr program has_inst assert_true
+    "string table" "hello" 0 program.strings.get assert_str_eq
+}
+
+fn test_bytecode_push_char {
+    "bytecode_push_char" test_start
+
+    "'a'" compile_source = program
+    "PushChar" InstKind::PushChar program has_inst assert_true
+}
+
+# ---------------------------------------------------------------------------
+# Print
+# ---------------------------------------------------------------------------
+
+fn test_bytecode_print {
+    "bytecode_print" test_start
+
+    "42 print" compile_source = program
+    "PrintInt" InstKind::PrintInt program has_inst assert_true
+
+    "\"hello\" print" compile_source = program
+    "PrintStr" InstKind::PrintStr program has_inst assert_true
+
+    "true print" compile_source = program
+    "PrintBool" InstKind::PrintBool program has_inst assert_true
+
+    "'a' print" compile_source = program
+    "PrintChar" InstKind::PrintChar program has_inst assert_true
+}
+
+# ---------------------------------------------------------------------------
+# Heap
+# ---------------------------------------------------------------------------
+
+fn test_bytecode_heap {
+    "bytecode_heap" test_start
+
+    "10 alloc" compile_source = program
+    "HeapAlloc" InstKind::HeapAlloc program has_inst assert_true
+}
+
+fn test_bytecode_load_store {
+    "bytecode_load_store" test_start
+
+    "42 10 alloc store64 10 alloc load64" compile_source = program
+    "Store64" InstKind::Store64 program has_inst assert_true
+    "Load64" InstKind::Load64 program has_inst assert_true
+}
+
+fn test_bytecode_sized_load {
+    "bytecode_sized_load" test_start
+
+    "10 alloc load8" compile_source = program
+    "Load8" InstKind::Load8 program has_inst assert_true
+
+    "10 alloc load16" compile_source = program
+    "Load16" InstKind::Load16 program has_inst assert_true
+
+    "10 alloc load32" compile_source = program
+    "Load32" InstKind::Load32 program has_inst assert_true
+
+    "10 alloc load64" compile_source = program
+    "Load64" InstKind::Load64 program has_inst assert_true
+}
+
+fn test_bytecode_sized_store {
+    "bytecode_sized_store" test_start
+
+    "42 10 alloc store8" compile_source = program
+    "Store8" InstKind::Store8 program has_inst assert_true
+
+    "42 10 alloc store16" compile_source = program
+    "Store16" InstKind::Store16 program has_inst assert_true
+
+    "42 10 alloc store32" compile_source = program
+    "Store32" InstKind::Store32 program has_inst assert_true
+
+    "42 10 alloc store64" compile_source = program
+    "Store64" InstKind::Store64 program has_inst assert_true
+}
+
+# ---------------------------------------------------------------------------
+# Globals
+# ---------------------------------------------------------------------------
+
+fn test_bytecode_globals {
+    "bytecode_globals" test_start
+
+    "42 = x x" compile_source = program
+    "globals_count" 0 program.globals_count > assert_true
+    "GlobalSet" InstKind::GlobalSet program has_inst assert_true
+    "GlobalGet" InstKind::GlobalGet program has_inst assert_true
+}
+
+# ---------------------------------------------------------------------------
+# Locals
+# ---------------------------------------------------------------------------
+
+fn test_bytecode_locals {
+    "bytecode_locals" test_start
+
+    "fn foo a:int -> int { a } 5 foo" compile_source = program
+    "LocalsInit" InstKind::LocalsInit program has_inst_in_functions assert_true
+    "LocalsUninit" InstKind::LocalsUninit program has_inst_in_functions assert_true
+    "LocalSet" InstKind::LocalSet program has_inst_in_functions assert_true
+    "LocalGet" InstKind::LocalGet program has_inst_in_functions assert_true
+}
+
+# ---------------------------------------------------------------------------
+# Function call / return
+# ---------------------------------------------------------------------------
+
+fn test_bytecode_fn_call {
+    "bytecode_fn_call" test_start
+
+    "fn greet { } greet" compile_source = program
+    "FnCall" InstKind::FnCall program has_inst assert_true
+    "fn registered" "greet" program.functions.has assert_true
+}
+
+fn test_bytecode_fn_return {
+    "bytecode_fn_return" test_start
+
+    "fn noop { } noop" compile_source = program
+    "FnReturn" InstKind::FnReturn program has_inst_in_functions assert_true
+}
+
+# ---------------------------------------------------------------------------
+# Lambda: FnPush / FnExec
+# ---------------------------------------------------------------------------
+
+fn test_bytecode_lambda {
+    "bytecode_lambda" test_start
+
+    "42 { 1 + } exec" compile_source = program
+    "FnPush" InstKind::FnPush program has_inst assert_true
+    "FnExec" InstKind::FnExec program has_inst assert_true
+}
+
+# ---------------------------------------------------------------------------
+# Function references
+# ---------------------------------------------------------------------------
+
+fn test_bytecode_fn_ref {
+    "bytecode_fn_ref" test_start
+
+    "fn add a:int b:int -> int { a b + } &add" compile_source = program
+    "FnPush" InstKind::FnPush program has_inst assert_true
+}
+
+# ---------------------------------------------------------------------------
+# Constants (captures)
+# ---------------------------------------------------------------------------
+
+fn test_bytecode_constants {
+    "bytecode_constants" test_start
+
+    "42 = x { x } exec" compile_source = program
+    "constants_count" 0 program.constants_count > assert_true
+    "ConstantStore" InstKind::ConstantStore program has_inst assert_true
+    "ConstantLoad" InstKind::ConstantLoad program has_inst_in_functions assert_true
+}
+
+# ---------------------------------------------------------------------------
+# Control flow: if
+# ---------------------------------------------------------------------------
+
+fn test_bytecode_if {
+    "bytecode_if" test_start
+
+    "if true then 1 drop fi" compile_source = program
+    "Label" InstKind::Label program has_inst assert_true
+    "JumpNe" InstKind::JumpNe program has_inst assert_true
+}
+
+# ---------------------------------------------------------------------------
+# Control flow: while
+# ---------------------------------------------------------------------------
+
+fn test_bytecode_while {
+    "bytecode_while" test_start
+
+    "while false do done" compile_source = program
+    "Label" InstKind::Label program has_inst assert_true
+    "Jump" InstKind::Jump program has_inst assert_true
+    "JumpNe" InstKind::JumpNe program has_inst assert_true
+}
+
+# ---------------------------------------------------------------------------
+# String interning
+# ---------------------------------------------------------------------------
+
+fn test_bytecode_string_interning {
+    "bytecode_string_interning" test_start
+
+    "\"hello\" print \"hello\" print \"world\" print" compile_source = program
+    # "hello" should appear only once in the string table
+    "string count" 2 program.strings.length assert_eq
+}
+
+# ---------------------------------------------------------------------------
+# Run all tests
+# ---------------------------------------------------------------------------
+
+test_bytecode_simple_ops
+test_bytecode_syscalls
+test_bytecode_push_int
+test_bytecode_push_bool
+test_bytecode_push_str
+test_bytecode_push_char
+test_bytecode_print
+test_bytecode_heap
+test_bytecode_load_store
+test_bytecode_sized_load
+test_bytecode_sized_store
+test_bytecode_globals
+test_bytecode_locals
+test_bytecode_fn_call
+test_bytecode_fn_return
+test_bytecode_lambda
+test_bytecode_fn_ref
+test_bytecode_constants
+test_bytecode_if
+test_bytecode_while
+test_bytecode_string_interning
+test_summary

--- a/tests/self_hosted/test_emitter.casa
+++ b/tests/self_hosted/test_emitter.casa
@@ -1,0 +1,447 @@
+include "../../self_hosted/lexer.casa"
+include "../../self_hosted/parser.casa"
+include "../../self_hosted/bytecode.casa"
+include "../../self_hosted/emitter.casa"
+include "../../lib/test.casa"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+fn emit_source source:str -> str {
+    source lex = tokens
+    List::new (List[str]) = string_table
+    Map::new (Map[str Function]) = functions
+    Map::new (Map[str StructDef]) = structs
+    Map::new (Map[str EnumDef]) = enums
+    Map::new (Map[str str]) "" 0 "__global__" "" Map::new (Map[str str]) enums structs functions string_table tokens ParseContext = ctx
+    ctx parse = ops
+    ctx.functions ctx.string_table ops compile_bytecode = program
+    program emit_program
+}
+
+fn assert_contains asm:str pattern:str msg:str {
+    if 0 asm pattern str::find >= then
+        1 += test_pass_count
+    else
+        f"[FAIL] {test_current_name}: {msg} (pattern '{pattern}' not found)\n" eprint
+        1 += test_fail_count
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Sections
+# ---------------------------------------------------------------------------
+
+fn test_emit_sections {
+    "emit_sections" test_start
+    "42" emit_source = asm
+    ".section .bss" ".section .bss" asm assert_contains
+    ".section .data" ".section .data" asm assert_contains
+    ".section .text" ".section .text" asm assert_contains
+    ".globl _start" ".globl _start" asm assert_contains
+}
+
+# ---------------------------------------------------------------------------
+# Push
+# ---------------------------------------------------------------------------
+
+fn test_emit_push_int {
+    "emit_push_int" test_start
+    "42" emit_source = asm
+    "pushq $42" "pushq $42" asm assert_contains
+}
+
+fn test_emit_negative_int {
+    "emit_negative_int" test_start
+    "-42" emit_source = asm
+    "pushq $-42" "pushq $-42" asm assert_contains
+}
+
+fn test_emit_push_str {
+    "emit_push_str" test_start
+    "\"hello\"" emit_source = asm
+    ".quad 5" ".quad 5" asm assert_contains
+    "str_0:" "str_0:" asm assert_contains
+    "has asciz" ".asciz" asm assert_contains
+}
+
+fn test_emit_push_char {
+    "emit_push_char" test_start
+    "'a'" emit_source = asm
+    "pushq $97" "pushq $97" asm assert_contains
+}
+
+fn test_emit_push_char_newline {
+    "emit_push_char_newline" test_start
+    "'\\n'" emit_source = asm
+    "pushq $10" "pushq $10" asm assert_contains
+}
+
+# ---------------------------------------------------------------------------
+# Stack operations
+# ---------------------------------------------------------------------------
+
+fn test_emit_drop {
+    "emit_drop" test_start
+    "42 drop" emit_source = asm
+    "addq $8, %rsp" "addq $8, %rsp" asm assert_contains
+}
+
+fn test_emit_dup {
+    "emit_dup" test_start
+    "42 dup" emit_source = asm
+    "pushq (%rsp)" "pushq (%rsp)" asm assert_contains
+}
+
+fn test_emit_swap {
+    "emit_swap" test_start
+    "1 2 swap" emit_source = asm
+    "popq %rax" "popq %rax" asm assert_contains
+    "popq %rbx" "popq %rbx" asm assert_contains
+    "pushq %rax" "pushq %rax" asm assert_contains
+    "pushq %rbx" "pushq %rbx" asm assert_contains
+}
+
+fn test_emit_over {
+    "emit_over" test_start
+    "1 2 over" emit_source = asm
+    "pushq 8(%rsp)" "pushq 8(%rsp)" asm assert_contains
+}
+
+# ---------------------------------------------------------------------------
+# Arithmetic
+# ---------------------------------------------------------------------------
+
+fn test_emit_arithmetic {
+    "emit_arithmetic" test_start
+
+    "1 2 +" emit_source = asm
+    "addq" "addq" asm assert_contains
+
+    "1 2 -" emit_source = asm
+    "subq" "subq" asm assert_contains
+
+    "1 2 *" emit_source = asm
+    "imulq" "imulq" asm assert_contains
+
+    "1 2 /" emit_source = asm
+    "idivq" "idivq" asm assert_contains
+}
+
+# ---------------------------------------------------------------------------
+# Bitshift
+# ---------------------------------------------------------------------------
+
+fn test_emit_bitshift {
+    "emit_bitshift" test_start
+
+    "8 2 <<" emit_source = asm
+    "shlq %cl" "shlq %cl" asm assert_contains
+
+    "8 2 >>" emit_source = asm
+    "sarq %cl" "sarq %cl" asm assert_contains
+}
+
+# ---------------------------------------------------------------------------
+# Boolean
+# ---------------------------------------------------------------------------
+
+fn test_emit_boolean {
+    "emit_boolean" test_start
+
+    "true false &&" emit_source = asm
+    "andb" "andb" asm assert_contains
+
+    "true false ||" emit_source = asm
+    "orq" "orq" asm assert_contains
+
+    "true !" emit_source = asm
+    "not sete" "sete" asm assert_contains
+}
+
+# ---------------------------------------------------------------------------
+# Comparison
+# ---------------------------------------------------------------------------
+
+fn test_emit_comparison {
+    "emit_comparison" test_start
+
+    "1 2 ==" emit_source = asm
+    "eq sete" "sete" asm assert_contains
+
+    "1 2 !=" emit_source = asm
+    "ne setne" "setne" asm assert_contains
+
+    "1 2 <" emit_source = asm
+    "lt setl" "setl" asm assert_contains
+
+    "1 2 <=" emit_source = asm
+    "le setle" "setle" asm assert_contains
+
+    "1 2 >" emit_source = asm
+    "gt setg" "setg" asm assert_contains
+
+    "1 2 >=" emit_source = asm
+    "ge setge" "setge" asm assert_contains
+}
+
+# ---------------------------------------------------------------------------
+# Labels and jumps
+# ---------------------------------------------------------------------------
+
+fn test_emit_label_jump {
+    "emit_label_jump" test_start
+
+    "if true then 1 drop fi" emit_source = asm
+    "has label" ".L" asm assert_contains
+    "has jz" "jz" asm assert_contains
+}
+
+fn test_emit_while_jump {
+    "emit_while_jump" test_start
+
+    "while false do done" emit_source = asm
+    "has jmp" "jmp .L" asm assert_contains
+    "has jz" "jz .L" asm assert_contains
+}
+
+# ---------------------------------------------------------------------------
+# Functions
+# ---------------------------------------------------------------------------
+
+fn test_emit_fn_call {
+    "emit_fn_call" test_start
+
+    "fn greet { } greet" emit_source = asm
+    "jmp fn_greet" "jmp fn_greet" asm assert_contains
+    ".Lret_" ".Lret_" asm assert_contains
+}
+
+fn test_emit_fn_return {
+    "emit_fn_return" test_start
+
+    "fn noop { } noop" emit_source = asm
+    "jmpq *(%r14)" "jmpq *(%r14)" asm assert_contains
+}
+
+fn test_emit_fn_exec {
+    "emit_fn_exec" test_start
+
+    "42 { 1 + } exec" emit_source = asm
+    "jmpq *%rax" "jmpq *%rax" asm assert_contains
+}
+
+fn test_emit_fn_push {
+    "emit_fn_push" test_start
+
+    "{ 1 + }" emit_source = asm
+    "leaq fn_lambda__" "leaq fn_lambda__" asm assert_contains
+}
+
+fn test_emit_fn_ref {
+    "emit_fn_ref" test_start
+
+    "fn add a:int b:int -> int { a b + } &add" emit_source = asm
+    "leaq fn_add" "leaq fn_add" asm assert_contains
+}
+
+# ---------------------------------------------------------------------------
+# Globals
+# ---------------------------------------------------------------------------
+
+fn test_emit_globals {
+    "emit_globals" test_start
+
+    "42 = x x" emit_source = asm
+    "globals+" "globals+" asm assert_contains
+}
+
+# ---------------------------------------------------------------------------
+# Locals
+# ---------------------------------------------------------------------------
+
+fn test_emit_locals {
+    "emit_locals" test_start
+
+    "fn foo a:int -> int { a } 5 foo" emit_source = asm
+    "(%r14)" "(%r14)" asm assert_contains
+    "rep stosq" "rep stosq" asm assert_contains
+}
+
+# ---------------------------------------------------------------------------
+# Constants (captures)
+# ---------------------------------------------------------------------------
+
+fn test_emit_constants {
+    "emit_constants" test_start
+
+    "42 = x { x } exec" emit_source = asm
+    "constants+" "constants+" asm assert_contains
+}
+
+# ---------------------------------------------------------------------------
+# Heap
+# ---------------------------------------------------------------------------
+
+fn test_emit_heap {
+    "emit_heap" test_start
+
+    "10 alloc" emit_source = asm
+    "heap_ptr" "heap_ptr" asm assert_contains
+}
+
+# ---------------------------------------------------------------------------
+# Print
+# ---------------------------------------------------------------------------
+
+fn test_emit_print {
+    "emit_print" test_start
+
+    "42 print" emit_source = asm
+    "jmp print_int" "jmp print_int" asm assert_contains
+
+    "\"hello\" print" emit_source = asm
+    "jmp print_str" "jmp print_str" asm assert_contains
+
+    "'a' print" emit_source = asm
+    "print_char movb" "movb %al" asm assert_contains
+}
+
+# ---------------------------------------------------------------------------
+# Syscall intrinsics
+# ---------------------------------------------------------------------------
+
+fn test_emit_syscalls {
+    "emit_syscalls" test_start
+
+    "60 syscall0" emit_source = asm
+    "syscall0 popq rax" "popq %rax" asm assert_contains
+    "syscall" "syscall" asm assert_contains
+    "syscall0 pushq rax" "pushq %rax" asm assert_contains
+
+    "0 60 syscall1" emit_source = asm
+    "syscall1 popq rdi" "popq %rdi" asm assert_contains
+
+    "0 0 60 syscall2" emit_source = asm
+    "syscall2 popq rsi" "popq %rsi" asm assert_contains
+
+    "0 0 0 60 syscall3" emit_source = asm
+    "syscall3 popq rdx" "popq %rdx" asm assert_contains
+
+    "0 0 0 0 60 syscall4" emit_source = asm
+    "syscall4 popq r10" "popq %r10" asm assert_contains
+
+    "0 0 0 0 0 60 syscall5" emit_source = asm
+    "syscall5 popq r8" "popq %r8" asm assert_contains
+
+    "0 0 0 0 0 0 60 syscall6" emit_source = asm
+    "syscall6 popq r9" "popq %r9" asm assert_contains
+}
+
+# ---------------------------------------------------------------------------
+# Exit syscall
+# ---------------------------------------------------------------------------
+
+fn test_emit_exit {
+    "emit_exit" test_start
+
+    "42" emit_source = asm
+    "exit movq 60" "movq $60, %rax" asm assert_contains
+}
+
+# ---------------------------------------------------------------------------
+# Name sanitization
+# ---------------------------------------------------------------------------
+
+fn test_emit_sanitized_names {
+    "emit_sanitized_names" test_start
+
+    "struct Foo { x: int } 42 Foo .x" emit_source = asm
+    "fn_Foo__x" "fn_Foo__x" asm assert_contains
+}
+
+# ---------------------------------------------------------------------------
+# Load/Store assembly patterns
+# ---------------------------------------------------------------------------
+
+fn test_emit_load_patterns {
+    "emit_load_patterns" test_start
+
+    "10 alloc load8" emit_source = asm
+    "load8 movzbl" "movzbl" asm assert_contains
+
+    "10 alloc load16" emit_source = asm
+    "load16 movzwl" "movzwl" asm assert_contains
+
+    "10 alloc load32" emit_source = asm
+    "load32 movl" "movl" asm assert_contains
+
+    "10 alloc load64" emit_source = asm
+    "load64 heap" "leaq heap(%rip)" asm assert_contains
+}
+
+fn test_emit_store_patterns {
+    "emit_store_patterns" test_start
+
+    "42 10 alloc store8" emit_source = asm
+    "store8 movb" "movb" asm assert_contains
+
+    "42 10 alloc store16" emit_source = asm
+    "store16 movw" "movw" asm assert_contains
+
+    "42 10 alloc store32" emit_source = asm
+    "store32 movl" "movl" asm assert_contains
+
+    "42 10 alloc store64" emit_source = asm
+    "store64 heap" "leaq heap(%rip)" asm assert_contains
+}
+
+# ---------------------------------------------------------------------------
+# Escaped strings in assembly
+# ---------------------------------------------------------------------------
+
+fn test_emit_escaped_strings {
+    "emit_escaped_strings" test_start
+
+    "\"hello\\nworld\"" emit_source = asm
+    "has asciz" ".asciz" asm assert_contains
+}
+
+# ---------------------------------------------------------------------------
+# Run all tests
+# ---------------------------------------------------------------------------
+
+test_emit_sections
+test_emit_push_int
+test_emit_negative_int
+test_emit_push_str
+test_emit_push_char
+test_emit_push_char_newline
+test_emit_drop
+test_emit_dup
+test_emit_swap
+test_emit_over
+test_emit_arithmetic
+test_emit_bitshift
+test_emit_boolean
+test_emit_comparison
+test_emit_label_jump
+test_emit_while_jump
+test_emit_fn_call
+test_emit_fn_return
+test_emit_fn_exec
+test_emit_fn_push
+test_emit_fn_ref
+test_emit_globals
+test_emit_locals
+test_emit_constants
+test_emit_heap
+test_emit_print
+test_emit_syscalls
+test_emit_exit
+test_emit_sanitized_names
+test_emit_load_patterns
+test_emit_store_patterns
+test_emit_escaped_strings
+test_summary

--- a/tests/self_hosted/test_lexer.casa
+++ b/tests/self_hosted/test_lexer.casa
@@ -1,0 +1,824 @@
+# Unit tests for the self-hosted lexer.
+
+include "../../self_hosted/lexer.casa"
+include "../../lib/test.casa"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+fn tokenkind_to_str kind:TokenKind -> str {
+    kind match
+        TokenKind::Delimiter  => "Delimiter"
+        TokenKind::Eof        => "Eof"
+        TokenKind::Identifier => "Identifier"
+        TokenKind::Intrinsic  => "Intrinsic"
+        TokenKind::Keyword    => "Keyword"
+        TokenKind::Literal    => "Literal"
+        TokenKind::Operator   => "Operator"
+    end
+}
+
+fn assert_token_kind actual:TokenKind expected:TokenKind msg:str {
+    if expected actual == then
+        1 += test_pass_count
+    else
+        f"[FAIL] {test_current_name}: {msg} (expected {expected tokenkind_to_str}, got {actual tokenkind_to_str})\n" eprint
+        1 += test_fail_count
+    fi
+}
+
+fn assert_token token:Token expected_kind:TokenKind expected_value:str {
+    f"token kind for '{expected_value}'" expected_kind token.kind assert_token_kind
+    f"token value" expected_value token.value assert_str_eq
+}
+
+fn count_non_eof tokens:List[Token] -> int {
+    0 = count
+    0 = index
+    while index tokens.length > do
+        if index tokens.get .kind TokenKind::Eof != then
+            1 += count
+        fi
+        1 += index
+    done
+    count
+}
+
+# ---------------------------------------------------------------------------
+# Keywords
+# ---------------------------------------------------------------------------
+
+fn test_lex_keywords {
+    "lex_keywords" test_start
+
+    "if" lex = tokens
+    "if" TokenKind::Keyword 0 tokens.get assert_token
+
+    "then" lex = tokens
+    "then" TokenKind::Keyword 0 tokens.get assert_token
+
+    "elif" lex = tokens
+    "elif" TokenKind::Keyword 0 tokens.get assert_token
+
+    "else" lex = tokens
+    "else" TokenKind::Keyword 0 tokens.get assert_token
+
+    "fi" lex = tokens
+    "fi" TokenKind::Keyword 0 tokens.get assert_token
+
+    "while" lex = tokens
+    "while" TokenKind::Keyword 0 tokens.get assert_token
+
+    "do" lex = tokens
+    "do" TokenKind::Keyword 0 tokens.get assert_token
+
+    "done" lex = tokens
+    "done" TokenKind::Keyword 0 tokens.get assert_token
+
+    "break" lex = tokens
+    "break" TokenKind::Keyword 0 tokens.get assert_token
+
+    "continue" lex = tokens
+    "continue" TokenKind::Keyword 0 tokens.get assert_token
+
+    "fn" lex = tokens
+    "fn" TokenKind::Keyword 0 tokens.get assert_token
+
+    "return" lex = tokens
+    "return" TokenKind::Keyword 0 tokens.get assert_token
+
+    "struct" lex = tokens
+    "struct" TokenKind::Keyword 0 tokens.get assert_token
+
+    "enum" lex = tokens
+    "enum" TokenKind::Keyword 0 tokens.get assert_token
+
+    "match" lex = tokens
+    "match" TokenKind::Keyword 0 tokens.get assert_token
+
+    "end" lex = tokens
+    "end" TokenKind::Keyword 0 tokens.get assert_token
+
+    "include" lex = tokens
+    "include" TokenKind::Keyword 0 tokens.get assert_token
+
+    "impl" lex = tokens
+    "impl" TokenKind::Keyword 0 tokens.get assert_token
+
+    "trait" lex = tokens
+    "trait" TokenKind::Keyword 0 tokens.get assert_token
+
+    "is" lex = tokens
+    "is" TokenKind::Keyword 0 tokens.get assert_token
+
+    # Self-hosted lexer also treats true, false, _ as keywords
+    "true" lex = tokens
+    "true" TokenKind::Keyword 0 tokens.get assert_token
+
+    "false" lex = tokens
+    "false" TokenKind::Keyword 0 tokens.get assert_token
+
+    "_" lex = tokens
+    "_" TokenKind::Keyword 0 tokens.get assert_token
+}
+
+# ---------------------------------------------------------------------------
+# Intrinsics
+# ---------------------------------------------------------------------------
+
+fn test_lex_intrinsics {
+    "lex_intrinsics" test_start
+
+    "drop" lex = tokens
+    "drop" TokenKind::Intrinsic 0 tokens.get assert_token
+
+    "dup" lex = tokens
+    "dup" TokenKind::Intrinsic 0 tokens.get assert_token
+
+    "over" lex = tokens
+    "over" TokenKind::Intrinsic 0 tokens.get assert_token
+
+    "rot" lex = tokens
+    "rot" TokenKind::Intrinsic 0 tokens.get assert_token
+
+    "swap" lex = tokens
+    "swap" TokenKind::Intrinsic 0 tokens.get assert_token
+
+    "alloc" lex = tokens
+    "alloc" TokenKind::Intrinsic 0 tokens.get assert_token
+
+    "load8" lex = tokens
+    "load8" TokenKind::Intrinsic 0 tokens.get assert_token
+
+    "load16" lex = tokens
+    "load16" TokenKind::Intrinsic 0 tokens.get assert_token
+
+    "load32" lex = tokens
+    "load32" TokenKind::Intrinsic 0 tokens.get assert_token
+
+    "load64" lex = tokens
+    "load64" TokenKind::Intrinsic 0 tokens.get assert_token
+
+    "store8" lex = tokens
+    "store8" TokenKind::Intrinsic 0 tokens.get assert_token
+
+    "store16" lex = tokens
+    "store16" TokenKind::Intrinsic 0 tokens.get assert_token
+
+    "store32" lex = tokens
+    "store32" TokenKind::Intrinsic 0 tokens.get assert_token
+
+    "store64" lex = tokens
+    "store64" TokenKind::Intrinsic 0 tokens.get assert_token
+
+    "print" lex = tokens
+    "print" TokenKind::Intrinsic 0 tokens.get assert_token
+
+    "exec" lex = tokens
+    "exec" TokenKind::Intrinsic 0 tokens.get assert_token
+
+    "syscall0" lex = tokens
+    "syscall0" TokenKind::Intrinsic 0 tokens.get assert_token
+
+    "syscall1" lex = tokens
+    "syscall1" TokenKind::Intrinsic 0 tokens.get assert_token
+
+    "syscall2" lex = tokens
+    "syscall2" TokenKind::Intrinsic 0 tokens.get assert_token
+
+    "syscall3" lex = tokens
+    "syscall3" TokenKind::Intrinsic 0 tokens.get assert_token
+
+    "syscall4" lex = tokens
+    "syscall4" TokenKind::Intrinsic 0 tokens.get assert_token
+
+    "syscall5" lex = tokens
+    "syscall5" TokenKind::Intrinsic 0 tokens.get assert_token
+
+    "syscall6" lex = tokens
+    "syscall6" TokenKind::Intrinsic 0 tokens.get assert_token
+
+    "argc" lex = tokens
+    "argc" TokenKind::Intrinsic 0 tokens.get assert_token
+
+    "argv" lex = tokens
+    "argv" TokenKind::Intrinsic 0 tokens.get assert_token
+
+    "print_str" lex = tokens
+    "print_str" TokenKind::Intrinsic 0 tokens.get assert_token
+
+    "print_bool" lex = tokens
+    "print_bool" TokenKind::Intrinsic 0 tokens.get assert_token
+
+    "print_char" lex = tokens
+    "print_char" TokenKind::Intrinsic 0 tokens.get assert_token
+
+    "print_cstr" lex = tokens
+    "print_cstr" TokenKind::Intrinsic 0 tokens.get assert_token
+}
+
+# ---------------------------------------------------------------------------
+# Operators
+# ---------------------------------------------------------------------------
+
+fn test_lex_operators {
+    "lex_operators" test_start
+
+    "+" lex = tokens
+    "+" TokenKind::Operator 0 tokens.get assert_token
+
+    "- " lex = tokens
+    "-" TokenKind::Operator 0 tokens.get assert_token
+
+    "*" lex = tokens
+    "*" TokenKind::Operator 0 tokens.get assert_token
+
+    "/" lex = tokens
+    "/" TokenKind::Operator 0 tokens.get assert_token
+
+    "%" lex = tokens
+    "%" TokenKind::Operator 0 tokens.get assert_token
+
+    "<<" lex = tokens
+    "<<" TokenKind::Operator 0 tokens.get assert_token
+
+    ">>" lex = tokens
+    ">>" TokenKind::Operator 0 tokens.get assert_token
+
+    "&&" lex = tokens
+    "&&" TokenKind::Operator 0 tokens.get assert_token
+
+    "||" lex = tokens
+    "||" TokenKind::Operator 0 tokens.get assert_token
+
+    "!" lex = tokens
+    "!" TokenKind::Operator 0 tokens.get assert_token
+
+    "==" lex = tokens
+    "==" TokenKind::Operator 0 tokens.get assert_token
+
+    ">=" lex = tokens
+    ">=" TokenKind::Operator 0 tokens.get assert_token
+
+    ">" lex = tokens
+    ">" TokenKind::Operator 0 tokens.get assert_token
+
+    "<=" lex = tokens
+    "<=" TokenKind::Operator 0 tokens.get assert_token
+
+    "<" lex = tokens
+    "<" TokenKind::Operator 0 tokens.get assert_token
+
+    "!=" lex = tokens
+    "!=" TokenKind::Operator 0 tokens.get assert_token
+
+    "= " lex = tokens
+    "=" TokenKind::Operator 0 tokens.get assert_token
+
+    "-= " lex = tokens
+    "-=" TokenKind::Operator 0 tokens.get assert_token
+
+    "+= " lex = tokens
+    "+=" TokenKind::Operator 0 tokens.get assert_token
+
+    "& " lex = tokens
+    "&" TokenKind::Operator 0 tokens.get assert_token
+
+    "| " lex = tokens
+    "|" TokenKind::Operator 0 tokens.get assert_token
+
+    "^" lex = tokens
+    "^" TokenKind::Operator 0 tokens.get assert_token
+
+    "~" lex = tokens
+    "~" TokenKind::Operator 0 tokens.get assert_token
+}
+
+# ---------------------------------------------------------------------------
+# Delimiters
+# ---------------------------------------------------------------------------
+
+fn test_lex_delimiters {
+    "lex_delimiters" test_start
+
+    "{" lex = tokens
+    "{" TokenKind::Delimiter 0 tokens.get assert_token
+
+    "}" lex = tokens
+    "}" TokenKind::Delimiter 0 tokens.get assert_token
+
+    ":" lex = tokens
+    ":" TokenKind::Delimiter 0 tokens.get assert_token
+
+    "(" lex = tokens
+    "(" TokenKind::Delimiter 0 tokens.get assert_token
+
+    ")" lex = tokens
+    ")" TokenKind::Delimiter 0 tokens.get assert_token
+
+    "," lex = tokens
+    "," TokenKind::Delimiter 0 tokens.get assert_token
+
+    "[" lex = tokens
+    "[" TokenKind::Delimiter 0 tokens.get assert_token
+
+    "]" lex = tokens
+    "]" TokenKind::Delimiter 0 tokens.get assert_token
+
+    "." lex = tokens
+    "." TokenKind::Delimiter 0 tokens.get assert_token
+
+    "-> " lex = tokens
+    "->" TokenKind::Delimiter 0 tokens.get assert_token
+}
+
+# ---------------------------------------------------------------------------
+# Comments
+# ---------------------------------------------------------------------------
+
+fn test_lex_comment_skipping {
+    "lex_comment_skipping" test_start
+
+    # Comment-only input produces just EOF
+    "# this is a comment" lex = tokens
+    "comment only produces EOF" 1 tokens.length assert_eq
+    "is EOF" TokenKind::Eof 0 tokens.get .kind assert_token_kind
+
+    # Code before comment
+    "42 # comment\n43" lex = tokens
+    "two non-EOF tokens" 2 tokens count_non_eof assert_eq
+    "first value" "42" 0 tokens.get .value assert_str_eq
+    "second value" "43" 1 tokens.get .value assert_str_eq
+
+    # Empty comment
+    "#" lex = tokens
+    "empty comment" 1 tokens.length assert_eq
+    "empty comment is EOF" TokenKind::Eof 0 tokens.get .kind assert_token_kind
+
+    # Multiple comment lines
+    "1\n# comment\n2\n# another\n3" lex = tokens
+    "three non-EOF tokens" 3 tokens count_non_eof assert_eq
+    "first" "1" 0 tokens.get .value assert_str_eq
+    "second" "2" 1 tokens.get .value assert_str_eq
+    "third" "3" 2 tokens.get .value assert_str_eq
+
+    # Comment at end of file
+    "42 # trailing comment" lex = tokens
+    "one non-EOF token" 1 tokens count_non_eof assert_eq
+    "value before comment" "42" 0 tokens.get .value assert_str_eq
+}
+
+# ---------------------------------------------------------------------------
+# Literals
+# ---------------------------------------------------------------------------
+
+fn test_lex_integer_literals {
+    "lex_integer_literals" test_start
+
+    "42" lex = tokens
+    "int kind" TokenKind::Literal 0 tokens.get .kind assert_token_kind
+    "int value" "42" 0 tokens.get .value assert_str_eq
+
+    "0" lex = tokens
+    "zero kind" TokenKind::Literal 0 tokens.get .kind assert_token_kind
+    "zero value" "0" 0 tokens.get .value assert_str_eq
+
+    # Negative integer literal (no space between - and digits)
+    "-42" lex = tokens
+    "neg int kind" TokenKind::Literal 0 tokens.get .kind assert_token_kind
+    "neg int value" "-42" 0 tokens.get .value assert_str_eq
+}
+
+fn test_lex_minus_operator_with_space {
+    "lex_minus_operator_with_space" test_start
+
+    "- 42" lex = tokens
+    "minus kind" TokenKind::Operator 0 tokens.get .kind assert_token_kind
+    "minus value" "-" 0 tokens.get .value assert_str_eq
+    "42 kind" TokenKind::Literal 1 tokens.get .kind assert_token_kind
+    "42 value" "42" 1 tokens.get .value assert_str_eq
+}
+
+fn test_lex_string_literals {
+    "lex_string_literals" test_start
+
+    # String literal: "hello" -> Token { kind: Literal, value: '"hello' }
+    "\"hello\"" lex = tokens
+    "str kind" TokenKind::Literal 0 tokens.get .kind assert_token_kind
+    "str value" "\"hello" 0 tokens.get .value assert_str_eq
+
+    # Empty string: "" -> Token { kind: Literal, value: '"' }
+    "\"\"" lex = tokens
+    "empty str kind" TokenKind::Literal 0 tokens.get .kind assert_token_kind
+    "empty str value" "\"" 0 tokens.get .value assert_str_eq
+}
+
+fn test_lex_char_literals {
+    "lex_char_literals" test_start
+
+    # Char literal: 'a' -> Token { kind: Literal, value: "'97" }
+    "'a'" lex = tokens
+    "char kind" TokenKind::Literal 0 tokens.get .kind assert_token_kind
+    "char 'a' value" "'97" 0 tokens.get .value assert_str_eq
+
+    # Char 'A' -> ordinal 65
+    "'A'" lex = tokens
+    "char 'A' value" "'65" 0 tokens.get .value assert_str_eq
+
+    # Char '0' -> ordinal 48
+    "'0'" lex = tokens
+    "char '0' value" "'48" 0 tokens.get .value assert_str_eq
+
+    # Char ' ' -> ordinal 32
+    "' '" lex = tokens
+    "char ' ' value" "'32" 0 tokens.get .value assert_str_eq
+}
+
+fn test_lex_char_escape_sequences {
+    "lex_char_escape_sequences" test_start
+
+    # '\n' -> ordinal 10
+    "'\\n'" lex = tokens
+    "escaped newline kind" TokenKind::Literal 0 tokens.get .kind assert_token_kind
+    "escaped newline value" "'10" 0 tokens.get .value assert_str_eq
+
+    # '\t' -> ordinal 9
+    "'\\t'" lex = tokens
+    "escaped tab value" "'9" 0 tokens.get .value assert_str_eq
+
+    # '\\' -> ordinal 92
+    "'\\\\'" lex = tokens
+    "escaped backslash value" "'92" 0 tokens.get .value assert_str_eq
+
+    # '\0' -> ordinal 0
+    "'\\0'" lex = tokens
+    "escaped null value" "'0" 0 tokens.get .value assert_str_eq
+}
+
+fn test_lex_boolean_literals {
+    "lex_boolean_literals" test_start
+
+    # In self-hosted lexer, true/false are keywords (not literals like Python)
+    "true" lex = tokens
+    "true kind" TokenKind::Keyword 0 tokens.get .kind assert_token_kind
+    "true value" "true" 0 tokens.get .value assert_str_eq
+
+    "false" lex = tokens
+    "false kind" TokenKind::Keyword 0 tokens.get .kind assert_token_kind
+    "false value" "false" 0 tokens.get .value assert_str_eq
+}
+
+# ---------------------------------------------------------------------------
+# Identifiers
+# ---------------------------------------------------------------------------
+
+fn test_lex_identifiers {
+    "lex_identifiers" test_start
+
+    "my_var" lex = tokens
+    "identifier kind" TokenKind::Identifier 0 tokens.get .kind assert_token_kind
+    "identifier value" "my_var" 0 tokens.get .value assert_str_eq
+
+    "Person" lex = tokens
+    "capitalized kind" TokenKind::Identifier 0 tokens.get .kind assert_token_kind
+    "capitalized value" "Person" 0 tokens.get .value assert_str_eq
+
+    # none and some are identifiers
+    "none" lex = tokens
+    "none kind" TokenKind::Identifier 0 tokens.get .kind assert_token_kind
+    "none value" "none" 0 tokens.get .value assert_str_eq
+
+    "some" lex = tokens
+    "some kind" TokenKind::Identifier 0 tokens.get .kind assert_token_kind
+    "some value" "some" 0 tokens.get .value assert_str_eq
+}
+
+# ---------------------------------------------------------------------------
+# Namespace (::)
+# ---------------------------------------------------------------------------
+
+fn test_lex_namespace {
+    "lex_namespace" test_start
+
+    "Foo::bar" lex = tokens
+    "namespace kind" TokenKind::Identifier 0 tokens.get .kind assert_token_kind
+    "namespace value" "Foo::bar" 0 tokens.get .value assert_str_eq
+
+    # Chained namespace
+    "A::B::c" lex = tokens
+    "chained kind" TokenKind::Identifier 0 tokens.get .kind assert_token_kind
+    "chained value" "A::B::c" 0 tokens.get .value assert_str_eq
+
+    # Namespace in expression
+    "42 Foo::bar" lex = tokens
+    "namespace in expr count" 2 tokens count_non_eof assert_eq
+    "lit kind" TokenKind::Literal 0 tokens.get .kind assert_token_kind
+    "ns kind" TokenKind::Identifier 1 tokens.get .kind assert_token_kind
+    "ns value" "Foo::bar" 1 tokens.get .value assert_str_eq
+}
+
+# ---------------------------------------------------------------------------
+# Function reference (&)
+# ---------------------------------------------------------------------------
+
+fn test_lex_function_reference {
+    "lex_function_reference" test_start
+
+    "&foo" lex = tokens
+    "fn ref kind" TokenKind::Identifier 0 tokens.get .kind assert_token_kind
+    "fn ref value" "&foo" 0 tokens.get .value assert_str_eq
+}
+
+# ---------------------------------------------------------------------------
+# EOF
+# ---------------------------------------------------------------------------
+
+fn test_lex_eof {
+    "lex_eof" test_start
+
+    "" lex = tokens
+    "empty input length" 1 tokens.length assert_eq
+    "eof kind" TokenKind::Eof 0 tokens.get .kind assert_token_kind
+}
+
+# ---------------------------------------------------------------------------
+# Whitespace handling
+# ---------------------------------------------------------------------------
+
+fn test_lex_whitespace {
+    "lex_whitespace" test_start
+
+    # Whitespace-only input
+    "   \t\n  " lex = tokens
+    "whitespace only" 1 tokens.length assert_eq
+    "whitespace eof" TokenKind::Eof 0 tokens.get .kind assert_token_kind
+
+    # Multiple whitespace between tokens
+    "42   \t   hello" lex = tokens
+    "whitespace between count" 2 tokens count_non_eof assert_eq
+    "first value" "42" 0 tokens.get .value assert_str_eq
+    "second value" "hello" 1 tokens.get .value assert_str_eq
+
+    # Leading and trailing whitespace
+    "   42   " lex = tokens
+    "leading/trailing ws" 1 tokens count_non_eof assert_eq
+    "ws value" "42" 0 tokens.get .value assert_str_eq
+
+    # Newlines between tokens
+    "42\n43\n44" lex = tokens
+    "newline separated count" 3 tokens count_non_eof assert_eq
+    "nl first" "42" 0 tokens.get .value assert_str_eq
+    "nl second" "43" 1 tokens.get .value assert_str_eq
+    "nl third" "44" 2 tokens.get .value assert_str_eq
+}
+
+# ---------------------------------------------------------------------------
+# Full expression
+# ---------------------------------------------------------------------------
+
+fn test_lex_full_expression {
+    "lex_full_expression" test_start
+
+    "34 35 + print" lex = tokens
+    "full expr length (incl EOF)" 5 tokens.length assert_eq
+    "first lit kind" TokenKind::Literal 0 tokens.get .kind assert_token_kind
+    "first lit value" "34" 0 tokens.get .value assert_str_eq
+    "second lit kind" TokenKind::Literal 1 tokens.get .kind assert_token_kind
+    "second lit value" "35" 1 tokens.get .value assert_str_eq
+    "op kind" TokenKind::Operator 2 tokens.get .kind assert_token_kind
+    "op value" "+" 2 tokens.get .value assert_str_eq
+    "intrinsic kind" TokenKind::Intrinsic 3 tokens.get .kind assert_token_kind
+    "intrinsic value" "print" 3 tokens.get .value assert_str_eq
+    "eof kind" TokenKind::Eof 4 tokens.get .kind assert_token_kind
+}
+
+# ---------------------------------------------------------------------------
+# Arrow (->) handling
+# ---------------------------------------------------------------------------
+
+fn test_lex_arrow {
+    "lex_arrow" test_start
+
+    # Standalone ->
+    "-> " lex = tokens
+    "arrow kind" TokenKind::Delimiter 0 tokens.get .kind assert_token_kind
+    "arrow value" "->" 0 tokens.get .value assert_str_eq
+
+    # -> with spaces
+    "a -> b" lex = tokens
+    "arrow with spaces count" 3 tokens count_non_eof assert_eq
+    "before arrow" "a" 0 tokens.get .value assert_str_eq
+    "arrow kind" TokenKind::Delimiter 1 tokens.get .kind assert_token_kind
+    "arrow value" "->" 1 tokens.get .value assert_str_eq
+    "after arrow" "b" 2 tokens.get .value assert_str_eq
+
+    # -> in function signature
+    "fn foo x:int -> int" lex = tokens
+    false = found_arrow
+    0 = search_index
+    while search_index tokens.length > do
+        if "->" search_index tokens.get .value == then
+            "fn sig arrow kind" TokenKind::Delimiter search_index tokens.get .kind assert_token_kind
+            true = found_arrow
+        fi
+        1 += search_index
+    done
+    "arrow found in fn sig" found_arrow assert_true
+}
+
+# ---------------------------------------------------------------------------
+# Mixed token sequences
+# ---------------------------------------------------------------------------
+
+fn test_lex_struct_instantiation {
+    "lex_struct_instantiation" test_start
+
+    "18 \"John\" Person" lex = tokens
+    "struct inst count" 3 tokens count_non_eof assert_eq
+    "18 kind" TokenKind::Literal 0 tokens.get .kind assert_token_kind
+    "18 value" "18" 0 tokens.get .value assert_str_eq
+    "John kind" TokenKind::Literal 1 tokens.get .kind assert_token_kind
+    "John value" "\"John" 1 tokens.get .value assert_str_eq
+    "Person kind" TokenKind::Identifier 2 tokens.get .kind assert_token_kind
+    "Person value" "Person" 2 tokens.get .value assert_str_eq
+}
+
+fn test_lex_dot_accessor {
+    "lex_dot_accessor" test_start
+
+    "person.name" lex = tokens
+    "dot accessor count" 3 tokens count_non_eof assert_eq
+    "before dot" "person" 0 tokens.get .value assert_str_eq
+    "dot kind" TokenKind::Delimiter 1 tokens.get .kind assert_token_kind
+    "dot value" "." 1 tokens.get .value assert_str_eq
+    "after dot" "name" 2 tokens.get .value assert_str_eq
+}
+
+fn test_lex_type_cast {
+    "lex_type_cast" test_start
+
+    "(SomeType)" lex = tokens
+    "type cast count" 3 tokens count_non_eof assert_eq
+    "open paren kind" TokenKind::Delimiter 0 tokens.get .kind assert_token_kind
+    "open paren" "(" 0 tokens.get .value assert_str_eq
+    "type name kind" TokenKind::Identifier 1 tokens.get .kind assert_token_kind
+    "type name" "SomeType" 1 tokens.get .value assert_str_eq
+    "close paren kind" TokenKind::Delimiter 2 tokens.get .kind assert_token_kind
+    "close paren" ")" 2 tokens.get .value assert_str_eq
+}
+
+fn test_lex_array_literal {
+    "lex_array_literal" test_start
+
+    "[1, 2, 3]" lex = tokens
+    "array literal count" 7 tokens count_non_eof assert_eq
+    "open bracket" "[" 0 tokens.get .value assert_str_eq
+    "first elem" "1" 1 tokens.get .value assert_str_eq
+    "first comma" "," 2 tokens.get .value assert_str_eq
+    "second elem" "2" 3 tokens.get .value assert_str_eq
+    "second comma" "," 4 tokens.get .value assert_str_eq
+    "third elem" "3" 5 tokens.get .value assert_str_eq
+    "close bracket" "]" 6 tokens.get .value assert_str_eq
+}
+
+fn test_lex_lambda_block {
+    "lex_lambda_block" test_start
+
+    "{ 2 * }" lex = tokens
+    "lambda count" 4 tokens count_non_eof assert_eq
+    "open brace kind" TokenKind::Delimiter 0 tokens.get .kind assert_token_kind
+    "open brace" "{" 0 tokens.get .value assert_str_eq
+    "close brace kind" TokenKind::Delimiter 3 tokens.get .kind assert_token_kind
+    "close brace" "}" 3 tokens.get .value assert_str_eq
+}
+
+fn test_lex_char_in_expression {
+    "lex_char_in_expression" test_start
+
+    "'a' print" lex = tokens
+    "char expr count" 2 tokens count_non_eof assert_eq
+    "char kind" TokenKind::Literal 0 tokens.get .kind assert_token_kind
+    "print kind" TokenKind::Intrinsic 1 tokens.get .kind assert_token_kind
+}
+
+# ---------------------------------------------------------------------------
+# String escape sequences
+# ---------------------------------------------------------------------------
+
+fn test_lex_string_escape_sequences {
+    "lex_string_escape_sequences" test_start
+
+    # Newline escape
+    "\"hello\\nworld\"" lex = tokens
+    "newline escape kind" TokenKind::Literal 0 tokens.get .kind assert_token_kind
+
+    # Tab escape
+    "\"hello\\tworld\"" lex = tokens
+    "tab escape kind" TokenKind::Literal 0 tokens.get .kind assert_token_kind
+
+    # Backslash escape
+    "\"hello\\\\world\"" lex = tokens
+    "backslash escape kind" TokenKind::Literal 0 tokens.get .kind assert_token_kind
+
+    # Null escape
+    "\"hello\\0world\"" lex = tokens
+    "null escape kind" TokenKind::Literal 0 tokens.get .kind assert_token_kind
+
+    # Carriage return escape
+    "\"hello\\rworld\"" lex = tokens
+    "cr escape kind" TokenKind::Literal 0 tokens.get .kind assert_token_kind
+}
+
+# ---------------------------------------------------------------------------
+# Negative integer in context
+# ---------------------------------------------------------------------------
+
+fn test_lex_negative_in_context {
+    "lex_negative_in_context" test_start
+
+    # "10-3" in the self-hosted lexer: -3 is a negative literal
+    "10-3" lex = tokens
+    "10-3 token count" 2 tokens count_non_eof assert_eq
+    "10 kind" TokenKind::Literal 0 tokens.get .kind assert_token_kind
+    "10 value" "10" 0 tokens.get .value assert_str_eq
+    "-3 kind" TokenKind::Literal 1 tokens.get .kind assert_token_kind
+    "-3 value" "-3" 1 tokens.get .value assert_str_eq
+}
+
+# ---------------------------------------------------------------------------
+# F-string tokenization
+# Note: Self-hosted lexer desugars f-strings into push/concat sequences,
+# unlike Python which uses FSTRING_* token types.
+# ---------------------------------------------------------------------------
+
+fn test_lex_fstring_plain {
+    "lex_fstring_plain" test_start
+
+    # f"hello world" desugars to a string literal token
+    "f\"hello world\"" lex = tokens
+    # Should have at least one literal token for the text
+    "fstring text kind" TokenKind::Literal 0 tokens.get .kind assert_token_kind
+    "fstring text value" "\"hello world" 0 tokens.get .value assert_str_eq
+}
+
+fn test_lex_fstring_with_expression {
+    "lex_fstring_with_expression" test_start
+
+    # f"val={x .to_str}" desugars into component tokens
+    "f\"val={x .to_str}\"" lex = tokens
+    # Should contain a literal for "val=" text segment
+    "fstring prefix kind" TokenKind::Literal 0 tokens.get .kind assert_token_kind
+    "fstring prefix value" "\"val=" 0 tokens.get .value assert_str_eq
+}
+
+# ---------------------------------------------------------------------------
+# Setter syntax
+# ---------------------------------------------------------------------------
+
+fn test_lex_setter_syntax {
+    "lex_setter_syntax" test_start
+
+    "\"Jane\" person->name" lex = tokens
+    "setter count" 4 tokens count_non_eof assert_eq
+    "str lit kind" TokenKind::Literal 0 tokens.get .kind assert_token_kind
+    "person" "person" 1 tokens.get .value assert_str_eq
+    "arrow kind" TokenKind::Delimiter 2 tokens.get .kind assert_token_kind
+    "arrow" "->" 2 tokens.get .value assert_str_eq
+    "name" "name" 3 tokens.get .value assert_str_eq
+}
+
+# ---------------------------------------------------------------------------
+# Run all tests
+# ---------------------------------------------------------------------------
+
+test_lex_keywords
+test_lex_intrinsics
+test_lex_operators
+test_lex_delimiters
+test_lex_comment_skipping
+test_lex_integer_literals
+test_lex_minus_operator_with_space
+test_lex_string_literals
+test_lex_char_literals
+test_lex_char_escape_sequences
+test_lex_boolean_literals
+test_lex_identifiers
+test_lex_namespace
+test_lex_function_reference
+test_lex_eof
+test_lex_whitespace
+test_lex_full_expression
+test_lex_arrow
+test_lex_struct_instantiation
+test_lex_dot_accessor
+test_lex_type_cast
+test_lex_array_literal
+test_lex_lambda_block
+test_lex_char_in_expression
+test_lex_string_escape_sequences
+test_lex_negative_in_context
+test_lex_fstring_plain
+test_lex_fstring_with_expression
+test_lex_setter_syntax
+test_summary

--- a/tests/self_hosted/test_parser.casa
+++ b/tests/self_hosted/test_parser.casa
@@ -1,0 +1,808 @@
+# Unit tests for the self-hosted parser.
+
+include "../../self_hosted/lexer.casa"
+include "../../self_hosted/parser.casa"
+include "../../lib/test.casa"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+fn opkind_to_str kind:OpKind -> str {
+    kind match
+        OpKind::PushInt           => "PushInt"
+        OpKind::PushStr           => "PushStr"
+        OpKind::PushChar          => "PushChar"
+        OpKind::PushBool          => "PushBool"
+        OpKind::Add               => "Add"
+        OpKind::Sub               => "Sub"
+        OpKind::Mul               => "Mul"
+        OpKind::Div               => "Div"
+        OpKind::Mod               => "Mod"
+        OpKind::BitAnd            => "BitAnd"
+        OpKind::BitOr             => "BitOr"
+        OpKind::BitXor            => "BitXor"
+        OpKind::BitNot            => "BitNot"
+        OpKind::Shl               => "Shl"
+        OpKind::Shr               => "Shr"
+        OpKind::Eq                => "Eq"
+        OpKind::Ne                => "Ne"
+        OpKind::Lt                => "Lt"
+        OpKind::Gt                => "Gt"
+        OpKind::Le                => "Le"
+        OpKind::Ge                => "Ge"
+        OpKind::And               => "And"
+        OpKind::Or                => "Or"
+        OpKind::Not               => "Not"
+        OpKind::Drop              => "Drop"
+        OpKind::Dup               => "Dup"
+        OpKind::Swap              => "Swap"
+        OpKind::Over              => "Over"
+        OpKind::Rot               => "Rot"
+        OpKind::PrintInt          => "PrintInt"
+        OpKind::PrintStr          => "PrintStr"
+        OpKind::PrintBool         => "PrintBool"
+        OpKind::PrintChar         => "PrintChar"
+        OpKind::PrintCstr         => "PrintCstr"
+        OpKind::AssignVariable    => "AssignVariable"
+        OpKind::AssignIncrement   => "AssignIncrement"
+        OpKind::AssignDecrement   => "AssignDecrement"
+        OpKind::PushVariable      => "PushVariable"
+        OpKind::IfStart           => "IfStart"
+        OpKind::IfCondition       => "IfCondition"
+        OpKind::IfElif            => "IfElif"
+        OpKind::IfElse            => "IfElse"
+        OpKind::IfEnd             => "IfEnd"
+        OpKind::WhileStart        => "WhileStart"
+        OpKind::WhileCondition    => "WhileCondition"
+        OpKind::WhileBreak        => "WhileBreak"
+        OpKind::WhileContinue     => "WhileContinue"
+        OpKind::WhileEnd          => "WhileEnd"
+        OpKind::FnCall            => "FnCall"
+        OpKind::FnReturn          => "FnReturn"
+        OpKind::Alloc             => "Alloc"
+        OpKind::HeapAlloc         => "HeapAlloc"
+        OpKind::Load8             => "Load8"
+        OpKind::Load16            => "Load16"
+        OpKind::Load32            => "Load32"
+        OpKind::Load64            => "Load64"
+        OpKind::Store8            => "Store8"
+        OpKind::Store16           => "Store16"
+        OpKind::Store32           => "Store32"
+        OpKind::Store64           => "Store64"
+        OpKind::Syscall0          => "Syscall0"
+        OpKind::Syscall1          => "Syscall1"
+        OpKind::Syscall2          => "Syscall2"
+        OpKind::Syscall3          => "Syscall3"
+        OpKind::Syscall4          => "Syscall4"
+        OpKind::Syscall5          => "Syscall5"
+        OpKind::Syscall6          => "Syscall6"
+        OpKind::Argc              => "Argc"
+        OpKind::Argv              => "Argv"
+        OpKind::TypeCast          => "TypeCast"
+        OpKind::StructNew         => "StructNew"
+        OpKind::PushEnumVariant   => "PushEnumVariant"
+        OpKind::MatchStart        => "MatchStart"
+        OpKind::MatchArm          => "MatchArm"
+        OpKind::MatchEnd          => "MatchEnd"
+        OpKind::FnExec            => "FnExec"
+        OpKind::FnPush            => "FnPush"
+        OpKind::PushCapture       => "PushCapture"
+        OpKind::FstringConcat     => "FstringConcat"
+        OpKind::IsCheck           => "IsCheck"
+    end
+}
+
+fn assert_opkind actual:OpKind expected:OpKind msg:str {
+    if expected actual == then
+        1 += test_pass_count
+    else
+        f"[FAIL] {test_current_name}: {msg} (expected {expected opkind_to_str}, got {actual opkind_to_str})\n" eprint
+        1 += test_fail_count
+    fi
+}
+
+# Create a fresh parse context from tokens
+fn make_test_context tokens:List[Token] -> ParseContext {
+    List::new (List[str]) = string_table
+    Map::new (Map[str Function]) = functions
+    Map::new (Map[str StructDef]) = structs
+    Map::new (Map[str EnumDef]) = enums
+    Map::new (Map[str str]) "" 0 "__global__" "" Map::new (Map[str str]) enums structs functions string_table tokens ParseContext
+}
+
+# Lex source and create a parse context (does not call parse)
+fn make_context source:str -> ParseContext {
+    source lex = tokens
+    tokens make_test_context
+}
+
+# Find first op with given kind, return index (-1 if not found)
+fn find_op ops:List[Op] kind:OpKind -> int {
+    0 = index
+    while index ops.length > do
+        if kind index ops.get .kind == then
+            index return
+        fi
+        1 += index
+    done
+    -1
+}
+
+# Check if any op has the given kind
+fn has_op ops:List[Op] kind:OpKind -> bool {
+    0 kind ops find_op >=
+}
+
+# ---------------------------------------------------------------------------
+# Literals
+# ---------------------------------------------------------------------------
+
+fn test_parse_push_int {
+    "parse_push_int" test_start
+
+    "42" lex = tokens
+    tokens make_test_context = ctx
+    ctx parse = ops
+
+    "op count" 1 ops.length assert_eq
+    "kind" OpKind::PushInt 0 ops.get .kind assert_opkind
+    "value" 42 0 ops.get .value op_int_value assert_eq
+}
+
+fn test_parse_push_bool {
+    "parse_push_bool" test_start
+
+    "true" lex = tokens
+    tokens make_test_context = ctx
+    ctx parse = ops
+    "true kind" OpKind::PushBool 0 ops.get .kind assert_opkind
+    "true value" 1 0 ops.get .value op_int_value assert_eq
+
+    "false" lex = tokens
+    tokens make_test_context = ctx
+    ctx parse = ops
+    "false kind" OpKind::PushBool 0 ops.get .kind assert_opkind
+    "false value" 0 0 ops.get .value op_int_value assert_eq
+}
+
+fn test_parse_push_str {
+    "parse_push_str" test_start
+
+    "\"hello\"" lex = tokens
+    tokens make_test_context = ctx
+    ctx parse = ops
+    "kind" OpKind::PushStr 0 ops.get .kind assert_opkind
+    # Value is string table index; check string table has "hello"
+    "string table" "hello" 0 ctx.string_table.get assert_str_eq
+}
+
+fn test_parse_push_char {
+    "parse_push_char" test_start
+
+    "'a'" lex = tokens
+    tokens make_test_context = ctx
+    ctx parse = ops
+    "kind" OpKind::PushChar 0 ops.get .kind assert_opkind
+    # Value is ordinal of 'a' = 97
+    "value" 97 0 ops.get .value op_int_value assert_eq
+}
+
+fn test_parse_negative_int {
+    "parse_negative_int" test_start
+
+    "-42" lex = tokens
+    tokens make_test_context = ctx
+    ctx parse = ops
+    "count" 1 ops.length assert_eq
+    "kind" OpKind::PushInt 0 ops.get .kind assert_opkind
+    "value" -42 0 ops.get .value op_int_value assert_eq
+}
+
+# ---------------------------------------------------------------------------
+# Operators
+# ---------------------------------------------------------------------------
+
+fn test_parse_operators {
+    "parse_operators" test_start
+
+    "1 2 +" make_context = ctx
+    ctx parse = ops
+    "Add" OpKind::Add ops has_op assert_true
+
+    "1 2 -" make_context = ctx
+    ctx parse = ops
+    "Sub" OpKind::Sub ops has_op assert_true
+
+    "1 2 *" make_context = ctx
+    ctx parse = ops
+    "Mul" OpKind::Mul ops has_op assert_true
+
+    "1 2 /" make_context = ctx
+    ctx parse = ops
+    "Div" OpKind::Div ops has_op assert_true
+
+    "1 2 %" make_context = ctx
+    ctx parse = ops
+    "Mod" OpKind::Mod ops has_op assert_true
+
+    "1 2 <<" make_context = ctx
+    ctx parse = ops
+    "Shl" OpKind::Shl ops has_op assert_true
+
+    "1 2 >>" make_context = ctx
+    ctx parse = ops
+    "Shr" OpKind::Shr ops has_op assert_true
+
+    "1 2 &&" make_context = ctx
+    ctx parse = ops
+    "And" OpKind::And ops has_op assert_true
+
+    "1 2 ||" make_context = ctx
+    ctx parse = ops
+    "Or" OpKind::Or ops has_op assert_true
+
+    "1 !" make_context = ctx
+    ctx parse = ops
+    "Not" OpKind::Not ops has_op assert_true
+
+    "1 2 ==" make_context = ctx
+    ctx parse = ops
+    "Eq" OpKind::Eq ops has_op assert_true
+
+    "1 2 !=" make_context = ctx
+    ctx parse = ops
+    "Ne" OpKind::Ne ops has_op assert_true
+
+    "1 2 <" make_context = ctx
+    ctx parse = ops
+    "Lt" OpKind::Lt ops has_op assert_true
+
+    "1 2 >" make_context = ctx
+    ctx parse = ops
+    "Gt" OpKind::Gt ops has_op assert_true
+
+    "1 2 <=" make_context = ctx
+    ctx parse = ops
+    "Le" OpKind::Le ops has_op assert_true
+
+    "1 2 >=" make_context = ctx
+    ctx parse = ops
+    "Ge" OpKind::Ge ops has_op assert_true
+
+    "1 2 &" make_context = ctx
+    ctx parse = ops
+    "BitAnd" OpKind::BitAnd ops has_op assert_true
+
+    "1 2 |" make_context = ctx
+    ctx parse = ops
+    "BitOr" OpKind::BitOr ops has_op assert_true
+
+    "1 2 ^" make_context = ctx
+    ctx parse = ops
+    "BitXor" OpKind::BitXor ops has_op assert_true
+
+    "1 ~" make_context = ctx
+    ctx parse = ops
+    "BitNot" OpKind::BitNot ops has_op assert_true
+}
+
+# ---------------------------------------------------------------------------
+# Intrinsics
+# ---------------------------------------------------------------------------
+
+fn test_parse_intrinsics {
+    "parse_intrinsics" test_start
+
+    "1 drop" make_context = ctx
+    ctx parse = ops
+    "Drop" OpKind::Drop ops has_op assert_true
+
+    "1 dup" make_context = ctx
+    ctx parse = ops
+    "Dup" OpKind::Dup ops has_op assert_true
+
+    "1 2 swap" make_context = ctx
+    ctx parse = ops
+    "Swap" OpKind::Swap ops has_op assert_true
+
+    "1 2 over" make_context = ctx
+    ctx parse = ops
+    "Over" OpKind::Over ops has_op assert_true
+
+    "1 2 3 rot" make_context = ctx
+    ctx parse = ops
+    "Rot" OpKind::Rot ops has_op assert_true
+
+    "1 alloc" make_context = ctx
+    ctx parse = ops
+    "Alloc" OpKind::Alloc ops has_op assert_true
+
+    "1 load8" make_context = ctx
+    ctx parse = ops
+    "Load8" OpKind::Load8 ops has_op assert_true
+
+    "1 load16" make_context = ctx
+    ctx parse = ops
+    "Load16" OpKind::Load16 ops has_op assert_true
+
+    "1 load32" make_context = ctx
+    ctx parse = ops
+    "Load32" OpKind::Load32 ops has_op assert_true
+
+    "1 load64" make_context = ctx
+    ctx parse = ops
+    "Load64" OpKind::Load64 ops has_op assert_true
+
+    "1 2 store8" make_context = ctx
+    ctx parse = ops
+    "Store8" OpKind::Store8 ops has_op assert_true
+
+    "1 2 store16" make_context = ctx
+    ctx parse = ops
+    "Store16" OpKind::Store16 ops has_op assert_true
+
+    "1 2 store32" make_context = ctx
+    ctx parse = ops
+    "Store32" OpKind::Store32 ops has_op assert_true
+
+    "1 2 store64" make_context = ctx
+    ctx parse = ops
+    "Store64" OpKind::Store64 ops has_op assert_true
+
+    "42 print" make_context = ctx
+    ctx parse = ops
+    "PrintInt" OpKind::PrintInt ops has_op assert_true
+
+    "1 exec" make_context = ctx
+    ctx parse = ops
+    "FnExec" OpKind::FnExec ops has_op assert_true
+
+    "60 syscall0" make_context = ctx
+    ctx parse = ops
+    "Syscall0" OpKind::Syscall0 ops has_op assert_true
+
+    "0 60 syscall1" make_context = ctx
+    ctx parse = ops
+    "Syscall1" OpKind::Syscall1 ops has_op assert_true
+
+    "0 0 60 syscall2" make_context = ctx
+    ctx parse = ops
+    "Syscall2" OpKind::Syscall2 ops has_op assert_true
+
+    "0 0 0 60 syscall3" make_context = ctx
+    ctx parse = ops
+    "Syscall3" OpKind::Syscall3 ops has_op assert_true
+
+    "0 0 0 0 60 syscall4" make_context = ctx
+    ctx parse = ops
+    "Syscall4" OpKind::Syscall4 ops has_op assert_true
+
+    "0 0 0 0 0 60 syscall5" make_context = ctx
+    ctx parse = ops
+    "Syscall5" OpKind::Syscall5 ops has_op assert_true
+
+    "0 0 0 0 0 0 60 syscall6" make_context = ctx
+    ctx parse = ops
+    "Syscall6" OpKind::Syscall6 ops has_op assert_true
+}
+
+# ---------------------------------------------------------------------------
+# Control flow: if/elif/else/fi
+# ---------------------------------------------------------------------------
+
+fn test_parse_if_then_fi {
+    "parse_if_then_fi" test_start
+
+    "if true then 1 fi" lex = tokens
+    tokens make_test_context = ctx
+    ctx parse = ops
+    "IfStart" OpKind::IfStart ops has_op assert_true
+    "IfCondition" OpKind::IfCondition ops has_op assert_true
+    "IfEnd" OpKind::IfEnd ops has_op assert_true
+}
+
+fn test_parse_if_elif_else {
+    "parse_if_elif_else" test_start
+
+    "if true then 1 elif false then 2 else 3 fi" lex = tokens
+    tokens make_test_context = ctx
+    ctx parse = ops
+    "IfElif" OpKind::IfElif ops has_op assert_true
+    "IfElse" OpKind::IfElse ops has_op assert_true
+}
+
+# ---------------------------------------------------------------------------
+# Control flow: while/do/done
+# ---------------------------------------------------------------------------
+
+fn test_parse_while_do_done {
+    "parse_while_do_done" test_start
+
+    "while true do 1 drop done" lex = tokens
+    tokens make_test_context = ctx
+    ctx parse = ops
+    "WhileStart" OpKind::WhileStart ops has_op assert_true
+    "WhileCondition" OpKind::WhileCondition ops has_op assert_true
+    "WhileEnd" OpKind::WhileEnd ops has_op assert_true
+}
+
+fn test_parse_while_break_continue {
+    "parse_while_break_continue" test_start
+
+    "while true do break continue done" lex = tokens
+    tokens make_test_context = ctx
+    ctx parse = ops
+    "WhileBreak" OpKind::WhileBreak ops has_op assert_true
+    "WhileContinue" OpKind::WhileContinue ops has_op assert_true
+}
+
+# ---------------------------------------------------------------------------
+# Variables
+# ---------------------------------------------------------------------------
+
+fn test_parse_assign_variable {
+    "parse_assign_variable" test_start
+
+    "42 = x" lex = tokens
+    tokens make_test_context = ctx
+    ctx parse = ops
+    OpKind::AssignVariable ops find_op = idx
+    "found" 0 idx >= assert_true
+    "value" "x" idx ops.get .value op_str_value assert_str_eq
+}
+
+fn test_parse_assign_increment {
+    "parse_assign_increment" test_start
+
+    "1 += x" lex = tokens
+    tokens make_test_context = ctx
+    ctx parse = ops
+    OpKind::AssignIncrement ops find_op = idx
+    "found" 0 idx >= assert_true
+    "value" "x" idx ops.get .value op_str_value assert_str_eq
+}
+
+fn test_parse_assign_decrement {
+    "parse_assign_decrement" test_start
+
+    "1 -= x" lex = tokens
+    tokens make_test_context = ctx
+    ctx parse = ops
+    OpKind::AssignDecrement ops find_op = idx
+    "found" 0 idx >= assert_true
+    "value" "x" idx ops.get .value op_str_value assert_str_eq
+}
+
+fn test_parse_push_variable {
+    "parse_push_variable" test_start
+
+    "42 = x x" lex = tokens
+    tokens make_test_context = ctx
+    ctx parse = ops
+    "PushVariable" OpKind::PushVariable ops has_op assert_true
+    OpKind::PushVariable ops find_op = idx
+    "value" "x" idx ops.get .value op_str_value assert_str_eq
+}
+
+# ---------------------------------------------------------------------------
+# Functions
+# ---------------------------------------------------------------------------
+
+fn test_parse_function {
+    "parse_function" test_start
+
+    "fn add a:int b:int -> int { a b + }" lex = tokens
+    tokens make_test_context = ctx
+    ctx parse = ops
+    "registered" "add" ctx.functions.has assert_true
+}
+
+fn test_parse_function_void {
+    "parse_function_void" test_start
+
+    "fn greet { }" lex = tokens
+    tokens make_test_context = ctx
+    ctx parse = ops
+    "registered" "greet" ctx.functions.has assert_true
+}
+
+fn test_parse_function_call {
+    "parse_function_call" test_start
+
+    "fn greet { } greet" lex = tokens
+    tokens make_test_context = ctx
+    ctx parse = ops
+    "FnCall" OpKind::FnCall ops has_op assert_true
+    OpKind::FnCall ops find_op = idx
+    "value" "greet" idx ops.get .value op_str_value assert_str_eq
+}
+
+fn test_parse_function_return {
+    "parse_function_return" test_start
+
+    "fn check x:int -> int { if x 0 == then 99 return fi x 2 * }" lex = tokens
+    tokens make_test_context = ctx
+    ctx parse = ops
+    "registered" "check" ctx.functions.has assert_true
+    "check" ctx.functions.get .unwrap .ops = fn_ops
+    "FnReturn" OpKind::FnReturn fn_ops has_op assert_true
+}
+
+# ---------------------------------------------------------------------------
+# Structs
+# ---------------------------------------------------------------------------
+
+fn test_parse_struct {
+    "parse_struct" test_start
+
+    "struct Person { name: str age: int }" lex = tokens
+    tokens make_test_context = ctx
+    ctx parse = ops
+    "registered" "Person" ctx.structs.has assert_true
+    "Person" ctx.structs.get .unwrap = person_struct
+    "member count" 2 person_struct.member_names.length assert_eq
+    "first member" "name" 0 person_struct.member_names.get assert_str_eq
+    "second member" "age" 1 person_struct.member_names.get assert_str_eq
+}
+
+fn test_parse_struct_generates_accessors {
+    "parse_struct_generates_accessors" test_start
+
+    "struct Point { x: int y: int }" lex = tokens
+    tokens make_test_context = ctx
+    ctx parse = ops
+    "getter x" "Point::x" ctx.functions.has assert_true
+    "getter y" "Point::y" ctx.functions.has assert_true
+    "setter x" "Point::set_x" ctx.functions.has assert_true
+    "setter y" "Point::set_y" ctx.functions.has assert_true
+}
+
+fn test_parse_struct_new {
+    "parse_struct_new" test_start
+
+    "struct Foo { val: int } 42 Foo" lex = tokens
+    tokens make_test_context = ctx
+    ctx parse = ops
+    "StructNew" OpKind::StructNew ops has_op assert_true
+}
+
+# ---------------------------------------------------------------------------
+# Enums
+# ---------------------------------------------------------------------------
+
+fn test_parse_enum {
+    "parse_enum" test_start
+
+    "enum Color { Red Green Blue }" lex = tokens
+    tokens make_test_context = ctx
+    ctx parse = ops
+    "registered" "Color" ctx.enums.has assert_true
+    "Color" ctx.enums.get .unwrap = color_enum
+    "variant count" 3 color_enum.variants.length assert_eq
+    "first" "Red" 0 color_enum.variants.get assert_str_eq
+    "second" "Green" 1 color_enum.variants.get assert_str_eq
+    "third" "Blue" 2 color_enum.variants.get assert_str_eq
+}
+
+fn test_parse_enum_variant_push {
+    "parse_enum_variant_push" test_start
+
+    "enum Dir { North South } Dir::North" lex = tokens
+    tokens make_test_context = ctx
+    ctx parse = ops
+    "PushEnumVariant" OpKind::PushEnumVariant ops has_op assert_true
+}
+
+# ---------------------------------------------------------------------------
+# Match
+# ---------------------------------------------------------------------------
+
+fn test_parse_match {
+    "parse_match" test_start
+
+    "enum Color { Red Green Blue } Color::Red match Color::Red => 1 Color::Green => 2 Color::Blue => 3 end" lex = tokens
+    tokens make_test_context = ctx
+    ctx parse = ops
+    "MatchStart" OpKind::MatchStart ops has_op assert_true
+    "MatchArm" OpKind::MatchArm ops has_op assert_true
+    "MatchEnd" OpKind::MatchEnd ops has_op assert_true
+}
+
+# ---------------------------------------------------------------------------
+# Impl blocks
+# ---------------------------------------------------------------------------
+
+fn test_parse_impl_block {
+    "parse_impl_block" test_start
+
+    "struct Foo { val: int } impl Foo { fn double self:Foo -> int { self Foo::val 2 * } }" lex = tokens
+    tokens make_test_context = ctx
+    ctx parse = ops
+    "method registered" "Foo::double" ctx.functions.has assert_true
+}
+
+# ---------------------------------------------------------------------------
+# Lambdas
+# ---------------------------------------------------------------------------
+
+fn test_parse_lambda {
+    "parse_lambda" test_start
+
+    "{ 1 + }" lex = tokens
+    tokens make_test_context = ctx
+    ctx parse = ops
+    "FnPush" OpKind::FnPush ops has_op assert_true
+}
+
+# ---------------------------------------------------------------------------
+# Type cast
+# ---------------------------------------------------------------------------
+
+fn test_parse_type_cast {
+    "parse_type_cast" test_start
+
+    # Self-hosted parser doesn't emit TypeCast op; it updates expression_type
+    "42 (str)" lex = tokens
+    tokens make_test_context = ctx
+    ctx parse = ops
+    # Should parse without error and produce PushInt
+    "PushInt" OpKind::PushInt ops has_op assert_true
+    "expression_type" "str" ctx.expression_type assert_str_eq
+}
+
+# ---------------------------------------------------------------------------
+# Print dispatch
+# ---------------------------------------------------------------------------
+
+fn test_parse_print_dispatch {
+    "parse_print_dispatch" test_start
+
+    # Integer print
+    "42 print" lex = tokens
+    tokens make_test_context = ctx
+    ctx parse = ops
+    "PrintInt" OpKind::PrintInt ops has_op assert_true
+
+    # String print
+    "\"hello\" print" lex = tokens
+    tokens make_test_context = ctx
+    ctx parse = ops
+    "PrintStr" OpKind::PrintStr ops has_op assert_true
+
+    # Bool print
+    "true print" lex = tokens
+    tokens make_test_context = ctx
+    ctx parse = ops
+    "PrintBool" OpKind::PrintBool ops has_op assert_true
+
+    # Char print
+    "'a' print" lex = tokens
+    tokens make_test_context = ctx
+    ctx parse = ops
+    "PrintChar" OpKind::PrintChar ops has_op assert_true
+}
+
+# ---------------------------------------------------------------------------
+# F-strings
+# ---------------------------------------------------------------------------
+
+fn test_parse_fstring_plain {
+    "parse_fstring_plain" test_start
+
+    "f\"hello\"" lex = tokens
+    tokens make_test_context = ctx
+    ctx parse = ops
+    # Plain f-string with no expressions produces PushStr
+    "PushStr" OpKind::PushStr ops has_op assert_true
+}
+
+fn test_parse_fstring_with_expression {
+    "parse_fstring_with_expression" test_start
+
+    # Use a simple expression without method calls that need std.casa
+    "fn to_str_helper n:int -> str { \"x\" } 42 = x f\"val={x to_str_helper}\"" lex = tokens
+    tokens make_test_context = ctx
+    ctx parse = ops
+    "FstringConcat" OpKind::FstringConcat ops has_op assert_true
+}
+
+# ---------------------------------------------------------------------------
+# Traits
+# ---------------------------------------------------------------------------
+
+fn test_parse_trait {
+    "parse_trait" test_start
+
+    "trait Printable { fn show self:self }" lex = tokens
+    tokens make_test_context = ctx
+    ctx parse = ops
+    # Trait is parsed without error (no registration check needed)
+    "parsed ok" true assert_true
+}
+
+# ---------------------------------------------------------------------------
+# Generic structs
+# ---------------------------------------------------------------------------
+
+fn test_parse_generic_struct {
+    "parse_generic_struct" test_start
+
+    "struct Pair[A B] { first: A second: B }" lex = tokens
+    tokens make_test_context = ctx
+    ctx parse = ops
+    "registered" "Pair" ctx.structs.has assert_true
+    "Pair" ctx.structs.get .unwrap = pair_struct
+    "member count" 2 pair_struct.member_names.length assert_eq
+    "type params" 2 pair_struct.type_params.length assert_eq
+}
+
+# ---------------------------------------------------------------------------
+# Data-carrying enums
+# ---------------------------------------------------------------------------
+
+fn test_parse_data_carrying_enum {
+    "parse_data_carrying_enum" test_start
+
+    "enum Wrapper { Empty Val(int) }" lex = tokens
+    tokens make_test_context = ctx
+    ctx parse = ops
+    "registered" "Wrapper" ctx.enums.has assert_true
+    "Wrapper" ctx.enums.get .unwrap = wrapper_enum
+    "has_inner" wrapper_enum.has_inner_values assert_true
+    "variant count" 2 wrapper_enum.variants.length assert_eq
+}
+
+# ---------------------------------------------------------------------------
+# Is check
+# ---------------------------------------------------------------------------
+
+fn test_parse_is_check {
+    "parse_is_check" test_start
+
+    "enum Option[T] { None Some(T) } Option::None = val if val Option::Some(x) is then 1 fi" lex = tokens
+    tokens make_test_context = ctx
+    ctx parse = ops
+    "IsCheck" OpKind::IsCheck ops has_op assert_true
+}
+
+# ---------------------------------------------------------------------------
+# Run all tests
+# ---------------------------------------------------------------------------
+
+test_parse_push_int
+test_parse_push_bool
+test_parse_push_str
+test_parse_push_char
+test_parse_negative_int
+test_parse_operators
+test_parse_intrinsics
+test_parse_if_then_fi
+test_parse_if_elif_else
+test_parse_while_do_done
+test_parse_while_break_continue
+test_parse_assign_variable
+test_parse_assign_increment
+test_parse_assign_decrement
+test_parse_push_variable
+test_parse_function
+test_parse_function_void
+test_parse_function_call
+test_parse_function_return
+test_parse_struct
+test_parse_struct_generates_accessors
+test_parse_struct_new
+test_parse_enum
+test_parse_enum_variant_push
+test_parse_match
+test_parse_impl_block
+test_parse_lambda
+test_parse_type_cast
+test_parse_print_dispatch
+test_parse_fstring_plain
+test_parse_fstring_with_expression
+test_parse_trait
+test_parse_generic_struct
+test_parse_data_carrying_enum
+test_parse_is_check
+test_summary

--- a/tests/test_self_hosted_unit.sh
+++ b/tests/test_self_hosted_unit.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env sh
+set -eu
+
+ROOT_DIR=$(git rev-parse --show-toplevel)
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+RESET='\033[0m'
+
+pass=0
+fail=0
+
+run_unit_test() {
+    name="$1"
+    source="$2"
+    binary="/tmp/casa_unit_test_$name"
+
+    printf "Compiling: %s... " "$name"
+    if ! python3 "$ROOT_DIR/casa.py" "$source" -o "$binary" 2>&1; then
+        printf "${RED}[X]${RESET}  Compile failed: %s\n" "$name"
+        fail=$((fail+1))
+        return
+    fi
+
+    set +e
+    output=$("$binary" 2>&1)
+    exit_code=$?
+    set -e
+    rm -f "$binary"
+
+    if [ "$exit_code" -eq 0 ]; then
+        printf "${GREEN}[OK]${RESET} %s - %s\n" "$name" "$output"
+        pass=$((pass+1))
+    else
+        printf "${RED}[X]${RESET}  %s\n" "$name"
+        printf "%s\n" "$output"
+        fail=$((fail+1))
+    fi
+}
+
+run_unit_test "lexer" "$ROOT_DIR/tests/self_hosted/test_lexer.casa"
+run_unit_test "parser" "$ROOT_DIR/tests/self_hosted/test_parser.casa"
+run_unit_test "bytecode" "$ROOT_DIR/tests/self_hosted/test_bytecode.casa"
+run_unit_test "emitter" "$ROOT_DIR/tests/self_hosted/test_emitter.casa"
+
+echo
+echo "Summary: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## Summary
- Add `lib/test.casa` test assertion library with `assert_true`, `assert_eq`, `assert_str_eq`, `test_start`, and `test_summary`
- Add 580 unit tests across 4 test files covering all self-hosted compiler pipeline stages:
  - `tests/self_hosted/test_lexer.casa` (316 tests): keywords, intrinsics, operators, delimiters, literals, identifiers, namespaces, comments, whitespace, f-strings, escapes
  - `tests/self_hosted/test_parser.casa` (117 tests): literals, operators, intrinsics, control flow, variables, functions, structs, enums, match, impl blocks, lambdas, type casts, print dispatch, f-strings, traits, generics
  - `tests/self_hosted/test_bytecode.casa` (76 tests): simple ops, push instructions, print, heap, load/store, globals, locals, function call/return, lambdas, function references, constants, control flow, string interning
  - `tests/self_hosted/test_emitter.casa` (71 tests): sections, push patterns, stack ops, arithmetic, bitshift, boolean, comparison, labels/jumps, functions, globals, locals, constants, heap, print, syscalls, exit, name sanitization, load/store patterns
- Add `tests/test_self_hosted_unit.sh` runner script
- Fix missing `is` keyword in self-hosted lexer
- Fix chained namespace lexing (e.g., `A::B::c`)
- Fix reversed comparison operators for `pushq` vs `movabsq` integer emission threshold

## Test plan
- [x] `tests/test_self_hosted_unit.sh` - all 580 unit tests pass
- [x] `tests/test_self_hosted.sh` - all 88 integration tests pass
- [x] `tests/test_examples.sh` - all 31 example tests pass
- [x] `pytest tests` - all 1191 Python tests pass