### PR TITLE
Add install script and update README for self-hosted compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,22 +21,37 @@ Casa compiles to x86-64 Linux executables via GNU assembly. It features static t
 ## Requirements
 
 - **Linux x86-64**
-- **Python 3.11+**
-- **GNU assembler** (`as`) and **linker** (`ld`)
+- **GNU assembler** (`as`) and **linker** (`ld`) — typically from the `binutils` package
+
+## Installation
+
+Clone the repository and run the install script to download the latest compiler binary:
+
+```sh
+git clone https://github.com/frendsick/casa.git
+cd casa
+./install.sh
+```
+
+Or download and run the install script directly:
+
+```sh
+curl -sSL https://raw.githubusercontent.com/frendsick/casa/main/install.sh | sh
+```
 
 ## Getting Started
 
 Compile and run a program:
 
 ```sh
-python3 casa.py examples/hello_world.casa -r
+./casac examples/hello_world.casa -r
 # Hello world!
 ```
 
 Compile with a custom output name:
 
 ```sh
-python3 casa.py examples/fibonacci.casa -o fib
+./casac examples/fibonacci.casa -o fib
 ./fib
 # 6765
 ```
@@ -44,7 +59,7 @@ python3 casa.py examples/fibonacci.casa -o fib
 ## CLI Usage
 
 ```
-python3 casa.py <file> [-o name] [--keep-asm] [-r] [-v]
+./casac <file> [-o name] [--keep-asm] [-r] [-v]
 ```
 
 | Flag | Description |
@@ -98,30 +113,24 @@ More examples: [examples](./examples/)
 
 ## Editor Integration
 
-Casa ships with an LSP language server that provides real-time error and warning diagnostics. It runs the compiler pipeline on every file open and save, reporting issues back to the editor.
+Casa ships with an LSP language server written in Casa. It provides diagnostics, go-to-definition, hover, completion, references, rename, and semantic tokens.
 
-### Setup
+### Building the Language Server
 
-Install the Python LSP framework in the project virtualenv:
-
-```sh
-.venv/bin/pip install pygls
-```
-
-### Running the Language Server
-
-The server communicates over stdio:
+Compile the LSP server with the Casa compiler:
 
 ```sh
-.venv/bin/python casa_ls.py
+./casac self_hosted/lsp.casa -o casa_lsp
 ```
 
