### PR TITLE
feat: add type checker for self-hosted compiler

### DIFF
--- a/self_hosted/bytecode.casa
+++ b/self_hosted/bytecode.casa
@@ -321,7 +321,7 @@ fn op_to_inst op:Op -> Inst {
 # Compile a list of ops into bytecode, resolving variables against
 # the given function_variables (locals) and global_variables lists.
 # New locals discovered via AssignVariable are added to function_variables.
-fn compile_ops ops:List[Op] func_variables:List[str] global_variables:List[str] label_offset:int functions:Map[str Function] constants_table:List[str] current_function_name:str -> List[Inst] int {
+fn compile_ops ops:List[Op] func_variables:List[str] global_variables:List[str] label_offset:int functions:Map[str Function] structs:Map[str StructDef] constants_table:List[str] current_function_name:str -> List[Inst] int {
     List::new (List[Inst]) = bytecode
     label_offset ops make_label_state = state
     0 = op_index
@@ -443,7 +443,7 @@ fn compile_ops ops:List[Op] func_variables:List[str] global_variables:List[str] 
 
         # Struct construction
         elif op_kind OpKind::StructNew == then
-            current_op.value op_int_value = member_count
+            current_op.value op_str_value structs.get .unwrap .member_names.length = member_count
             member_count 8 * InstValue::Int InstKind::Push Inst bytecode.push
             InstValue::None InstKind::HeapAlloc Inst bytecode.push
             0 = field_index
@@ -689,7 +689,7 @@ fn compile_ops ops:List[Op] func_variables:List[str] global_variables:List[str] 
 
 # Compile a function's ops into bytecode with locals framing.
 # Parameters are the first variables in the function's variable list.
-fn compile_function function:Function global_variables:List[str] label_offset:int functions:Map[str Function] constants_table:List[str] -> List[Inst] int {
+fn compile_function function:Function global_variables:List[str] label_offset:int functions:Map[str Function] structs:Map[str StructDef] constants_table:List[str] -> List[Inst] int {
     # Copy the function's parameter list as initial variables
     List::new (List[str]) = func_variables
     0 = param_index
@@ -699,7 +699,7 @@ fn compile_function function:Function global_variables:List[str] label_offset:in
     done
 
     # Compile function body
-    function.name constants_table functions label_offset global_variables func_variables function.ops compile_ops = label_count = body_bytecode
+    function.name constants_table structs functions label_offset global_variables func_variables function.ops compile_ops = label_count = body_bytecode
 
     # Determine locals count (params + any new locals discovered during compilation)
     func_variables.length = locals_count
@@ -778,7 +778,7 @@ fn find_reachable_functions ops:List[Op] functions:Map[str Function] -> Map[str 
     visited
 }
 
-fn compile_bytecode ops:List[Op] string_table:List[str] functions:Map[str Function] -> Program {
+fn compile_bytecode ops:List[Op] string_table:List[str] functions:Map[str Function] structs:Map[str StructDef] -> Program {
     # Build global variable list for resolution
     # Global variables are discovered by scanning global ops for AssignVariable
     List::new (List[str]) = global_variables
@@ -811,7 +811,7 @@ fn compile_bytecode ops:List[Op] string_table:List[str] functions:Map[str Functi
 
     # Compile global scope
     List::new (List[str]) = empty_locals
-    "__global__" constants_table functions 0 global_variables empty_locals ops compile_ops = label_count = bytecode
+    "__global__" constants_table structs functions 0 global_variables empty_locals ops compile_ops = label_count = bytecode
 
     # Compile only reachable functions
     Map::new (Map[str List[Inst]]) = compiled_functions
@@ -824,7 +824,7 @@ fn compile_bytecode ops:List[Op] string_table:List[str] functions:Map[str Functi
         func_index reachable_names.get = func_name
         if func_name functions.has then
             func_name functions.get .unwrap = function
-            constants_table functions total_label_count global_variables function compile_function = func_label_count = func_bytecode
+            constants_table structs functions total_label_count global_variables function compile_function = func_label_count = func_bytecode
             func_name func_bytecode compiled_functions.set drop
             func_label_count = total_label_count
         fi
@@ -849,7 +849,7 @@ fn compile_bytecode ops:List[Op] string_table:List[str] functions:Map[str Functi
                     scan_inst.value inst_str_value = called_fn
                     if called_fn compiled_functions.has ! called_fn functions.has && then
                         called_fn functions.get .unwrap = extra_function
-                        constants_table functions total_label_count global_variables extra_function compile_function = extra_label_count = extra_bytecode
+                        constants_table structs functions total_label_count global_variables extra_function compile_function = extra_label_count = extra_bytecode
                         called_fn extra_bytecode compiled_functions.set drop
                         extra_label_count = total_label_count
                         true = found_new

--- a/self_hosted/casa.casa
+++ b/self_hosted/casa.casa
@@ -5,6 +5,7 @@
 
 include "lexer.casa"
 include "parser.casa"
+include "typechecker.casa"
 include "bytecode.casa"
 include "emitter.casa"
 include "compiler.casa"
@@ -34,7 +35,7 @@ while arg_index argc > do
     1 += arg_index
 done
 
-# Pipeline: lex -> parse -> bytecode -> emit -> compile
+# Pipeline: lex -> parse -> type check -> bytecode -> emit -> compile
 Set::new (Set[str]) = included_files
 included_files input_path lex_file = token_list
 List::new (List[str]) = string_table
@@ -43,6 +44,7 @@ Map::new (Map[str StructDef]) = structs
 Map::new (Map[str EnumDef]) = enums
 Map::new (Map[str str]) "" 0 "__global__" "" Map::new (Map[str str]) enums structs functions string_table token_list ParseContext = ctx
 ctx parse = parsed_ops
-ctx.functions ctx.string_table parsed_ops compile_bytecode = program
+ctx.enums ctx.structs ctx.functions parsed_ops type_check
+ctx.structs ctx.functions ctx.string_table parsed_ops compile_bytecode = program
 program emit_program = asm_source
 keep_asm output_path asm_source compile_binary

--- a/self_hosted/common.casa
+++ b/self_hosted/common.casa
@@ -82,6 +82,7 @@ enum OpKind {
     PushCapture
     FstringConcat
     IsCheck
+    MethodCall
 }
 
 # ---------------------------------------------------------------------------
@@ -137,6 +138,7 @@ struct Function {
     name:        str
     ops:         List[Op]
     variables:   List[str]
+    param_types: List[str]
     return_type: str
     captures:    List[str]
 }

--- a/self_hosted/parser.casa
+++ b/self_hosted/parser.casa
@@ -261,7 +261,8 @@ fn parse_lambda ops:List[Op] ctx:ParseContext index:int -> int {
 
     # Create and register the lambda function
     List::new (List[str]) = lambda_vars
-    captures "" lambda_vars lambda_ops lambda_name Function = lambda_func
+    List::new (List[str]) = lambda_param_types
+    captures "" lambda_param_types lambda_vars lambda_ops lambda_name Function = lambda_func
     lambda_name lambda_func ctx.functions.set drop
 
     # Emit FnPush op
@@ -521,7 +522,7 @@ fn parse_token token:Token index:int ctx:ParseContext ops:List[Op] -> int {
                 token.value ctx.secondary_types.get .unwrap ctx->pending_type
             fi
         elif token.value ctx.structs.has then
-            token.value ctx.structs.get .unwrap .member_names.length OpValue::Int OpKind::StructNew Op ops.push
+            token.value OpValue::Str OpKind::StructNew Op ops.push
             token.value ctx->expression_type
         else
             # Try is-check first for enum variant identifiers
@@ -562,17 +563,17 @@ fn parse_token token:Token index:int ctx:ParseContext ops:List[Op] -> int {
         fi
     elif kind TokenKind::Delimiter == then
         if "." token.value == then
-            # Method call: resolve .method_name to Type::method_name
+            # Method call: emit MethodCall for type checker to resolve
             index ctx.tokens.get .value = method_name
             1 += index
-            method_name ops ctx resolve_method_call = qualified_name
-            qualified_name OpValue::Str OpKind::FnCall Op ops.push
+            method_name OpValue::Str OpKind::MethodCall Op ops.push
+            "" ctx->expression_type
         elif "->" token.value == then
-            # Field setter: resolve ->field to Type::set_field
+            # Field setter: emit MethodCall with set_ prefix
             index ctx.tokens.get .value = setter_field
             1 += index
-            f"set_{setter_field}" ops ctx resolve_method_call = qualified_name
-            qualified_name OpValue::Str OpKind::FnCall Op ops.push
+            f"set_{setter_field}" OpValue::Str OpKind::MethodCall Op ops.push
+            "" ctx->expression_type
         elif "(" token.value == then
             # Type cast: read full type name including generics for expression tracking
             "" = cast_type_name
@@ -636,6 +637,7 @@ fn parse_function ctx:ParseContext index:int -> int {
 
     # Parse parameters and collect variable names and types
     List::new (List[str]) = variables
+    List::new (List[str]) = param_types
     "" = return_type_str
     while index ctx.tokens.length > do
         index ctx.tokens.get = param_token
@@ -682,6 +684,7 @@ fn parse_function ctx:ParseContext index:int -> int {
         fi
 
         param_token.value variables.push
+        param_type param_types.push
         # Track parameter types for method resolution
         param_token.value param_type ctx.variable_types.set drop
     done
@@ -702,7 +705,8 @@ fn parse_function ctx:ParseContext index:int -> int {
     List::new (List[Op]) = placeholder_ops
     List::new (List[str]) = placeholder_vars
     List::new (List[str]) = placeholder_captures
-    placeholder_captures return_type_str placeholder_vars placeholder_ops func_name Function = placeholder
+    List::new (List[str]) = placeholder_param_types
+    placeholder_captures return_type_str placeholder_param_types placeholder_vars placeholder_ops func_name Function = placeholder
     func_name placeholder ctx.functions.set drop
 
     # Save and set current function context for lambda naming
@@ -749,7 +753,7 @@ fn parse_function ctx:ParseContext index:int -> int {
     saved_function ctx->current_function
 
     List::new (List[str]) = empty_captures
-    empty_captures return_type_str variables body_ops func_name Function = function
+    empty_captures return_type_str param_types variables body_ops func_name Function = function
     func_name function ctx.functions.set drop
 
     index
@@ -1193,8 +1197,10 @@ fn parse_struct ctx:ParseContext index:int -> int {
 
         List::new (List[str]) = getter_vars
         "self" getter_vars.push
+        List::new (List[str]) = getter_param_types
+        struct_name getter_param_types.push
         List::new (List[str]) = getter_captures
-        getter_captures field_type getter_vars getter_ops f"{struct_name}::{field_name}" Function = getter_func
+        getter_captures field_type getter_param_types getter_vars getter_ops f"{struct_name}::{field_name}" Function = getter_func
         f"{struct_name}::{field_name}" getter_func ctx.functions.set drop
 
         # Setter: StructName::set_field_name
@@ -1215,8 +1221,11 @@ fn parse_struct ctx:ParseContext index:int -> int {
         List::new (List[str]) = setter_vars
         "self" setter_vars.push
         "value" setter_vars.push
+        List::new (List[str]) = setter_param_types
+        struct_name setter_param_types.push
+        field_type setter_param_types.push
         List::new (List[str]) = setter_captures
-        setter_captures "" setter_vars setter_ops f"{struct_name}::set_{field_name}" Function = setter_func
+        setter_captures "" setter_param_types setter_vars setter_ops f"{struct_name}::set_{field_name}" Function = setter_func
         f"{struct_name}::set_{field_name}" setter_func ctx.functions.set drop
 
         1 += field_index
@@ -1366,7 +1375,8 @@ fn parse_impl ctx:ParseContext index:int -> int {
             List::new (List[Op]) = pre_ops
             List::new (List[str]) = pre_vars
             List::new (List[str]) = pre_captures
-            pre_captures "" pre_vars pre_ops qualified_name Function = pre_func
+            List::new (List[str]) = pre_param_types
+            pre_captures "" pre_param_types pre_vars pre_ops qualified_name Function = pre_func
             qualified_name pre_func ctx.functions.set drop
 
             index ctx parse_function = index

--- a/self_hosted/typechecker.casa
+++ b/self_hosted/typechecker.casa
@@ -1,0 +1,676 @@
+# Stack-based type checker for the Casa compiler.
+#
+# Processes the op tree after parsing and resolves MethodCall ops to FnCall ops
+# using symbolic stack type inference. Also tracks types for all operations.
+
+include "common.casa"
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+struct BranchState {
+    before: List[str]
+}
+
+struct TypeCheckerState {
+    stack:            List[str]
+    functions:        Map[str Function]
+    structs:          Map[str StructDef]
+    enums:            Map[str EnumDef]
+    variable_types:   Map[str str]
+    branch_stacks:    List[BranchState]
+    current_function: str
+}
+
+# ---------------------------------------------------------------------------
+# Stack helpers
+# ---------------------------------------------------------------------------
+
+fn tc_push state:TypeCheckerState typ:str {
+    typ state.stack.push
+}
+
+fn tc_pop state:TypeCheckerState -> str {
+    if 0 state.stack.length == then
+        "any"
+    else
+        state.stack.pop
+    fi
+}
+
+fn tc_peek state:TypeCheckerState -> str {
+    if 0 state.stack.length == then
+        "any"
+    else
+        state.stack.length 1 - state.stack.get
+    fi
+}
+
+fn copy_str_list source:List[str] -> List[str] {
+    List::new (List[str]) = result
+    0 = copy_index
+    while copy_index source.length > do
+        copy_index source.get result.push
+        1 += copy_index
+    done
+    result
+}
+
+# ---------------------------------------------------------------------------
+# Enum inner value helpers
+# ---------------------------------------------------------------------------
+
+# Parse a data-carrying enum variant's inner count and pop that many values.
+# Enum info format: "ordinal:inner_count" (e.g., "0:1" for Some(T)).
+fn tc_parse_enum_inner_count enum_info:str -> int {
+    enum_info ":" str::find = colon_pos
+    if 0 colon_pos > ! then 0 return fi
+    enum_info colon_pos 1 + enum_info.length colon_pos - 1 - str::substring = inner_str
+    inner_str ":" str::find = second_colon
+    if 0 second_colon >= then
+        inner_str second_colon 1 + inner_str.length second_colon - 1 - str::substring str_to_int
+    else
+        inner_str str_to_int
+    fi
+}
+
+fn tc_pop_enum_inner_values state:TypeCheckerState op:Op {
+    if op.value OpValue::Str(enum_info) is then
+        enum_info tc_parse_enum_inner_count = inner_count
+        0 = inner_pop_index
+        while inner_pop_index inner_count > do
+            state tc_pop drop
+            1 += inner_pop_index
+        done
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Branch tracking
+# ---------------------------------------------------------------------------
+
+fn tc_save_branch state:TypeCheckerState {
+    state.stack copy_str_list BranchState state.branch_stacks.push
+}
+
+fn tc_restore_branch state:TypeCheckerState {
+    if 0 state.branch_stacks.length == then return fi
+    state.branch_stacks.length 1 - state.branch_stacks.get = branch
+    branch.before copy_str_list = restored
+    # Clear and restore stack
+    while 0 state.stack.length > do
+        state.stack.pop drop
+    done
+    0 = restore_index
+    while restore_index restored.length > do
+        restore_index restored.get state.stack.push
+        1 += restore_index
+    done
+}
+
+fn tc_pop_branch state:TypeCheckerState {
+    if 0 state.branch_stacks.length == then return fi
+    state tc_restore_branch
+    state.branch_stacks.pop drop
+}
+
+# ---------------------------------------------------------------------------
+# Generic type resolution
+# ---------------------------------------------------------------------------
+
+# Look up a type parameter name in type_params and return the corresponding type arg.
+# Returns "" if not found.
+fn tc_find_type_param type_params:List[str] type_args:List[str] return_type:str -> str {
+    0 = param_index
+    while param_index type_params.length > do
+        if return_type param_index type_params.get == param_index type_args.length > && then
+            param_index type_args.get return
+        fi
+        1 += param_index
+    done
+    ""
+}
+
+# Extract the first generic type argument from a receiver type string.
+# E.g., "List[Token]" -> "Token", "Map[str int]" -> "str"
+fn tc_extract_first_type_arg receiver_type:str bracket_pos:int -> str {
+    bracket_pos 1 + = fallback_start
+    fallback_start = fallback_end
+    while fallback_end receiver_type.length > do
+        fallback_end receiver_type str::at = fallback_ch
+        if fallback_ch ' ' == fallback_ch ']' == || then break fi
+        1 += fallback_end
+    done
+    if fallback_start fallback_end > then
+        receiver_type fallback_start fallback_end fallback_start - str::substring return
+    fi
+    ""
+}
+
+fn tc_resolve_return_type state:TypeCheckerState receiver_type:str return_type:str -> str {
+    if "" return_type == then "" return fi
+
+    receiver_type extract_base_type = base_type
+
+    if base_type state.structs.has then
+        base_type state.structs.get .unwrap = struct_def
+        struct_def.type_params = type_params
+
+        if 0 type_params.length > then
+            receiver_type extract_type_args = type_args
+
+            # Direct match: return type is a type param
+            return_type type_args type_params tc_find_type_param = direct_result
+            if "" direct_result != then direct_result return fi
+
+            # Composite match: return type contains type params
+            return_type = resolved
+            0 = sub_index
+            while sub_index type_params.length > do
+                sub_index type_params.get = sub_param
+                if sub_index type_args.length > then
+                    sub_index type_args.get = sub_arg
+                    sub_param sub_arg resolved substitute_type_param = resolved
+                fi
+                1 += sub_index
+            done
+            if resolved return_type != then resolved return fi
+        fi
+    fi
+
+    # Fallback: short type variable name with receiver generic args
+    receiver_type "[" str::find = fallback_bracket
+    if 0 fallback_bracket >= 0 return_type.length > && 3 return_type.length > ! && then
+        fallback_bracket receiver_type tc_extract_first_type_arg = fallback_result
+        if "" fallback_result != then fallback_result return fi
+    fi
+
+    return_type
+}
+
+# ---------------------------------------------------------------------------
+# Function signature application
+# ---------------------------------------------------------------------------
+
+fn tc_apply_fn_signature state:TypeCheckerState receiver_type:str target_fn:Function {
+    # Pop parameters from stack
+    target_fn.param_types.length = param_count
+    0 = pop_index
+    while pop_index param_count > do
+        state tc_pop drop
+        1 += pop_index
+    done
+
+    # Push return type (resolved for generics)
+    if "" target_fn.return_type != then
+        target_fn.return_type receiver_type state tc_resolve_return_type state tc_push
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Method disambiguation
+# ---------------------------------------------------------------------------
+
+# Check if a qualified function name has the given type prefix.
+# E.g., "List::push" has prefix "List".
+fn tc_fn_has_type_prefix fn_name:str base_type:str -> bool {
+    fn_name "::" str::find = colon_pos
+    if 0 colon_pos >= then
+        fn_name 0 colon_pos str::substring base_type ==
+    else
+        false
+    fi
+}
+
+# Search all function names for a unique match with the given base type prefix.
+# Returns the qualified name if found, "" otherwise.
+fn tc_disambiguate_method all_fn_names:List[str] search_suffix:str base_type:str -> str {
+    0 = retry_index
+    while retry_index all_fn_names.length > do
+        retry_index all_fn_names.get = retry_name
+        if retry_name search_suffix str::ends_with then
+            if retry_name base_type tc_fn_has_type_prefix then
+                retry_name return
+            fi
+        fi
+        1 += retry_index
+    done
+    ""
+}
+
+# ---------------------------------------------------------------------------
+# MethodCall resolution
+# ---------------------------------------------------------------------------
+
+fn tc_check_method_call state:TypeCheckerState ops:List[Op] op_index:int {
+    op_index ops.get = op
+    op.value op_str_value = method_name
+    state tc_peek = receiver_type
+    receiver_type extract_base_type = base_type
+
+    # Strategy 1: Direct type resolution (BaseType::method)
+    f"{base_type}::{method_name}" = qualified
+    if qualified state.functions.has then
+        qualified state.functions.get .unwrap = target_fn
+        target_fn receiver_type state tc_apply_fn_signature
+        qualified OpValue::Str OpKind::FnCall Op op_index ops.set
+        return
+    fi
+
+    # Strategy 2: Full receiver type (ReceiverType::method)
+    if base_type receiver_type != then
+        f"{receiver_type}::{method_name}" = full_qualified
+        if full_qualified state.functions.has then
+            full_qualified state.functions.get .unwrap = target_fn
+            target_fn receiver_type state tc_apply_fn_signature
+            full_qualified OpValue::Str OpKind::FnCall Op op_index ops.set
+            return
+        fi
+    fi
+
+    # Strategy 3: Search all functions for unique ::method_name suffix
+    state.functions.keys = all_fn_names
+    f"::{method_name}" = search_suffix
+    "" = found_name
+    0 = match_count
+    0 = search_index
+    while search_index all_fn_names.length > do
+        search_index all_fn_names.get = fn_name
+        if fn_name search_suffix str::ends_with then
+            if 0 match_count == then
+                fn_name = found_name
+            fi
+            1 += match_count
+        fi
+        1 += search_index
+    done
+    if 1 match_count == then
+        found_name state.functions.get .unwrap = target_fn
+        target_fn receiver_type state tc_apply_fn_signature
+        found_name OpValue::Str OpKind::FnCall Op op_index ops.set
+        return
+    fi
+
+    # Multiple matches: try to disambiguate using receiver type
+    if 0 match_count > then
+        base_type search_suffix all_fn_names tc_disambiguate_method = disambiguated
+        if "" disambiguated != then
+            disambiguated state.functions.get .unwrap = target_fn
+            target_fn receiver_type state tc_apply_fn_signature
+            disambiguated OpValue::Str OpKind::FnCall Op op_index ops.set
+            return
+        fi
+        # Fallback: pick first match (safe for same-struct-offset methods)
+        found_name state.functions.get .unwrap = target_fn
+        target_fn receiver_type state tc_apply_fn_signature
+        found_name OpValue::Str OpKind::FnCall Op op_index ops.set
+        return
+    fi
+
+    f"cannot resolve method: .{method_name} (receiver type: {receiver_type}) in {state.current_function}\n" eprintln
+    1 exit
+}
+
+# ---------------------------------------------------------------------------
+# FnCall type checking
+# ---------------------------------------------------------------------------
+
+fn tc_check_fn_call state:TypeCheckerState op:Op {
+    op.value op_str_value = fn_name
+
+    if fn_name state.functions.has then
+        fn_name state.functions.get .unwrap = target_fn
+
+        # Determine receiver type for generic resolution
+        "" = fn_receiver_type
+        if 0 target_fn.param_types.length > then
+            0 target_fn.param_types.get = first_param_type
+            # If the first param type matches a struct, use the actual stack type
+            first_param_type extract_base_type = first_base
+            if first_base state.structs.has then
+                state tc_peek = fn_receiver_type
+            fi
+        fi
+
+        target_fn fn_receiver_type state tc_apply_fn_signature
+    else
+        # Unknown function: could be forward ref or trait method
+        # Push "any" as return type to keep stack tracking going
+        "any" state tc_push
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Main op dispatch
+# ---------------------------------------------------------------------------
+
+fn type_check_ops state:TypeCheckerState ops:List[Op] {
+    0 = op_index
+    while op_index ops.length > do
+        op_index ops.get = current_op
+        current_op.kind = op_kind
+
+        # Literals
+        if op_kind OpKind::PushInt == then
+            "int" state tc_push
+        elif op_kind OpKind::PushStr == then
+            "str" state tc_push
+        elif op_kind OpKind::PushChar == then
+            "char" state tc_push
+        elif op_kind OpKind::PushBool == then
+            "int" state tc_push
+
+        # Arithmetic: pop 2, push int
+        elif op_kind OpKind::Add ==
+             op_kind OpKind::Sub == ||
+             op_kind OpKind::Mul == ||
+             op_kind OpKind::Div == ||
+             op_kind OpKind::Mod == ||
+             op_kind OpKind::BitAnd == ||
+             op_kind OpKind::BitOr == ||
+             op_kind OpKind::BitXor == ||
+             op_kind OpKind::Shl == ||
+             op_kind OpKind::Shr == ||
+        then
+            state tc_pop drop
+            state tc_pop drop
+            "int" state tc_push
+
+        # Unary ops: pop 1, push int
+        elif op_kind OpKind::BitNot ==
+             op_kind OpKind::Not == ||
+        then
+            state tc_pop drop
+            "int" state tc_push
+
+        # Comparison: pop 2, push int (bool)
+        elif op_kind OpKind::Eq ==
+             op_kind OpKind::Ne == ||
+             op_kind OpKind::Lt == ||
+             op_kind OpKind::Gt == ||
+             op_kind OpKind::Le == ||
+             op_kind OpKind::Ge == ||
+             op_kind OpKind::And == ||
+             op_kind OpKind::Or == ||
+        then
+            state tc_pop drop
+            state tc_pop drop
+            "int" state tc_push
+
+        # Stack manipulation
+        elif op_kind OpKind::Drop == then
+            state tc_pop drop
+        elif op_kind OpKind::Dup == then
+            state tc_peek state tc_push
+        elif op_kind OpKind::Swap == then
+            state tc_pop = swap_a
+            state tc_pop = swap_b
+            swap_a state tc_push
+            swap_b state tc_push
+        elif op_kind OpKind::Over == then
+            state tc_pop = over_a
+            state tc_pop = over_b
+            over_b state tc_push
+            over_a state tc_push
+            over_b state tc_push
+        elif op_kind OpKind::Rot == then
+            state tc_pop = rot_a
+            state tc_pop = rot_b
+            state tc_pop = rot_c
+            rot_b state tc_push
+            rot_a state tc_push
+            rot_c state tc_push
+
+        # Print: pop 1
+        elif op_kind OpKind::PrintInt ==
+             op_kind OpKind::PrintStr == ||
+             op_kind OpKind::PrintBool == ||
+             op_kind OpKind::PrintChar == ||
+             op_kind OpKind::PrintCstr == ||
+        then
+            state tc_pop drop
+
+        # Variable assignment: pop 1, store type
+        elif op_kind OpKind::AssignVariable == then
+            state tc_pop = assign_type
+            current_op.value op_str_value = assign_name
+            assign_name assign_type state.variable_types.set drop
+
+        # Compound assignment: pop 1
+        elif op_kind OpKind::AssignIncrement ==
+             op_kind OpKind::AssignDecrement == ||
+        then
+            state tc_pop drop
+
+        # Variable push: look up type
+        elif op_kind OpKind::PushVariable == then
+            current_op.value op_str_value = push_var_name
+            if push_var_name state.variable_types.has then
+                push_var_name state.variable_types.get .unwrap state tc_push
+            else
+                "any" state tc_push
+            fi
+
+        # If/elif/else/fi branching
+        elif op_kind OpKind::IfStart == then
+            state tc_save_branch
+        elif op_kind OpKind::IfCondition == then
+            state tc_pop drop
+        elif op_kind OpKind::IfElif ==
+             op_kind OpKind::IfElse == ||
+        then
+            state tc_restore_branch
+        elif op_kind OpKind::IfEnd == then
+            state tc_pop_branch
+
+        # While loops
+        elif op_kind OpKind::WhileStart == then
+            state tc_save_branch
+        elif op_kind OpKind::WhileCondition == then
+            state tc_pop drop
+        elif op_kind OpKind::WhileBreak ==
+             op_kind OpKind::WhileContinue == ||
+        then
+            # No stack effect
+        elif op_kind OpKind::WhileEnd == then
+            state tc_pop_branch
+
+        # Function call
+        elif op_kind OpKind::FnCall == then
+            current_op state tc_check_fn_call
+
+        # Function return
+        elif op_kind OpKind::FnReturn == then
+            # No stack tracking needed
+
+        # Memory operations
+        elif op_kind OpKind::Alloc ==
+             op_kind OpKind::HeapAlloc == ||
+        then
+            state tc_pop drop
+            "ptr" state tc_push
+        elif op_kind OpKind::Load8 ==
+             op_kind OpKind::Load16 == ||
+             op_kind OpKind::Load32 == ||
+             op_kind OpKind::Load64 == ||
+        then
+            state tc_pop drop
+            "int" state tc_push
+        elif op_kind OpKind::Store8 ==
+             op_kind OpKind::Store16 == ||
+             op_kind OpKind::Store32 == ||
+             op_kind OpKind::Store64 == ||
+        then
+            state tc_pop drop
+            state tc_pop drop
+
+        # Syscalls: pop (N+1) args (N data + syscall number), push int
+        elif op_kind OpKind::Syscall0 == then
+            state tc_pop drop
+            "int" state tc_push
+        elif op_kind OpKind::Syscall1 == then
+            state tc_pop drop
+            state tc_pop drop
+            "int" state tc_push
+        elif op_kind OpKind::Syscall2 == then
+            state tc_pop drop
+            state tc_pop drop
+            state tc_pop drop
+            "int" state tc_push
+        elif op_kind OpKind::Syscall3 == then
+            state tc_pop drop
+            state tc_pop drop
+            state tc_pop drop
+            state tc_pop drop
+            "int" state tc_push
+        elif op_kind OpKind::Syscall4 == then
+            state tc_pop drop
+            state tc_pop drop
+            state tc_pop drop
+            state tc_pop drop
+            state tc_pop drop
+            "int" state tc_push
+        elif op_kind OpKind::Syscall5 == then
+            state tc_pop drop
+            state tc_pop drop
+            state tc_pop drop
+            state tc_pop drop
+            state tc_pop drop
+            state tc_pop drop
+            "int" state tc_push
+        elif op_kind OpKind::Syscall6 == then
+            state tc_pop drop
+            state tc_pop drop
+            state tc_pop drop
+            state tc_pop drop
+            state tc_pop drop
+            state tc_pop drop
+            state tc_pop drop
+            "int" state tc_push
+
+        # Argc/Argv
+        elif op_kind OpKind::Argc == then
+            "int" state tc_push
+        elif op_kind OpKind::Argv == then
+            "ptr" state tc_push
+
+        # Type cast: pop 1, push "any"
+        elif op_kind OpKind::TypeCast == then
+            state tc_pop drop
+            "any" state tc_push
+
+        # Struct construction: pop N members, push struct type
+        elif op_kind OpKind::StructNew == then
+            current_op.value op_str_value = struct_name
+            if struct_name state.structs.has then
+                struct_name state.structs.get .unwrap .member_names.length = tc_member_count
+                0 = tc_member_index
+                while tc_member_index tc_member_count > do
+                    state tc_pop drop
+                    1 += tc_member_index
+                done
+            fi
+            struct_name state tc_push
+
+        # Enum variant: push int (ordinal)
+        elif op_kind OpKind::PushEnumVariant == then
+            current_op state tc_pop_enum_inner_values
+            "int" state tc_push
+
+        # Match expressions: pop matched value before saving state
+        elif op_kind OpKind::MatchStart == then
+            state tc_pop drop
+            state tc_save_branch
+        elif op_kind OpKind::MatchArm == then
+            state tc_restore_branch
+        elif op_kind OpKind::MatchEnd == then
+            state tc_pop_branch
+
+        # Function push (lambda or &name reference)
+        elif op_kind OpKind::FnPush == then
+            "fn" state tc_push
+
+        # Function exec (indirect call)
+        elif op_kind OpKind::FnExec == then
+            state tc_pop drop
+            "any" state tc_push
+
+        # Capture push
+        elif op_kind OpKind::PushCapture == then
+            "any" state tc_push
+
+        # F-string concatenation: pop N parts, push str
+        elif op_kind OpKind::FstringConcat == then
+            current_op.value op_int_value = fstr_count
+            0 = fstr_index
+            while fstr_index fstr_count > do
+                state tc_pop drop
+                1 += fstr_index
+            done
+            "str" state tc_push
+
+        # Is-check: pop value, push bool
+        elif op_kind OpKind::IsCheck == then
+            state tc_pop drop
+            "int" state tc_push
+
+        # MethodCall: resolve to FnCall
+        elif op_kind OpKind::MethodCall == then
+            op_index ops state tc_check_method_call
+
+        fi
+
+        1 += op_index
+    done
+}
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+fn type_check ops:List[Op] functions:Map[str Function] structs:Map[str StructDef] enums:Map[str EnumDef] {
+    # Type check global ops
+    List::new (List[str]) = global_stack
+    List::new (List[BranchState]) = global_branches
+    Map::new (Map[str str]) = global_var_types
+    "__global__" global_branches global_var_types enums structs functions global_stack TypeCheckerState = global_state
+    ops global_state type_check_ops
+
+    # Type check each function body
+    functions.keys = fn_names
+    0 = fn_index
+    while fn_index fn_names.length > do
+        fn_index fn_names.get = fn_name
+        fn_name functions.get .unwrap = func
+
+        # Create fresh state for this function
+        List::new (List[str]) = fn_stack
+        List::new (List[BranchState]) = fn_branches
+        Map::new (Map[str str]) = fn_var_types
+
+        # Push parameter types onto stack in reverse order
+        # (first param = top of stack, last param = bottom)
+        func.param_types.length 1 - = rev_index
+        while 0 rev_index >= do
+            rev_index func.param_types.get fn_stack.push
+            rev_index 1 - = rev_index
+        done
+
+        # Initialize variable types from parameter declarations
+        0 = param_init_index
+        while param_init_index func.param_types.length > do
+            if param_init_index func.variables.length > then
+                param_init_index func.variables.get = param_var_name
+                param_init_index func.param_types.get = param_var_type
+                param_var_name param_var_type fn_var_types.set drop
+            fi
+            1 += param_init_index
+        done
+
+        fn_name fn_branches fn_var_types enums structs functions fn_stack TypeCheckerState = fn_state
+        func.ops fn_state type_check_ops
+
+        1 += fn_index
+    done
+}

--- a/tests/self_hosted/test_bytecode.casa
+++ b/tests/self_hosted/test_bytecode.casa
@@ -2,6 +2,7 @@
 
 include "../../self_hosted/lexer.casa"
 include "../../self_hosted/parser.casa"
+include "../../self_hosted/typechecker.casa"
 include "../../self_hosted/bytecode.casa"
 include "../../lib/test.casa"
 
@@ -100,7 +101,8 @@ fn compile_source source:str -> Program {
     Map::new (Map[str EnumDef]) = enums
     Map::new (Map[str str]) "" 0 "__global__" "" Map::new (Map[str str]) enums structs functions string_table tokens ParseContext = ctx
     ctx parse = ops
-    ctx.functions ctx.string_table ops compile_bytecode
+    ctx.enums ctx.structs ctx.functions ops type_check
+    ctx.structs ctx.functions ctx.string_table ops compile_bytecode
 }
 
 # Check if any instruction in main bytecode has the given kind

--- a/tests/self_hosted/test_emitter.casa
+++ b/tests/self_hosted/test_emitter.casa
@@ -1,5 +1,6 @@
 include "../../self_hosted/lexer.casa"
 include "../../self_hosted/parser.casa"
+include "../../self_hosted/typechecker.casa"
 include "../../self_hosted/bytecode.casa"
 include "../../self_hosted/emitter.casa"
 include "../../lib/test.casa"
@@ -16,7 +17,8 @@ fn emit_source source:str -> str {
     Map::new (Map[str EnumDef]) = enums
     Map::new (Map[str str]) "" 0 "__global__" "" Map::new (Map[str str]) enums structs functions string_table tokens ParseContext = ctx
     ctx parse = ops
-    ctx.functions ctx.string_table ops compile_bytecode = program
+    ctx.enums ctx.structs ctx.functions ops type_check
+    ctx.structs ctx.functions ctx.string_table ops compile_bytecode = program
     program emit_program
 }
 

--- a/tests/self_hosted/test_parser.casa
+++ b/tests/self_hosted/test_parser.casa
@@ -90,6 +90,7 @@ fn opkind_to_str kind:OpKind -> str {
         OpKind::PushCapture       => "PushCapture"
         OpKind::FstringConcat     => "FstringConcat"
         OpKind::IsCheck           => "IsCheck"
+        OpKind::MethodCall        => "MethodCall"
     end
 }
 


### PR DESCRIPTION
## Summary
- Add a stack-based type checker phase between parsing and bytecode compilation
- The type checker resolves `MethodCall` ops to `FnCall` ops using symbolic stack type inference, enabling `.` and `->` syntax in programs compiled by the self-hosted compiler
- Parser now emits `MethodCall` for `.method` and `->field` instead of resolving them directly with heuristics

## Changes
- `common.casa`: Add `MethodCall` to `OpKind`, add `param_types: List[str]` to `Function`
- `parser.casa`: Emit `MethodCall` ops, store param types in `Function`, change `StructNew` to store struct name
- `typechecker.casa`: New file — full stack-based type checker with method resolution, generic type resolution, and branch tracking
- `bytecode.casa`: Accept `structs` parameter for `StructNew` member count lookup
- `casa.casa`: Integrate type checker into pipeline (lex → parse → **type check** → bytecode → emit)
- Test files updated for new `OpKind` variant and pipeline changes

## Test plan
- [x] All 88 self-hosted integration tests pass
- [x] All 580 self-hosted unit tests pass (316 lexer + 117 parser + 76 bytecode + 71 emitter)
- [x] All 31 Python compiler example tests pass
- [x] Verified `.` and `->` syntax produces identical output between Python and self-hosted compilers
- [x] Tested struct field access, field mutation, method calls, List operations, and string operations