### PR TITLE
fix: LSP rename and references at function definition sites

### DIFF
--- a/self_hosted/lsp.casa
+++ b/self_hosted/lsp.casa
@@ -528,6 +528,48 @@ fn find_op_at_position state:DocumentState line:int col:int -> Option[FindResult
     find_state FindOpState::best
 }
 
+fn find_function_at_position state:DocumentState line:int col:int -> Option[Function] {
+    col line state DocumentState::source position_to_offset = target_offset
+    state DocumentState::functions .keys = func_keys
+    0 = func_index
+    while func_index func_keys .length > do
+        func_index func_keys .get state DocumentState::functions .get .unwrap = func
+        if
+            "" func Function::location Location::file ==
+            func Function::location Location::file state DocumentState::file_path != ||
+        then
+            1 += func_index
+            continue
+        fi
+        if
+            func Function::name "lambda__" str::starts_with
+            func Function::name "__" str::starts_with ||
+        then
+            1 += func_index
+            continue
+        fi
+        func Function::location Location::span Span::offset = fn_offset
+        func Function::location Location::span Span::length = fn_length
+        if
+            fn_offset target_offset >=
+            target_offset fn_offset fn_length + > &&
+        then
+            func Option::Some return
+        fi
+        1 += func_index
+    done
+    Option::None (Option[Function])
+}
+
+fn function_short_name name:str -> str {
+    name "::" str::find = separator
+    if 0 separator < then
+        name
+    else
+        name separator 2 + name .length separator - 2 - str::substring
+    fi
+}
+
 fn find_containing_function state:DocumentState offset:int -> Option[Function] {
     state DocumentState::functions .keys = func_keys
     0 = index
@@ -1667,14 +1709,21 @@ fn handle_references message:JsonValue {
     state_opt .unwrap = state
 
     message extract_position = position
-    position LspRange::start_col position LspRange::start_line state find_op_at_position = result
-    if result .is_none then
-        json_null_value request_id send_response
-        return
+    # Check function definition name first (parameter ops share the name token location)
+    position LspRange::start_col position LspRange::start_line state find_function_at_position = fn_at_pos
+    if fn_at_pos Option::Some(matched_function) is then
+        matched_function Function::location OpKind::OpFnCall (int) matched_function Function::name make_op_str = op
+        Option::None (Option[Function]) = func
+    else
+        position LspRange::start_col position LspRange::start_line state find_op_at_position = result
+        if result .is_none then
+            json_null_value request_id send_response
+            return
+        fi
+        result .unwrap = find
+        find FindResult::op = op
+        find FindResult::function = func
     fi
-    result .unwrap = find
-    find FindResult::op = op
-    find FindResult::function = func
 
     # includeDeclaration
     "context" "params" message json_get_object .unwrap json_get_object = context_opt
@@ -1716,17 +1765,25 @@ fn handle_rename message:JsonValue {
     state_opt .unwrap = state
 
     message extract_position = position
-    position LspRange::start_col position LspRange::start_line state find_op_at_position = result
-    if result .is_none then
-        json_null_value request_id send_response
-        return
+    # Check function definition name first (parameter ops share the name token location)
+    position LspRange::start_col position LspRange::start_line state find_function_at_position = fn_at_pos
+    if fn_at_pos Option::Some(matched_function) is then
+        matched_function Function::location OpKind::OpFnCall (int) matched_function Function::name make_op_str = op
+        Option::None (Option[Function]) = func
+        matched_function Function::name function_short_name = old_name
+    else
+        position LspRange::start_col position LspRange::start_line state find_op_at_position = result
+        if result .is_none then
+            json_null_value request_id send_response
+            return
+        fi
+        result .unwrap = find
+        find FindResult::op = op
+        find FindResult::function = func
+        op op_str_value = old_name
     fi
-    result .unwrap = find
-    find FindResult::op = op
-    find FindResult::function = func
 
     "newName" "params" message json_get_object .unwrap json_get_str .unwrap = new_name
-    op op_str_value = old_name
 
     true func op state find_all_references = refs
     if 0 refs .length == then


### PR DESCRIPTION
## Summary
- Add `find_function_at_position` helper that checks if cursor is on a function/method definition name by matching against `Function::location` spans
- Add `function_short_name` helper to extract method name from qualified names (e.g., `"int::add_one"` → `"add_one"`)
- Update `handle_rename` and `handle_references` to check function definitions first, then fall back to op lookup

## Test plan
- [x] Place cursor on method name in impl block definition (e.g., `add_one` in `fn add_one`), trigger rename — should rename at both definition and call sites
- [x] Place cursor on regular function definition name, trigger rename — should work
- [x] Find references from definition site — should list definition and all call sites
- [x] Verify rename from call sites (e.g., `.add_one`) still works as before