-Point your editor's LSP client at this command. For example, in Neovim with `nvim-lspconfig`:
+### Editor Configuration
+
+The server communicates over stdio. Point your editor's LSP client at the compiled binary. For example, in Neovim with `nvim-lspconfig`:
 
 ```lua
 require('lspconfig.configs').casa = {
   default_config = {
-    cmd = { '.venv/bin/python', 'casa_ls.py' },
+    cmd = { '/path/to/casa/casa_lsp' },
     filetypes = { 'casa' },
     root_dir = function(fname)
       return vim.fs.dirname(fname)
@@ -135,8 +144,13 @@ require('lspconfig').casa.setup({})
 
 | Feature | Trigger |
 |---------|---------|
-| Error diagnostics | File open, file save |
-| Warning diagnostics | File open, file save |
+| Error/warning diagnostics | File open, file save |
+| Go-to-definition | `gd` or equivalent |
+| Hover | Hover over identifier |
+| Completion | Typing |
+| Find references | `gr` or equivalent |
+| Rename | `<leader>rn` or equivalent |
+| Semantic tokens | Automatic |
 
 ## Testing
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,240 @@
+#!/bin/sh
+
+# Exit if any command exists with a non-zero status
+set -e
+
+# Configuration
+GITHUB_REPO="frendsick/casa"
+RELEASE_VERSION="latest"
+CASA_COMPILER="casac"
+
+# List of dependencies
+DEPENDENCIES="as ld"
+
+# Script entry point
+main() {
+    # Fetch latest release from the Github REST API
+    # https://docs.github.com/en/rest/releases/releases
+    log "INFO" "List assets from Github" "$GITHUB_REPO"
+    release_json=$(
+        curl \
+            --silent \
+            --fail \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/$GITHUB_REPO/releases/$RELEASE_VERSION"
+    ) || { log "ERROR" "Failed to fetch release info" "$GITHUB_REPO"; exit 1; }
+
+    # Parse asset name and URL pairs
+    release_asset_urls=$(
+        echo "$release_json" |
+            grep -E '"name"|"browser_download_url"' |
+            sed -E 's/[",]//g' |
+            awk '
+                /name:/ {name=$2}
+                /browser_download_url:/ {print name, $2}
+            '
+    )
+
+    # Handle each asset from the release
+    echo "$release_asset_urls" | while read -r asset_name asset_url; do
+
+        # Download the compiler executable and make it executable
+        if [ "$asset_name" = "$CASA_COMPILER" ]; then
+            download_asset "$asset_url" "$asset_name"
+            chmod +x "$asset_name"
+            log "SUCCESS" "Make executable" "$asset_name"
+
+        else
+            log "INFO" "Skipping asset" "$asset_name"
+        fi
+    done
+
+    # Verify that the compiler binary was downloaded
+    if [ ! -f "$CASA_COMPILER" ]; then
+        log "ERROR" "Compiler binary not downloaded" "$CASA_COMPILER"
+        exit 1
+    fi
+
+    # Offer to install missing dependencies for supported distros
+    missing_dependencies=$(get_missing_dependencies)
+    if [ -n "$missing_dependencies" ]; then
+        log "WARNING" "Dependencies missing" "$missing_dependencies"
+        install_dependencies "$missing_dependencies"
+
+        # Verify that dependencies were installed
+        missing_dependencies=$(get_missing_dependencies)
+        if [ -n "$missing_dependencies" ]; then
+            log "WARNING" "Please install missing dependencies manually:" "$missing_dependencies"
+            exit 0
+        fi
+    fi
+
+    log "SUCCESS" "All set. Happy hacking!" ""
+}
+
+are_you_sure() {
+    if [ "$#" -ne 1 ]; then
+        log "ERROR" "Invalid arguments" "Usage: are_you_sure <message>"
+        exit 1
+    fi
+
+    message="$1"
+
+    while true; do
+        printf "%s (Y/n) " "$message" >/dev/tty
+        read -r yn </dev/tty
+        case $yn in
+        # Interpret empty answer as yes
+        "")
+            echo true
+            break
+            ;;
+        [Yy])
+            echo true
+            break
+            ;;
+        [Nn])
+            echo false
+            break
+            ;;
+        *) ;;
+        esac
+    done
+}
+
+download_asset() {
+    if [ "$#" -ne 2 ]; then
+        log "ERROR" "Invalid arguments" "Usage: download_asset <url> <output_file>"
+        exit 1
+    fi
+
+    url="$1"
+    output_file="$2"
+    should_download=true
+
+    if [ -e "$output_file" ]; then
+        log "INFO" "File already exists" "$output_file"
+        should_download=$(are_you_sure "Reinstall $output_file?")
+    fi
+
+    if $should_download; then
+        log "SUCCESS" "Download asset" "$output_file"
+        if ! curl --silent --location --output "$output_file" "$url"; then
+            log "WARNING" "Download failed" "$output_file"
+        fi
+    else
+        log "INFO" "Skip downloading asset" "$output_file"
+    fi
+}
+
+get_missing_dependencies() {
+    # Gather missing packages to this variable
+    missing_dependencies=""
+
+    for dependency in $DEPENDENCIES; do
+        # Check if dependency already exists
+        if ! command -v "$dependency" >/dev/null 2>&1; then
+            missing_dependencies="$dependency $missing_dependencies"
+        fi
+    done
+
+    echo "$missing_dependencies"
+}
+
+# Install dependencies for supported Linux distros
+install_dependencies() {
+    if [ "$#" -ne 1 ]; then
+        log "ERROR" "Invalid arguments" "Usage: install_dependencies <dependencies>"
+        exit 1
+    fi
+
+    dependencies="$1"
+    distro=$(
+        command -v lsb_release >/dev/null 2>&1 &&
+            lsb_release -i | awk '{print $NF}'
+    )
+
+    # Debian derivates
+    if [ "$distro" = "Debian" ] ||
+        [ "$distro" = "Kali" ] ||
+        [ "$distro" = "Ubuntu" ]; then
+        # APT has both `as` and `ld` in the `binutils` package
+        install_packages "apt" "binutils"
+    # Could not determine the distro
+    elif [ -z "$distro" ]; then
+        log "WARNING" "Install dependencies" 'Could not determine the Linux distribution with `lsb_release`'
+    # Not supported distro
+    else
+        log "WARNING" "Install dependencies" "Dependency installation is not implemented for $distro"
+    fi
+}
+
+install_packages() {
+    if [ "$#" -ne 2 ]; then
+        log "ERROR" "Invalid arguments" "Usage: install_packages <package_manager> <packages>"
+        exit 1
+    fi
+
+    package_manager="$1"
+    packages="$2"
+
+    # Ask from the user if script should install dependencies
+    install=$(are_you_sure "Install dependencies from $package_manager?")
+
+    # Install packages with supported package manager
+    if [ "$install" != "true" ]; then
+        log "INFO" "Skip dependency install" ""
+    elif [ "$package_manager" = "apt" ]; then
+        sudo apt-get update && sudo apt-get install -y $packages
+
+        # Verify that dependencies were installed
+        missing_dependencies=$(get_missing_dependencies)
+        if [ -n "$missing_dependencies" ]; then
+            log "ERROR" "Dependency installation failed" ""
+        fi
+    fi
+}
+
+log() {
+    if [ "$#" -ne 3 ]; then
+        log "ERROR" "Invalid arguments" "Usage: log <log_level> <summary> <description>"
+        exit 1
+    fi
+
+    # $description starts at least $SUMMARY_WIDTH characters from the beginning of $summary
+    SUMMARY_WIDTH=26
+    log_level="$1"
+    summary="$2"
+    description="$3"
+
+    # Colors
+    ERROR="\e[91m"
+    INFO="\e[94m"
+    SUCCESS="\e[92m"
+    WARNING="\e[1;31m"
+    RESET="\e[0m"
+
+    # Construct $prefix based on the log level
+    if [ "$log_level" = "INFO" ]; then
+        prefix="[${INFO}*${RESET}]" # [*]
+    elif [ "$log_level" = "ERROR" ]; then
+        prefix="[${ERROR}x${RESET}]" # [x]
+    elif [ "$log_level" = "SUCCESS" ]; then
+        prefix="[${SUCCESS}+${RESET}]" # [+]
+    elif [ "$log_level" = "WARNING" ]; then
+        prefix="[${WARNING}-${RESET}]" # [-]
+    else
+        log "ERROR" "Unknown log level" "$log_level"
+        exit 1
+    fi
+
+    if [ "$log_level" = "ERROR" ] || [ "$log_level" = "WARNING" ]; then
+        # Print log to stderr
+        >&2 printf "%b %-*s %s\n" "$prefix" "$SUMMARY_WIDTH" "$summary" "$description"
+    else
+        # Print log to stdout
+        printf "%b %-*s %s\n" "$prefix" "$SUMMARY_WIDTH" "$summary" "$description"
+    fi
+}
+
+main

--- a/self_hosted/ROADMAP
+++ b/self_hosted/ROADMAP
@@ -53,10 +53,9 @@ Infrastructure for building, testing, and distributing without Python.
      Targets: bootstrap, stage1, stage2, verify, test, test-examples,
      install, clean. Support BOOTSTRAP=python for dev.
 
-3.2  GitHub Release workflow
-     Triggered on version tags. Build stage1 from Python, stage2 from
-     stage1, verify fixed-point, publish casa-linux-x86_64 binary +
-     SHA256 checksum.
+3.2  GitHub Release workflow  [DONE — manual]
+     v1.0.0 release created manually with casac binary.
+     install.sh script downloads the latest release.
 
 3.3  Update CI workflows
      Download release binary → build stage2 → run all tests.


### PR DESCRIPTION
## Summary
- Add `install.sh` script that downloads the `casac` compiler binary from the latest GitHub release
- Update `README.md` to document installation via install script, self-hosted compiler usage, and Casa LSP
- Mark ROADMAP item 3.2 (GitHub Release) as done

## Changes
- **install.sh**: Downloads `casac` from GitHub releases, checks for `as`/`ld` dependencies, offers to install `binutils` on Debian/Ubuntu/Kali
- **README.md**: Updated requirements (removed Python), added installation section, updated CLI examples to use `./casac`, updated editor integration for Casa LSP
- **self_hosted/ROADMAP**: Marked 3.2 as done (manual release)

## Test plan
- [x] All 32 example tests pass
- [x] v1.0.0 release created with `casac` binary
- [x] Release API returns correct asset info
- [x] Bootstrap fixed-point verified (stage2.s == stage3.s)