### PR TITLE
Allow all comparison operators on enum values

### DIFF
--- a/casa/bytecode.py
+++ b/casa/bytecode.py
@@ -556,8 +556,15 @@ class Compiler:
         bytecode.append(self.inst(InstKind.LOCAL_GET, args=[local_a]))
         bytecode.append(self.inst(InstKind.LOAD64))
         # Compare ordinals
-        inst_kind = InstKind.EQ if op.kind == OpKind.EQ else InstKind.NE
-        bytecode.append(self.inst(inst_kind))
+        enum_cmp_ops = {
+            OpKind.EQ: InstKind.EQ,
+            OpKind.NE: InstKind.NE,
+            OpKind.LT: InstKind.LT,
+            OpKind.LE: InstKind.LE,
+            OpKind.GT: InstKind.GT,
+            OpKind.GE: InstKind.GE,
+        }
+        bytecode.append(self.inst(enum_cmp_ops[op.kind]))
 
     def _compile_is_check(self, op: Op, bytecode: list[Inst]) -> None:
         """Compile IS_CHECK: variant check that pushes bool, optionally extracts bindings."""
@@ -789,7 +796,15 @@ class Compiler:
             if op.kind in DIRECT_OP_TO_INST:
                 # Data-carrying enum comparison: load ordinals from heap
                 if (
-                    op.kind in (OpKind.EQ, OpKind.NE)
+                    op.kind
+                    in (
+                        OpKind.EQ,
+                        OpKind.NE,
+                        OpKind.LT,
+                        OpKind.LE,
+                        OpKind.GT,
+                        OpKind.GE,
+                    )
                     and op.type_annotation
                     and op.type_annotation in GLOBAL_ENUMS
                 ):

--- a/casa/typechecker.py
+++ b/casa/typechecker.py
@@ -392,12 +392,6 @@ class TypeChecker:
                     f"Cannot compare `{t2}` with `{t1}`",
                     self.current_location,
                 )
-            if op.kind not in (OpKind.EQ, OpKind.NE):
-                raise_error(
-                    ErrorKind.TYPE_MISMATCH,
-                    f"Enum type `{t1}` only supports `==` and `!=` comparison",
-                    self.current_location,
-                )
             # Annotate for bytecode: data-carrying enums need heap tag comparison
             assert t1_enum is not None
             casa_enum = GLOBAL_ENUMS[t1_enum]

--- a/docs/enums.md
+++ b/docs/enums.md
@@ -76,13 +76,15 @@ Color::Blue = my_color
 
 ## Comparison
 
-Enum values of the same type can be compared with `==` and `!=`. For data-carrying enums, comparison checks the variant tag only (not inner values).
+Enum values of the same type can be compared with all comparison operators (`==`, `!=`, `<`, `<=`, `>`, `>=`). Ordering is based on the declaration order of variants (0-based ordinal). For data-carrying enums, comparison checks the variant tag only (not inner values).
 
 **Stack effect:** `EnumName EnumName -> bool`
 
 ```casa
 Color::Red Color::Red == print     # true
 Color::Red Color::Blue != print    # true
+Color::Blue Color::Red < print     # true (Red < Blue, ordinal 0 < 2)
+Color::Red Color::Blue > print     # true (Blue > Red, ordinal 2 > 0)
 ```
 
 Comparing values of different enum types is a compile-time error:

--- a/docs/types-and-literals.md
+++ b/docs/types-and-literals.md
@@ -377,7 +377,7 @@ enum Color { Red Green Blue }
 Color::Red = c    # c has type Color
 ```
 
-Enum values support `==` and `!=` comparison (same enum type only). Printing outputs the ordinal. Pattern matching is done with `match`/`end`.
+Enum values support all comparison operators (`==`, `!=`, `<`, `<=`, `>`, `>=`) on the same enum type. Ordering is by declaration order. Printing outputs the ordinal. Pattern matching is done with `match`/`end`.
 
 See [Enums](enums.md) for details.
 

--- a/examples/enum.casa
+++ b/examples/enum.casa
@@ -13,9 +13,12 @@ Color::Red print "\n" print
 Color::Green print "\n" print
 Color::Blue print "\n" print
 
-# Comparison with == and !=
+# Comparison with ==, !=, <, <=, >, >=
 color Color::Green == print "\n" print
 color Color::Red != print "\n" print
+# RPN: Color::Blue Color::Red < means Red < Blue (0 < 2)
+Color::Blue Color::Red < print "\n" print
+Color::Red Color::Blue > print "\n" print
 
 # Match statement with side effects
 color match

--- a/examples/outputs/enum.out
+++ b/examples/outputs/enum.out
@@ -3,6 +3,8 @@
 2
 true
 true
+true
+true
 green
 cool
 0

--- a/lib/test_helpers.casa
+++ b/lib/test_helpers.casa
@@ -45,7 +45,7 @@ fn assert_error_contains needle:str msg:str {
     msg aec_found assert_true
 }
 
-fn assert_error_kind expected_kind:int msg:str {
+fn assert_error_kind expected_kind:ErrorKind msg:str {
     false = aek_found
     0 = aek_i
     while aek_i ERRORS .length > do

--- a/self_hosted/bytecode.casa
+++ b/self_hosted/bytecode.casa
@@ -113,36 +113,36 @@ fn resolve_variable compiler:BytecodeCompiler variable_name:str -> ResolvedVaria
         variable_name function Function::variables variable_list_contains = is_local
         if is_local then
             variable_name function Function::variables variable_list_index = local_index
-            local_index InstKind::InstLocalSet (int) InstKind::InstLocalGet (int) ResolvedVariable return
+            local_index InstKind::InstLocalSet InstKind::InstLocalGet ResolvedVariable return
         fi
     fi
     variable_name GLOBAL_VARIABLES .has = is_global
     if is_global then
         variable_name GLOBAL_VARIABLES .keys string_list_index = global_index
-        global_index InstKind::InstGlobalSet (int) InstKind::InstGlobalGet (int) ResolvedVariable return
+        global_index InstKind::InstGlobalSet InstKind::InstGlobalGet ResolvedVariable return
     fi
     f"Variable `{variable_name}` is not defined\n" eprint
     1 exit
-    0 0 0 ResolvedVariable
+    0 InstKind::InstAdd InstKind::InstAdd ResolvedVariable
 }
 
 # ============================================================================
 # Block matching (find_matching_label)
 # ============================================================================
 
-fn is_block_start_kind kind:int -> bool {
-    OpKind::OpIfStart (int) kind ==
-    OpKind::OpWhileStart (int) kind == ||
-    OpKind::OpMatchStart (int) kind == ||
+fn is_block_start_kind kind:OpKind -> bool {
+    OpKind::OpIfStart kind ==
+    OpKind::OpWhileStart kind == ||
+    OpKind::OpMatchStart kind == ||
 }
 
-fn is_block_end_kind kind:int -> bool {
-    OpKind::OpIfEnd (int) kind ==
-    OpKind::OpWhileEnd (int) kind == ||
-    OpKind::OpMatchEnd (int) kind == ||
+fn is_block_end_kind kind:OpKind -> bool {
+    OpKind::OpIfEnd kind ==
+    OpKind::OpWhileEnd kind == ||
+    OpKind::OpMatchEnd kind == ||
 }
 
-fn find_matching_label_forward ops:List[Op] op_index:int end_kind:int target_kinds:List[int] -> Option[int] {
+fn find_matching_label_forward ops:List[Op] op_index:int end_kind:OpKind target_kinds:List[OpKind] -> Option[int] {
     # Search forward from op_index+1 for matching target, respecting nesting.
     1 = depth
     op_index 1 + = index
@@ -150,7 +150,7 @@ fn find_matching_label_forward ops:List[Op] op_index:int end_kind:int target_kin
         index ops .get = other_op
         other_op Op::kind = kind
         if 1 depth <= then
-            kind target_kinds int_list_contains = found
+            kind target_kinds opkind_list_contains = found
             if found then
                 index ops op_ptr_to_label Option::Some return
             fi
@@ -170,7 +170,7 @@ fn find_matching_label_forward ops:List[Op] op_index:int end_kind:int target_kin
     Option::None
 }
 
-fn find_matching_label_reverse ops:List[Op] op_index:int start_kind:int target_kinds:List[int] -> Option[int] {
+fn find_matching_label_reverse ops:List[Op] op_index:int start_kind:OpKind target_kinds:List[OpKind] -> Option[int] {
     # Search backward from op_index-1 for matching target, respecting nesting.
     1 = depth
     op_index 1 - = index
@@ -178,7 +178,7 @@ fn find_matching_label_reverse ops:List[Op] op_index:int start_kind:int target_k
         index ops .get = other_op
         other_op Op::kind = kind
         if 1 depth <= then
-            kind target_kinds int_list_contains = found
+            kind target_kinds opkind_list_contains = found
             if found then
                 index ops op_ptr_to_label Option::Some return
             fi
@@ -198,7 +198,7 @@ fn find_matching_label_reverse ops:List[Op] op_index:int start_kind:int target_k
     Option::None
 }
 
-fn int_list_contains items:List[int] value:int -> bool {
+fn opkind_list_contains items:List[OpKind] value:OpKind -> bool {
     0 = index
     while index items .length > do
         if value index items .get == then
@@ -209,20 +209,20 @@ fn int_list_contains items:List[int] value:int -> bool {
     false
 }
 
-fn require_matching_forward ops:List[Op] op_index:int end_kind:int target_kinds:List[int] location:Location message:str -> int {
+fn require_matching_forward ops:List[Op] op_index:int end_kind:OpKind target_kinds:List[OpKind] location:Location message:str -> int {
     target_kinds end_kind op_index ops find_matching_label_forward = result
     if result .is_none then
-        location message ErrorKind::UnmatchedBlock (int) make_error ERRORS .push
+        location message ErrorKind::UnmatchedBlock make_error ERRORS .push
         0
     else
         result .unwrap
     fi
 }
 
-fn require_matching_reverse ops:List[Op] op_index:int start_kind:int target_kinds:List[int] location:Location message:str -> int {
+fn require_matching_reverse ops:List[Op] op_index:int start_kind:OpKind target_kinds:List[OpKind] location:Location message:str -> int {
     target_kinds start_kind op_index ops find_matching_label_reverse = result
     if result .is_none then
-        location message ErrorKind::UnmatchedBlock (int) make_error ERRORS .push
+        location message ErrorKind::UnmatchedBlock make_error ERRORS .push
         0
     else
         result .unwrap
@@ -240,16 +240,16 @@ fn compile_assignment compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
     resolved ResolvedVariable::set_kind = set_kind
     resolved ResolvedVariable::index = var_index
 
-    if OpKind::OpAssignDec (int) op Op::kind == then
+    if OpKind::OpAssignDec op Op::kind == then
         var_index get_kind make_inst_int bytecode .push
-        InstKind::InstSwap (int) make_inst bytecode .push
-        InstKind::InstSub (int) make_inst bytecode .push
+        InstKind::InstSwap make_inst bytecode .push
+        InstKind::InstSub make_inst bytecode .push
         var_index set_kind make_inst_int bytecode .push
-    elif OpKind::OpAssignInc (int) op Op::kind == then
+    elif OpKind::OpAssignInc op Op::kind == then
         var_index get_kind make_inst_int bytecode .push
-        InstKind::InstAdd (int) make_inst bytecode .push
+        InstKind::InstAdd make_inst bytecode .push
         var_index set_kind make_inst_int bytecode .push
-    elif OpKind::OpAssignVar (int) op Op::kind == then
+    elif OpKind::OpAssignVar op Op::kind == then
         var_index set_kind make_inst_int bytecode .push
     fi
 }
@@ -262,42 +262,42 @@ fn compile_if_block compiler:BytecodeCompiler op:Op op_index:int bytecode:List[I
     compiler BytecodeCompiler::ops = ops
     op Op::location = loc
 
-    List::new (List[int]) = start_targets
-    OpKind::OpIfStart (int) start_targets .push
+    List::new (List[OpKind]) = start_targets
+    OpKind::OpIfStart start_targets .push
 
-    List::new (List[int]) = elif_else_end
-    OpKind::OpIfElif (int) elif_else_end .push
-    OpKind::OpIfElse (int) elif_else_end .push
-    OpKind::OpIfEnd (int) elif_else_end .push
+    List::new (List[OpKind]) = elif_else_end
+    OpKind::OpIfElif elif_else_end .push
+    OpKind::OpIfElse elif_else_end .push
+    OpKind::OpIfEnd elif_else_end .push
 
-    List::new (List[int]) = end_targets
-    OpKind::OpIfEnd (int) end_targets .push
+    List::new (List[OpKind]) = end_targets
+    OpKind::OpIfEnd end_targets .push
 
-    List::new (List[int]) = else_targets
-    OpKind::OpIfElse (int) else_targets .push
+    List::new (List[OpKind]) = else_targets
+    OpKind::OpIfElse else_targets .push
 
-    if OpKind::OpIfCondition (int) op Op::kind == then
-        "`then` without matching `if`" loc start_targets OpKind::OpIfStart (int) op_index ops require_matching_reverse drop
-        "`then` without matching `fi`" loc elif_else_end OpKind::OpIfEnd (int) op_index ops require_matching_forward = end_label
-        end_label InstKind::InstJumpNe (int) make_inst_int bytecode .push
-    elif OpKind::OpIfElif (int) op Op::kind == then
-        "`elif` without parent `if`" loc start_targets OpKind::OpIfStart (int) op_index ops require_matching_reverse drop
+    if OpKind::OpIfCondition op Op::kind == then
+        "`then` without matching `if`" loc start_targets OpKind::OpIfStart op_index ops require_matching_reverse drop
+        "`then` without matching `fi`" loc elif_else_end OpKind::OpIfEnd op_index ops require_matching_forward = end_label
+        end_label InstKind::InstJumpNe make_inst_int bytecode .push
+    elif OpKind::OpIfElif op Op::kind == then
+        "`elif` without parent `if`" loc start_targets OpKind::OpIfStart op_index ops require_matching_reverse drop
         op_index compiler BytecodeCompiler::ops op_ptr_to_label = elif_label
-        "`elif` without matching `fi`" loc end_targets OpKind::OpIfEnd (int) op_index ops require_matching_forward = end_label_2
-        end_label_2 InstKind::InstJump (int) make_inst_int bytecode .push
-        elif_label InstKind::InstLabel (int) make_inst_int bytecode .push
-    elif OpKind::OpIfElse (int) op Op::kind == then
-        "`else` without parent `if`" loc start_targets OpKind::OpIfStart (int) op_index ops require_matching_reverse drop
+        "`elif` without matching `fi`" loc end_targets OpKind::OpIfEnd op_index ops require_matching_forward = end_label_2
+        end_label_2 InstKind::InstJump make_inst_int bytecode .push
+        elif_label InstKind::InstLabel make_inst_int bytecode .push
+    elif OpKind::OpIfElse op Op::kind == then
+        "`else` without parent `if`" loc start_targets OpKind::OpIfStart op_index ops require_matching_reverse drop
         op_index compiler BytecodeCompiler::ops op_ptr_to_label = else_label
-        "`else` without matching `fi`" loc end_targets OpKind::OpIfEnd (int) op_index ops require_matching_forward = end_label_3
-        end_label_3 InstKind::InstJump (int) make_inst_int bytecode .push
-        else_label InstKind::InstLabel (int) make_inst_int bytecode .push
-    elif OpKind::OpIfEnd (int) op Op::kind == then
-        "`fi` without parent `if`" loc start_targets OpKind::OpIfStart (int) op_index ops require_matching_reverse drop
+        "`else` without matching `fi`" loc end_targets OpKind::OpIfEnd op_index ops require_matching_forward = end_label_3
+        end_label_3 InstKind::InstJump make_inst_int bytecode .push
+        else_label InstKind::InstLabel make_inst_int bytecode .push
+    elif OpKind::OpIfEnd op Op::kind == then
+        "`fi` without parent `if`" loc start_targets OpKind::OpIfStart op_index ops require_matching_reverse drop
         op_index compiler BytecodeCompiler::ops op_ptr_to_label = fi_label
-        fi_label InstKind::InstLabel (int) make_inst_int bytecode .push
-    elif OpKind::OpIfStart (int) op Op::kind == then
-        "`if` without matching `fi`" loc end_targets OpKind::OpIfEnd (int) op_index ops require_matching_forward drop
+        fi_label InstKind::InstLabel make_inst_int bytecode .push
+    elif OpKind::OpIfStart op Op::kind == then
+        "`if` without matching `fi`" loc end_targets OpKind::OpIfEnd op_index ops require_matching_forward drop
     fi
 }
 
@@ -309,31 +309,31 @@ fn compile_while_block compiler:BytecodeCompiler op:Op op_index:int bytecode:Lis
     compiler BytecodeCompiler::ops = ops
     op Op::location = loc
 
-    List::new (List[int]) = start_targets
-    OpKind::OpWhileStart (int) start_targets .push
+    List::new (List[OpKind]) = start_targets
+    OpKind::OpWhileStart start_targets .push
 
-    List::new (List[int]) = end_targets
-    OpKind::OpWhileEnd (int) end_targets .push
+    List::new (List[OpKind]) = end_targets
+    OpKind::OpWhileEnd end_targets .push
 
-    if OpKind::OpWhileBreak (int) op Op::kind == then
-        "`break` without parent `while`" loc start_targets OpKind::OpWhileStart (int) op_index ops require_matching_reverse drop
-        "`break` without matching `done`" loc end_targets OpKind::OpWhileEnd (int) op_index ops require_matching_forward = end_label
-        end_label InstKind::InstJump (int) make_inst_int bytecode .push
-    elif OpKind::OpWhileCondition (int) op Op::kind == then
-        "`do` without parent `while`" loc start_targets OpKind::OpWhileStart (int) op_index ops require_matching_reverse drop
-        "`do` without matching `done`" loc end_targets OpKind::OpWhileEnd (int) op_index ops require_matching_forward = end_label_2
-        end_label_2 InstKind::InstJumpNe (int) make_inst_int bytecode .push
-    elif OpKind::OpWhileContinue (int) op Op::kind == then
-        "`continue` without parent `while`" loc start_targets OpKind::OpWhileStart (int) op_index ops require_matching_reverse = continue_target
-        continue_target InstKind::InstJump (int) make_inst_int bytecode .push
-    elif OpKind::OpWhileEnd (int) op Op::kind == then
+    if OpKind::OpWhileBreak op Op::kind == then
+        "`break` without parent `while`" loc start_targets OpKind::OpWhileStart op_index ops require_matching_reverse drop
+        "`break` without matching `done`" loc end_targets OpKind::OpWhileEnd op_index ops require_matching_forward = end_label
+        end_label InstKind::InstJump make_inst_int bytecode .push
+    elif OpKind::OpWhileCondition op Op::kind == then
+        "`do` without parent `while`" loc start_targets OpKind::OpWhileStart op_index ops require_matching_reverse drop
+        "`do` without matching `done`" loc end_targets OpKind::OpWhileEnd op_index ops require_matching_forward = end_label_2
+        end_label_2 InstKind::InstJumpNe make_inst_int bytecode .push
+    elif OpKind::OpWhileContinue op Op::kind == then
+        "`continue` without parent `while`" loc start_targets OpKind::OpWhileStart op_index ops require_matching_reverse = continue_target
+        continue_target InstKind::InstJump make_inst_int bytecode .push
+    elif OpKind::OpWhileEnd op Op::kind == then
         op_index compiler BytecodeCompiler::ops op_ptr_to_label = while_label
-        "`done` without parent `while`" loc start_targets OpKind::OpWhileStart (int) op_index ops require_matching_reverse = loop_start
-        loop_start InstKind::InstJump (int) make_inst_int bytecode .push
-        while_label InstKind::InstLabel (int) make_inst_int bytecode .push
-    elif OpKind::OpWhileStart (int) op Op::kind == then
+        "`done` without parent `while`" loc start_targets OpKind::OpWhileStart op_index ops require_matching_reverse = loop_start
+        loop_start InstKind::InstJump make_inst_int bytecode .push
+        while_label InstKind::InstLabel make_inst_int bytecode .push
+    elif OpKind::OpWhileStart op Op::kind == then
         op_index compiler BytecodeCompiler::ops op_ptr_to_label = start_label
-        start_label InstKind::InstLabel (int) make_inst_int bytecode .push
+        start_label InstKind::InstLabel make_inst_int bytecode .push
     fi
 }
 
@@ -347,50 +347,50 @@ fn compile_match_arm_enum compiler:BytecodeCompiler pattern_ptr:int is_last:bool
     enum_name GLOBAL_ENUMS .get .unwrap = casa_enum
 
     if is_last ! variant is_wildcard_variant ! && then
-        InstKind::InstDup (int) make_inst bytecode .push
-        InstKind::InstLoad64 (int) make_inst bytecode .push
-        variant EnumVariant::ordinal .unwrap InstKind::InstPush (int) make_inst_int bytecode .push
-        InstKind::InstEq (int) make_inst bytecode .push
-        next_arm .unwrap InstKind::InstJumpNe (int) make_inst_int bytecode .push
+        InstKind::InstDup make_inst bytecode .push
+        InstKind::InstLoad64 make_inst bytecode .push
+        variant EnumVariant::ordinal .unwrap InstKind::InstPush make_inst_int bytecode .push
+        InstKind::InstEq make_inst bytecode .push
+        next_arm .unwrap InstKind::InstJumpNe make_inst_int bytecode .push
     fi
 
     # Extract bindings
     0 = index
     while index variant EnumVariant::bindings .length > do
         index 1 + 8 * = offset
-        InstKind::InstDup (int) make_inst bytecode .push
-        offset InstKind::InstPush (int) make_inst_int bytecode .push
-        InstKind::InstAdd (int) make_inst bytecode .push
-        InstKind::InstLoad64 (int) make_inst bytecode .push
+        InstKind::InstDup make_inst bytecode .push
+        offset InstKind::InstPush make_inst_int bytecode .push
+        InstKind::InstAdd make_inst bytecode .push
+        InstKind::InstLoad64 make_inst bytecode .push
         index variant EnumVariant::bindings .get = var_name
         var_name compiler resolve_variable = resolved
         resolved ResolvedVariable::index resolved ResolvedVariable::set_kind make_inst_int bytecode .push
         1 += index
     done
-    InstKind::InstDrop (int) make_inst bytecode .push
+    InstKind::InstDrop make_inst bytecode .push
 }
 
 fn compile_match_arm_literal compiler:BytecodeCompiler pattern_ptr:int is_last:bool next_arm:Option[int] bytecode:List[Inst] {
     pattern_ptr (LiteralPattern) = pattern
     if is_last then
-        InstKind::InstDrop (int) make_inst bytecode .push
+        InstKind::InstDrop make_inst bytecode .push
         return
     fi
-    InstKind::InstDup (int) make_inst bytecode .push
+    InstKind::InstDup make_inst bytecode .push
     if "str" pattern LiteralPattern::typ == then
         pattern LiteralPattern::value (str) = str_value
         str_value compiler intern_string = str_index
-        str_index InstKind::InstPushStr (int) make_inst_int bytecode .push
-        InstKind::InstStrEq (int) make_inst bytecode .push
+        str_index InstKind::InstPushStr make_inst_int bytecode .push
+        InstKind::InstStrEq make_inst bytecode .push
     elif "char" pattern LiteralPattern::typ == then
-        pattern LiteralPattern::value InstKind::InstPush (int) make_inst_int bytecode .push
-        InstKind::InstEq (int) make_inst bytecode .push
+        pattern LiteralPattern::value InstKind::InstPush make_inst_int bytecode .push
+        InstKind::InstEq make_inst bytecode .push
     else
-        pattern LiteralPattern::value InstKind::InstPush (int) make_inst_int bytecode .push
-        InstKind::InstEq (int) make_inst bytecode .push
+        pattern LiteralPattern::value InstKind::InstPush make_inst_int bytecode .push
+        InstKind::InstEq make_inst bytecode .push
     fi
-    next_arm .unwrap InstKind::InstJumpNe (int) make_inst_int bytecode .push
-    InstKind::InstDrop (int) make_inst bytecode .push
+    next_arm .unwrap InstKind::InstJumpNe make_inst_int bytecode .push
+    InstKind::InstDrop make_inst bytecode .push
 }
 
 fn compile_match_arm_struct compiler:BytecodeCompiler pattern_ptr:int bytecode:List[Inst] {
@@ -406,47 +406,47 @@ fn compile_match_arm_struct compiler:BytecodeCompiler pattern_ptr:int bytecode:L
         # Check if this field is bound
         field_name pattern StructPattern::bindings .get = binding
         if binding .is_some then
-            InstKind::InstDup (int) make_inst bytecode .push
+            InstKind::InstDup make_inst bytecode .push
             if 0 offset > then
-                offset InstKind::InstPush (int) make_inst_int bytecode .push
-                InstKind::InstAdd (int) make_inst bytecode .push
+                offset InstKind::InstPush make_inst_int bytecode .push
+                InstKind::InstAdd make_inst bytecode .push
             fi
-            InstKind::InstLoad64 (int) make_inst bytecode .push
+            InstKind::InstLoad64 make_inst bytecode .push
             binding .unwrap = var_name
             var_name compiler resolve_variable = resolved
             resolved ResolvedVariable::index resolved ResolvedVariable::set_kind make_inst_int bytecode .push
         fi
         1 += index
     done
-    InstKind::InstDrop (int) make_inst bytecode .push
+    InstKind::InstDrop make_inst bytecode .push
 }
 
 fn compile_match_block compiler:BytecodeCompiler op:Op op_index:int bytecode:List[Inst] {
     compiler BytecodeCompiler::ops = ops
 
-    if OpKind::OpMatchStart (int) op Op::kind == then
+    if OpKind::OpMatchStart op Op::kind == then
         # Nothing to emit
-    elif OpKind::OpMatchArm (int) op Op::kind == then
+    elif OpKind::OpMatchArm op Op::kind == then
         op Op::location = loc
 
-        List::new (List[int]) = end_targets
-        OpKind::OpMatchEnd (int) end_targets .push
+        List::new (List[OpKind]) = end_targets
+        OpKind::OpMatchEnd end_targets .push
 
-        "`match` arm without matching `end`" loc end_targets OpKind::OpMatchEnd (int) op_index ops require_matching_forward = end_label
+        "`match` arm without matching `end`" loc end_targets OpKind::OpMatchEnd op_index ops require_matching_forward = end_label
 
         # Check if this is the first arm (label not yet assigned)
         op_index ops .get (int) OP_LABEL_MAP .get = existing
         existing .is_some ! = is_first
 
         if is_first ! then
-            end_label InstKind::InstJump (int) make_inst_int bytecode .push
-            existing .unwrap InstKind::InstLabel (int) make_inst_int bytecode .push
+            end_label InstKind::InstJump make_inst_int bytecode .push
+            existing .unwrap InstKind::InstLabel make_inst_int bytecode .push
         fi
 
         # Find next arm
-        List::new (List[int]) = arm_targets
-        OpKind::OpMatchArm (int) arm_targets .push
-        arm_targets OpKind::OpMatchEnd (int) op_index ops find_matching_label_forward = next_arm
+        List::new (List[OpKind]) = arm_targets
+        OpKind::OpMatchArm arm_targets .push
+        arm_targets OpKind::OpMatchEnd op_index ops find_matching_label_forward = next_arm
         next_arm .is_none = is_last
 
         op Op::value = pattern_ptr
@@ -469,27 +469,27 @@ fn compile_match_block compiler:BytecodeCompiler op:Op op_index:int bytecode:Lis
                 if has_inner then
                     bytecode next_arm is_last pattern_ptr compiler compile_match_arm_enum
                 elif is_last then
-                    InstKind::InstDrop (int) make_inst bytecode .push
+                    InstKind::InstDrop make_inst bytecode .push
                 else
-                    InstKind::InstDup (int) make_inst bytecode .push
-                    variant EnumVariant::ordinal .unwrap InstKind::InstPush (int) make_inst_int bytecode .push
-                    InstKind::InstEq (int) make_inst bytecode .push
-                    next_arm .unwrap InstKind::InstJumpNe (int) make_inst_int bytecode .push
-                    InstKind::InstDrop (int) make_inst bytecode .push
+                    InstKind::InstDup make_inst bytecode .push
+                    variant EnumVariant::ordinal .unwrap InstKind::InstPush make_inst_int bytecode .push
+                    InstKind::InstEq make_inst bytecode .push
+                    next_arm .unwrap InstKind::InstJumpNe make_inst_int bytecode .push
+                    InstKind::InstDrop make_inst bytecode .push
                 fi
             elif is_last then
-                InstKind::InstDrop (int) make_inst bytecode .push
+                InstKind::InstDrop make_inst bytecode .push
             else
-                InstKind::InstDup (int) make_inst bytecode .push
-                variant EnumVariant::ordinal .unwrap InstKind::InstPush (int) make_inst_int bytecode .push
-                InstKind::InstEq (int) make_inst bytecode .push
-                next_arm .unwrap InstKind::InstJumpNe (int) make_inst_int bytecode .push
-                InstKind::InstDrop (int) make_inst bytecode .push
+                InstKind::InstDup make_inst bytecode .push
+                variant EnumVariant::ordinal .unwrap InstKind::InstPush make_inst_int bytecode .push
+                InstKind::InstEq make_inst bytecode .push
+                next_arm .unwrap InstKind::InstJumpNe make_inst_int bytecode .push
+                InstKind::InstDrop make_inst bytecode .push
             fi
         fi
-    elif OpKind::OpMatchEnd (int) op Op::kind == then
+    elif OpKind::OpMatchEnd op Op::kind == then
         op_index compiler BytecodeCompiler::ops op_ptr_to_label = end_match_label
-        end_match_label InstKind::InstLabel (int) make_inst_int bytecode .push
+        end_match_label InstKind::InstLabel make_inst_int bytecode .push
     fi
 }
 
@@ -500,17 +500,17 @@ fn compile_match_block compiler:BytecodeCompiler op:Op op_index:int bytecode:Lis
 fn compile_struct_new compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
     op Op::value (CasaStruct) = casa_struct
     casa_struct CasaStruct::members .length = count
-    count 8 * InstKind::InstPush (int) make_inst_int bytecode .push
-    InstKind::InstHeapAlloc (int) make_inst bytecode .push
+    count 8 * InstKind::InstPush make_inst_int bytecode .push
+    InstKind::InstHeapAlloc make_inst bytecode .push
     0 = index
     while index count > do
-        InstKind::InstSwap (int) make_inst bytecode .push
-        InstKind::InstOver (int) make_inst bytecode .push
+        InstKind::InstSwap make_inst bytecode .push
+        InstKind::InstOver make_inst bytecode .push
         if 0 index > then
-            index 8 * InstKind::InstPush (int) make_inst_int bytecode .push
-            InstKind::InstAdd (int) make_inst bytecode .push
+            index 8 * InstKind::InstPush make_inst_int bytecode .push
+            InstKind::InstAdd make_inst bytecode .push
         fi
-        InstKind::InstStore64 (int) make_inst bytecode .push
+        InstKind::InstStore64 make_inst bytecode .push
         1 += index
     done
 }
@@ -535,21 +535,21 @@ fn compile_enum_variant compiler:BytecodeCompiler variant:EnumVariant casa_enum:
         compiler BytecodeCompiler::locals_count = local_index
         compiler BytecodeCompiler::locals_count 1 + compiler->locals_count
         local_index temps .push
-        local_index InstKind::InstLocalSet (int) make_inst_int bytecode .push
+        local_index InstKind::InstLocalSet make_inst_int bytecode .push
         1 += index
     done
 
     # Allocate heap
     compiler BytecodeCompiler::locals_count = ptr_local
     compiler BytecodeCompiler::locals_count 1 + compiler->locals_count
-    slot_count 8 * InstKind::InstPush (int) make_inst_int bytecode .push
-    InstKind::InstHeapAlloc (int) make_inst bytecode .push
-    ptr_local InstKind::InstLocalSet (int) make_inst_int bytecode .push
+    slot_count 8 * InstKind::InstPush make_inst_int bytecode .push
+    InstKind::InstHeapAlloc make_inst bytecode .push
+    ptr_local InstKind::InstLocalSet make_inst_int bytecode .push
 
     # Store ordinal at offset 0
-    variant EnumVariant::ordinal .unwrap InstKind::InstPush (int) make_inst_int bytecode .push
-    ptr_local InstKind::InstLocalGet (int) make_inst_int bytecode .push
-    InstKind::InstStore64 (int) make_inst bytecode .push
+    variant EnumVariant::ordinal .unwrap InstKind::InstPush make_inst_int bytecode .push
+    ptr_local InstKind::InstLocalGet make_inst_int bytecode .push
+    InstKind::InstStore64 make_inst bytecode .push
 
     # Store inner values at offsets 8, 16, ...
     # Reversed temp_locals
@@ -557,18 +557,18 @@ fn compile_enum_variant compiler:BytecodeCompiler variant:EnumVariant casa_enum:
     while inner_index inner_count > do
         inner_count 1 - inner_index - = reverse_index
         inner_index 1 + 8 * = offset
-        ptr_local InstKind::InstLocalGet (int) make_inst_int bytecode .push
-        offset InstKind::InstPush (int) make_inst_int bytecode .push
-        InstKind::InstAdd (int) make_inst bytecode .push
+        ptr_local InstKind::InstLocalGet make_inst_int bytecode .push
+        offset InstKind::InstPush make_inst_int bytecode .push
+        InstKind::InstAdd make_inst bytecode .push
         reverse_index temps .get = temp_local
-        temp_local InstKind::InstLocalGet (int) make_inst_int bytecode .push
-        InstKind::InstSwap (int) make_inst bytecode .push
-        InstKind::InstStore64 (int) make_inst bytecode .push
+        temp_local InstKind::InstLocalGet make_inst_int bytecode .push
+        InstKind::InstSwap make_inst bytecode .push
+        InstKind::InstStore64 make_inst bytecode .push
         1 += inner_index
     done
 
     # Push pointer
-    ptr_local InstKind::InstLocalGet (int) make_inst_int bytecode .push
+    ptr_local InstKind::InstLocalGet make_inst_int bytecode .push
 }
 
 # ============================================================================
@@ -582,16 +582,16 @@ fn compile_is_check compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
 
     if casa_enum has_inner_values ! then
         # Plain enum: compare ordinal directly
-        variant EnumVariant::ordinal .unwrap InstKind::InstPush (int) make_inst_int bytecode .push
-        InstKind::InstEq (int) make_inst bytecode .push
+        variant EnumVariant::ordinal .unwrap InstKind::InstPush make_inst_int bytecode .push
+        InstKind::InstEq make_inst bytecode .push
         return
     fi
 
     if 0 variant EnumVariant::bindings .length == then
         # Data-carrying enum, no bindings: load ordinal and compare
-        InstKind::InstLoad64 (int) make_inst bytecode .push
-        variant EnumVariant::ordinal .unwrap InstKind::InstPush (int) make_inst_int bytecode .push
-        InstKind::InstEq (int) make_inst bytecode .push
+        InstKind::InstLoad64 make_inst bytecode .push
+        variant EnumVariant::ordinal .unwrap InstKind::InstPush make_inst_int bytecode .push
+        InstKind::InstEq make_inst bytecode .push
         return
     fi
 
@@ -602,33 +602,33 @@ fn compile_is_check compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
     new_label = skip_bindings
 
     # Save enum pointer
-    temp_ptr InstKind::InstLocalSet (int) make_inst_int bytecode .push
+    temp_ptr InstKind::InstLocalSet make_inst_int bytecode .push
 
     # Load ordinal and compare
-    temp_ptr InstKind::InstLocalGet (int) make_inst_int bytecode .push
-    InstKind::InstLoad64 (int) make_inst bytecode .push
-    variant EnumVariant::ordinal .unwrap InstKind::InstPush (int) make_inst_int bytecode .push
-    InstKind::InstEq (int) make_inst bytecode .push
+    temp_ptr InstKind::InstLocalGet make_inst_int bytecode .push
+    InstKind::InstLoad64 make_inst bytecode .push
+    variant EnumVariant::ordinal .unwrap InstKind::InstPush make_inst_int bytecode .push
+    InstKind::InstEq make_inst bytecode .push
 
     # Duplicate bool
-    InstKind::InstDup (int) make_inst bytecode .push
-    skip_bindings InstKind::InstJumpNe (int) make_inst_int bytecode .push
+    InstKind::InstDup make_inst bytecode .push
+    skip_bindings InstKind::InstJumpNe make_inst_int bytecode .push
 
     # Extract bindings
     0 = index
     while index variant EnumVariant::bindings .length > do
         index 1 + 8 * = offset
-        temp_ptr InstKind::InstLocalGet (int) make_inst_int bytecode .push
-        offset InstKind::InstPush (int) make_inst_int bytecode .push
-        InstKind::InstAdd (int) make_inst bytecode .push
-        InstKind::InstLoad64 (int) make_inst bytecode .push
+        temp_ptr InstKind::InstLocalGet make_inst_int bytecode .push
+        offset InstKind::InstPush make_inst_int bytecode .push
+        InstKind::InstAdd make_inst bytecode .push
+        InstKind::InstLoad64 make_inst bytecode .push
         index variant EnumVariant::bindings .get = var_name
         var_name compiler resolve_variable = resolved
         resolved ResolvedVariable::index resolved ResolvedVariable::set_kind make_inst_int bytecode .push
         1 += index
     done
 
-    skip_bindings InstKind::InstLabel (int) make_inst_int bytecode .push
+    skip_bindings InstKind::InstLabel make_inst_int bytecode .push
 }
 
 # ============================================================================
@@ -649,27 +649,27 @@ fn compile_struct_literal compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
         compiler BytecodeCompiler::locals_count 1 + compiler->locals_count
         field_index literal StructLiteral::field_order .get = field_name
         field_name local_index temp_locals .set = temp_locals
-        local_index InstKind::InstLocalSet (int) make_inst_int bytecode .push
+        local_index InstKind::InstLocalSet make_inst_int bytecode .push
         field_index 1 - = field_index
     done
 
     # Allocate struct on heap
-    count 8 * InstKind::InstPush (int) make_inst_int bytecode .push
-    InstKind::InstHeapAlloc (int) make_inst bytecode .push
+    count 8 * InstKind::InstPush make_inst_int bytecode .push
+    InstKind::InstHeapAlloc make_inst bytecode .push
 
     # Store each field at its correct offset
     0 = member_index
     while member_index casa_struct CasaStruct::members .length > do
         member_index casa_struct CasaStruct::members .get Member::name = member_name
         member_index 8 * = member_offset
-        InstKind::InstDup (int) make_inst bytecode .push
+        InstKind::InstDup make_inst bytecode .push
         if 0 member_offset > then
-            member_offset InstKind::InstPush (int) make_inst_int bytecode .push
-            InstKind::InstAdd (int) make_inst bytecode .push
+            member_offset InstKind::InstPush make_inst_int bytecode .push
+            InstKind::InstAdd make_inst bytecode .push
         fi
-        member_name temp_locals .get .unwrap InstKind::InstLocalGet (int) make_inst_int bytecode .push
-        InstKind::InstSwap (int) make_inst bytecode .push
-        InstKind::InstStore64 (int) make_inst bytecode .push
+        member_name temp_locals .get .unwrap InstKind::InstLocalGet make_inst_int bytecode .push
+        InstKind::InstSwap make_inst bytecode .push
+        InstKind::InstStore64 make_inst bytecode .push
         1 += member_index
     done
 }
@@ -693,58 +693,58 @@ fn compile_push_array compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
     # Allocate memory: header (data_ptr + length) + elements
     compiler BytecodeCompiler::locals_count = list_local
     compiler BytecodeCompiler::locals_count 1 + compiler->locals_count
-    length 2 + 8 * InstKind::InstPush (int) make_inst_int bytecode .push
-    InstKind::InstHeapAlloc (int) make_inst bytecode .push
-    list_local InstKind::InstLocalSet (int) make_inst_int bytecode .push
+    length 2 + 8 * InstKind::InstPush make_inst_int bytecode .push
+    InstKind::InstHeapAlloc make_inst bytecode .push
+    list_local InstKind::InstLocalSet make_inst_int bytecode .push
 
     # Store data_ptr (allocation + 16) at offset 0
-    list_local InstKind::InstLocalGet (int) make_inst_int bytecode .push
-    16 InstKind::InstPush (int) make_inst_int bytecode .push
-    InstKind::InstAdd (int) make_inst bytecode .push
-    list_local InstKind::InstLocalGet (int) make_inst_int bytecode .push
-    InstKind::InstStore64 (int) make_inst bytecode .push
+    list_local InstKind::InstLocalGet make_inst_int bytecode .push
+    16 InstKind::InstPush make_inst_int bytecode .push
+    InstKind::InstAdd make_inst bytecode .push
+    list_local InstKind::InstLocalGet make_inst_int bytecode .push
+    InstKind::InstStore64 make_inst bytecode .push
 
     # Store length at offset 8
-    length InstKind::InstPush (int) make_inst_int bytecode .push
-    list_local InstKind::InstLocalGet (int) make_inst_int bytecode .push
-    8 InstKind::InstPush (int) make_inst_int bytecode .push
-    InstKind::InstAdd (int) make_inst bytecode .push
-    InstKind::InstStore64 (int) make_inst bytecode .push
+    length InstKind::InstPush make_inst_int bytecode .push
+    list_local InstKind::InstLocalGet make_inst_int bytecode .push
+    8 InstKind::InstPush make_inst_int bytecode .push
+    InstKind::InstAdd make_inst bytecode .push
+    InstKind::InstStore64 make_inst bytecode .push
 
     # Store elements starting at offset 16
     compiler BytecodeCompiler::locals_count = index_local
     compiler BytecodeCompiler::locals_count 1 + compiler->locals_count
-    16 InstKind::InstPush (int) make_inst_int bytecode .push
-    index_local InstKind::InstLocalSet (int) make_inst_int bytecode .push
+    16 InstKind::InstPush make_inst_int bytecode .push
+    index_local InstKind::InstLocalSet make_inst_int bytecode .push
 
     new_label = start_label
     new_label = end_label
 
     # while index limit > do
-    start_label InstKind::InstLabel (int) make_inst_int bytecode .push
-    index_local InstKind::InstLocalGet (int) make_inst_int bytecode .push
-    length 2 + 8 * InstKind::InstPush (int) make_inst_int bytecode .push
-    InstKind::InstGt (int) make_inst bytecode .push
-    end_label InstKind::InstJumpNe (int) make_inst_int bytecode .push
+    start_label InstKind::InstLabel make_inst_int bytecode .push
+    index_local InstKind::InstLocalGet make_inst_int bytecode .push
+    length 2 + 8 * InstKind::InstPush make_inst_int bytecode .push
+    InstKind::InstGt make_inst bytecode .push
+    end_label InstKind::InstJumpNe make_inst_int bytecode .push
 
     # list index + store64
-    list_local InstKind::InstLocalGet (int) make_inst_int bytecode .push
-    index_local InstKind::InstLocalGet (int) make_inst_int bytecode .push
-    InstKind::InstAdd (int) make_inst bytecode .push
-    InstKind::InstStore64 (int) make_inst bytecode .push
+    list_local InstKind::InstLocalGet make_inst_int bytecode .push
+    index_local InstKind::InstLocalGet make_inst_int bytecode .push
+    InstKind::InstAdd make_inst bytecode .push
+    InstKind::InstStore64 make_inst bytecode .push
 
     # 8 += index
-    index_local InstKind::InstLocalGet (int) make_inst_int bytecode .push
-    8 InstKind::InstPush (int) make_inst_int bytecode .push
-    InstKind::InstAdd (int) make_inst bytecode .push
-    index_local InstKind::InstLocalSet (int) make_inst_int bytecode .push
+    index_local InstKind::InstLocalGet make_inst_int bytecode .push
+    8 InstKind::InstPush make_inst_int bytecode .push
+    InstKind::InstAdd make_inst bytecode .push
+    index_local InstKind::InstLocalSet make_inst_int bytecode .push
 
     # done
-    start_label InstKind::InstJump (int) make_inst_int bytecode .push
-    end_label InstKind::InstLabel (int) make_inst_int bytecode .push
+    start_label InstKind::InstJump make_inst_int bytecode .push
+    end_label InstKind::InstLabel make_inst_int bytecode .push
 
     # Push array pointer
-    list_local InstKind::InstLocalGet (int) make_inst_int bytecode .push
+    list_local InstKind::InstLocalGet make_inst_int bytecode .push
 }
 
 # ============================================================================
@@ -770,22 +770,22 @@ fn compile_function compiler:BytecodeCompiler function:Function op:Op {
     if locals_count 0 < then
         # Build new list with LOCALS_INIT at front
         List::new (List[Inst]) = final_bytecode
-        locals_count InstKind::InstLocalsInit (int) make_inst_int final_bytecode .push
+        locals_count InstKind::InstLocalsInit make_inst_int final_bytecode .push
 
         0 = index
         while index function_bytecode .length > do
             index function_bytecode .get = inst
-            if InstKind::InstFnReturn (int) inst Inst::kind == then
-                locals_count InstKind::InstLocalsUninit (int) make_inst_int final_bytecode .push
+            if InstKind::InstFnReturn inst Inst::kind == then
+                locals_count InstKind::InstLocalsUninit make_inst_int final_bytecode .push
             fi
             inst final_bytecode .push
             1 += index
         done
-        locals_count InstKind::InstLocalsUninit (int) make_inst_int final_bytecode .push
-        InstKind::InstFnReturn (int) make_inst final_bytecode .push
+        locals_count InstKind::InstLocalsUninit make_inst_int final_bytecode .push
+        InstKind::InstFnReturn make_inst final_bytecode .push
         final_bytecode = function_bytecode
     else
-        InstKind::InstFnReturn (int) make_inst function_bytecode .push
+        InstKind::InstFnReturn make_inst function_bytecode .push
     fi
 
     # Store bytecode on the function
@@ -799,14 +799,14 @@ fn compile_function compiler:BytecodeCompiler function:Function op:Op {
 fn compile_function_ops compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
     op op_str_value = name
 
-    if OpKind::OpFnCall (int) op Op::kind == then
+    if OpKind::OpFnCall op Op::kind == then
         name GLOBAL_FUNCTIONS .get .unwrap = function
         op function compiler compile_function
-        name InstKind::InstFnCall (int) make_inst_str bytecode .push
-    elif OpKind::OpFnPush (int) op Op::kind == then
+        name InstKind::InstFnCall make_inst_str bytecode .push
+    elif OpKind::OpFnPush op Op::kind == then
         name GLOBAL_FUNCTIONS .get = function_opt
         if function_opt .is_none then
-            op Op::location f"Function `{name}` is not defined" ErrorKind::UndefinedName (int) make_error ERRORS .push
+            op Op::location f"Function `{name}` is not defined" ErrorKind::UndefinedName make_error ERRORS .push
             return
         fi
         function_opt .unwrap = lambda
@@ -821,10 +821,10 @@ fn compile_function_ops compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
             capture_resolved ResolvedVariable::index capture_resolved ResolvedVariable::get_kind make_inst_int bytecode .push
             f"{lambda Function::name}_{capture_name}" = constant_key
             constant_key compiler intern_constant = constant_index
-            constant_index InstKind::InstConstantStore (int) make_inst_int bytecode .push
+            constant_index InstKind::InstConstantStore make_inst_int bytecode .push
             1 += capture_index
         done
-        name InstKind::InstFnPush (int) make_inst_str bytecode .push
+        name InstKind::InstFnPush make_inst_str bytecode .push
     fi
 }
 
@@ -835,15 +835,11 @@ fn compile_function_ops compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
 fn compile_enum_comparison compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
     compiler BytecodeCompiler::locals_count = local_a
     compiler BytecodeCompiler::locals_count 1 + compiler->locals_count
-    local_a InstKind::InstLocalSet (int) make_inst_int bytecode .push
-    InstKind::InstLoad64 (int) make_inst bytecode .push
-    local_a InstKind::InstLocalGet (int) make_inst_int bytecode .push
-    InstKind::InstLoad64 (int) make_inst bytecode .push
-    if OpKind::OpEq (int) op Op::kind == then
-        InstKind::InstEq (int) make_inst bytecode .push
-    else
-        InstKind::InstNe (int) make_inst bytecode .push
-    fi
+    local_a InstKind::InstLocalSet make_inst_int bytecode .push
+    InstKind::InstLoad64 make_inst bytecode .push
+    local_a InstKind::InstLocalGet make_inst_int bytecode .push
+    InstKind::InstLoad64 make_inst bytecode .push
+    op Op::kind DIRECT_OP_TO_INST .get .unwrap make_inst bytecode .push
 }
 
 # ============================================================================
@@ -854,11 +850,15 @@ fn compile_op compiler:BytecodeCompiler op:Op op_index:int bytecode:List[Inst] {
     op Op::kind = kind
 
     # Check direct op-to-inst mapping first
-    if kind (int) DIRECT_OP_TO_INST .has then
+    if kind DIRECT_OP_TO_INST .has then
         # Data-carrying enum comparison
         if
-            OpKind::OpEq (int) kind ==
-            OpKind::OpNe (int) kind == ||
+            OpKind::OpEq kind ==
+            OpKind::OpNe kind == ||
+            OpKind::OpLt kind == ||
+            OpKind::OpLe kind == ||
+            OpKind::OpGt kind == ||
+            OpKind::OpGe kind == ||
             "" op Op::type_annotation != &&
             op Op::type_annotation GLOBAL_ENUMS .has &&
         then
@@ -867,95 +867,95 @@ fn compile_op compiler:BytecodeCompiler op:Op op_index:int bytecode:List[Inst] {
         fi
         # String content comparison
         if
-            OpKind::OpEq (int) kind ==
-            OpKind::OpNe (int) kind == ||
+            OpKind::OpEq kind ==
+            OpKind::OpNe kind == ||
             "str" op Op::type_annotation == &&
         then
-            InstKind::InstStrEq (int) make_inst bytecode .push
-            if OpKind::OpNe (int) kind == then
-                InstKind::InstNot (int) make_inst bytecode .push
+            InstKind::InstStrEq make_inst bytecode .push
+            if OpKind::OpNe kind == then
+                InstKind::InstNot make_inst bytecode .push
             fi
             return
         fi
         # Data-carrying enum print
-        if OpKind::OpPrintInt (int) kind == "" op Op::type_annotation != && then
-            InstKind::InstLoad64 (int) make_inst bytecode .push
-            InstKind::InstPrintInt (int) make_inst bytecode .push
+        if OpKind::OpPrintInt kind == "" op Op::type_annotation != && then
+            InstKind::InstLoad64 make_inst bytecode .push
+            InstKind::InstPrintInt make_inst bytecode .push
             return
         fi
-        kind (int) DIRECT_OP_TO_INST .get .unwrap make_inst bytecode .push
+        kind DIRECT_OP_TO_INST .get .unwrap make_inst bytecode .push
         return
     fi
 
     # Non-direct ops
     if
-        OpKind::OpAssignDec (int) kind ==
-        OpKind::OpAssignInc (int) kind == ||
-        OpKind::OpAssignVar (int) kind == ||
+        OpKind::OpAssignDec kind ==
+        OpKind::OpAssignInc kind == ||
+        OpKind::OpAssignVar kind == ||
     then
         bytecode op compiler compile_assignment
-    elif OpKind::OpFstringConcat (int) kind == then
-        op op_int_value InstKind::InstFstringConcat (int) make_inst_int bytecode .push
-    elif OpKind::OpFnCall (int) kind == OpKind::OpFnPush (int) kind == || then
-        if OpKind::OpFnPush (int) kind == then
+    elif OpKind::OpFstringConcat kind == then
+        op op_int_value InstKind::InstFstringConcat make_inst_int bytecode .push
+    elif OpKind::OpFnCall kind == OpKind::OpFnPush kind == || then
+        if OpKind::OpFnPush kind == then
             op op_str_value GLOBAL_FUNCTIONS .get = function_opt
             if function_opt .is_some then
                 function_opt .unwrap = function_check
                 if function_check Function::has_deferred_methods then
-                    0 InstKind::InstPush (int) make_inst_int bytecode .push
+                    0 InstKind::InstPush make_inst_int bytecode .push
                     return
                 fi
             fi
         fi
         bytecode op compiler compile_function_ops
-    elif OpKind::OpIdentifier (int) kind == then
+    elif OpKind::OpIdentifier kind == then
         f"Identifier `{op op_str_value}` should be resolved by the parser\n" eprint
         1 exit
     elif
-        OpKind::OpIfCondition (int) kind ==
-        OpKind::OpIfElif (int) kind == ||
-        OpKind::OpIfElse (int) kind == ||
-        OpKind::OpIfEnd (int) kind == ||
-        OpKind::OpIfStart (int) kind == ||
+        OpKind::OpIfCondition kind ==
+        OpKind::OpIfElif kind == ||
+        OpKind::OpIfElse kind == ||
+        OpKind::OpIfEnd kind == ||
+        OpKind::OpIfStart kind == ||
     then
         bytecode op_index op compiler compile_if_block
-    elif OpKind::OpIncludeFile (int) kind == OpKind::OpTypeCast (int) kind == || then
+    elif OpKind::OpIncludeFile kind == OpKind::OpTypeCast kind == || then
         # No instruction emitted
-    elif OpKind::OpPushEnumVariant (int) kind == then
+    elif OpKind::OpPushEnumVariant kind == then
         op Op::value (EnumVariant) = variant
         variant EnumVariant::enum_name GLOBAL_ENUMS .get .unwrap = casa_enum
         if casa_enum has_inner_values then
             bytecode casa_enum variant compiler compile_enum_variant
         else
-            variant EnumVariant::ordinal .unwrap InstKind::InstPush (int) make_inst_int bytecode .push
+            variant EnumVariant::ordinal .unwrap InstKind::InstPush make_inst_int bytecode .push
         fi
-    elif OpKind::OpIsCheck (int) kind == then
+    elif OpKind::OpIsCheck kind == then
         bytecode op compiler compile_is_check
     elif
-        OpKind::OpMatchStart (int) kind ==
-        OpKind::OpMatchArm (int) kind == ||
-        OpKind::OpMatchEnd (int) kind == ||
+        OpKind::OpMatchStart kind ==
+        OpKind::OpMatchArm kind == ||
+        OpKind::OpMatchEnd kind == ||
     then
         bytecode op_index op compiler compile_match_block
-    elif OpKind::OpMethodCall (int) kind == then
+    elif OpKind::OpMethodCall kind == then
         "Method call should be transpiled to function call during type checking\n" eprint
         1 exit
-    elif OpKind::OpPrint (int) kind == then
+    elif OpKind::OpPrint kind == then
         "PRINT should be resolved by type checker\n" eprint
         1 exit
-    elif OpKind::OpTypeof (int) kind == then
+    elif OpKind::OpTypeof kind == then
         op Op::type_annotation = type_name
         type_name compiler intern_string = typeof_index
-        InstKind::InstDrop (int) make_inst bytecode .push
-        typeof_index InstKind::InstPushStr (int) make_inst_int bytecode .push
-        InstKind::InstPrintStr (int) make_inst bytecode .push
-    elif OpKind::OpPushArray (int) kind == then
+        InstKind::InstDrop make_inst bytecode .push
+        typeof_index InstKind::InstPushStr make_inst_int bytecode .push
+        InstKind::InstPrintStr make_inst bytecode .push
+    elif OpKind::OpPushArray kind == then
         bytecode op compiler compile_push_array
-    elif OpKind::OpPushBool (int) kind == then
-        op op_int_value InstKind::InstPush (int) make_inst_int bytecode .push
-    elif OpKind::OpPushChar (int) kind == then
-        op op_int_value InstKind::InstPushChar (int) make_inst_int bytecode .push
-    elif OpKind::OpPushCapture (int) kind == then
+    elif OpKind::OpPushBool kind == then
+        op op_int_value InstKind::InstPush make_inst_int bytecode .push
+    elif OpKind::OpPushChar kind == then
+        op op_int_value InstKind::InstPushChar make_inst_int bytecode .push
+    elif OpKind::OpPushCapture kind == then
         op op_str_value = capture_name
         compiler BytecodeCompiler::function = function_ptr
         if 0 function_ptr != then
@@ -964,30 +964,30 @@ fn compile_op compiler:BytecodeCompiler op:Op op_index:int bytecode:List[Inst] {
             GLOBAL_SCOPE_LABEL = function_name
         fi
         f"{function_name}_{capture_name}" compiler intern_constant = capture_index
-        capture_index InstKind::InstConstantLoad (int) make_inst_int bytecode .push
-    elif OpKind::OpPushInt (int) kind == then
-        op op_int_value InstKind::InstPush (int) make_inst_int bytecode .push
-    elif OpKind::OpPushStr (int) kind == then
+        capture_index InstKind::InstConstantLoad make_inst_int bytecode .push
+    elif OpKind::OpPushInt kind == then
+        op op_int_value InstKind::InstPush make_inst_int bytecode .push
+    elif OpKind::OpPushStr kind == then
         op op_str_value compiler intern_string = string_index
-        string_index InstKind::InstPushStr (int) make_inst_int bytecode .push
-    elif OpKind::OpPushVar (int) kind == then
+        string_index InstKind::InstPushStr make_inst_int bytecode .push
+    elif OpKind::OpPushVar kind == then
         op op_str_value = var_name
         var_name compiler resolve_variable = var_resolved
         var_resolved ResolvedVariable::index var_resolved ResolvedVariable::get_kind make_inst_int bytecode .push
         # Emit FN_EXEC after trait-bound variable push
         if "trait_exec" op Op::type_annotation == then
-            InstKind::InstFnExec (int) make_inst bytecode .push
+            InstKind::InstFnExec make_inst bytecode .push
         fi
-    elif OpKind::OpStructNew (int) kind == then
+    elif OpKind::OpStructNew kind == then
         bytecode op compiler compile_struct_new
-    elif OpKind::OpStructLiteral (int) kind == then
+    elif OpKind::OpStructLiteral kind == then
         bytecode op compiler compile_struct_literal
     elif
-        OpKind::OpWhileBreak (int) kind ==
-        OpKind::OpWhileCondition (int) kind == ||
-        OpKind::OpWhileContinue (int) kind == ||
-        OpKind::OpWhileEnd (int) kind == ||
-        OpKind::OpWhileStart (int) kind == ||
+        OpKind::OpWhileBreak kind ==
+        OpKind::OpWhileCondition kind == ||
+        OpKind::OpWhileContinue kind == ||
+        OpKind::OpWhileEnd kind == ||
+        OpKind::OpWhileStart kind == ||
     then
         bytecode op_index op compiler compile_while_block
     fi
@@ -1007,7 +1007,7 @@ fn compile_ops compiler:BytecodeCompiler bytecode:List[Inst] {
 
     # Function label
     new_label = function_label
-    function_label InstKind::InstLabel (int) make_inst_int bytecode .push
+    function_label InstKind::InstLabel make_inst_int bytecode .push
 
     0 = index
     while index compiler BytecodeCompiler::ops .length > do
@@ -1029,7 +1029,7 @@ fn compile_bytecode ops:List[Op] -> Program {
 
     # Emit globals init if needed
     if 0 GLOBAL_VARIABLES .length != then
-        GLOBAL_VARIABLES .length InstKind::InstGlobalsInit (int) make_inst_int bytecode .push
+        GLOBAL_VARIABLES .length InstKind::InstGlobalsInit make_inst_int bytecode .push
     fi
 
     bytecode compiler compile_ops
@@ -1038,13 +1038,13 @@ fn compile_bytecode ops:List[Op] -> Program {
     compiler BytecodeCompiler::locals_count = locals_count
     if locals_count 0 < then
         List::new (List[Inst]) = final_bytecode
-        locals_count InstKind::InstLocalsInit (int) make_inst_int final_bytecode .push
+        locals_count InstKind::InstLocalsInit make_inst_int final_bytecode .push
         0 = index
         while index bytecode .length > do
             index bytecode .get final_bytecode .push
             1 += index
         done
-        locals_count InstKind::InstLocalsUninit (int) make_inst_int final_bytecode .push
+        locals_count InstKind::InstLocalsUninit make_inst_int final_bytecode .push
         final_bytecode = bytecode
     fi
 

--- a/self_hosted/common.casa
+++ b/self_hosted/common.casa
@@ -359,6 +359,45 @@ enum WarningKind {
 }
 
 # ============================================================================
+# Hashable impls for enums (needed for Map keys)
+# ============================================================================
+
+impl TokenKind {
+    fn hash self:TokenKind -> int { self (int) int_hash }
+    fn eq self:TokenKind other:TokenKind -> bool { self other == }
+}
+
+impl IntrinsicKind {
+    fn hash self:IntrinsicKind -> int { self (int) int_hash }
+    fn eq self:IntrinsicKind other:IntrinsicKind -> bool { self other == }
+}
+
+impl KeywordKind {
+    fn hash self:KeywordKind -> int { self (int) int_hash }
+    fn eq self:KeywordKind other:KeywordKind -> bool { self other == }
+}
+
+impl DelimiterKind {
+    fn hash self:DelimiterKind -> int { self (int) int_hash }
+    fn eq self:DelimiterKind other:DelimiterKind -> bool { self other == }
+}
+
+impl OperatorKind {
+    fn hash self:OperatorKind -> int { self (int) int_hash }
+    fn eq self:OperatorKind other:OperatorKind -> bool { self other == }
+}
+
+impl OpKind {
+    fn hash self:OpKind -> int { self (int) int_hash }
+    fn eq self:OpKind other:OpKind -> bool { self other == }
+}
+
+impl InstKind {
+    fn hash self:InstKind -> int { self (int) int_hash }
+    fn eq self:InstKind other:InstKind -> bool { self other == }
+}
+
+# ============================================================================
 # Core data structures
 # ============================================================================
 
@@ -382,11 +421,11 @@ fn empty_location -> Location {
 
 struct Token {
     value:    str
-    kind:     int
+    kind:     TokenKind
     location: Location
 }
 
-fn make_token value:str kind:int location:Location -> Token {
+fn make_token value:str kind:TokenKind location:Location -> Token {
     location kind value Token
 }
 
@@ -408,21 +447,21 @@ fn make_token value:str kind:int location:Location -> Token {
 
 struct Op {
     value:               int
-    kind:                int
+    kind:                OpKind
     location:            Location
     type_annotation:     str
     deferred_return_type: str
 }
 
-fn make_op value:int kind:int location:Location -> Op {
+fn make_op value:int kind:OpKind location:Location -> Op {
     "" "" location kind value Op
 }
 
-fn make_op_str value:str kind:int location:Location -> Op {
+fn make_op_str value:str kind:OpKind location:Location -> Op {
     "" "" location kind value (int) Op
 }
 
-fn make_op_annotated value:int kind:int location:Location annotation:str -> Op {
+fn make_op_annotated value:int kind:OpKind location:Location annotation:str -> Op {
     "" annotation location kind value Op
 }
 
@@ -439,20 +478,20 @@ fn op_int_value op:Op -> int {
 # ============================================================================
 
 struct Inst {
-    kind:     int
+    kind:     InstKind
     int_arg:  int
     str_arg:  str
 }
 
-fn make_inst kind:int -> Inst {
+fn make_inst kind:InstKind -> Inst {
     "" 0 kind Inst
 }
 
-fn make_inst_int kind:int arg:int -> Inst {
+fn make_inst_int kind:InstKind arg:int -> Inst {
     "" arg kind Inst
 }
 
-fn make_inst_str kind:int arg:str -> Inst {
+fn make_inst_str kind:InstKind arg:str -> Inst {
     arg 0 kind Inst
 }
 
@@ -510,8 +549,8 @@ fn make_variable name:str -> Variable {
 }
 
 struct ResolvedVariable {
-    get_kind: int
-    set_kind: int
+    get_kind: InstKind
+    set_kind: InstKind
     index:    int
 }
 
@@ -975,127 +1014,127 @@ fn resolve_trait_sig sig:Signature type_var:str -> Signature {
 # Lookup functions (string -> enum ordinal)
 # ============================================================================
 
-Map::new (Map[str int]) = KEYWORD_MAP
-"fn" KeywordKind::Fn (int) KEYWORD_MAP .set = KEYWORD_MAP
-"impl" KeywordKind::Impl (int) KEYWORD_MAP .set = KEYWORD_MAP
-"return" KeywordKind::Return (int) KEYWORD_MAP .set = KEYWORD_MAP
-"while" KeywordKind::While (int) KEYWORD_MAP .set = KEYWORD_MAP
-"do" KeywordKind::Do (int) KEYWORD_MAP .set = KEYWORD_MAP
-"break" KeywordKind::Break (int) KEYWORD_MAP .set = KEYWORD_MAP
-"continue" KeywordKind::Continue (int) KEYWORD_MAP .set = KEYWORD_MAP
-"done" KeywordKind::Done (int) KEYWORD_MAP .set = KEYWORD_MAP
-"if" KeywordKind::If (int) KEYWORD_MAP .set = KEYWORD_MAP
-"then" KeywordKind::Then (int) KEYWORD_MAP .set = KEYWORD_MAP
-"elif" KeywordKind::Elif (int) KEYWORD_MAP .set = KEYWORD_MAP
-"else" KeywordKind::Else (int) KEYWORD_MAP .set = KEYWORD_MAP
-"fi" KeywordKind::Fi (int) KEYWORD_MAP .set = KEYWORD_MAP
-"enum" KeywordKind::EnumKw (int) KEYWORD_MAP .set = KEYWORD_MAP
-"struct" KeywordKind::StructKw (int) KEYWORD_MAP .set = KEYWORD_MAP
-"trait" KeywordKind::TraitKw (int) KEYWORD_MAP .set = KEYWORD_MAP
-"end" KeywordKind::End (int) KEYWORD_MAP .set = KEYWORD_MAP
-"match" KeywordKind::Match (int) KEYWORD_MAP .set = KEYWORD_MAP
-"is" KeywordKind::Is (int) KEYWORD_MAP .set = KEYWORD_MAP
-"include" KeywordKind::Include (int) KEYWORD_MAP .set = KEYWORD_MAP
+Map::new (Map[str KeywordKind]) = KEYWORD_MAP
+"fn" KeywordKind::Fn KEYWORD_MAP .set = KEYWORD_MAP
+"impl" KeywordKind::Impl KEYWORD_MAP .set = KEYWORD_MAP
+"return" KeywordKind::Return KEYWORD_MAP .set = KEYWORD_MAP
+"while" KeywordKind::While KEYWORD_MAP .set = KEYWORD_MAP
+"do" KeywordKind::Do KEYWORD_MAP .set = KEYWORD_MAP
+"break" KeywordKind::Break KEYWORD_MAP .set = KEYWORD_MAP
+"continue" KeywordKind::Continue KEYWORD_MAP .set = KEYWORD_MAP
+"done" KeywordKind::Done KEYWORD_MAP .set = KEYWORD_MAP
+"if" KeywordKind::If KEYWORD_MAP .set = KEYWORD_MAP
+"then" KeywordKind::Then KEYWORD_MAP .set = KEYWORD_MAP
+"elif" KeywordKind::Elif KEYWORD_MAP .set = KEYWORD_MAP
+"else" KeywordKind::Else KEYWORD_MAP .set = KEYWORD_MAP
+"fi" KeywordKind::Fi KEYWORD_MAP .set = KEYWORD_MAP
+"enum" KeywordKind::EnumKw KEYWORD_MAP .set = KEYWORD_MAP
+"struct" KeywordKind::StructKw KEYWORD_MAP .set = KEYWORD_MAP
+"trait" KeywordKind::TraitKw KEYWORD_MAP .set = KEYWORD_MAP
+"end" KeywordKind::End KEYWORD_MAP .set = KEYWORD_MAP
+"match" KeywordKind::Match KEYWORD_MAP .set = KEYWORD_MAP
+"is" KeywordKind::Is KEYWORD_MAP .set = KEYWORD_MAP
+"include" KeywordKind::Include KEYWORD_MAP .set = KEYWORD_MAP
 
-fn keyword_from_str value:str -> Option[int] {
+fn keyword_from_str value:str -> Option[KeywordKind] {
     value KEYWORD_MAP .get
 }
 
-Map::new (Map[str int]) = INTRINSIC_MAP
-"drop" IntrinsicKind::Drop (int) INTRINSIC_MAP .set = INTRINSIC_MAP
-"dup" IntrinsicKind::Dup (int) INTRINSIC_MAP .set = INTRINSIC_MAP
-"over" IntrinsicKind::Over (int) INTRINSIC_MAP .set = INTRINSIC_MAP
-"rot" IntrinsicKind::Rot (int) INTRINSIC_MAP .set = INTRINSIC_MAP
-"swap" IntrinsicKind::Swap (int) INTRINSIC_MAP .set = INTRINSIC_MAP
-"alloc" IntrinsicKind::Alloc (int) INTRINSIC_MAP .set = INTRINSIC_MAP
-"load8" IntrinsicKind::Load8 (int) INTRINSIC_MAP .set = INTRINSIC_MAP
-"load16" IntrinsicKind::Load16 (int) INTRINSIC_MAP .set = INTRINSIC_MAP
-"load32" IntrinsicKind::Load32 (int) INTRINSIC_MAP .set = INTRINSIC_MAP
-"load64" IntrinsicKind::Load64 (int) INTRINSIC_MAP .set = INTRINSIC_MAP
-"store8" IntrinsicKind::Store8 (int) INTRINSIC_MAP .set = INTRINSIC_MAP
-"store16" IntrinsicKind::Store16 (int) INTRINSIC_MAP .set = INTRINSIC_MAP
-"store32" IntrinsicKind::Store32 (int) INTRINSIC_MAP .set = INTRINSIC_MAP
-"store64" IntrinsicKind::Store64 (int) INTRINSIC_MAP .set = INTRINSIC_MAP
-"print" IntrinsicKind::Print (int) INTRINSIC_MAP .set = INTRINSIC_MAP
-"typeof" IntrinsicKind::Typeof (int) INTRINSIC_MAP .set = INTRINSIC_MAP
-"exec" IntrinsicKind::Exec (int) INTRINSIC_MAP .set = INTRINSIC_MAP
-"syscall0" IntrinsicKind::Syscall0 (int) INTRINSIC_MAP .set = INTRINSIC_MAP
-"syscall1" IntrinsicKind::Syscall1 (int) INTRINSIC_MAP .set = INTRINSIC_MAP
-"syscall2" IntrinsicKind::Syscall2 (int) INTRINSIC_MAP .set = INTRINSIC_MAP
-"syscall3" IntrinsicKind::Syscall3 (int) INTRINSIC_MAP .set = INTRINSIC_MAP
-"syscall4" IntrinsicKind::Syscall4 (int) INTRINSIC_MAP .set = INTRINSIC_MAP
-"syscall5" IntrinsicKind::Syscall5 (int) INTRINSIC_MAP .set = INTRINSIC_MAP
-"syscall6" IntrinsicKind::Syscall6 (int) INTRINSIC_MAP .set = INTRINSIC_MAP
-"argc" IntrinsicKind::Argc (int) INTRINSIC_MAP .set = INTRINSIC_MAP
-"argv" IntrinsicKind::Argv (int) INTRINSIC_MAP .set = INTRINSIC_MAP
-"print_int" IntrinsicKind::Print (int) INTRINSIC_MAP .set = INTRINSIC_MAP
-"print_str" IntrinsicKind::Print (int) INTRINSIC_MAP .set = INTRINSIC_MAP
-"print_bool" IntrinsicKind::Print (int) INTRINSIC_MAP .set = INTRINSIC_MAP
-"print_char" IntrinsicKind::Print (int) INTRINSIC_MAP .set = INTRINSIC_MAP
-"print_cstr" IntrinsicKind::Print (int) INTRINSIC_MAP .set = INTRINSIC_MAP
+Map::new (Map[str IntrinsicKind]) = INTRINSIC_MAP
+"drop" IntrinsicKind::Drop INTRINSIC_MAP .set = INTRINSIC_MAP
+"dup" IntrinsicKind::Dup INTRINSIC_MAP .set = INTRINSIC_MAP
+"over" IntrinsicKind::Over INTRINSIC_MAP .set = INTRINSIC_MAP
+"rot" IntrinsicKind::Rot INTRINSIC_MAP .set = INTRINSIC_MAP
+"swap" IntrinsicKind::Swap INTRINSIC_MAP .set = INTRINSIC_MAP
+"alloc" IntrinsicKind::Alloc INTRINSIC_MAP .set = INTRINSIC_MAP
+"load8" IntrinsicKind::Load8 INTRINSIC_MAP .set = INTRINSIC_MAP
+"load16" IntrinsicKind::Load16 INTRINSIC_MAP .set = INTRINSIC_MAP
+"load32" IntrinsicKind::Load32 INTRINSIC_MAP .set = INTRINSIC_MAP
+"load64" IntrinsicKind::Load64 INTRINSIC_MAP .set = INTRINSIC_MAP
+"store8" IntrinsicKind::Store8 INTRINSIC_MAP .set = INTRINSIC_MAP
+"store16" IntrinsicKind::Store16 INTRINSIC_MAP .set = INTRINSIC_MAP
+"store32" IntrinsicKind::Store32 INTRINSIC_MAP .set = INTRINSIC_MAP
+"store64" IntrinsicKind::Store64 INTRINSIC_MAP .set = INTRINSIC_MAP
+"print" IntrinsicKind::Print INTRINSIC_MAP .set = INTRINSIC_MAP
+"typeof" IntrinsicKind::Typeof INTRINSIC_MAP .set = INTRINSIC_MAP
+"exec" IntrinsicKind::Exec INTRINSIC_MAP .set = INTRINSIC_MAP
+"syscall0" IntrinsicKind::Syscall0 INTRINSIC_MAP .set = INTRINSIC_MAP
+"syscall1" IntrinsicKind::Syscall1 INTRINSIC_MAP .set = INTRINSIC_MAP
+"syscall2" IntrinsicKind::Syscall2 INTRINSIC_MAP .set = INTRINSIC_MAP
+"syscall3" IntrinsicKind::Syscall3 INTRINSIC_MAP .set = INTRINSIC_MAP
+"syscall4" IntrinsicKind::Syscall4 INTRINSIC_MAP .set = INTRINSIC_MAP
+"syscall5" IntrinsicKind::Syscall5 INTRINSIC_MAP .set = INTRINSIC_MAP
+"syscall6" IntrinsicKind::Syscall6 INTRINSIC_MAP .set = INTRINSIC_MAP
+"argc" IntrinsicKind::Argc INTRINSIC_MAP .set = INTRINSIC_MAP
+"argv" IntrinsicKind::Argv INTRINSIC_MAP .set = INTRINSIC_MAP
+"print_int" IntrinsicKind::Print INTRINSIC_MAP .set = INTRINSIC_MAP
+"print_str" IntrinsicKind::Print INTRINSIC_MAP .set = INTRINSIC_MAP
+"print_bool" IntrinsicKind::Print INTRINSIC_MAP .set = INTRINSIC_MAP
+"print_char" IntrinsicKind::Print INTRINSIC_MAP .set = INTRINSIC_MAP
+"print_cstr" IntrinsicKind::Print INTRINSIC_MAP .set = INTRINSIC_MAP
 
-fn intrinsic_from_str value:str -> Option[int] {
+fn intrinsic_from_str value:str -> Option[IntrinsicKind] {
     value INTRINSIC_MAP .get
 }
 
-Map::new (Map[str int]) = OPERATOR_MAP
-"+" OperatorKind::Plus (int) OPERATOR_MAP .set = OPERATOR_MAP
-"-" OperatorKind::Minus (int) OPERATOR_MAP .set = OPERATOR_MAP
-"*" OperatorKind::Mul (int) OPERATOR_MAP .set = OPERATOR_MAP
-"/" OperatorKind::Div (int) OPERATOR_MAP .set = OPERATOR_MAP
-"%" OperatorKind::Mod (int) OPERATOR_MAP .set = OPERATOR_MAP
-"<<" OperatorKind::Shl (int) OPERATOR_MAP .set = OPERATOR_MAP
-">>" OperatorKind::Shr (int) OPERATOR_MAP .set = OPERATOR_MAP
-"&" OperatorKind::BitAnd (int) OPERATOR_MAP .set = OPERATOR_MAP
-"|" OperatorKind::BitOr (int) OPERATOR_MAP .set = OPERATOR_MAP
-"^" OperatorKind::BitXor (int) OPERATOR_MAP .set = OPERATOR_MAP
-"~" OperatorKind::BitNot (int) OPERATOR_MAP .set = OPERATOR_MAP
-"&&" OperatorKind::And (int) OPERATOR_MAP .set = OPERATOR_MAP
-"||" OperatorKind::Or (int) OPERATOR_MAP .set = OPERATOR_MAP
-"!" OperatorKind::Not (int) OPERATOR_MAP .set = OPERATOR_MAP
-"==" OperatorKind::Eq (int) OPERATOR_MAP .set = OPERATOR_MAP
-">=" OperatorKind::Ge (int) OPERATOR_MAP .set = OPERATOR_MAP
-">" OperatorKind::Gt (int) OPERATOR_MAP .set = OPERATOR_MAP
-"<=" OperatorKind::Le (int) OPERATOR_MAP .set = OPERATOR_MAP
-"<" OperatorKind::Lt (int) OPERATOR_MAP .set = OPERATOR_MAP
-"!=" OperatorKind::Ne (int) OPERATOR_MAP .set = OPERATOR_MAP
-"=" OperatorKind::Assign (int) OPERATOR_MAP .set = OPERATOR_MAP
-"-=" OperatorKind::AssignDec (int) OPERATOR_MAP .set = OPERATOR_MAP
-"+=" OperatorKind::AssignInc (int) OPERATOR_MAP .set = OPERATOR_MAP
+Map::new (Map[str OperatorKind]) = OPERATOR_MAP
+"+" OperatorKind::Plus OPERATOR_MAP .set = OPERATOR_MAP
+"-" OperatorKind::Minus OPERATOR_MAP .set = OPERATOR_MAP
+"*" OperatorKind::Mul OPERATOR_MAP .set = OPERATOR_MAP
+"/" OperatorKind::Div OPERATOR_MAP .set = OPERATOR_MAP
+"%" OperatorKind::Mod OPERATOR_MAP .set = OPERATOR_MAP
+"<<" OperatorKind::Shl OPERATOR_MAP .set = OPERATOR_MAP
+">>" OperatorKind::Shr OPERATOR_MAP .set = OPERATOR_MAP
+"&" OperatorKind::BitAnd OPERATOR_MAP .set = OPERATOR_MAP
+"|" OperatorKind::BitOr OPERATOR_MAP .set = OPERATOR_MAP
+"^" OperatorKind::BitXor OPERATOR_MAP .set = OPERATOR_MAP
+"~" OperatorKind::BitNot OPERATOR_MAP .set = OPERATOR_MAP
+"&&" OperatorKind::And OPERATOR_MAP .set = OPERATOR_MAP
+"||" OperatorKind::Or OPERATOR_MAP .set = OPERATOR_MAP
+"!" OperatorKind::Not OPERATOR_MAP .set = OPERATOR_MAP
+"==" OperatorKind::Eq OPERATOR_MAP .set = OPERATOR_MAP
+">=" OperatorKind::Ge OPERATOR_MAP .set = OPERATOR_MAP
+">" OperatorKind::Gt OPERATOR_MAP .set = OPERATOR_MAP
+"<=" OperatorKind::Le OPERATOR_MAP .set = OPERATOR_MAP
+"<" OperatorKind::Lt OPERATOR_MAP .set = OPERATOR_MAP
+"!=" OperatorKind::Ne OPERATOR_MAP .set = OPERATOR_MAP
+"=" OperatorKind::Assign OPERATOR_MAP .set = OPERATOR_MAP
+"-=" OperatorKind::AssignDec OPERATOR_MAP .set = OPERATOR_MAP
+"+=" OperatorKind::AssignInc OPERATOR_MAP .set = OPERATOR_MAP
 
-fn operator_from_str value:str -> Option[int] {
+fn operator_from_str value:str -> Option[OperatorKind] {
     value OPERATOR_MAP .get
 }
 
-Map::new (Map[str int]) = DELIMITER_MAP
-"->" DelimiterKind::Arrow (int) DELIMITER_MAP .set = DELIMITER_MAP
-"," DelimiterKind::Comma (int) DELIMITER_MAP .set = DELIMITER_MAP
-"=>" DelimiterKind::FatArrow (int) DELIMITER_MAP .set = DELIMITER_MAP
-":" DelimiterKind::Colon (int) DELIMITER_MAP .set = DELIMITER_MAP
-"." DelimiterKind::Dot (int) DELIMITER_MAP .set = DELIMITER_MAP
-"#" DelimiterKind::Hashtag (int) DELIMITER_MAP .set = DELIMITER_MAP
-"{" DelimiterKind::OpenBrace (int) DELIMITER_MAP .set = DELIMITER_MAP
-"}" DelimiterKind::CloseBrace (int) DELIMITER_MAP .set = DELIMITER_MAP
-"[" DelimiterKind::OpenBracket (int) DELIMITER_MAP .set = DELIMITER_MAP
-"]" DelimiterKind::CloseBracket (int) DELIMITER_MAP .set = DELIMITER_MAP
-"(" DelimiterKind::OpenParen (int) DELIMITER_MAP .set = DELIMITER_MAP
-")" DelimiterKind::CloseParen (int) DELIMITER_MAP .set = DELIMITER_MAP
+Map::new (Map[str DelimiterKind]) = DELIMITER_MAP
+"->" DelimiterKind::Arrow DELIMITER_MAP .set = DELIMITER_MAP
+"," DelimiterKind::Comma DELIMITER_MAP .set = DELIMITER_MAP
+"=>" DelimiterKind::FatArrow DELIMITER_MAP .set = DELIMITER_MAP
+":" DelimiterKind::Colon DELIMITER_MAP .set = DELIMITER_MAP
+"." DelimiterKind::Dot DELIMITER_MAP .set = DELIMITER_MAP
+"#" DelimiterKind::Hashtag DELIMITER_MAP .set = DELIMITER_MAP
+"{" DelimiterKind::OpenBrace DELIMITER_MAP .set = DELIMITER_MAP
+"}" DelimiterKind::CloseBrace DELIMITER_MAP .set = DELIMITER_MAP
+"[" DelimiterKind::OpenBracket DELIMITER_MAP .set = DELIMITER_MAP
+"]" DelimiterKind::CloseBracket DELIMITER_MAP .set = DELIMITER_MAP
+"(" DelimiterKind::OpenParen DELIMITER_MAP .set = DELIMITER_MAP
+")" DelimiterKind::CloseParen DELIMITER_MAP .set = DELIMITER_MAP
 
-fn delimiter_from_str value:str -> Option[int] {
+fn delimiter_from_str value:str -> Option[DelimiterKind] {
     value DELIMITER_MAP .get
 }
 
-fn delimiter_from_char c:char -> Option[int] {
-    if ',' c == then DelimiterKind::Comma (int) Option::Some
-    elif ':' c == then DelimiterKind::Colon (int) Option::Some
-    elif '.' c == then DelimiterKind::Dot (int) Option::Some
-    elif '#' c == then DelimiterKind::Hashtag (int) Option::Some
-    elif '{' c == then DelimiterKind::OpenBrace (int) Option::Some
-    elif '}' c == then DelimiterKind::CloseBrace (int) Option::Some
-    elif '[' c == then DelimiterKind::OpenBracket (int) Option::Some
-    elif ']' c == then DelimiterKind::CloseBracket (int) Option::Some
-    elif '(' c == then DelimiterKind::OpenParen (int) Option::Some
-    elif ')' c == then DelimiterKind::CloseParen (int) Option::Some
+fn delimiter_from_char c:char -> Option[DelimiterKind] {
+    if ',' c == then DelimiterKind::Comma Option::Some
+    elif ':' c == then DelimiterKind::Colon Option::Some
+    elif '.' c == then DelimiterKind::Dot Option::Some
+    elif '#' c == then DelimiterKind::Hashtag Option::Some
+    elif '{' c == then DelimiterKind::OpenBrace Option::Some
+    elif '}' c == then DelimiterKind::CloseBrace Option::Some
+    elif '[' c == then DelimiterKind::OpenBracket Option::Some
+    elif ']' c == then DelimiterKind::CloseBracket Option::Some
+    elif '(' c == then DelimiterKind::OpenParen Option::Some
+    elif ')' c == then DelimiterKind::CloseParen Option::Some
     else Option::None
     fi
 }
@@ -1104,89 +1143,89 @@ fn delimiter_from_char c:char -> Option[int] {
 # Intrinsic to OpKind mapping
 # ============================================================================
 
-Map::new (Map[int int]) = INTRINSIC_TO_OPKIND
-IntrinsicKind::Alloc (int) OpKind::OpHeapAlloc (int) INTRINSIC_TO_OPKIND .set = INTRINSIC_TO_OPKIND
-IntrinsicKind::Drop (int) OpKind::OpDrop (int) INTRINSIC_TO_OPKIND .set = INTRINSIC_TO_OPKIND
-IntrinsicKind::Dup (int) OpKind::OpDup (int) INTRINSIC_TO_OPKIND .set = INTRINSIC_TO_OPKIND
-IntrinsicKind::Exec (int) OpKind::OpFnExec (int) INTRINSIC_TO_OPKIND .set = INTRINSIC_TO_OPKIND
-IntrinsicKind::Load8 (int) OpKind::OpLoad8 (int) INTRINSIC_TO_OPKIND .set = INTRINSIC_TO_OPKIND
-IntrinsicKind::Load16 (int) OpKind::OpLoad16 (int) INTRINSIC_TO_OPKIND .set = INTRINSIC_TO_OPKIND
-IntrinsicKind::Load32 (int) OpKind::OpLoad32 (int) INTRINSIC_TO_OPKIND .set = INTRINSIC_TO_OPKIND
-IntrinsicKind::Load64 (int) OpKind::OpLoad64 (int) INTRINSIC_TO_OPKIND .set = INTRINSIC_TO_OPKIND
-IntrinsicKind::Over (int) OpKind::OpOver (int) INTRINSIC_TO_OPKIND .set = INTRINSIC_TO_OPKIND
-IntrinsicKind::Print (int) OpKind::OpPrint (int) INTRINSIC_TO_OPKIND .set = INTRINSIC_TO_OPKIND
-IntrinsicKind::Rot (int) OpKind::OpRot (int) INTRINSIC_TO_OPKIND .set = INTRINSIC_TO_OPKIND
-IntrinsicKind::Store8 (int) OpKind::OpStore8 (int) INTRINSIC_TO_OPKIND .set = INTRINSIC_TO_OPKIND
-IntrinsicKind::Store16 (int) OpKind::OpStore16 (int) INTRINSIC_TO_OPKIND .set = INTRINSIC_TO_OPKIND
-IntrinsicKind::Store32 (int) OpKind::OpStore32 (int) INTRINSIC_TO_OPKIND .set = INTRINSIC_TO_OPKIND
-IntrinsicKind::Store64 (int) OpKind::OpStore64 (int) INTRINSIC_TO_OPKIND .set = INTRINSIC_TO_OPKIND
-IntrinsicKind::Swap (int) OpKind::OpSwap (int) INTRINSIC_TO_OPKIND .set = INTRINSIC_TO_OPKIND
-IntrinsicKind::Typeof (int) OpKind::OpTypeof (int) INTRINSIC_TO_OPKIND .set = INTRINSIC_TO_OPKIND
-IntrinsicKind::Syscall0 (int) OpKind::OpSyscall0 (int) INTRINSIC_TO_OPKIND .set = INTRINSIC_TO_OPKIND
-IntrinsicKind::Syscall1 (int) OpKind::OpSyscall1 (int) INTRINSIC_TO_OPKIND .set = INTRINSIC_TO_OPKIND
-IntrinsicKind::Syscall2 (int) OpKind::OpSyscall2 (int) INTRINSIC_TO_OPKIND .set = INTRINSIC_TO_OPKIND
-IntrinsicKind::Syscall3 (int) OpKind::OpSyscall3 (int) INTRINSIC_TO_OPKIND .set = INTRINSIC_TO_OPKIND
-IntrinsicKind::Syscall4 (int) OpKind::OpSyscall4 (int) INTRINSIC_TO_OPKIND .set = INTRINSIC_TO_OPKIND
-IntrinsicKind::Syscall5 (int) OpKind::OpSyscall5 (int) INTRINSIC_TO_OPKIND .set = INTRINSIC_TO_OPKIND
-IntrinsicKind::Syscall6 (int) OpKind::OpSyscall6 (int) INTRINSIC_TO_OPKIND .set = INTRINSIC_TO_OPKIND
-IntrinsicKind::Argc (int) OpKind::OpArgc (int) INTRINSIC_TO_OPKIND .set = INTRINSIC_TO_OPKIND
-IntrinsicKind::Argv (int) OpKind::OpArgv (int) INTRINSIC_TO_OPKIND .set = INTRINSIC_TO_OPKIND
+Map::new (Map[IntrinsicKind OpKind]) = INTRINSIC_TO_OPKIND
+IntrinsicKind::Alloc OpKind::OpHeapAlloc INTRINSIC_TO_OPKIND .set = INTRINSIC_TO_OPKIND
+IntrinsicKind::Drop OpKind::OpDrop INTRINSIC_TO_OPKIND .set = INTRINSIC_TO_OPKIND
+IntrinsicKind::Dup OpKind::OpDup INTRINSIC_TO_OPKIND .set = INTRINSIC_TO_OPKIND
+IntrinsicKind::Exec OpKind::OpFnExec INTRINSIC_TO_OPKIND .set = INTRINSIC_TO_OPKIND
+IntrinsicKind::Load8 OpKind::OpLoad8 INTRINSIC_TO_OPKIND .set = INTRINSIC_TO_OPKIND
+IntrinsicKind::Load16 OpKind::OpLoad16 INTRINSIC_TO_OPKIND .set = INTRINSIC_TO_OPKIND
+IntrinsicKind::Load32 OpKind::OpLoad32 INTRINSIC_TO_OPKIND .set = INTRINSIC_TO_OPKIND
+IntrinsicKind::Load64 OpKind::OpLoad64 INTRINSIC_TO_OPKIND .set = INTRINSIC_TO_OPKIND
+IntrinsicKind::Over OpKind::OpOver INTRINSIC_TO_OPKIND .set = INTRINSIC_TO_OPKIND
+IntrinsicKind::Print OpKind::OpPrint INTRINSIC_TO_OPKIND .set = INTRINSIC_TO_OPKIND
+IntrinsicKind::Rot OpKind::OpRot INTRINSIC_TO_OPKIND .set = INTRINSIC_TO_OPKIND
+IntrinsicKind::Store8 OpKind::OpStore8 INTRINSIC_TO_OPKIND .set = INTRINSIC_TO_OPKIND
+IntrinsicKind::Store16 OpKind::OpStore16 INTRINSIC_TO_OPKIND .set = INTRINSIC_TO_OPKIND
+IntrinsicKind::Store32 OpKind::OpStore32 INTRINSIC_TO_OPKIND .set = INTRINSIC_TO_OPKIND
+IntrinsicKind::Store64 OpKind::OpStore64 INTRINSIC_TO_OPKIND .set = INTRINSIC_TO_OPKIND
+IntrinsicKind::Swap OpKind::OpSwap INTRINSIC_TO_OPKIND .set = INTRINSIC_TO_OPKIND
+IntrinsicKind::Typeof OpKind::OpTypeof INTRINSIC_TO_OPKIND .set = INTRINSIC_TO_OPKIND
+IntrinsicKind::Syscall0 OpKind::OpSyscall0 INTRINSIC_TO_OPKIND .set = INTRINSIC_TO_OPKIND
+IntrinsicKind::Syscall1 OpKind::OpSyscall1 INTRINSIC_TO_OPKIND .set = INTRINSIC_TO_OPKIND
+IntrinsicKind::Syscall2 OpKind::OpSyscall2 INTRINSIC_TO_OPKIND .set = INTRINSIC_TO_OPKIND
+IntrinsicKind::Syscall3 OpKind::OpSyscall3 INTRINSIC_TO_OPKIND .set = INTRINSIC_TO_OPKIND
+IntrinsicKind::Syscall4 OpKind::OpSyscall4 INTRINSIC_TO_OPKIND .set = INTRINSIC_TO_OPKIND
+IntrinsicKind::Syscall5 OpKind::OpSyscall5 INTRINSIC_TO_OPKIND .set = INTRINSIC_TO_OPKIND
+IntrinsicKind::Syscall6 OpKind::OpSyscall6 INTRINSIC_TO_OPKIND .set = INTRINSIC_TO_OPKIND
+IntrinsicKind::Argc OpKind::OpArgc INTRINSIC_TO_OPKIND .set = INTRINSIC_TO_OPKIND
+IntrinsicKind::Argv OpKind::OpArgv INTRINSIC_TO_OPKIND .set = INTRINSIC_TO_OPKIND
 
 # ============================================================================
 # OpKind to InstKind direct mapping
 # ============================================================================
 
-Map::new (Map[int int]) = DIRECT_OP_TO_INST
-OpKind::OpAdd (int) InstKind::InstAdd (int) DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
-OpKind::OpAnd (int) InstKind::InstAnd (int) DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
-OpKind::OpBitAnd (int) InstKind::InstBitAnd (int) DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
-OpKind::OpBitNot (int) InstKind::InstBitNot (int) DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
-OpKind::OpBitOr (int) InstKind::InstBitOr (int) DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
-OpKind::OpBitXor (int) InstKind::InstBitXor (int) DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
-OpKind::OpDiv (int) InstKind::InstDiv (int) DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
-OpKind::OpDrop (int) InstKind::InstDrop (int) DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
-OpKind::OpDup (int) InstKind::InstDup (int) DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
-OpKind::OpEq (int) InstKind::InstEq (int) DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
-OpKind::OpFnExec (int) InstKind::InstFnExec (int) DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
-OpKind::OpFnReturn (int) InstKind::InstFnReturn (int) DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
-OpKind::OpGe (int) InstKind::InstGe (int) DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
-OpKind::OpGt (int) InstKind::InstGt (int) DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
-OpKind::OpHeapAlloc (int) InstKind::InstHeapAlloc (int) DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
-OpKind::OpLe (int) InstKind::InstLe (int) DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
-OpKind::OpLoad8 (int) InstKind::InstLoad8 (int) DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
-OpKind::OpLoad16 (int) InstKind::InstLoad16 (int) DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
-OpKind::OpLoad32 (int) InstKind::InstLoad32 (int) DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
-OpKind::OpLoad64 (int) InstKind::InstLoad64 (int) DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
-OpKind::OpLt (int) InstKind::InstLt (int) DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
-OpKind::OpMod (int) InstKind::InstMod (int) DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
-OpKind::OpMul (int) InstKind::InstMul (int) DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
-OpKind::OpNe (int) InstKind::InstNe (int) DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
-OpKind::OpNot (int) InstKind::InstNot (int) DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
-OpKind::OpOr (int) InstKind::InstOr (int) DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
-OpKind::OpOver (int) InstKind::InstOver (int) DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
-OpKind::OpPrintBool (int) InstKind::InstPrintBool (int) DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
-OpKind::OpPrintChar (int) InstKind::InstPrintChar (int) DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
-OpKind::OpPrintCstr (int) InstKind::InstPrintCstr (int) DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
-OpKind::OpPrintInt (int) InstKind::InstPrintInt (int) DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
-OpKind::OpPrintStr (int) InstKind::InstPrintStr (int) DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
-OpKind::OpRot (int) InstKind::InstRot (int) DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
-OpKind::OpShl (int) InstKind::InstShl (int) DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
-OpKind::OpShr (int) InstKind::InstShr (int) DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
-OpKind::OpStore8 (int) InstKind::InstStore8 (int) DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
-OpKind::OpStore16 (int) InstKind::InstStore16 (int) DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
-OpKind::OpStore32 (int) InstKind::InstStore32 (int) DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
-OpKind::OpStore64 (int) InstKind::InstStore64 (int) DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
-OpKind::OpSub (int) InstKind::InstSub (int) DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
-OpKind::OpSwap (int) InstKind::InstSwap (int) DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
-OpKind::OpSyscall0 (int) InstKind::InstSyscall0 (int) DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
-OpKind::OpSyscall1 (int) InstKind::InstSyscall1 (int) DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
-OpKind::OpSyscall2 (int) InstKind::InstSyscall2 (int) DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
-OpKind::OpSyscall3 (int) InstKind::InstSyscall3 (int) DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
-OpKind::OpSyscall4 (int) InstKind::InstSyscall4 (int) DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
-OpKind::OpSyscall5 (int) InstKind::InstSyscall5 (int) DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
-OpKind::OpSyscall6 (int) InstKind::InstSyscall6 (int) DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
-OpKind::OpArgc (int) InstKind::InstArgc (int) DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
-OpKind::OpArgv (int) InstKind::InstArgv (int) DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
+Map::new (Map[OpKind InstKind]) = DIRECT_OP_TO_INST
+OpKind::OpAdd InstKind::InstAdd DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
+OpKind::OpAnd InstKind::InstAnd DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
+OpKind::OpBitAnd InstKind::InstBitAnd DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
+OpKind::OpBitNot InstKind::InstBitNot DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
+OpKind::OpBitOr InstKind::InstBitOr DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
+OpKind::OpBitXor InstKind::InstBitXor DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
+OpKind::OpDiv InstKind::InstDiv DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
+OpKind::OpDrop InstKind::InstDrop DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
+OpKind::OpDup InstKind::InstDup DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
+OpKind::OpEq InstKind::InstEq DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
+OpKind::OpFnExec InstKind::InstFnExec DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
+OpKind::OpFnReturn InstKind::InstFnReturn DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
+OpKind::OpGe InstKind::InstGe DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
+OpKind::OpGt InstKind::InstGt DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
+OpKind::OpHeapAlloc InstKind::InstHeapAlloc DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
+OpKind::OpLe InstKind::InstLe DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
+OpKind::OpLoad8 InstKind::InstLoad8 DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
+OpKind::OpLoad16 InstKind::InstLoad16 DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
+OpKind::OpLoad32 InstKind::InstLoad32 DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
+OpKind::OpLoad64 InstKind::InstLoad64 DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
+OpKind::OpLt InstKind::InstLt DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
+OpKind::OpMod InstKind::InstMod DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
+OpKind::OpMul InstKind::InstMul DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
+OpKind::OpNe InstKind::InstNe DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
+OpKind::OpNot InstKind::InstNot DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
+OpKind::OpOr InstKind::InstOr DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
+OpKind::OpOver InstKind::InstOver DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
+OpKind::OpPrintBool InstKind::InstPrintBool DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
+OpKind::OpPrintChar InstKind::InstPrintChar DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
+OpKind::OpPrintCstr InstKind::InstPrintCstr DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
+OpKind::OpPrintInt InstKind::InstPrintInt DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
+OpKind::OpPrintStr InstKind::InstPrintStr DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
+OpKind::OpRot InstKind::InstRot DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
+OpKind::OpShl InstKind::InstShl DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
+OpKind::OpShr InstKind::InstShr DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
+OpKind::OpStore8 InstKind::InstStore8 DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
+OpKind::OpStore16 InstKind::InstStore16 DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
+OpKind::OpStore32 InstKind::InstStore32 DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
+OpKind::OpStore64 InstKind::InstStore64 DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
+OpKind::OpSub InstKind::InstSub DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
+OpKind::OpSwap InstKind::InstSwap DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
+OpKind::OpSyscall0 InstKind::InstSyscall0 DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
+OpKind::OpSyscall1 InstKind::InstSyscall1 DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
+OpKind::OpSyscall2 InstKind::InstSyscall2 DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
+OpKind::OpSyscall3 InstKind::InstSyscall3 DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
+OpKind::OpSyscall4 InstKind::InstSyscall4 DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
+OpKind::OpSyscall5 InstKind::InstSyscall5 DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
+OpKind::OpSyscall6 InstKind::InstSyscall6 DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
+OpKind::OpArgc InstKind::InstArgc DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
+OpKind::OpArgv InstKind::InstArgv DIRECT_OP_TO_INST .set = DIRECT_OP_TO_INST
 
 # ============================================================================
 # Print intrinsic dispatch names
@@ -1202,13 +1241,13 @@ fn print_intrinsic_name name:str -> str {
     fi
 }
 
-fn print_opkind_for_name name:str -> int {
-    if "print_int" name == then OpKind::OpPrintInt (int)
-    elif "print_str" name == then OpKind::OpPrintStr (int)
-    elif "print_bool" name == then OpKind::OpPrintBool (int)
-    elif "print_char" name == then OpKind::OpPrintChar (int)
-    elif "print_cstr" name == then OpKind::OpPrintCstr (int)
-    else -1
+fn print_opkind_for_name name:str -> Option[OpKind] {
+    if "print_int" name == then OpKind::OpPrintInt Option::Some
+    elif "print_str" name == then OpKind::OpPrintStr Option::Some
+    elif "print_bool" name == then OpKind::OpPrintBool Option::Some
+    elif "print_char" name == then OpKind::OpPrintChar Option::Some
+    elif "print_cstr" name == then OpKind::OpPrintCstr Option::Some
+    else Option::None
     fi
 }
 

--- a/self_hosted/emitter.casa
+++ b/self_hosted/emitter.casa
@@ -323,7 +323,7 @@ fn emit_syscall arg_count:int asm:StringBuilder {
 
 fn emit_stack_ops asm:StringBuilder inst:Inst {
     inst Inst::kind = kind
-    if InstKind::InstPush (int) kind == then
+    if InstKind::InstPush kind == then
         inst Inst::int_arg = value
         if
             INT32_MIN value >=
@@ -334,23 +334,23 @@ fn emit_stack_ops asm:StringBuilder inst:Inst {
             f"movabsq ${value .to_str}, %rax" asm emit_indent
             "pushq %rax" asm emit_indent
         fi
-    elif InstKind::InstPushStr (int) kind == then
+    elif InstKind::InstPushStr kind == then
         f"leaq str_{inst Inst::int_arg .to_str}(%rip), %rax" asm emit_indent
         "pushq %rax" asm emit_indent
-    elif InstKind::InstPushChar (int) kind == then
+    elif InstKind::InstPushChar kind == then
         f"pushq ${inst Inst::int_arg .to_str}" asm emit_indent
-    elif InstKind::InstDrop (int) kind == then
+    elif InstKind::InstDrop kind == then
         "addq $8, %rsp" asm emit_indent
-    elif InstKind::InstDup (int) kind == then
+    elif InstKind::InstDup kind == then
         "pushq (%rsp)" asm emit_indent
-    elif InstKind::InstSwap (int) kind == then
+    elif InstKind::InstSwap kind == then
         "popq %rax" asm emit_indent
         "popq %rbx" asm emit_indent
         "pushq %rax" asm emit_indent
         "pushq %rbx" asm emit_indent
-    elif InstKind::InstOver (int) kind == then
+    elif InstKind::InstOver kind == then
         "pushq 8(%rsp)" asm emit_indent
-    elif InstKind::InstRot (int) kind == then
+    elif InstKind::InstRot kind == then
         "popq %rax" asm emit_indent
         "popq %rbx" asm emit_indent
         "popq %rcx" asm emit_indent
@@ -366,46 +366,46 @@ fn emit_stack_ops asm:StringBuilder inst:Inst {
 
 fn emit_arithmetic asm:StringBuilder inst:Inst {
     inst Inst::kind = kind
-    if InstKind::InstAdd (int) kind == then
+    if InstKind::InstAdd kind == then
         "popq %rax" asm emit_indent
         "addq %rax, (%rsp)" asm emit_indent
-    elif InstKind::InstSub (int) kind == then
+    elif InstKind::InstSub kind == then
         "popq %rax" asm emit_indent
         "subq %rax, (%rsp)" asm emit_indent
-    elif InstKind::InstMul (int) kind == then
+    elif InstKind::InstMul kind == then
         "popq %rax" asm emit_indent
         "imulq (%rsp), %rax" asm emit_indent
         "movq %rax, (%rsp)" asm emit_indent
-    elif InstKind::InstDiv (int) kind == then
+    elif InstKind::InstDiv kind == then
         "popq %rbx" asm emit_indent
         "popq %rax" asm emit_indent
         "cqto" asm emit_indent
         "idivq %rbx" asm emit_indent
         "pushq %rax" asm emit_indent
-    elif InstKind::InstMod (int) kind == then
+    elif InstKind::InstMod kind == then
         "popq %rbx" asm emit_indent
         "popq %rax" asm emit_indent
         "cqto" asm emit_indent
         "idivq %rbx" asm emit_indent
         "pushq %rdx" asm emit_indent
-    elif InstKind::InstShl (int) kind == then
+    elif InstKind::InstShl kind == then
         "popq %rcx" asm emit_indent
         "shlq %cl, (%rsp)" asm emit_indent
-    elif InstKind::InstShr (int) kind == then
+    elif InstKind::InstShr kind == then
         "popq %rcx" asm emit_indent
         "sarq %cl, (%rsp)" asm emit_indent
-    elif InstKind::InstBitAnd (int) kind == then
+    elif InstKind::InstBitAnd kind == then
         "popq %rax" asm emit_indent
         "andq %rax, (%rsp)" asm emit_indent
-    elif InstKind::InstBitOr (int) kind == then
+    elif InstKind::InstBitOr kind == then
         "popq %rax" asm emit_indent
         "orq %rax, (%rsp)" asm emit_indent
-    elif InstKind::InstBitXor (int) kind == then
+    elif InstKind::InstBitXor kind == then
         "popq %rax" asm emit_indent
         "xorq %rax, (%rsp)" asm emit_indent
-    elif InstKind::InstBitNot (int) kind == then
+    elif InstKind::InstBitNot kind == then
         "notq (%rsp)" asm emit_indent
-    elif InstKind::InstAnd (int) kind == then
+    elif InstKind::InstAnd kind == then
         "popq %rax" asm emit_indent
         "testq %rax, %rax" asm emit_indent
         "setne %al" asm emit_indent
@@ -414,28 +414,28 @@ fn emit_arithmetic asm:StringBuilder inst:Inst {
         "andb %cl, %al" asm emit_indent
         "movzbq %al, %rax" asm emit_indent
         "movq %rax, (%rsp)" asm emit_indent
-    elif InstKind::InstOr (int) kind == then
+    elif InstKind::InstOr kind == then
         "popq %rax" asm emit_indent
         "orq %rax, (%rsp)" asm emit_indent
         "setne %al" asm emit_indent
         "movzbq %al, %rax" asm emit_indent
         "movq %rax, (%rsp)" asm emit_indent
-    elif InstKind::InstNot (int) kind == then
+    elif InstKind::InstNot kind == then
         "cmpq $0, (%rsp)" asm emit_indent
         "sete %al" asm emit_indent
         "movzbq %al, %rax" asm emit_indent
         "movq %rax, (%rsp)" asm emit_indent
-    elif InstKind::InstEq (int) kind == then
+    elif InstKind::InstEq kind == then
         asm "sete" emit_comparison
-    elif InstKind::InstNe (int) kind == then
+    elif InstKind::InstNe kind == then
         asm "setne" emit_comparison
-    elif InstKind::InstLt (int) kind == then
+    elif InstKind::InstLt kind == then
         asm "setl" emit_comparison
-    elif InstKind::InstLe (int) kind == then
+    elif InstKind::InstLe kind == then
         asm "setle" emit_comparison
-    elif InstKind::InstGt (int) kind == then
+    elif InstKind::InstGt kind == then
         asm "setg" emit_comparison
-    elif InstKind::InstGe (int) kind == then
+    elif InstKind::InstGe kind == then
         asm "setge" emit_comparison
     fi
 }
@@ -446,25 +446,25 @@ fn emit_arithmetic asm:StringBuilder inst:Inst {
 
 fn emit_control_flow asm:StringBuilder inst:Inst is_global:bool {
     inst Inst::kind = kind
-    if InstKind::InstLabel (int) kind == then
+    if InstKind::InstLabel kind == then
         f".L{inst Inst::int_arg .to_str}:" asm emit_line
-    elif InstKind::InstJump (int) kind == then
+    elif InstKind::InstJump kind == then
         f"jmp .L{inst Inst::int_arg .to_str}" asm emit_indent
-    elif InstKind::InstJumpNe (int) kind == then
+    elif InstKind::InstJumpNe kind == then
         "popq %rax" asm emit_indent
         "testq %rax, %rax" asm emit_indent
         f"jz .L{inst Inst::int_arg .to_str}" asm emit_indent
-    elif InstKind::InstGlobalsInit (int) kind == then
+    elif InstKind::InstGlobalsInit kind == then
         # Nothing needed, BSS handles it
-    elif InstKind::InstGlobalGet (int) kind == then
+    elif InstKind::InstGlobalGet kind == then
         inst Inst::int_arg 8 * = offset
         f"movq globals+{offset .to_str}(%rip), %rax" asm emit_indent
         "pushq %rax" asm emit_indent
-    elif InstKind::InstGlobalSet (int) kind == then
+    elif InstKind::InstGlobalSet kind == then
         inst Inst::int_arg 8 * = offset
         "popq %rax" asm emit_indent
         f"movq %rax, globals+{offset .to_str}(%rip)" asm emit_indent
-    elif InstKind::InstLocalsInit (int) kind == then
+    elif InstKind::InstLocalsInit kind == then
         inst Inst::int_arg = count
         if 0 count != then
             "movq %r14, %rdi" asm emit_indent
@@ -473,28 +473,28 @@ fn emit_control_flow asm:StringBuilder inst:Inst is_global:bool {
             "rep stosq" asm emit_indent
             f"addq ${count 8 * .to_str}, %r14" asm emit_indent
         fi
-    elif InstKind::InstLocalsUninit (int) kind == then
+    elif InstKind::InstLocalsUninit kind == then
         inst Inst::int_arg = count
         if 0 count != then
             f"subq ${count 8 * .to_str}, %r14" asm emit_indent
         fi
-    elif InstKind::InstLocalGet (int) kind == then
+    elif InstKind::InstLocalGet kind == then
         inst Inst::int_arg 1 + 8 * = offset
         f"movq -{offset .to_str}(%r14), %rax" asm emit_indent
         "pushq %rax" asm emit_indent
-    elif InstKind::InstLocalSet (int) kind == then
+    elif InstKind::InstLocalSet kind == then
         inst Inst::int_arg 1 + 8 * = offset
         "popq %rax" asm emit_indent
         f"movq %rax, -{offset .to_str}(%r14)" asm emit_indent
-    elif InstKind::InstConstantLoad (int) kind == then
+    elif InstKind::InstConstantLoad kind == then
         inst Inst::int_arg 8 * = offset
         f"movq constants+{offset .to_str}(%rip), %rax" asm emit_indent
         "pushq %rax" asm emit_indent
-    elif InstKind::InstConstantStore (int) kind == then
+    elif InstKind::InstConstantStore kind == then
         inst Inst::int_arg 8 * = offset
         "popq %rax" asm emit_indent
         f"movq %rax, constants+{offset .to_str}(%rip)" asm emit_indent
-    elif InstKind::InstFnCall (int) kind == then
+    elif InstKind::InstFnCall kind == then
         inst Inst::str_arg sanitize_name = label
         emit_uid = uid
         f"leaq .Lret_{uid .to_str}(%rip), %rax" asm emit_indent
@@ -502,7 +502,7 @@ fn emit_control_flow asm:StringBuilder inst:Inst is_global:bool {
         "addq $8, %r14" asm emit_indent
         f"jmp fn_{label}" asm emit_indent
         f".Lret_{uid .to_str}:" asm emit_line
-    elif InstKind::InstFnExec (int) kind == then
+    elif InstKind::InstFnExec kind == then
         emit_uid = uid
         f"leaq .Lret_{uid .to_str}(%rip), %rax" asm emit_indent
         "movq %rax, (%r14)" asm emit_indent
@@ -510,11 +510,11 @@ fn emit_control_flow asm:StringBuilder inst:Inst is_global:bool {
         "popq %rax" asm emit_indent
         "jmpq *%rax" asm emit_indent
         f".Lret_{uid .to_str}:" asm emit_line
-    elif InstKind::InstFnPush (int) kind == then
+    elif InstKind::InstFnPush kind == then
         inst Inst::str_arg sanitize_name = label
         f"leaq fn_{label}(%rip), %rax" asm emit_indent
         "pushq %rax" asm emit_indent
-    elif InstKind::InstFnReturn (int) kind == then
+    elif InstKind::InstFnReturn kind == then
         if is_global then
             "movq $60, %rax" asm emit_indent
             "xorq %rdi, %rdi" asm emit_indent
@@ -532,7 +532,7 @@ fn emit_control_flow asm:StringBuilder inst:Inst is_global:bool {
 
 fn emit_memory asm:StringBuilder inst:Inst {
     inst Inst::kind = kind
-    if InstKind::InstHeapAlloc (int) kind == then
+    if InstKind::InstHeapAlloc kind == then
         "popq %rax" asm emit_indent
         "leaq heap(%rip), %rbx" asm emit_indent
         "movq heap_ptr(%rip), %rcx" asm emit_indent
@@ -540,35 +540,35 @@ fn emit_memory asm:StringBuilder inst:Inst {
         "pushq %rdx" asm emit_indent
         "addq %rax, %rcx" asm emit_indent
         "movq %rcx, heap_ptr(%rip)" asm emit_indent
-    elif InstKind::InstLoad8 (int) kind == then
+    elif InstKind::InstLoad8 kind == then
         "popq %rax" asm emit_indent
         "movzbl (%rax), %eax" asm emit_indent
         "pushq %rax" asm emit_indent
-    elif InstKind::InstLoad16 (int) kind == then
+    elif InstKind::InstLoad16 kind == then
         "popq %rax" asm emit_indent
         "movzwl (%rax), %eax" asm emit_indent
         "pushq %rax" asm emit_indent
-    elif InstKind::InstLoad32 (int) kind == then
+    elif InstKind::InstLoad32 kind == then
         "popq %rax" asm emit_indent
         "movl (%rax), %eax" asm emit_indent
         "pushq %rax" asm emit_indent
-    elif InstKind::InstLoad64 (int) kind == then
+    elif InstKind::InstLoad64 kind == then
         "popq %rax" asm emit_indent
         "movq (%rax), %rax" asm emit_indent
         "pushq %rax" asm emit_indent
-    elif InstKind::InstStore8 (int) kind == then
+    elif InstKind::InstStore8 kind == then
         "popq %rax" asm emit_indent
         "popq %rbx" asm emit_indent
         "movb %bl, (%rax)" asm emit_indent
-    elif InstKind::InstStore16 (int) kind == then
+    elif InstKind::InstStore16 kind == then
         "popq %rax" asm emit_indent
         "popq %rbx" asm emit_indent
         "movw %bx, (%rax)" asm emit_indent
-    elif InstKind::InstStore32 (int) kind == then
+    elif InstKind::InstStore32 kind == then
         "popq %rax" asm emit_indent
         "popq %rbx" asm emit_indent
         "movl %ebx, (%rax)" asm emit_indent
-    elif InstKind::InstStore64 (int) kind == then
+    elif InstKind::InstStore64 kind == then
         "popq %rax" asm emit_indent
         "popq %rbx" asm emit_indent
         "movq %rbx, (%rax)" asm emit_indent
@@ -581,7 +581,7 @@ fn emit_memory asm:StringBuilder inst:Inst {
 
 fn emit_io_ops asm:StringBuilder inst:Inst {
     inst Inst::kind = kind
-    if InstKind::InstPrintInt (int) kind == then
+    if InstKind::InstPrintInt kind == then
         emit_uid = uid
         "popq %rdi" asm emit_indent
         f"leaq .Lprint_done_{uid .to_str}(%rip), %rax" asm emit_indent
@@ -589,7 +589,7 @@ fn emit_io_ops asm:StringBuilder inst:Inst {
         "addq $8, %r14" asm emit_indent
         "jmp print_int" asm emit_indent
         f".Lprint_done_{uid .to_str}:" asm emit_line
-    elif InstKind::InstPrintBool (int) kind == then
+    elif InstKind::InstPrintBool kind == then
         emit_uid = uid
         "popq %rax" asm emit_indent
         "testq %rax, %rax" asm emit_indent
@@ -604,7 +604,7 @@ fn emit_io_ops asm:StringBuilder inst:Inst {
         "movq $1, %rdi" asm emit_indent
         "movq $1, %rax" asm emit_indent
         "syscall" asm emit_indent
-    elif InstKind::InstPrintStr (int) kind == then
+    elif InstKind::InstPrintStr kind == then
         emit_uid = uid
         "popq %rdi" asm emit_indent
         f"leaq .Lprint_done_{uid .to_str}(%rip), %rax" asm emit_indent
@@ -612,7 +612,7 @@ fn emit_io_ops asm:StringBuilder inst:Inst {
         "addq $8, %r14" asm emit_indent
         "jmp print_str" asm emit_indent
         f".Lprint_done_{uid .to_str}:" asm emit_line
-    elif InstKind::InstPrintChar (int) kind == then
+    elif InstKind::InstPrintChar kind == then
         "popq %rax" asm emit_indent
         "movb %al, -1(%rsp)" asm emit_indent
         "leaq -1(%rsp), %rsi" asm emit_indent
@@ -620,7 +620,7 @@ fn emit_io_ops asm:StringBuilder inst:Inst {
         "movq $1, %rdi" asm emit_indent
         "movq $1, %rax" asm emit_indent
         "syscall" asm emit_indent
-    elif InstKind::InstPrintCstr (int) kind == then
+    elif InstKind::InstPrintCstr kind == then
         emit_uid = uid
         "popq %rsi" asm emit_indent
         "movq %rsi, %rdi" asm emit_indent
@@ -636,7 +636,7 @@ fn emit_io_ops asm:StringBuilder inst:Inst {
         "movq $1, %rdi" asm emit_indent
         "movq $1, %rax" asm emit_indent
         "syscall" asm emit_indent
-    elif InstKind::InstFstringConcat (int) kind == then
+    elif InstKind::InstFstringConcat kind == then
         emit_uid = uid
         f"movq ${inst Inst::int_arg .to_str}, %rdi" asm emit_indent
         f"leaq .Lconcat_done_{uid .to_str}(%rip), %rax" asm emit_indent
@@ -678,124 +678,124 @@ fn emit_inst asm:StringBuilder inst:Inst is_global:bool {
 
     # Stack operations
     if
-        InstKind::InstPush (int) kind ==
-        InstKind::InstPushStr (int) kind == ||
-        InstKind::InstPushChar (int) kind == ||
-        InstKind::InstDrop (int) kind == ||
-        InstKind::InstDup (int) kind == ||
-        InstKind::InstSwap (int) kind == ||
-        InstKind::InstOver (int) kind == ||
-        InstKind::InstRot (int) kind == ||
+        InstKind::InstPush kind ==
+        InstKind::InstPushStr kind == ||
+        InstKind::InstPushChar kind == ||
+        InstKind::InstDrop kind == ||
+        InstKind::InstDup kind == ||
+        InstKind::InstSwap kind == ||
+        InstKind::InstOver kind == ||
+        InstKind::InstRot kind == ||
     then
         inst asm emit_stack_ops
 
     # Arithmetic / bitwise / boolean / comparison
     elif
-        InstKind::InstAdd (int) kind ==
-        InstKind::InstSub (int) kind == ||
-        InstKind::InstMul (int) kind == ||
-        InstKind::InstDiv (int) kind == ||
-        InstKind::InstMod (int) kind == ||
-        InstKind::InstShl (int) kind == ||
-        InstKind::InstShr (int) kind == ||
-        InstKind::InstBitAnd (int) kind == ||
-        InstKind::InstBitOr (int) kind == ||
-        InstKind::InstBitXor (int) kind == ||
-        InstKind::InstBitNot (int) kind == ||
-        InstKind::InstAnd (int) kind == ||
-        InstKind::InstOr (int) kind == ||
-        InstKind::InstNot (int) kind == ||
-        InstKind::InstEq (int) kind == ||
-        InstKind::InstNe (int) kind == ||
-        InstKind::InstLt (int) kind == ||
-        InstKind::InstLe (int) kind == ||
-        InstKind::InstGt (int) kind == ||
-        InstKind::InstGe (int) kind == ||
+        InstKind::InstAdd kind ==
+        InstKind::InstSub kind == ||
+        InstKind::InstMul kind == ||
+        InstKind::InstDiv kind == ||
+        InstKind::InstMod kind == ||
+        InstKind::InstShl kind == ||
+        InstKind::InstShr kind == ||
+        InstKind::InstBitAnd kind == ||
+        InstKind::InstBitOr kind == ||
+        InstKind::InstBitXor kind == ||
+        InstKind::InstBitNot kind == ||
+        InstKind::InstAnd kind == ||
+        InstKind::InstOr kind == ||
+        InstKind::InstNot kind == ||
+        InstKind::InstEq kind == ||
+        InstKind::InstNe kind == ||
+        InstKind::InstLt kind == ||
+        InstKind::InstLe kind == ||
+        InstKind::InstGt kind == ||
+        InstKind::InstGe kind == ||
     then
         inst asm emit_arithmetic
 
     # Control flow / variables / functions
     elif
-        InstKind::InstLabel (int) kind ==
-        InstKind::InstJump (int) kind == ||
-        InstKind::InstJumpNe (int) kind == ||
-        InstKind::InstGlobalsInit (int) kind == ||
-        InstKind::InstGlobalGet (int) kind == ||
-        InstKind::InstGlobalSet (int) kind == ||
-        InstKind::InstLocalsInit (int) kind == ||
-        InstKind::InstLocalsUninit (int) kind == ||
-        InstKind::InstLocalGet (int) kind == ||
-        InstKind::InstLocalSet (int) kind == ||
-        InstKind::InstConstantLoad (int) kind == ||
-        InstKind::InstConstantStore (int) kind == ||
-        InstKind::InstFnCall (int) kind == ||
-        InstKind::InstFnExec (int) kind == ||
-        InstKind::InstFnPush (int) kind == ||
-        InstKind::InstFnReturn (int) kind == ||
+        InstKind::InstLabel kind ==
+        InstKind::InstJump kind == ||
+        InstKind::InstJumpNe kind == ||
+        InstKind::InstGlobalsInit kind == ||
+        InstKind::InstGlobalGet kind == ||
+        InstKind::InstGlobalSet kind == ||
+        InstKind::InstLocalsInit kind == ||
+        InstKind::InstLocalsUninit kind == ||
+        InstKind::InstLocalGet kind == ||
+        InstKind::InstLocalSet kind == ||
+        InstKind::InstConstantLoad kind == ||
+        InstKind::InstConstantStore kind == ||
+        InstKind::InstFnCall kind == ||
+        InstKind::InstFnExec kind == ||
+        InstKind::InstFnPush kind == ||
+        InstKind::InstFnReturn kind == ||
     then
         is_global inst asm emit_control_flow
 
     # Memory operations
     elif
-        InstKind::InstHeapAlloc (int) kind ==
-        InstKind::InstLoad8 (int) kind == ||
-        InstKind::InstLoad16 (int) kind == ||
-        InstKind::InstLoad32 (int) kind == ||
-        InstKind::InstLoad64 (int) kind == ||
-        InstKind::InstStore8 (int) kind == ||
-        InstKind::InstStore16 (int) kind == ||
-        InstKind::InstStore32 (int) kind == ||
-        InstKind::InstStore64 (int) kind == ||
+        InstKind::InstHeapAlloc kind ==
+        InstKind::InstLoad8 kind == ||
+        InstKind::InstLoad16 kind == ||
+        InstKind::InstLoad32 kind == ||
+        InstKind::InstLoad64 kind == ||
+        InstKind::InstStore8 kind == ||
+        InstKind::InstStore16 kind == ||
+        InstKind::InstStore32 kind == ||
+        InstKind::InstStore64 kind == ||
     then
         inst asm emit_memory
 
     # IO operations
     elif
-        InstKind::InstPrintInt (int) kind ==
-        InstKind::InstPrintBool (int) kind == ||
-        InstKind::InstPrintStr (int) kind == ||
-        InstKind::InstPrintChar (int) kind == ||
-        InstKind::InstPrintCstr (int) kind == ||
-        InstKind::InstFstringConcat (int) kind == ||
+        InstKind::InstPrintInt kind ==
+        InstKind::InstPrintBool kind == ||
+        InstKind::InstPrintStr kind == ||
+        InstKind::InstPrintChar kind == ||
+        InstKind::InstPrintCstr kind == ||
+        InstKind::InstFstringConcat kind == ||
     then
         inst asm emit_io_ops
 
     # String equality
-    elif InstKind::InstStrEq (int) kind == then
+    elif InstKind::InstStrEq kind == then
         asm emit_str_eq
 
     # Syscalls
     elif
-        InstKind::InstSyscall0 (int) kind ==
-        InstKind::InstSyscall1 (int) kind == ||
-        InstKind::InstSyscall2 (int) kind == ||
-        InstKind::InstSyscall3 (int) kind == ||
-        InstKind::InstSyscall4 (int) kind == ||
-        InstKind::InstSyscall5 (int) kind == ||
-        InstKind::InstSyscall6 (int) kind == ||
+        InstKind::InstSyscall0 kind ==
+        InstKind::InstSyscall1 kind == ||
+        InstKind::InstSyscall2 kind == ||
+        InstKind::InstSyscall3 kind == ||
+        InstKind::InstSyscall4 kind == ||
+        InstKind::InstSyscall5 kind == ||
+        InstKind::InstSyscall6 kind == ||
     then
         inst Inst::kind = syscall_kind
-        if InstKind::InstSyscall0 (int) syscall_kind == then
+        if InstKind::InstSyscall0 syscall_kind == then
             asm 0 emit_syscall
-        elif InstKind::InstSyscall1 (int) syscall_kind == then
+        elif InstKind::InstSyscall1 syscall_kind == then
             asm 1 emit_syscall
-        elif InstKind::InstSyscall2 (int) syscall_kind == then
+        elif InstKind::InstSyscall2 syscall_kind == then
             asm 2 emit_syscall
-        elif InstKind::InstSyscall3 (int) syscall_kind == then
+        elif InstKind::InstSyscall3 syscall_kind == then
             asm 3 emit_syscall
-        elif InstKind::InstSyscall4 (int) syscall_kind == then
+        elif InstKind::InstSyscall4 syscall_kind == then
             asm 4 emit_syscall
-        elif InstKind::InstSyscall5 (int) syscall_kind == then
+        elif InstKind::InstSyscall5 syscall_kind == then
             asm 5 emit_syscall
-        elif InstKind::InstSyscall6 (int) syscall_kind == then
+        elif InstKind::InstSyscall6 syscall_kind == then
             asm 6 emit_syscall
         fi
 
     # argc / argv
-    elif InstKind::InstArgc (int) kind == then
+    elif InstKind::InstArgc kind == then
         "movq __argc(%rip), %rax" asm emit_indent
         "pushq %rax" asm emit_indent
-    elif InstKind::InstArgv (int) kind == then
+    elif InstKind::InstArgv kind == then
         "movq __argv(%rip), %rax" asm emit_indent
         "pushq %rax" asm emit_indent
     fi

--- a/self_hosted/error.casa
+++ b/self_hosted/error.casa
@@ -21,7 +21,7 @@ struct CasaNote {
 }
 
 struct CasaError {
-    kind:      int
+    kind:      ErrorKind
     message:   str
     location:  Location
     expected:  Option[str]
@@ -30,11 +30,11 @@ struct CasaError {
     notes:     List[CasaNote]
 }
 
-fn make_error kind:int message:str location:Location -> CasaError {
+fn make_error kind:ErrorKind message:str location:Location -> CasaError {
     List::new (List[CasaNote]) "Got" Option::None Option::None location message kind CasaError
 }
 
-fn make_error_expected kind:int message:str location:Location expected:str got:str -> CasaError {
+fn make_error_expected kind:ErrorKind message:str location:Location expected:str got:str -> CasaError {
     List::new (List[CasaNote]) "Got" got Option::Some expected Option::Some location message kind CasaError
 }
 
@@ -43,7 +43,7 @@ fn make_error_expected kind:int message:str location:Location expected:str got:s
 # ============================================================================
 
 struct CasaWarning {
-    kind:     int
+    kind:     WarningKind
     message:  str
     location: Location
 }
@@ -118,21 +118,21 @@ fn offset_to_source_line source:str offset:int -> str {
 # Error formatting
 # ============================================================================
 
-fn error_kind_name kind:int -> str {
-    if ErrorKind::Syntax (int) kind == then "SYNTAX"
-    elif ErrorKind::UnexpectedToken (int) kind == then "UNEXPECTED_TOKEN"
-    elif ErrorKind::UndefinedName (int) kind == then "UNDEFINED_NAME"
-    elif ErrorKind::DuplicateName (int) kind == then "DUPLICATE_NAME"
-    elif ErrorKind::InvalidScope (int) kind == then "INVALID_SCOPE"
-    elif ErrorKind::TypeMismatch (int) kind == then "TYPE_MISMATCH"
-    elif ErrorKind::StackMismatch (int) kind == then "STACK_MISMATCH"
-    elif ErrorKind::SignatureMismatch (int) kind == then "SIGNATURE_MISMATCH"
-    elif ErrorKind::InvalidVariable (int) kind == then "INVALID_VARIABLE"
-    elif ErrorKind::UnmatchedBlock (int) kind == then "UNMATCHED_BLOCK"
-    elif ErrorKind::MissingTraitMethod (int) kind == then "MISSING_TRAIT_METHOD"
-    elif ErrorKind::TraitSignatureMismatch (int) kind == then "TRAIT_SIGNATURE_MISMATCH"
-    else "UNKNOWN"
-    fi
+fn error_kind_name kind:ErrorKind -> str {
+    kind match
+        ErrorKind::Syntax => "SYNTAX"
+        ErrorKind::UnexpectedToken => "UNEXPECTED_TOKEN"
+        ErrorKind::UndefinedName => "UNDEFINED_NAME"
+        ErrorKind::DuplicateName => "DUPLICATE_NAME"
+        ErrorKind::InvalidScope => "INVALID_SCOPE"
+        ErrorKind::TypeMismatch => "TYPE_MISMATCH"
+        ErrorKind::StackMismatch => "STACK_MISMATCH"
+        ErrorKind::SignatureMismatch => "SIGNATURE_MISMATCH"
+        ErrorKind::InvalidVariable => "INVALID_VARIABLE"
+        ErrorKind::UnmatchedBlock => "UNMATCHED_BLOCK"
+        ErrorKind::MissingTraitMethod => "MISSING_TRAIT_METHOD"
+        ErrorKind::TraitSignatureMismatch => "TRAIT_SIGNATURE_MISMATCH"
+    end
 }
 
 fn format_source_context file:str source:str span_offset:int span_length:int -> str {
@@ -266,7 +266,7 @@ fn report_warnings {
         index WARNINGS .get = warning
         StringBuilder::new = builder
         "warning[" builder .append
-        if WarningKind::UnusedParameter (int) warning CasaWarning::kind == then
+        if WarningKind::UnusedParameter warning CasaWarning::kind == then
             "UNUSED_PARAMETER" builder .append
         else
             "LOSSY_TYPE_ANNOTATION" builder .append
@@ -282,15 +282,15 @@ fn report_warnings {
 # Convenience functions
 # ============================================================================
 
-fn add_error kind:int message:str location:Location {
+fn add_error kind:ErrorKind message:str location:Location {
     location message kind make_error ERRORS .push
 }
 
-fn add_error_expected kind:int message:str location:Location expected:str got:str {
+fn add_error_expected kind:ErrorKind message:str location:Location expected:str got:str {
     got expected location message kind make_error_expected ERRORS .push
 }
 
-fn raise_error kind:int message:str location:Location {
+fn raise_error kind:ErrorKind message:str location:Location {
     location message kind make_error ERRORS .push
     if TEST_MODE ! RESILIENT_MODE ! && then
         ERRORS report_errors
@@ -298,7 +298,7 @@ fn raise_error kind:int message:str location:Location {
     fi
 }
 
-fn raise_error_expected kind:int message:str location:Location expected:str got:str {
+fn raise_error_expected kind:ErrorKind message:str location:Location expected:str got:str {
     got expected location message kind make_error_expected ERRORS .push
     if TEST_MODE ! RESILIENT_MODE ! && then
         ERRORS report_errors

--- a/self_hosted/lexer.casa
+++ b/self_hosted/lexer.casa
@@ -60,7 +60,7 @@ fn lexer_startswith lexer:Lexer prefix:str -> bool {
     prefix lexer Lexer::cursor .starts_with
 }
 
-fn lexer_add_error lexer:Lexer kind:int message:str loc:Location {
+fn lexer_add_error lexer:Lexer kind:ErrorKind message:str loc:Location {
     loc message kind make_error lexer Lexer::errors .push
 }
 
@@ -79,7 +79,7 @@ fn lexer_lex_integer lexer:Lexer -> Token {
         lexer Lexer::cursor .advance drop
     done
     lexer Lexer::cursor Cursor::pos start - start lexer lexer_loc = loc
-    loc TokenKind::Literal (int) builder .build make_token
+    loc TokenKind::Literal builder .build make_token
 }
 
 # ============================================================================
@@ -96,7 +96,7 @@ fn lexer_parse_escape lexer:Lexer -> Option[str] {
         result return
     fi
     2 lexer Lexer::cursor Cursor::pos 2 - lexer lexer_loc = loc
-    loc f"Invalid escape sequence" ErrorKind::Syntax (int) lexer lexer_add_error
+    loc f"Invalid escape sequence" ErrorKind::Syntax lexer lexer_add_error
     "" Option::Some
 }
 
@@ -129,7 +129,7 @@ fn lexer_parse_string lexer:Lexer -> str {
     done
     if closed ! then
         lexer Lexer::cursor Cursor::pos start - start lexer lexer_loc = error_loc
-        error_loc "Unclosed string literal" ErrorKind::Syntax (int) lexer lexer_add_error
+        error_loc "Unclosed string literal" ErrorKind::Syntax lexer lexer_add_error
     fi
     builder .build
 }
@@ -145,8 +145,8 @@ fn lexer_parse_char lexer:Lexer -> Token {
     lexer Lexer::cursor .advance = next_opt
     if next_opt .is_none then
         lexer Lexer::cursor Cursor::pos start - start lexer lexer_loc = error_loc
-        error_loc "Unclosed char literal" ErrorKind::Syntax (int) lexer lexer_add_error
-        error_loc TokenKind::Literal (int) "'\0'" make_token return
+        error_loc "Unclosed char literal" ErrorKind::Syntax lexer lexer_add_error
+        error_loc TokenKind::Literal "'\0'" make_token return
     fi
     next_opt .unwrap = next_char
     "" = char_value
@@ -155,13 +155,13 @@ fn lexer_parse_char lexer:Lexer -> Token {
         lexer lexer_parse_escape = escape
         if escape .is_none then
             lexer Lexer::cursor Cursor::pos start - start lexer lexer_loc = error_loc2
-            error_loc2 TokenKind::Literal (int) "'\0'" make_token return
+            error_loc2 TokenKind::Literal "'\0'" make_token return
         fi
         escape .unwrap = char_value
     elif '\'' next_char == then
         lexer Lexer::cursor Cursor::pos start - start lexer lexer_loc = error_loc3
-        error_loc3 "Empty char literal" ErrorKind::Syntax (int) lexer lexer_add_error
-        error_loc3 TokenKind::Literal (int) "'\0'" make_token return
+        error_loc3 "Empty char literal" ErrorKind::Syntax lexer lexer_add_error
+        error_loc3 TokenKind::Literal "'\0'" make_token return
     else
         StringBuilder::new = char_builder
         next_char char_builder .append_char
@@ -172,10 +172,10 @@ fn lexer_parse_char lexer:Lexer -> Token {
     lexer Lexer::cursor .advance = closing
     if closing .is_none then
         lexer Lexer::cursor Cursor::pos start - start lexer lexer_loc = error_loc4
-        error_loc4 "Unclosed char literal" ErrorKind::Syntax (int) lexer lexer_add_error
+        error_loc4 "Unclosed char literal" ErrorKind::Syntax lexer lexer_add_error
     elif '\'' closing .unwrap != then
         lexer Lexer::cursor Cursor::pos start - start lexer lexer_loc = error_loc5
-        error_loc5 "Unclosed char literal" ErrorKind::Syntax (int) lexer lexer_add_error
+        error_loc5 "Unclosed char literal" ErrorKind::Syntax lexer lexer_add_error
     fi
 
     lexer Lexer::cursor Cursor::pos start - start lexer lexer_loc = final_loc
@@ -183,7 +183,7 @@ fn lexer_parse_char lexer:Lexer -> Token {
     '\'' result .append_char
     char_value result .append
     '\'' result .append_char
-    final_loc TokenKind::Literal (int) result .build make_token
+    final_loc TokenKind::Literal result .build make_token
 }
 
 # ============================================================================
@@ -248,7 +248,7 @@ fn lexer_lex_multichar lexer:Lexer -> Option[Token] {
     if "\"" lexer lexer_startswith then
         lexer lexer_parse_string = str_value
         lexer Lexer::cursor Cursor::pos start - start lexer lexer_loc = str_loc
-        str_loc TokenKind::Literal (int) str_value make_token Option::Some return
+        str_loc TokenKind::Literal str_value make_token Option::Some return
     fi
 
     lexer lexer_peek_word = word_opt
@@ -268,43 +268,43 @@ fn lexer_lex_multichar lexer:Lexer -> Option[Token] {
 
     # Negative integer literal
     if value is_negative_integer_literal prev_digit ! && then
-        loc TokenKind::Literal (int) value make_token Option::Some return
+        loc TokenKind::Literal value make_token Option::Some return
     fi
     # Boolean literals
     if "true" value == "false" value == || then
-        loc TokenKind::Literal (int) value make_token Option::Some return
+        loc TokenKind::Literal value make_token Option::Some return
     fi
     # Delimiter
     if value delimiter_from_str .is_some then
-        loc TokenKind::Delimiter (int) value make_token Option::Some return
+        loc TokenKind::Delimiter value make_token Option::Some return
     fi
     # Intrinsic
     if value intrinsic_from_str .is_some then
-        loc TokenKind::Intrinsic (int) value make_token Option::Some return
+        loc TokenKind::Intrinsic value make_token Option::Some return
     fi
     # Keyword
     if value keyword_from_str .is_some then
-        loc TokenKind::Keyword (int) value make_token Option::Some return
+        loc TokenKind::Keyword value make_token Option::Some return
     fi
     # Operator
     if value operator_from_str .is_some then
-        loc TokenKind::Operator (int) value make_token Option::Some return
+        loc TokenKind::Operator value make_token Option::Some return
     fi
     # :: chaining
     if "::" lexer lexer_startswith then
         lexer Lexer::cursor Cursor::pos 2 + lexer Lexer::cursor Cursor::set_pos
         lexer lexer_lex_multichar = method_opt
         if method_opt .is_none then
-            loc "Expected method name after `::`" ErrorKind::Syntax (int) lexer lexer_add_error
-            loc TokenKind::Identifier (int) value make_token Option::Some return
+            loc "Expected method name after `::`" ErrorKind::Syntax lexer lexer_add_error
+            loc TokenKind::Identifier value make_token Option::Some return
         fi
         method_opt .unwrap Token::value = method_name
         f"{value}::{method_name}" = full_name
         full_name .length start lexer lexer_loc = full_loc
-        full_loc TokenKind::Identifier (int) full_name make_token Option::Some return
+        full_loc TokenKind::Identifier full_name make_token Option::Some return
     fi
     # Identifier
-    loc TokenKind::Identifier (int) value make_token Option::Some
+    loc TokenKind::Identifier value make_token Option::Some
 }
 
 # ============================================================================
@@ -325,7 +325,7 @@ fn lexer_lex_fstring_expr lexer:Lexer tokens:List[Token] {
         # Closing }
         if '}' ch == 0 depth == && then
             1 lexer lexer_cur_loc = end_loc
-            end_loc TokenKind::FstringExprEnd (int) "}" make_token tokens .push
+            end_loc TokenKind::FstringExprEnd "}" make_token tokens .push
             lexer Lexer::cursor .advance drop
             return
         fi
@@ -336,7 +336,7 @@ fn lexer_lex_fstring_expr lexer:Lexer tokens:List[Token] {
             token_opt .unwrap tokens .push
         fi
     done
-    0 lexer lexer_cur_loc "Unclosed f-string expression" ErrorKind::Syntax (int) lexer lexer_add_error
+    0 lexer lexer_cur_loc "Unclosed f-string expression" ErrorKind::Syntax lexer lexer_add_error
 }
 
 fn lexer_lex_fstring lexer:Lexer tokens:List[Token] {
@@ -344,7 +344,7 @@ fn lexer_lex_fstring lexer:Lexer tokens:List[Token] {
     2 start lexer lexer_loc = start_loc
     lexer Lexer::cursor Cursor::pos 2 + lexer Lexer::cursor Cursor::set_pos
 
-    start_loc TokenKind::FstringStart (int) "" make_token tokens .push
+    start_loc TokenKind::FstringStart "" make_token tokens .push
     StringBuilder::new = text
     lexer Lexer::cursor Cursor::pos = text_start
 
@@ -362,11 +362,11 @@ fn lexer_lex_fstring lexer:Lexer tokens:List[Token] {
         if '{' ch == then
             if 0 text .length != then
                 lexer Lexer::cursor Cursor::pos text_start - text_start lexer lexer_loc = text_loc
-                text_loc TokenKind::FstringText (int) text .build make_token tokens .push
+                text_loc TokenKind::FstringText text .build make_token tokens .push
                 StringBuilder::new = text
             fi
             1 lexer Lexer::cursor Cursor::pos lexer lexer_loc = expr_loc
-            expr_loc TokenKind::FstringExprStart (int) "{" make_token tokens .push
+            expr_loc TokenKind::FstringExprStart "{" make_token tokens .push
             lexer Lexer::cursor .advance drop
             tokens lexer lexer_lex_fstring_expr
             lexer Lexer::cursor Cursor::pos = text_start
@@ -376,18 +376,18 @@ fn lexer_lex_fstring lexer:Lexer tokens:List[Token] {
         if '"' ch == then
             if 0 text .length != then
                 lexer Lexer::cursor Cursor::pos text_start - text_start lexer lexer_loc = text_loc2
-                text_loc2 TokenKind::FstringText (int) text .build make_token tokens .push
+                text_loc2 TokenKind::FstringText text .build make_token tokens .push
             fi
             lexer Lexer::cursor .advance drop
             1 lexer Lexer::cursor Cursor::pos 1 - lexer lexer_loc = end_loc
-            end_loc TokenKind::FstringEnd (int) "" make_token tokens .push
+            end_loc TokenKind::FstringEnd "" make_token tokens .push
             return
         fi
         ch text .append_char
         lexer Lexer::cursor .advance drop
     done
     lexer Lexer::cursor Cursor::pos start - start lexer lexer_loc
-    "Unclosed f-string" ErrorKind::Syntax (int) lexer lexer_add_error
+    "Unclosed f-string" ErrorKind::Syntax lexer lexer_add_error
 }
 
 # ============================================================================
@@ -415,7 +415,7 @@ fn lexer_parse_single_token lexer:Lexer -> Option[Token] {
         StringBuilder::new = builder
         ch builder .append_char
         1 pos lexer lexer_loc = loc
-        loc TokenKind::Delimiter (int) builder .build make_token Option::Some
+        loc TokenKind::Delimiter builder .build make_token Option::Some
         lexer Lexer::cursor .advance drop
         return
     fi
@@ -445,7 +445,7 @@ fn lexer_lex lexer:Lexer -> List[Token] {
             token_opt .unwrap tokens .push
         fi
     done
-    0 lexer lexer_cur_loc TokenKind::Eof (int) "" make_token tokens .push
+    0 lexer lexer_cur_loc TokenKind::Eof "" make_token tokens .push
     if 0 lexer Lexer::errors .length != then
         if RESILIENT_MODE then
             0 = lex_err_i

--- a/self_hosted/lsp.casa
+++ b/self_hosted/lsp.casa
@@ -120,8 +120,8 @@ struct FindOpState {
 
 Map::new (Map[str DocumentState]) = DOCUMENT_STATES
 StdinReader::new = STDIN_READER
-Map::new (Map[int str]) = STACK_EFFECTS
-Map::new (Map[int int]) = TOKEN_TYPE_MAP
+Map::new (Map[OpKind str]) = STACK_EFFECTS
+Map::new (Map[OpKind int]) = TOKEN_TYPE_MAP
 
 # ============================================================================
 # Coordinate conversion utilities
@@ -708,7 +708,7 @@ fn find_best_assignment name:str ops:List[Op] usage_offset:int best:Option[Op] -
     0 = index
     while index ops .length > do
         index ops .get = op
-        if OpKind::OpAssignVar (int) op Op::kind != then
+        if OpKind::OpAssignVar op Op::kind != then
             1 += index
             continue
         fi
@@ -775,7 +775,7 @@ fn handle_definition message:JsonValue {
     op Op::kind = kind
 
     # FN_CALL / FN_PUSH
-    if OpKind::OpFnCall (int) kind == OpKind::OpFnPush (int) kind == || then
+    if OpKind::OpFnCall kind == OpKind::OpFnPush kind == || then
         if QPART_TYPE qpart == then
             op op_str_value "::" str::split = parts
             0 parts .get = type_name
@@ -803,7 +803,7 @@ fn handle_definition message:JsonValue {
     fi
 
     # PUSH_VARIABLE / PUSH_CAPTURE
-    if OpKind::OpPushVar (int) kind == OpKind::OpPushCapture (int) kind == || then
+    if OpKind::OpPushVar kind == OpKind::OpPushCapture kind == || then
         op Op::location Location::span Span::offset state func op op_str_value find_variable_definition = var_loc
         if var_loc .is_some then
             var_loc .unwrap lsp_location_to_json request_id send_response
@@ -814,13 +814,13 @@ fn handle_definition message:JsonValue {
     fi
 
     # STRUCT_NEW
-    if OpKind::OpStructNew (int) kind == then
+    if OpKind::OpStructNew kind == then
         op Op::value (CasaStruct) CasaStruct::location casa_location_to_lsp lsp_location_to_json request_id send_response
         return
     fi
 
     # PUSH_ENUM_VARIANT
-    if OpKind::OpPushEnumVariant (int) kind == then
+    if OpKind::OpPushEnumVariant kind == then
         op Op::value (EnumVariant) EnumVariant::enum_name = enum_name
         if enum_name state DocumentState::enums .has ! then
             json_null_value request_id send_response
@@ -837,7 +837,7 @@ fn handle_definition message:JsonValue {
     fi
 
     # TYPE_CAST
-    if OpKind::OpTypeCast (int) kind == then
+    if OpKind::OpTypeCast kind == then
         op op_str_value = cast_type
         if cast_type state DocumentState::structs .has then
             cast_type state DocumentState::structs .get .unwrap CasaStruct::location casa_location_to_lsp lsp_location_to_json request_id send_response
@@ -897,7 +897,7 @@ fn format_hover op:Op state:DocumentState func:Option[Function] -> Option[str] {
     op Op::kind = kind
 
     # Function call/push
-    if OpKind::OpFnCall (int) kind == OpKind::OpFnPush (int) kind == || then
+    if OpKind::OpFnCall kind == OpKind::OpFnPush kind == || then
         op op_str_value state DocumentState::functions .get = fn_opt
         if fn_opt .is_some then
             fn_opt .unwrap = hover_func
@@ -938,7 +938,7 @@ fn format_hover op:Op state:DocumentState func:Option[Function] -> Option[str] {
     fi
 
     # Variables
-    if OpKind::OpPushVar (int) kind == OpKind::OpPushCapture (int) kind == || then
+    if OpKind::OpPushVar kind == OpKind::OpPushCapture kind == || then
         op op_str_value = var_name
         state func var_name resolve_variable_type = var_type
         if var_type .is_some then
@@ -950,7 +950,7 @@ fn format_hover op:Op state:DocumentState func:Option[Function] -> Option[str] {
     fi
 
     # Struct new
-    if OpKind::OpStructNew (int) kind == then
+    if OpKind::OpStructNew kind == then
         op Op::value (CasaStruct) = struct_val
         StringBuilder::new = struct_builder
         "struct " struct_builder .append
@@ -971,22 +971,22 @@ fn format_hover op:Op state:DocumentState func:Option[Function] -> Option[str] {
     fi
 
     # Enum variant
-    if OpKind::OpPushEnumVariant (int) kind == then
+    if OpKind::OpPushEnumVariant kind == then
         op Op::value (EnumVariant) = variant
         f"{variant EnumVariant::enum_name}::{variant EnumVariant::variant_name}" Option::Some
         return
     fi
 
     # Literals
-    if OpKind::OpPushInt (int) kind == then
+    if OpKind::OpPushInt kind == then
         f"(int) {op op_int_value .to_str}" Option::Some
         return
     fi
-    if OpKind::OpPushStr (int) kind == then
+    if OpKind::OpPushStr kind == then
         f"(str) \"{op op_str_value}\"" Option::Some
         return
     fi
-    if OpKind::OpPushBool (int) kind == then
+    if OpKind::OpPushBool kind == then
         if op op_int_value 0 != then
             "(bool) true" Option::Some
         else
@@ -994,7 +994,7 @@ fn format_hover op:Op state:DocumentState func:Option[Function] -> Option[str] {
         fi
         return
     fi
-    if OpKind::OpPushChar (int) kind == then
+    if OpKind::OpPushChar kind == then
         # Build char string manually
         10 alloc (str) = char_buf
         1 char_buf (ptr) store64
@@ -1005,7 +1005,7 @@ fn format_hover op:Op state:DocumentState func:Option[Function] -> Option[str] {
     fi
 
     # Assignment
-    if OpKind::OpAssignVar (int) kind == then
+    if OpKind::OpAssignVar kind == then
         op op_str_value = assign_name
         state func assign_name resolve_variable_type = assign_type
         if assign_type .is_some then
@@ -1058,7 +1058,7 @@ fn handle_hover message:JsonValue {
     # Qualified function call
     if
         QPART_NONE qpart !=
-        OpKind::OpFnCall (int) op Op::kind == OpKind::OpFnPush (int) op Op::kind == || &&
+        OpKind::OpFnCall op Op::kind == OpKind::OpFnPush op Op::kind == || &&
     then
         op op_str_value "::" str::split = qualified_parts
         0 qualified_parts .get = qualified_type_name
@@ -1134,7 +1134,7 @@ fn handle_hover message:JsonValue {
     # Qualified enum variant
     if
         QPART_NONE qpart !=
-        OpKind::OpPushEnumVariant (int) op Op::kind == &&
+        OpKind::OpPushEnumVariant op Op::kind == &&
     then
         op Op::value (EnumVariant) = enum_variant
         if QPART_TYPE qpart == then
@@ -1493,7 +1493,7 @@ fn handle_completion message:JsonValue {
     KeywordKind = keyword_count
     0 = keyword_index
     while keyword_index keyword_count > do
-        keyword_index keyword_name = kw_name
+        keyword_index (KeywordKind) keyword_name = kw_name
         "" COMPLETION_KEYWORD kw_name CompletionItem items .push
         1 += keyword_index
     done
@@ -1502,7 +1502,7 @@ fn handle_completion message:JsonValue {
     IntrinsicKind = intrinsic_count
     0 = intrinsic_index
     while intrinsic_index intrinsic_count > do
-        intrinsic_index intrinsic_name = intr_name
+        intrinsic_index (IntrinsicKind) intrinsic_name = intr_name
         "" COMPLETION_KEYWORD intr_name CompletionItem items .push
         1 += intrinsic_index
     done
@@ -1528,7 +1528,7 @@ fn collect_fn_refs ops:List[Op] name:str results:List[LspLocation] {
     0 = index
     while index ops .length > do
         index ops .get = op
-        if OpKind::OpFnCall (int) op Op::kind != OpKind::OpFnPush (int) op Op::kind != && then
+        if OpKind::OpFnCall op Op::kind != OpKind::OpFnPush op Op::kind != && then
             1 += index
             continue
         fi
@@ -1543,11 +1543,11 @@ fn collect_fn_refs ops:List[Op] name:str results:List[LspLocation] {
 
 fn is_var_op op:Op -> bool {
     op Op::kind = kind
-    OpKind::OpPushVar (int) kind ==
-    OpKind::OpPushCapture (int) kind == ||
-    OpKind::OpAssignVar (int) kind == ||
-    OpKind::OpAssignInc (int) kind == ||
-    OpKind::OpAssignDec (int) kind == ||
+    OpKind::OpPushVar kind ==
+    OpKind::OpPushCapture kind == ||
+    OpKind::OpAssignVar kind == ||
+    OpKind::OpAssignInc kind == ||
+    OpKind::OpAssignDec kind == ||
 }
 
 fn collect_var_refs ops:List[Op] name:str results:List[LspLocation] {
@@ -1571,11 +1571,11 @@ fn collect_struct_refs ops:List[Op] name:str results:List[LspLocation] {
     0 = index
     while index ops .length > do
         index ops .get = op
-        if OpKind::OpStructNew (int) op Op::kind == then
+        if OpKind::OpStructNew op Op::kind == then
             if op Op::value (CasaStruct) CasaStruct::name name == then
                 op Op::location casa_location_to_lsp results .push
             fi
-        elif OpKind::OpTypeCast (int) op Op::kind == then
+        elif OpKind::OpTypeCast op Op::kind == then
             if op op_str_value name == then
                 op Op::location casa_location_to_lsp results .push
             fi
@@ -1588,7 +1588,7 @@ fn collect_enum_refs ops:List[Op] enum_name:str results:List[LspLocation] {
     0 = index
     while index ops .length > do
         index ops .get = op
-        if OpKind::OpPushEnumVariant (int) op Op::kind != then
+        if OpKind::OpPushEnumVariant op Op::kind != then
             1 += index
             continue
         fi
@@ -1641,7 +1641,7 @@ fn find_all_references state:DocumentState op:Op func:Option[Function] include_d
     op Op::kind = kind
 
     # Function call/push
-    if OpKind::OpFnCall (int) kind == OpKind::OpFnPush (int) kind == || then
+    if OpKind::OpFnCall kind == OpKind::OpFnPush kind == || then
         op op_str_value = fn_name
         if include_declaration then
             fn_name state DocumentState::functions .get = fn_opt
@@ -1671,7 +1671,7 @@ fn find_all_references state:DocumentState op:Op func:Option[Function] include_d
     fi
 
     # Struct
-    if OpKind::OpStructNew (int) kind == then
+    if OpKind::OpStructNew kind == then
         op Op::value (CasaStruct) CasaStruct::name = struct_name
         if include_declaration then
             op Op::value (CasaStruct) CasaStruct::location casa_location_to_lsp results .push
@@ -1683,7 +1683,7 @@ fn find_all_references state:DocumentState op:Op func:Option[Function] include_d
     fi
 
     # Enum variant
-    if OpKind::OpPushEnumVariant (int) kind == then
+    if OpKind::OpPushEnumVariant kind == then
         op Op::value (EnumVariant) EnumVariant::enum_name = enum_name
         if include_declaration enum_name state DocumentState::enums .has && then
             enum_name state DocumentState::enums .get .unwrap CasaEnum::location casa_location_to_lsp results .push
@@ -1712,7 +1712,7 @@ fn handle_references message:JsonValue {
     # Check function definition name first (parameter ops share the name token location)
     position LspRange::start_col position LspRange::start_line state find_function_at_position = fn_at_pos
     if fn_at_pos Option::Some(matched_function) is then
-        matched_function Function::location OpKind::OpFnCall (int) matched_function Function::name make_op_str = op
+        matched_function Function::location OpKind::OpFnCall matched_function Function::name make_op_str = op
         Option::None (Option[Function]) = func
     else
         position LspRange::start_col position LspRange::start_line state find_op_at_position = result
@@ -1768,7 +1768,7 @@ fn handle_rename message:JsonValue {
     # Check function definition name first (parameter ops share the name token location)
     position LspRange::start_col position LspRange::start_line state find_function_at_position = fn_at_pos
     if fn_at_pos Option::Some(matched_function) is then
-        matched_function Function::location OpKind::OpFnCall (int) matched_function Function::name make_op_str = op
+        matched_function Function::location OpKind::OpFnCall matched_function Function::name make_op_str = op
         Option::None (Option[Function]) = func
         matched_function Function::name function_short_name = old_name
     else
@@ -1843,84 +1843,84 @@ fn handle_rename message:JsonValue {
 # ============================================================================
 
 fn init_token_type_map {
-    OpKind::OpFnCall (int) TOKEN_FUNCTION TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpFnPush (int) TOKEN_FUNCTION TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpMethodCall (int) TOKEN_FUNCTION TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpPushVar (int) TOKEN_VARIABLE TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpPushCapture (int) TOKEN_VARIABLE TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpAssignVar (int) TOKEN_VARIABLE TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpAssignInc (int) TOKEN_VARIABLE TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpAssignDec (int) TOKEN_VARIABLE TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpPushStr (int) TOKEN_STRING TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpPushInt (int) TOKEN_NUMBER TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpPushChar (int) TOKEN_NUMBER TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpPushBool (int) TOKEN_KEYWORD TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpFnExec (int) TOKEN_KEYWORD TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpIfStart (int) TOKEN_KEYWORD TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpIfCondition (int) TOKEN_KEYWORD TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpIfElif (int) TOKEN_KEYWORD TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpIfElse (int) TOKEN_KEYWORD TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpIfEnd (int) TOKEN_KEYWORD TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpWhileStart (int) TOKEN_KEYWORD TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpWhileCondition (int) TOKEN_KEYWORD TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpWhileEnd (int) TOKEN_KEYWORD TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpWhileBreak (int) TOKEN_KEYWORD TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpWhileContinue (int) TOKEN_KEYWORD TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpMatchStart (int) TOKEN_KEYWORD TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpMatchArm (int) TOKEN_KEYWORD TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpMatchEnd (int) TOKEN_KEYWORD TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpFnReturn (int) TOKEN_KEYWORD TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpAdd (int) TOKEN_OPERATOR TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpSub (int) TOKEN_OPERATOR TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpMul (int) TOKEN_OPERATOR TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpDiv (int) TOKEN_OPERATOR TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpMod (int) TOKEN_OPERATOR TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpShl (int) TOKEN_OPERATOR TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpShr (int) TOKEN_OPERATOR TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpBitAnd (int) TOKEN_OPERATOR TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpBitOr (int) TOKEN_OPERATOR TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpBitXor (int) TOKEN_OPERATOR TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpBitNot (int) TOKEN_OPERATOR TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpAnd (int) TOKEN_OPERATOR TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpOr (int) TOKEN_OPERATOR TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpNot (int) TOKEN_OPERATOR TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpEq (int) TOKEN_OPERATOR TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpNe (int) TOKEN_OPERATOR TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpLt (int) TOKEN_OPERATOR TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpLe (int) TOKEN_OPERATOR TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpGt (int) TOKEN_OPERATOR TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpGe (int) TOKEN_OPERATOR TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpTypeCast (int) TOKEN_TYPE TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpPushEnumVariant (int) TOKEN_ENUM_MEMBER TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpStructNew (int) TOKEN_STRUCT TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpDrop (int) TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpDup (int) TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpSwap (int) TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpOver (int) TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpRot (int) TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpPrint (int) TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpPrintInt (int) TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpPrintStr (int) TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpPrintBool (int) TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpPrintChar (int) TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpPrintCstr (int) TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpHeapAlloc (int) TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpLoad8 (int) TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpLoad16 (int) TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpLoad32 (int) TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpLoad64 (int) TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpStore8 (int) TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpStore16 (int) TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpStore32 (int) TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpStore64 (int) TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpSyscall0 (int) TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpSyscall1 (int) TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpSyscall2 (int) TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpSyscall3 (int) TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpSyscall4 (int) TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpSyscall5 (int) TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpSyscall6 (int) TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
-    OpKind::OpTypeof (int) TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpFnCall TOKEN_FUNCTION TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpFnPush TOKEN_FUNCTION TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpMethodCall TOKEN_FUNCTION TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpPushVar TOKEN_VARIABLE TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpPushCapture TOKEN_VARIABLE TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpAssignVar TOKEN_VARIABLE TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpAssignInc TOKEN_VARIABLE TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpAssignDec TOKEN_VARIABLE TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpPushStr TOKEN_STRING TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpPushInt TOKEN_NUMBER TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpPushChar TOKEN_NUMBER TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpPushBool TOKEN_KEYWORD TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpFnExec TOKEN_KEYWORD TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpIfStart TOKEN_KEYWORD TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpIfCondition TOKEN_KEYWORD TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpIfElif TOKEN_KEYWORD TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpIfElse TOKEN_KEYWORD TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpIfEnd TOKEN_KEYWORD TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpWhileStart TOKEN_KEYWORD TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpWhileCondition TOKEN_KEYWORD TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpWhileEnd TOKEN_KEYWORD TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpWhileBreak TOKEN_KEYWORD TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpWhileContinue TOKEN_KEYWORD TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpMatchStart TOKEN_KEYWORD TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpMatchArm TOKEN_KEYWORD TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpMatchEnd TOKEN_KEYWORD TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpFnReturn TOKEN_KEYWORD TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpAdd TOKEN_OPERATOR TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpSub TOKEN_OPERATOR TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpMul TOKEN_OPERATOR TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpDiv TOKEN_OPERATOR TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpMod TOKEN_OPERATOR TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpShl TOKEN_OPERATOR TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpShr TOKEN_OPERATOR TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpBitAnd TOKEN_OPERATOR TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpBitOr TOKEN_OPERATOR TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpBitXor TOKEN_OPERATOR TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpBitNot TOKEN_OPERATOR TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpAnd TOKEN_OPERATOR TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpOr TOKEN_OPERATOR TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpNot TOKEN_OPERATOR TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpEq TOKEN_OPERATOR TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpNe TOKEN_OPERATOR TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpLt TOKEN_OPERATOR TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpLe TOKEN_OPERATOR TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpGt TOKEN_OPERATOR TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpGe TOKEN_OPERATOR TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpTypeCast TOKEN_TYPE TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpPushEnumVariant TOKEN_ENUM_MEMBER TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpStructNew TOKEN_STRUCT TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpDrop TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpDup TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpSwap TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpOver TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpRot TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpPrint TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpPrintInt TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpPrintStr TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpPrintBool TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpPrintChar TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpPrintCstr TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpHeapAlloc TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpLoad8 TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpLoad16 TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpLoad32 TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpLoad64 TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpStore8 TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpStore16 TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpStore32 TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpStore64 TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpSyscall0 TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpSyscall1 TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpSyscall2 TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpSyscall3 TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpSyscall4 TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpSyscall5 TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpSyscall6 TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
+    OpKind::OpTypeof TOKEN_MACRO TOKEN_TYPE_MAP .set = TOKEN_TYPE_MAP
 }
 
 # Qualified name token type maps
@@ -1954,9 +1954,9 @@ fn collect_semantic_tokens ops:List[Op] state:DocumentState tokens:List[Semantic
 
         # Check for qualified names
         if
-            OpKind::OpFnCall (int) op Op::kind ==
-            OpKind::OpFnPush (int) op Op::kind == ||
-            OpKind::OpPushEnumVariant (int) op Op::kind == ||
+            OpKind::OpFnCall op Op::kind ==
+            OpKind::OpFnPush op Op::kind == ||
+            OpKind::OpPushEnumVariant op Op::kind == ||
         then
             state DocumentState::source start length str::substring = text
             text "::" str::find = separator
@@ -1971,7 +1971,7 @@ fn collect_semantic_tokens ops:List[Op] state:DocumentState tokens:List[Semantic
                 if 0 member_length > then
                     member_start token_source offset_to_line_col 1 - = member_line
                     member_start token_source offset_to_col 1 - = member_col
-                    if OpKind::OpPushEnumVariant (int) op Op::kind == then QUALIFIED_MEMBER_ENUM_VARIANT else QUALIFIED_MEMBER_FN fi = member_token_type
+                    if OpKind::OpPushEnumVariant op Op::kind == then QUALIFIED_MEMBER_ENUM_VARIANT else QUALIFIED_MEMBER_FN fi = member_token_type
                     0 member_token_type member_length member_col member_line SemanticToken tokens .push
                 fi
                 1 += index
@@ -2156,117 +2156,117 @@ fn handle_semantic_tokens message:JsonValue {
 # ============================================================================
 
 fn init_stack_effects {
-    OpKind::OpAdd (int) "+: int int -> int" STACK_EFFECTS .set = STACK_EFFECTS
-    OpKind::OpSub (int) "-: int int -> int" STACK_EFFECTS .set = STACK_EFFECTS
-    OpKind::OpMul (int) "*: int int -> int" STACK_EFFECTS .set = STACK_EFFECTS
-    OpKind::OpDiv (int) "/: int int -> int" STACK_EFFECTS .set = STACK_EFFECTS
-    OpKind::OpMod (int) "%: int int -> int" STACK_EFFECTS .set = STACK_EFFECTS
-    OpKind::OpShl (int) "<<: int int -> int" STACK_EFFECTS .set = STACK_EFFECTS
-    OpKind::OpShr (int) ">>: int int -> int" STACK_EFFECTS .set = STACK_EFFECTS
-    OpKind::OpBitAnd (int) "&: int int -> int" STACK_EFFECTS .set = STACK_EFFECTS
-    OpKind::OpBitOr (int) "|: int int -> int" STACK_EFFECTS .set = STACK_EFFECTS
-    OpKind::OpBitXor (int) "^: int int -> int" STACK_EFFECTS .set = STACK_EFFECTS
-    OpKind::OpBitNot (int) "~: int -> int" STACK_EFFECTS .set = STACK_EFFECTS
-    OpKind::OpNot (int) "!: bool -> bool" STACK_EFFECTS .set = STACK_EFFECTS
-    OpKind::OpEq (int) "==: any any -> bool" STACK_EFFECTS .set = STACK_EFFECTS
-    OpKind::OpNe (int) "!=: any any -> bool" STACK_EFFECTS .set = STACK_EFFECTS
-    OpKind::OpLt (int) "<: any any -> bool" STACK_EFFECTS .set = STACK_EFFECTS
-    OpKind::OpLe (int) "<=: any any -> bool" STACK_EFFECTS .set = STACK_EFFECTS
-    OpKind::OpGt (int) ">: any any -> bool" STACK_EFFECTS .set = STACK_EFFECTS
-    OpKind::OpGe (int) ">=: any any -> bool" STACK_EFFECTS .set = STACK_EFFECTS
-    OpKind::OpAnd (int) "&&: bool bool -> bool" STACK_EFFECTS .set = STACK_EFFECTS
-    OpKind::OpOr (int) "||: bool bool -> bool" STACK_EFFECTS .set = STACK_EFFECTS
-    OpKind::OpDrop (int) "drop: any -> None" STACK_EFFECTS .set = STACK_EFFECTS
-    OpKind::OpDup (int) "dup: any -> any any" STACK_EFFECTS .set = STACK_EFFECTS
-    OpKind::OpSwap (int) "swap: any any -> any any" STACK_EFFECTS .set = STACK_EFFECTS
-    OpKind::OpOver (int) "over: any any -> any any any" STACK_EFFECTS .set = STACK_EFFECTS
-    OpKind::OpRot (int) "rot: any any any -> any any any" STACK_EFFECTS .set = STACK_EFFECTS
-    OpKind::OpPrint (int) "print: any -> None" STACK_EFFECTS .set = STACK_EFFECTS
-    OpKind::OpPrintInt (int) "print: any -> None" STACK_EFFECTS .set = STACK_EFFECTS
-    OpKind::OpPrintStr (int) "print: any -> None" STACK_EFFECTS .set = STACK_EFFECTS
-    OpKind::OpPrintBool (int) "print: any -> None" STACK_EFFECTS .set = STACK_EFFECTS
-    OpKind::OpPrintChar (int) "print: any -> None" STACK_EFFECTS .set = STACK_EFFECTS
-    OpKind::OpPrintCstr (int) "print: any -> None" STACK_EFFECTS .set = STACK_EFFECTS
-    OpKind::OpFnExec (int) "exec: fn[sig] -> ..." STACK_EFFECTS .set = STACK_EFFECTS
-    OpKind::OpTypeof (int) "typeof: any -> str" STACK_EFFECTS .set = STACK_EFFECTS
-    OpKind::OpAssignDec (int) "-=: int -> None" STACK_EFFECTS .set = STACK_EFFECTS
-    OpKind::OpAssignInc (int) "+=: int -> None" STACK_EFFECTS .set = STACK_EFFECTS
-    OpKind::OpHeapAlloc (int) "alloc: int -> ptr" STACK_EFFECTS .set = STACK_EFFECTS
-    OpKind::OpLoad8 (int) "load8: ptr -> int" STACK_EFFECTS .set = STACK_EFFECTS
-    OpKind::OpLoad16 (int) "load16: ptr -> int" STACK_EFFECTS .set = STACK_EFFECTS
-    OpKind::OpLoad32 (int) "load32: ptr -> int" STACK_EFFECTS .set = STACK_EFFECTS
-    OpKind::OpLoad64 (int) "load64: ptr -> int" STACK_EFFECTS .set = STACK_EFFECTS
-    OpKind::OpStore8 (int) "store8: any ptr -> None" STACK_EFFECTS .set = STACK_EFFECTS
-    OpKind::OpStore16 (int) "store16: any ptr -> None" STACK_EFFECTS .set = STACK_EFFECTS
-    OpKind::OpStore32 (int) "store32: any ptr -> None" STACK_EFFECTS .set = STACK_EFFECTS
-    OpKind::OpStore64 (int) "store64: any ptr -> None" STACK_EFFECTS .set = STACK_EFFECTS
-    OpKind::OpSyscall0 (int) "syscall0: int -> int" STACK_EFFECTS .set = STACK_EFFECTS
-    OpKind::OpSyscall1 (int) "syscall1: any int -> int" STACK_EFFECTS .set = STACK_EFFECTS
-    OpKind::OpSyscall2 (int) "syscall2: any any int -> int" STACK_EFFECTS .set = STACK_EFFECTS
-    OpKind::OpSyscall3 (int) "syscall3: any any any int -> int" STACK_EFFECTS .set = STACK_EFFECTS
-    OpKind::OpSyscall4 (int) "syscall4: any any any any int -> int" STACK_EFFECTS .set = STACK_EFFECTS
-    OpKind::OpSyscall5 (int) "syscall5: any any any any any int -> int" STACK_EFFECTS .set = STACK_EFFECTS
-    OpKind::OpSyscall6 (int) "syscall6: any any any any any any int -> int" STACK_EFFECTS .set = STACK_EFFECTS
-    OpKind::OpArgc (int) "argc: None -> int" STACK_EFFECTS .set = STACK_EFFECTS
-    OpKind::OpArgv (int) "argv: None -> ptr" STACK_EFFECTS .set = STACK_EFFECTS
+    OpKind::OpAdd "+: int int -> int" STACK_EFFECTS .set = STACK_EFFECTS
+    OpKind::OpSub "-: int int -> int" STACK_EFFECTS .set = STACK_EFFECTS
+    OpKind::OpMul "*: int int -> int" STACK_EFFECTS .set = STACK_EFFECTS
+    OpKind::OpDiv "/: int int -> int" STACK_EFFECTS .set = STACK_EFFECTS
+    OpKind::OpMod "%: int int -> int" STACK_EFFECTS .set = STACK_EFFECTS
+    OpKind::OpShl "<<: int int -> int" STACK_EFFECTS .set = STACK_EFFECTS
+    OpKind::OpShr ">>: int int -> int" STACK_EFFECTS .set = STACK_EFFECTS
+    OpKind::OpBitAnd "&: int int -> int" STACK_EFFECTS .set = STACK_EFFECTS
+    OpKind::OpBitOr "|: int int -> int" STACK_EFFECTS .set = STACK_EFFECTS
+    OpKind::OpBitXor "^: int int -> int" STACK_EFFECTS .set = STACK_EFFECTS
+    OpKind::OpBitNot "~: int -> int" STACK_EFFECTS .set = STACK_EFFECTS
+    OpKind::OpNot "!: bool -> bool" STACK_EFFECTS .set = STACK_EFFECTS
+    OpKind::OpEq "==: any any -> bool" STACK_EFFECTS .set = STACK_EFFECTS
+    OpKind::OpNe "!=: any any -> bool" STACK_EFFECTS .set = STACK_EFFECTS
+    OpKind::OpLt "<: any any -> bool" STACK_EFFECTS .set = STACK_EFFECTS
+    OpKind::OpLe "<=: any any -> bool" STACK_EFFECTS .set = STACK_EFFECTS
+    OpKind::OpGt ">: any any -> bool" STACK_EFFECTS .set = STACK_EFFECTS
+    OpKind::OpGe ">=: any any -> bool" STACK_EFFECTS .set = STACK_EFFECTS
+    OpKind::OpAnd "&&: bool bool -> bool" STACK_EFFECTS .set = STACK_EFFECTS
+    OpKind::OpOr "||: bool bool -> bool" STACK_EFFECTS .set = STACK_EFFECTS
+    OpKind::OpDrop "drop: any -> None" STACK_EFFECTS .set = STACK_EFFECTS
+    OpKind::OpDup "dup: any -> any any" STACK_EFFECTS .set = STACK_EFFECTS
+    OpKind::OpSwap "swap: any any -> any any" STACK_EFFECTS .set = STACK_EFFECTS
+    OpKind::OpOver "over: any any -> any any any" STACK_EFFECTS .set = STACK_EFFECTS
+    OpKind::OpRot "rot: any any any -> any any any" STACK_EFFECTS .set = STACK_EFFECTS
+    OpKind::OpPrint "print: any -> None" STACK_EFFECTS .set = STACK_EFFECTS
+    OpKind::OpPrintInt "print: any -> None" STACK_EFFECTS .set = STACK_EFFECTS
+    OpKind::OpPrintStr "print: any -> None" STACK_EFFECTS .set = STACK_EFFECTS
+    OpKind::OpPrintBool "print: any -> None" STACK_EFFECTS .set = STACK_EFFECTS
+    OpKind::OpPrintChar "print: any -> None" STACK_EFFECTS .set = STACK_EFFECTS
+    OpKind::OpPrintCstr "print: any -> None" STACK_EFFECTS .set = STACK_EFFECTS
+    OpKind::OpFnExec "exec: fn[sig] -> ..." STACK_EFFECTS .set = STACK_EFFECTS
+    OpKind::OpTypeof "typeof: any -> str" STACK_EFFECTS .set = STACK_EFFECTS
+    OpKind::OpAssignDec "-=: int -> None" STACK_EFFECTS .set = STACK_EFFECTS
+    OpKind::OpAssignInc "+=: int -> None" STACK_EFFECTS .set = STACK_EFFECTS
+    OpKind::OpHeapAlloc "alloc: int -> ptr" STACK_EFFECTS .set = STACK_EFFECTS
+    OpKind::OpLoad8 "load8: ptr -> int" STACK_EFFECTS .set = STACK_EFFECTS
+    OpKind::OpLoad16 "load16: ptr -> int" STACK_EFFECTS .set = STACK_EFFECTS
+    OpKind::OpLoad32 "load32: ptr -> int" STACK_EFFECTS .set = STACK_EFFECTS
+    OpKind::OpLoad64 "load64: ptr -> int" STACK_EFFECTS .set = STACK_EFFECTS
+    OpKind::OpStore8 "store8: any ptr -> None" STACK_EFFECTS .set = STACK_EFFECTS
+    OpKind::OpStore16 "store16: any ptr -> None" STACK_EFFECTS .set = STACK_EFFECTS
+    OpKind::OpStore32 "store32: any ptr -> None" STACK_EFFECTS .set = STACK_EFFECTS
+    OpKind::OpStore64 "store64: any ptr -> None" STACK_EFFECTS .set = STACK_EFFECTS
+    OpKind::OpSyscall0 "syscall0: int -> int" STACK_EFFECTS .set = STACK_EFFECTS
+    OpKind::OpSyscall1 "syscall1: any int -> int" STACK_EFFECTS .set = STACK_EFFECTS
+    OpKind::OpSyscall2 "syscall2: any any int -> int" STACK_EFFECTS .set = STACK_EFFECTS
+    OpKind::OpSyscall3 "syscall3: any any any int -> int" STACK_EFFECTS .set = STACK_EFFECTS
+    OpKind::OpSyscall4 "syscall4: any any any any int -> int" STACK_EFFECTS .set = STACK_EFFECTS
+    OpKind::OpSyscall5 "syscall5: any any any any any int -> int" STACK_EFFECTS .set = STACK_EFFECTS
+    OpKind::OpSyscall6 "syscall6: any any any any any any int -> int" STACK_EFFECTS .set = STACK_EFFECTS
+    OpKind::OpArgc "argc: None -> int" STACK_EFFECTS .set = STACK_EFFECTS
+    OpKind::OpArgv "argv: None -> ptr" STACK_EFFECTS .set = STACK_EFFECTS
 }
 
 # ============================================================================
 # Keyword and intrinsic name helpers
 # ============================================================================
 
-fn keyword_name kind:int -> str {
-    if KeywordKind::Fn (int) kind == then "fn"
-    elif KeywordKind::Impl (int) kind == then "impl"
-    elif KeywordKind::Return (int) kind == then "return"
-    elif KeywordKind::While (int) kind == then "while"
-    elif KeywordKind::Do (int) kind == then "do"
-    elif KeywordKind::Break (int) kind == then "break"
-    elif KeywordKind::Continue (int) kind == then "continue"
-    elif KeywordKind::Done (int) kind == then "done"
-    elif KeywordKind::If (int) kind == then "if"
-    elif KeywordKind::Then (int) kind == then "then"
-    elif KeywordKind::Elif (int) kind == then "elif"
-    elif KeywordKind::Else (int) kind == then "else"
-    elif KeywordKind::Fi (int) kind == then "fi"
-    elif KeywordKind::EnumKw (int) kind == then "enum"
-    elif KeywordKind::StructKw (int) kind == then "struct"
-    elif KeywordKind::TraitKw (int) kind == then "trait"
-    elif KeywordKind::End (int) kind == then "end"
-    elif KeywordKind::Match (int) kind == then "match"
-    elif KeywordKind::Is (int) kind == then "is"
-    elif KeywordKind::Include (int) kind == then "include"
+fn keyword_name kind:KeywordKind -> str {
+    if KeywordKind::Fn kind == then "fn"
+    elif KeywordKind::Impl kind == then "impl"
+    elif KeywordKind::Return kind == then "return"
+    elif KeywordKind::While kind == then "while"
+    elif KeywordKind::Do kind == then "do"
+    elif KeywordKind::Break kind == then "break"
+    elif KeywordKind::Continue kind == then "continue"
+    elif KeywordKind::Done kind == then "done"
+    elif KeywordKind::If kind == then "if"
+    elif KeywordKind::Then kind == then "then"
+    elif KeywordKind::Elif kind == then "elif"
+    elif KeywordKind::Else kind == then "else"
+    elif KeywordKind::Fi kind == then "fi"
+    elif KeywordKind::EnumKw kind == then "enum"
+    elif KeywordKind::StructKw kind == then "struct"
+    elif KeywordKind::TraitKw kind == then "trait"
+    elif KeywordKind::End kind == then "end"
+    elif KeywordKind::Match kind == then "match"
+    elif KeywordKind::Is kind == then "is"
+    elif KeywordKind::Include kind == then "include"
     else "unknown"
     fi
 }
 
-fn intrinsic_name kind:int -> str {
-    if IntrinsicKind::Drop (int) kind == then "drop"
-    elif IntrinsicKind::Dup (int) kind == then "dup"
-    elif IntrinsicKind::Over (int) kind == then "over"
-    elif IntrinsicKind::Rot (int) kind == then "rot"
-    elif IntrinsicKind::Swap (int) kind == then "swap"
-    elif IntrinsicKind::Alloc (int) kind == then "alloc"
-    elif IntrinsicKind::Load8 (int) kind == then "load8"
-    elif IntrinsicKind::Load16 (int) kind == then "load16"
-    elif IntrinsicKind::Load32 (int) kind == then "load32"
-    elif IntrinsicKind::Load64 (int) kind == then "load64"
-    elif IntrinsicKind::Store8 (int) kind == then "store8"
-    elif IntrinsicKind::Store16 (int) kind == then "store16"
-    elif IntrinsicKind::Store32 (int) kind == then "store32"
-    elif IntrinsicKind::Store64 (int) kind == then "store64"
-    elif IntrinsicKind::Print (int) kind == then "print"
-    elif IntrinsicKind::Typeof (int) kind == then "typeof"
-    elif IntrinsicKind::Exec (int) kind == then "exec"
-    elif IntrinsicKind::Syscall0 (int) kind == then "syscall0"
-    elif IntrinsicKind::Syscall1 (int) kind == then "syscall1"
-    elif IntrinsicKind::Syscall2 (int) kind == then "syscall2"
-    elif IntrinsicKind::Syscall3 (int) kind == then "syscall3"
-    elif IntrinsicKind::Syscall4 (int) kind == then "syscall4"
-    elif IntrinsicKind::Syscall5 (int) kind == then "syscall5"
-    elif IntrinsicKind::Syscall6 (int) kind == then "syscall6"
-    elif IntrinsicKind::Argc (int) kind == then "argc"
-    elif IntrinsicKind::Argv (int) kind == then "argv"
+fn intrinsic_name kind:IntrinsicKind -> str {
+    if IntrinsicKind::Drop kind == then "drop"
+    elif IntrinsicKind::Dup kind == then "dup"
+    elif IntrinsicKind::Over kind == then "over"
+    elif IntrinsicKind::Rot kind == then "rot"
+    elif IntrinsicKind::Swap kind == then "swap"
+    elif IntrinsicKind::Alloc kind == then "alloc"
+    elif IntrinsicKind::Load8 kind == then "load8"
+    elif IntrinsicKind::Load16 kind == then "load16"
+    elif IntrinsicKind::Load32 kind == then "load32"
+    elif IntrinsicKind::Load64 kind == then "load64"
+    elif IntrinsicKind::Store8 kind == then "store8"
+    elif IntrinsicKind::Store16 kind == then "store16"
+    elif IntrinsicKind::Store32 kind == then "store32"
+    elif IntrinsicKind::Store64 kind == then "store64"
+    elif IntrinsicKind::Print kind == then "print"
+    elif IntrinsicKind::Typeof kind == then "typeof"
+    elif IntrinsicKind::Exec kind == then "exec"
+    elif IntrinsicKind::Syscall0 kind == then "syscall0"
+    elif IntrinsicKind::Syscall1 kind == then "syscall1"
+    elif IntrinsicKind::Syscall2 kind == then "syscall2"
+    elif IntrinsicKind::Syscall3 kind == then "syscall3"
+    elif IntrinsicKind::Syscall4 kind == then "syscall4"
+    elif IntrinsicKind::Syscall5 kind == then "syscall5"
+    elif IntrinsicKind::Syscall6 kind == then "syscall6"
+    elif IntrinsicKind::Argc kind == then "argc"
+    elif IntrinsicKind::Argv kind == then "argv"
     else "unknown"
     fi
 }

--- a/self_hosted/parser.casa
+++ b/self_hosted/parser.casa
@@ -27,44 +27,44 @@ Set::new (Set[str]) = BUILTIN_TYPES
 # Simple keyword -> OpKind mapping
 # ============================================================================
 
-Map::new (Map[int int]) = SIMPLE_KEYWORD_OPS
-KeywordKind::Break (int) OpKind::OpWhileBreak (int) SIMPLE_KEYWORD_OPS .set = SIMPLE_KEYWORD_OPS
-KeywordKind::Continue (int) OpKind::OpWhileContinue (int) SIMPLE_KEYWORD_OPS .set = SIMPLE_KEYWORD_OPS
-KeywordKind::Do (int) OpKind::OpWhileCondition (int) SIMPLE_KEYWORD_OPS .set = SIMPLE_KEYWORD_OPS
-KeywordKind::Done (int) OpKind::OpWhileEnd (int) SIMPLE_KEYWORD_OPS .set = SIMPLE_KEYWORD_OPS
-KeywordKind::Elif (int) OpKind::OpIfElif (int) SIMPLE_KEYWORD_OPS .set = SIMPLE_KEYWORD_OPS
-KeywordKind::Else (int) OpKind::OpIfElse (int) SIMPLE_KEYWORD_OPS .set = SIMPLE_KEYWORD_OPS
-KeywordKind::Fi (int) OpKind::OpIfEnd (int) SIMPLE_KEYWORD_OPS .set = SIMPLE_KEYWORD_OPS
-KeywordKind::If (int) OpKind::OpIfStart (int) SIMPLE_KEYWORD_OPS .set = SIMPLE_KEYWORD_OPS
-KeywordKind::Return (int) OpKind::OpFnReturn (int) SIMPLE_KEYWORD_OPS .set = SIMPLE_KEYWORD_OPS
-KeywordKind::Then (int) OpKind::OpIfCondition (int) SIMPLE_KEYWORD_OPS .set = SIMPLE_KEYWORD_OPS
-KeywordKind::While (int) OpKind::OpWhileStart (int) SIMPLE_KEYWORD_OPS .set = SIMPLE_KEYWORD_OPS
+Map::new (Map[KeywordKind OpKind]) = SIMPLE_KEYWORD_OPS
+KeywordKind::Break OpKind::OpWhileBreak SIMPLE_KEYWORD_OPS .set = SIMPLE_KEYWORD_OPS
+KeywordKind::Continue OpKind::OpWhileContinue SIMPLE_KEYWORD_OPS .set = SIMPLE_KEYWORD_OPS
+KeywordKind::Do OpKind::OpWhileCondition SIMPLE_KEYWORD_OPS .set = SIMPLE_KEYWORD_OPS
+KeywordKind::Done OpKind::OpWhileEnd SIMPLE_KEYWORD_OPS .set = SIMPLE_KEYWORD_OPS
+KeywordKind::Elif OpKind::OpIfElif SIMPLE_KEYWORD_OPS .set = SIMPLE_KEYWORD_OPS
+KeywordKind::Else OpKind::OpIfElse SIMPLE_KEYWORD_OPS .set = SIMPLE_KEYWORD_OPS
+KeywordKind::Fi OpKind::OpIfEnd SIMPLE_KEYWORD_OPS .set = SIMPLE_KEYWORD_OPS
+KeywordKind::If OpKind::OpIfStart SIMPLE_KEYWORD_OPS .set = SIMPLE_KEYWORD_OPS
+KeywordKind::Return OpKind::OpFnReturn SIMPLE_KEYWORD_OPS .set = SIMPLE_KEYWORD_OPS
+KeywordKind::Then OpKind::OpIfCondition SIMPLE_KEYWORD_OPS .set = SIMPLE_KEYWORD_OPS
+KeywordKind::While OpKind::OpWhileStart SIMPLE_KEYWORD_OPS .set = SIMPLE_KEYWORD_OPS
 
 # ============================================================================
 # Operator -> OpKind mapping
 # ============================================================================
 
-Map::new (Map[int int]) = OPERATOR_TO_OPKIND
-OperatorKind::Plus (int) OpKind::OpAdd (int) OPERATOR_TO_OPKIND .set = OPERATOR_TO_OPKIND
-OperatorKind::Minus (int) OpKind::OpSub (int) OPERATOR_TO_OPKIND .set = OPERATOR_TO_OPKIND
-OperatorKind::Mul (int) OpKind::OpMul (int) OPERATOR_TO_OPKIND .set = OPERATOR_TO_OPKIND
-OperatorKind::Div (int) OpKind::OpDiv (int) OPERATOR_TO_OPKIND .set = OPERATOR_TO_OPKIND
-OperatorKind::Mod (int) OpKind::OpMod (int) OPERATOR_TO_OPKIND .set = OPERATOR_TO_OPKIND
-OperatorKind::Shl (int) OpKind::OpShl (int) OPERATOR_TO_OPKIND .set = OPERATOR_TO_OPKIND
-OperatorKind::Shr (int) OpKind::OpShr (int) OPERATOR_TO_OPKIND .set = OPERATOR_TO_OPKIND
-OperatorKind::BitAnd (int) OpKind::OpBitAnd (int) OPERATOR_TO_OPKIND .set = OPERATOR_TO_OPKIND
-OperatorKind::BitOr (int) OpKind::OpBitOr (int) OPERATOR_TO_OPKIND .set = OPERATOR_TO_OPKIND
-OperatorKind::BitXor (int) OpKind::OpBitXor (int) OPERATOR_TO_OPKIND .set = OPERATOR_TO_OPKIND
-OperatorKind::BitNot (int) OpKind::OpBitNot (int) OPERATOR_TO_OPKIND .set = OPERATOR_TO_OPKIND
-OperatorKind::And (int) OpKind::OpAnd (int) OPERATOR_TO_OPKIND .set = OPERATOR_TO_OPKIND
-OperatorKind::Or (int) OpKind::OpOr (int) OPERATOR_TO_OPKIND .set = OPERATOR_TO_OPKIND
-OperatorKind::Not (int) OpKind::OpNot (int) OPERATOR_TO_OPKIND .set = OPERATOR_TO_OPKIND
-OperatorKind::Eq (int) OpKind::OpEq (int) OPERATOR_TO_OPKIND .set = OPERATOR_TO_OPKIND
-OperatorKind::Ge (int) OpKind::OpGe (int) OPERATOR_TO_OPKIND .set = OPERATOR_TO_OPKIND
-OperatorKind::Gt (int) OpKind::OpGt (int) OPERATOR_TO_OPKIND .set = OPERATOR_TO_OPKIND
-OperatorKind::Le (int) OpKind::OpLe (int) OPERATOR_TO_OPKIND .set = OPERATOR_TO_OPKIND
-OperatorKind::Lt (int) OpKind::OpLt (int) OPERATOR_TO_OPKIND .set = OPERATOR_TO_OPKIND
-OperatorKind::Ne (int) OpKind::OpNe (int) OPERATOR_TO_OPKIND .set = OPERATOR_TO_OPKIND
+Map::new (Map[OperatorKind OpKind]) = OPERATOR_TO_OPKIND
+OperatorKind::Plus OpKind::OpAdd OPERATOR_TO_OPKIND .set = OPERATOR_TO_OPKIND
+OperatorKind::Minus OpKind::OpSub OPERATOR_TO_OPKIND .set = OPERATOR_TO_OPKIND
+OperatorKind::Mul OpKind::OpMul OPERATOR_TO_OPKIND .set = OPERATOR_TO_OPKIND
+OperatorKind::Div OpKind::OpDiv OPERATOR_TO_OPKIND .set = OPERATOR_TO_OPKIND
+OperatorKind::Mod OpKind::OpMod OPERATOR_TO_OPKIND .set = OPERATOR_TO_OPKIND
+OperatorKind::Shl OpKind::OpShl OPERATOR_TO_OPKIND .set = OPERATOR_TO_OPKIND
+OperatorKind::Shr OpKind::OpShr OPERATOR_TO_OPKIND .set = OPERATOR_TO_OPKIND
+OperatorKind::BitAnd OpKind::OpBitAnd OPERATOR_TO_OPKIND .set = OPERATOR_TO_OPKIND
+OperatorKind::BitOr OpKind::OpBitOr OPERATOR_TO_OPKIND .set = OPERATOR_TO_OPKIND
+OperatorKind::BitXor OpKind::OpBitXor OPERATOR_TO_OPKIND .set = OPERATOR_TO_OPKIND
+OperatorKind::BitNot OpKind::OpBitNot OPERATOR_TO_OPKIND .set = OPERATOR_TO_OPKIND
+OperatorKind::And OpKind::OpAnd OPERATOR_TO_OPKIND .set = OPERATOR_TO_OPKIND
+OperatorKind::Or OpKind::OpOr OPERATOR_TO_OPKIND .set = OPERATOR_TO_OPKIND
+OperatorKind::Not OpKind::OpNot OPERATOR_TO_OPKIND .set = OPERATOR_TO_OPKIND
+OperatorKind::Eq OpKind::OpEq OPERATOR_TO_OPKIND .set = OPERATOR_TO_OPKIND
+OperatorKind::Ge OpKind::OpGe OPERATOR_TO_OPKIND .set = OPERATOR_TO_OPKIND
+OperatorKind::Gt OpKind::OpGt OPERATOR_TO_OPKIND .set = OPERATOR_TO_OPKIND
+OperatorKind::Le OpKind::OpLe OPERATOR_TO_OPKIND .set = OPERATOR_TO_OPKIND
+OperatorKind::Lt OpKind::OpLt OPERATOR_TO_OPKIND .set = OPERATOR_TO_OPKIND
+OperatorKind::Ne OpKind::OpNe OPERATOR_TO_OPKIND .set = OPERATOR_TO_OPKIND
 
 # ============================================================================
 # Token cursor
@@ -122,11 +122,11 @@ fn tc_restore cursor:TokenCursor saved:int {
 fn expect_token cursor:TokenCursor -> Token {
     cursor tc_pop = result_opt
     if result_opt .is_none then
-        empty_location "Unexpected end of input" ErrorKind::UnexpectedToken (int) raise_error
+        empty_location "Unexpected end of input" ErrorKind::UnexpectedToken raise_error
     fi
     result_opt .unwrap = token
-    if TokenKind::Eof (int) token Token::kind == then
-        token Token::location "Unexpected end of input" ErrorKind::UnexpectedToken (int) raise_error
+    if TokenKind::Eof token Token::kind == then
+        token Token::location "Unexpected end of input" ErrorKind::UnexpectedToken raise_error
     fi
     token
 }
@@ -138,16 +138,16 @@ fn expect_token_value cursor:TokenCursor expected:str -> Token {
         f"`{expected}`"
         token Token::location
         "Unexpected token"
-        ErrorKind::UnexpectedToken (int)
+        ErrorKind::UnexpectedToken
         raise_error_expected
     fi
     token
 }
 
-fn expect_token_kind cursor:TokenCursor expected_kind:int -> Token {
+fn expect_token_kind cursor:TokenCursor expected_kind:TokenKind -> Token {
     cursor expect_token = token
     if expected_kind token Token::kind != then
-        token Token::location "Unexpected token" ErrorKind::UnexpectedToken (int) raise_error
+        token Token::location "Unexpected token" ErrorKind::UnexpectedToken raise_error
     fi
     token
 }
@@ -172,7 +172,7 @@ fn expect_delimiter cursor:TokenCursor expected_value:str -> bool {
 fn parse_type cursor:TokenCursor -> str {
     cursor tc_peek = peek_opt
     if peek_opt .is_none then
-        empty_location "Expected type" ErrorKind::UnexpectedToken (int) raise_error
+        empty_location "Expected type" ErrorKind::UnexpectedToken raise_error
     fi
     peek_opt .unwrap = peek
 
@@ -182,8 +182,8 @@ fn parse_type cursor:TokenCursor -> str {
         "fn" = base
     else
         cursor expect_token = base_token
-        if TokenKind::Identifier (int) base_token Token::kind != then
-            base_token Token::location "Expected type name" ErrorKind::UnexpectedToken (int) raise_error
+        if TokenKind::Identifier base_token Token::kind != then
+            base_token Token::location "Expected type name" ErrorKind::UnexpectedToken raise_error
         fi
         base_token Token::value = base
     fi
@@ -238,7 +238,7 @@ fn parse_type cursor:TokenCursor -> str {
         cursor parse_type inner_types .push
     done
     if 0 inner_types .length == then
-        empty_location f"Expected type parameter inside `{base}[...]`" ErrorKind::UnexpectedToken (int) raise_error
+        empty_location f"Expected type parameter inside `{base}[...]`" ErrorKind::UnexpectedToken raise_error
     fi
 
     # Join inner types with spaces
@@ -265,7 +265,7 @@ fn get_op_type_cast cursor:TokenCursor -> Op {
     close_token Token::location Location::span Span::offset = close_offset
     close_offset open_offset - 1 + = length
     length open_offset open_token Token::location Location::file make_location = loc
-    loc OpKind::OpTypeCast (int) cast_type make_op_str
+    loc OpKind::OpTypeCast cast_type make_op_str
 }
 
 # ============================================================================
@@ -275,15 +275,15 @@ fn get_op_type_cast cursor:TokenCursor -> Op {
 fn get_op_literal token:Token -> Op {
     token Token::value = value
     if "true" value == then
-        token Token::location OpKind::OpPushBool (int) 1 make_op return
+        token Token::location OpKind::OpPushBool 1 make_op return
     fi
     if "false" value == then
-        token Token::location OpKind::OpPushBool (int) 0 make_op return
+        token Token::location OpKind::OpPushBool 0 make_op return
     fi
     # Integer literal (positive or negative)
     if 0 value .at .is_digit value is_negative_integer_literal || then
         value str_to_int = int_value
-        token Token::location OpKind::OpPushInt (int) int_value make_op return
+        token Token::location OpKind::OpPushInt int_value make_op return
     fi
     # Char literal: 'X'
     if
@@ -292,16 +292,16 @@ fn get_op_literal token:Token -> Op {
         3 value .length == &&
     then
         1 value .at (int) = char_value
-        token Token::location OpKind::OpPushChar (int) char_value make_op return
+        token Token::location OpKind::OpPushChar char_value make_op return
     fi
     # String literal: "..."
     if '"' 0 value .at == '"' value .length 1 - value .at == && then
         value 1 value .length 2 - str::substring = str_value
-        token Token::location OpKind::OpPushStr (int) str_value make_op_str return
+        token Token::location OpKind::OpPushStr str_value make_op_str return
     fi
-    token Token::location f"Token `{value}` is not a literal" ErrorKind::Syntax (int) raise_error
+    token Token::location f"Token `{value}` is not a literal" ErrorKind::Syntax raise_error
     # Unreachable - raise_error exits
-    token Token::location OpKind::OpPushInt (int) 0 make_op
+    token Token::location OpKind::OpPushInt 0 make_op
 }
 
 # ============================================================================
@@ -311,12 +311,12 @@ fn get_op_literal token:Token -> Op {
 fn get_op_intrinsic token:Token -> Op {
     token Token::value intrinsic_from_str = kind_opt
     if kind_opt .is_none then
-        token Token::location f"Token `{token Token::value}` is not an intrinsic" ErrorKind::Syntax (int) raise_error
+        token Token::location f"Token `{token Token::value}` is not an intrinsic" ErrorKind::Syntax raise_error
     fi
     kind_opt .unwrap = intrinsic_kind
     intrinsic_kind INTRINSIC_TO_OPKIND .get = opkind_opt
     if opkind_opt .is_none then
-        token Token::location f"No OpKind for intrinsic `{token Token::value}`" ErrorKind::Syntax (int) raise_error
+        token Token::location f"No OpKind for intrinsic `{token Token::value}`" ErrorKind::Syntax raise_error
     fi
     token Token::location opkind_opt .unwrap 0 make_op
 }
@@ -328,13 +328,13 @@ fn get_op_intrinsic token:Token -> Op {
 fn get_op_operator token:Token cursor:TokenCursor function_name:str -> Op {
     token Token::value operator_from_str = kind_opt
     if kind_opt .is_none then
-        token Token::location f"Token `{token Token::value}` is not an operator" ErrorKind::Syntax (int) raise_error
+        token Token::location f"Token `{token Token::value}` is not an operator" ErrorKind::Syntax raise_error
     fi
     kind_opt .unwrap = operator_kind
 
     # Assignment: = varname
-    if OperatorKind::Assign (int) operator_kind == then
-        TokenKind::Identifier (int) cursor expect_token_kind = name_token
+    if OperatorKind::Assign operator_kind == then
+        TokenKind::Identifier cursor expect_token_kind = name_token
         name_token Token::value = var_name
 
         # Optional type annotation: = varname : type
@@ -347,29 +347,29 @@ fn get_op_operator token:Token cursor:TokenCursor function_name:str -> Op {
             fi
         fi
         if "" type_annotation == then
-            name_token Token::location OpKind::OpAssignVar (int) var_name make_op_str
+            name_token Token::location OpKind::OpAssignVar var_name make_op_str
         else
-            type_annotation name_token Token::location OpKind::OpAssignVar (int) var_name (int) make_op_annotated
+            type_annotation name_token Token::location OpKind::OpAssignVar var_name (int) make_op_annotated
         fi
         return
     fi
 
     # Compound assignment: += varname
-    if OperatorKind::AssignInc (int) operator_kind == then
-        TokenKind::Identifier (int) cursor expect_token_kind = inc_token
-        token Token::location OpKind::OpAssignInc (int) inc_token Token::value make_op_str return
+    if OperatorKind::AssignInc operator_kind == then
+        TokenKind::Identifier cursor expect_token_kind = inc_token
+        token Token::location OpKind::OpAssignInc inc_token Token::value make_op_str return
     fi
 
     # Compound assignment: -= varname
-    if OperatorKind::AssignDec (int) operator_kind == then
-        TokenKind::Identifier (int) cursor expect_token_kind = dec_token
-        token Token::location OpKind::OpAssignDec (int) dec_token Token::value make_op_str return
+    if OperatorKind::AssignDec operator_kind == then
+        TokenKind::Identifier cursor expect_token_kind = dec_token
+        token Token::location OpKind::OpAssignDec dec_token Token::value make_op_str return
     fi
 
     # Simple operator -> opkind via map
     operator_kind OPERATOR_TO_OPKIND .get = opkind_opt
     if opkind_opt .is_none then
-        token Token::location f"No OpKind for operator `{token Token::value}`" ErrorKind::Syntax (int) raise_error
+        token Token::location f"No OpKind for operator `{token Token::value}`" ErrorKind::Syntax raise_error
     fi
     token Token::location opkind_opt .unwrap 0 make_op
 }
@@ -399,19 +399,19 @@ fn get_op_array cursor:TokenCursor -> Op {
         fi
         cursor tc_pop = value_opt
         if value_opt .is_none then
-            open_token Token::location "Unexpected end of input in array literal" ErrorKind::UnexpectedToken (int) raise_error
+            open_token Token::location "Unexpected end of input in array literal" ErrorKind::UnexpectedToken raise_error
         fi
         value_opt .unwrap = value_token
-        if TokenKind::Literal (int) value_token Token::kind == then
+        if TokenKind::Literal value_token Token::kind == then
             value_token get_op_literal items .push
-        elif TokenKind::Identifier (int) value_token Token::kind == then
-            value_token Token::location OpKind::OpIdentifier (int) value_token Token::value make_op_str items .push
+        elif TokenKind::Identifier value_token Token::kind == then
+            value_token Token::location OpKind::OpIdentifier value_token Token::value make_op_str items .push
         else
-            value_token Token::location "Unexpected token in array literal" ErrorKind::UnexpectedToken (int) raise_error
+            value_token Token::location "Unexpected token in array literal" ErrorKind::UnexpectedToken raise_error
         fi
         "," cursor expect_delimiter drop
     done
-    open_token Token::location OpKind::OpPushArray (int) items (int) make_op
+    open_token Token::location OpKind::OpPushArray items (int) make_op
 }
 
 # ============================================================================
@@ -424,13 +424,13 @@ fn parse_block_ops cursor:TokenCursor function_name:str -> List[Op] {
     while true do
         cursor tc_pop = token_opt
         if token_opt .is_none then
-            open_token Token::location "Unclosed block" ErrorKind::UnmatchedBlock (int) raise_error
+            open_token Token::location "Unclosed block" ErrorKind::UnmatchedBlock raise_error
         fi
         token_opt .unwrap = token
         if "}" token Token::value == then
             ops return
         fi
-        if TokenKind::FstringStart (int) token Token::kind == then
+        if TokenKind::FstringStart token Token::kind == then
             ops function_name cursor token handle_fstring
             continue
         fi
@@ -449,10 +449,10 @@ fn parse_fstring_expr cursor:TokenCursor function_name:str -> List[Op] {
         cursor tc_pop = token_opt
         if token_opt .is_none then break fi
         token_opt .unwrap = token
-        if TokenKind::FstringExprEnd (int) token Token::kind == then
+        if TokenKind::FstringExprEnd token Token::kind == then
             break
         fi
-        if TokenKind::FstringStart (int) token Token::kind == then
+        if TokenKind::FstringStart token Token::kind == then
             ops function_name cursor token handle_fstring
             continue
         fi
@@ -467,27 +467,27 @@ fn handle_fstring start_token:Token cursor:TokenCursor function_name:str ops:Lis
         cursor tc_pop = token_opt
         if token_opt .is_none then break fi
         token_opt .unwrap = token
-        if TokenKind::FstringText (int) token Token::kind == then
-            token Token::location OpKind::OpPushStr (int) token Token::value make_op_str ops .push
+        if TokenKind::FstringText token Token::kind == then
+            token Token::location OpKind::OpPushStr token Token::value make_op_str ops .push
             1 += part_count
-        elif TokenKind::FstringExprStart (int) token Token::kind == then
+        elif TokenKind::FstringExprStart token Token::kind == then
             function_name cursor parse_fstring_expr = expr_ops
             f"lambda__{function_name}_o{token Token::location Location::span Span::offset .to_str}" = lambda_name
             token Token::location expr_ops lambda_name make_function = lambda_function
             lambda_name lambda_function GLOBAL_FUNCTIONS .set = GLOBAL_FUNCTIONS
-            token Token::location OpKind::OpFnPush (int) lambda_name make_op_str ops .push
-            token Token::location OpKind::OpFnExec (int) 0 make_op ops .push
+            token Token::location OpKind::OpFnPush lambda_name make_op_str ops .push
+            token Token::location OpKind::OpFnExec 0 make_op ops .push
             1 += part_count
-        elif TokenKind::FstringEnd (int) token Token::kind == then
+        elif TokenKind::FstringEnd token Token::kind == then
             break
         fi
     done
     if 0 part_count == then
-        start_token Token::location OpKind::OpPushStr (int) "" make_op_str ops .push
+        start_token Token::location OpKind::OpPushStr "" make_op_str ops .push
         1 = part_count
     fi
     if 1 part_count > then
-        start_token Token::location OpKind::OpFstringConcat (int) part_count make_op ops .push
+        start_token Token::location OpKind::OpFstringConcat part_count make_op ops .push
     fi
 }
 
@@ -500,16 +500,16 @@ fn get_op_delimiter token:Token cursor:TokenCursor function_name:str ops:List[Op
 
     # Arrow -> set_field
     if "->" value == then
-        TokenKind::Identifier (int) cursor expect_token_kind = member_token
+        TokenKind::Identifier cursor expect_token_kind = member_token
         f"set_{member_token Token::value}" = god_setter_name
-        member_token Token::location OpKind::OpMethodCall (int) god_setter_name make_op_str ops .push
+        member_token Token::location OpKind::OpMethodCall god_setter_name make_op_str ops .push
         return
     fi
 
     # Dot . method
     if "." value == then
-        TokenKind::Identifier (int) cursor expect_token_kind = method_token
-        method_token Token::location OpKind::OpMethodCall (int) method_token Token::value make_op_str ops .push
+        TokenKind::Identifier cursor expect_token_kind = method_token
+        method_token Token::location OpKind::OpMethodCall method_token Token::value make_op_str ops .push
         return
     fi
 
@@ -520,7 +520,7 @@ fn get_op_delimiter token:Token cursor:TokenCursor function_name:str ops:List[Op
         f"lambda__{function_name}_o{token Token::location Location::span Span::offset .to_str}" = lambda_name
         token Token::location lambda_ops lambda_name make_function = lambda_function
         lambda_name lambda_function GLOBAL_FUNCTIONS .set = GLOBAL_FUNCTIONS
-        token Token::location OpKind::OpFnPush (int) lambda_name make_op_str ops .push
+        token Token::location OpKind::OpFnPush lambda_name make_op_str ops .push
         return
     fi
 
@@ -572,7 +572,7 @@ fn try_parse_is_check token:Token cursor:TokenCursor -> Option[Op] {
                 fi
                 break
             fi
-            if TokenKind::Identifier (int) inner_opt .unwrap Token::kind != then
+            if TokenKind::Identifier inner_opt .unwrap Token::kind != then
                 saved_pos cursor tc_restore
                 Option::None return
             fi
@@ -600,7 +600,7 @@ fn try_parse_is_check token:Token cursor:TokenCursor -> Option[Op] {
 
     Option::None variant_name enum_name make_enum_variant = variant
     bindings variant EnumVariant::set_bindings
-    token Token::location OpKind::OpIsCheck (int) variant (int) make_op Option::Some
+    token Token::location OpKind::OpIsCheck variant (int) make_op Option::Some
 }
 
 # ============================================================================
@@ -609,7 +609,7 @@ fn try_parse_is_check token:Token cursor:TokenCursor -> Option[Op] {
 
 fn require_global_scope function_name:str what:str location:Location {
     if GLOBAL_SCOPE_LABEL function_name != then
-        location f"{what} should be defined in the global scope" ErrorKind::InvalidScope (int) raise_error
+        location f"{what} should be defined in the global scope" ErrorKind::InvalidScope raise_error
     fi
 }
 
@@ -629,22 +629,22 @@ fn parse_type_vars cursor:TokenCursor -> List[str] {
     while true do
         cursor tc_pop = token_opt
         if token_opt .is_none then
-            empty_location "Expected `]` to close type parameters" ErrorKind::Syntax (int) raise_error
+            empty_location "Expected `]` to close type parameters" ErrorKind::Syntax raise_error
         fi
         token_opt .unwrap = token
         if "]" token Token::value == then
             if 0 vars .length == then
-                token Token::location "Empty type parameter list `[]` is not allowed" ErrorKind::Syntax (int) raise_error
+                token Token::location "Empty type parameter list `[]` is not allowed" ErrorKind::Syntax raise_error
             fi
             vars return
         fi
         if "," token Token::value == then continue fi
-        if TokenKind::Identifier (int) token Token::kind == then
+        if TokenKind::Identifier token Token::kind == then
             if token Token::value BUILTIN_TYPES .has then
-                token Token::location f"Type variable `{token Token::value}` shadows built-in type" ErrorKind::DuplicateName (int) raise_error
+                token Token::location f"Type variable `{token Token::value}` shadows built-in type" ErrorKind::DuplicateName raise_error
             fi
             if token Token::value seen .has then
-                token Token::location f"Duplicate type variable `{token Token::value}`" ErrorKind::DuplicateName (int) raise_error
+                token Token::location f"Duplicate type variable `{token Token::value}`" ErrorKind::DuplicateName raise_error
             fi
             token Token::value vars .push
             token Token::value seen .add = seen
@@ -653,15 +653,15 @@ fn parse_type_vars cursor:TokenCursor -> List[str] {
             if colon_opt .is_some then
                 if ":" colon_opt .unwrap Token::value == then
                     cursor tc_pop drop  # consume :
-                    TokenKind::Identifier (int) cursor expect_token_kind = trait_token
+                    TokenKind::Identifier cursor expect_token_kind = trait_token
                     if trait_token Token::value GLOBAL_TRAITS .get .is_none then
-                        trait_token Token::location f"Trait `{trait_token Token::value}` is not defined" ErrorKind::UndefinedName (int) raise_error
+                        trait_token Token::location f"Trait `{trait_token Token::value}` is not defined" ErrorKind::UndefinedName raise_error
                     fi
                     token Token::value trait_token Token::value LAST_TRAIT_BOUNDS .set = LAST_TRAIT_BOUNDS
                 fi
             fi
         else
-            token Token::location "Unexpected token in type parameters" ErrorKind::UnexpectedToken (int) raise_error
+            token Token::location "Unexpected token in type parameters" ErrorKind::UnexpectedToken raise_error
         fi
     done
     vars
@@ -676,7 +676,7 @@ fn parse_parameters cursor:TokenCursor -> List[Parameter] {
     while true do
         cursor tc_pop = token_opt
         if token_opt .is_none then
-            empty_location "Unexpected end of input" ErrorKind::UnexpectedToken (int) raise_error
+            empty_location "Unexpected end of input" ErrorKind::UnexpectedToken raise_error
         fi
         token_opt .unwrap = token
 
@@ -693,8 +693,8 @@ fn parse_parameters cursor:TokenCursor -> List[Parameter] {
             continue
         fi
 
-        if TokenKind::Identifier (int) token Token::kind != then
-            token Token::location "Unexpected token in parameter list" ErrorKind::UnexpectedToken (int) raise_error
+        if TokenKind::Identifier token Token::kind != then
+            token Token::location "Unexpected token in parameter list" ErrorKind::UnexpectedToken raise_error
         fi
 
         # Check if named parameter: name:type
@@ -724,7 +724,7 @@ fn parse_return_types cursor:TokenCursor -> List[str] {
     while true do
         cursor tc_peek = peek_opt
         if peek_opt .is_none then
-            empty_location "Unexpected end of input" ErrorKind::UnexpectedToken (int) raise_error
+            empty_location "Unexpected end of input" ErrorKind::UnexpectedToken raise_error
         fi
         if "{" peek_opt .unwrap Token::value == then
             types return
@@ -744,7 +744,7 @@ fn parse_signature cursor:TokenCursor -> Signature {
 
     cursor tc_peek = next_opt
     if next_opt .is_none then
-        empty_location "Unexpected end of input" ErrorKind::UnexpectedToken (int) raise_error
+        empty_location "Unexpected end of input" ErrorKind::UnexpectedToken raise_error
     fi
     if "->" next_opt .unwrap Token::value == then
         cursor tc_advance  # consume ->
@@ -759,7 +759,7 @@ fn parse_signature cursor:TokenCursor -> Signature {
 
 fn parse_function cursor:TokenCursor -> Function {
     "fn" cursor expect_token_value drop
-    TokenKind::Identifier (int) cursor expect_token_kind = name_token
+    TokenKind::Identifier cursor expect_token_kind = name_token
 
     # Parse optional type parameters
     List::new (List[str]) = type_vars
@@ -805,7 +805,7 @@ fn parse_function cursor:TokenCursor -> Function {
                     f"fn[{hidden_sig signature_to_str}]" = hidden_type
                     hidden_name hidden_type make_named_param hidden_params .push
                     hidden_name make_variable variables .push
-                    name_token Token::location OpKind::OpAssignVar (int) hidden_name make_op_str ops .push
+                    name_token Token::location OpKind::OpAssignVar hidden_name make_op_str ops .push
                     1 += method_index
                 done
             fi
@@ -827,7 +827,7 @@ fn parse_function cursor:TokenCursor -> Function {
         if "" param Parameter::name != then
             if param Parameter::name "__trait_" str::starts_with ! then
                 param Parameter::typ param Parameter::name Variable variables .push
-                name_token Token::location OpKind::OpAssignVar (int) param Parameter::name make_op_str ops .push
+                name_token Token::location OpKind::OpAssignVar param Parameter::name make_op_str ops .push
             fi
         fi
         1 += param_iter
@@ -851,7 +851,7 @@ fn parse_function cursor:TokenCursor -> Function {
 
 fn parse_enum cursor:TokenCursor -> CasaEnum {
     "enum" cursor expect_token_value drop
-    TokenKind::Identifier (int) cursor expect_token_kind = name_token
+    TokenKind::Identifier cursor expect_token_kind = name_token
 
     # Parse optional type parameters
     List::new (List[str]) = type_vars
@@ -870,11 +870,11 @@ fn parse_enum cursor:TokenCursor -> CasaEnum {
     while true do
         cursor expect_token = variant_token
         if "}" variant_token Token::value == then break fi
-        if TokenKind::Identifier (int) variant_token Token::kind != then
-            variant_token Token::location "Expected variant name" ErrorKind::UnexpectedToken (int) raise_error
+        if TokenKind::Identifier variant_token Token::kind != then
+            variant_token Token::location "Expected variant name" ErrorKind::UnexpectedToken raise_error
         fi
         if variant_token Token::value variants string_list_contains then
-            variant_token Token::location f"Duplicate variant `{variant_token Token::value}`" ErrorKind::DuplicateName (int) raise_error
+            variant_token Token::location f"Duplicate variant `{variant_token Token::value}`" ErrorKind::DuplicateName raise_error
         fi
         variant_token Token::value variants .push
         variant_token Token::value variant_token Token::location variant_locations .set = variant_locations
@@ -888,7 +888,7 @@ fn parse_enum cursor:TokenCursor -> CasaEnum {
                 while true do
                     cursor tc_peek = inner_opt
                     if inner_opt .is_none then
-                        variant_token Token::location "Unexpected end of input in variant inner types" ErrorKind::UnexpectedToken (int) raise_error
+                        variant_token Token::location "Unexpected end of input in variant inner types" ErrorKind::UnexpectedToken raise_error
                     fi
                     if ")" inner_opt .unwrap Token::value == then
                         cursor tc_pop drop  # consume )
@@ -897,7 +897,7 @@ fn parse_enum cursor:TokenCursor -> CasaEnum {
                     cursor parse_type inner_types .push
                 done
                 if 0 inner_types .length == then
-                    variant_token Token::location "Variant inner types cannot be empty" ErrorKind::Syntax (int) raise_error
+                    variant_token Token::location "Variant inner types cannot be empty" ErrorKind::Syntax raise_error
                 fi
             fi
         fi
@@ -905,7 +905,7 @@ fn parse_enum cursor:TokenCursor -> CasaEnum {
     done
 
     if 0 variants .length == then
-        name_token Token::location "Enum must have at least one variant" ErrorKind::Syntax (int) raise_error
+        name_token Token::location "Enum must have at least one variant" ErrorKind::Syntax raise_error
     fi
 
     variant_locations type_vars variant_types name_token Token::location variants name_token Token::value CasaEnum
@@ -933,11 +933,11 @@ fn create_member_accessor struct_name:str member_name:str member_type:str member
     # Getter
     f"{struct_name}::{member_name}" = getter_name
     List::new (List[Op]) = getter_ops
-    location OpKind::OpTypeCast (int) "ptr" make_op_str getter_ops .push
-    location OpKind::OpPushInt (int) offset make_op getter_ops .push
-    location OpKind::OpAdd (int) 0 make_op getter_ops .push
-    location OpKind::OpLoad64 (int) 0 make_op getter_ops .push
-    location OpKind::OpTypeCast (int) member_type make_op_str getter_ops .push
+    location OpKind::OpTypeCast "ptr" make_op_str getter_ops .push
+    location OpKind::OpPushInt offset make_op getter_ops .push
+    location OpKind::OpAdd 0 make_op getter_ops .push
+    location OpKind::OpLoad64 0 make_op getter_ops .push
+    location OpKind::OpTypeCast member_type make_op_str getter_ops .push
 
     List::new (List[Parameter]) = getter_params
     param_type make_param getter_params .push
@@ -948,17 +948,17 @@ fn create_member_accessor struct_name:str member_name:str member_type:str member
     getter_sig location getter_ops getter_name make_function_with_sig = getter
 
     if getter_name GLOBAL_FUNCTIONS .get .is_some then
-        location f"Function `{getter_name}` is already defined" ErrorKind::DuplicateName (int) raise_error
+        location f"Function `{getter_name}` is already defined" ErrorKind::DuplicateName raise_error
     fi
     getter_name getter GLOBAL_FUNCTIONS .set = GLOBAL_FUNCTIONS
 
     # Setter
     f"{struct_name}::set_{member_name}" = setter_name
     List::new (List[Op]) = setter_ops
-    location OpKind::OpTypeCast (int) "ptr" make_op_str setter_ops .push
-    location OpKind::OpPushInt (int) offset make_op setter_ops .push
-    location OpKind::OpAdd (int) 0 make_op setter_ops .push
-    location OpKind::OpStore64 (int) 0 make_op setter_ops .push
+    location OpKind::OpTypeCast "ptr" make_op_str setter_ops .push
+    location OpKind::OpPushInt offset make_op setter_ops .push
+    location OpKind::OpAdd 0 make_op setter_ops .push
+    location OpKind::OpStore64 0 make_op setter_ops .push
 
     List::new (List[Parameter]) = setter_params
     param_type make_param setter_params .push
@@ -969,7 +969,7 @@ fn create_member_accessor struct_name:str member_name:str member_type:str member
     setter_sig location setter_ops setter_name make_function_with_sig = setter
 
     if setter_name GLOBAL_FUNCTIONS .get .is_some then
-        location f"Function `{setter_name}` is already defined" ErrorKind::DuplicateName (int) raise_error
+        location f"Function `{setter_name}` is already defined" ErrorKind::DuplicateName raise_error
     fi
     setter_name setter GLOBAL_FUNCTIONS .set = GLOBAL_FUNCTIONS
 }
@@ -980,7 +980,7 @@ fn create_member_accessor struct_name:str member_name:str member_type:str member
 
 fn parse_struct cursor:TokenCursor -> CasaStruct {
     "struct" cursor expect_token_value drop
-    TokenKind::Identifier (int) cursor expect_token_kind = name_token
+    TokenKind::Identifier cursor expect_token_kind = name_token
 
     # Parse optional type parameters
     List::new (List[str]) = type_vars
@@ -990,7 +990,7 @@ fn parse_struct cursor:TokenCursor -> CasaStruct {
             cursor parse_type_vars = type_vars
             # Trait bounds are not allowed on struct definitions
             if 0 LAST_TRAIT_BOUNDS .keys .length != then
-                name_token Token::location "Trait bounds are not allowed on struct definitions. Use `impl[K: Bound] StructName[K]` instead" ErrorKind::UnexpectedToken (int) raise_error
+                name_token Token::location "Trait bounds are not allowed on struct definitions. Use `impl[K: Bound] StructName[K]` instead" ErrorKind::UnexpectedToken raise_error
             fi
         fi
     fi
@@ -1001,8 +1001,8 @@ fn parse_struct cursor:TokenCursor -> CasaStruct {
     while true do
         cursor expect_token = member_token
         if "}" member_token Token::value == then break fi
-        if TokenKind::Identifier (int) member_token Token::kind != then
-            member_token Token::location "Expected member name" ErrorKind::UnexpectedToken (int) raise_error
+        if TokenKind::Identifier member_token Token::kind != then
+            member_token Token::location "Expected member name" ErrorKind::UnexpectedToken raise_error
         fi
         ":" cursor expect_token_value drop
         cursor parse_type = member_type
@@ -1037,10 +1037,10 @@ fn parse_trait_method_signature cursor:TokenCursor -> Signature {
         cursor tc_pop drop
 
         if
-            TokenKind::Identifier (int) peek Token::kind !=
+            TokenKind::Identifier peek Token::kind !=
             "fn" peek Token::value != &&
         then
-            peek Token::location "Unexpected token in trait method parameter list" ErrorKind::UnexpectedToken (int) raise_error
+            peek Token::location "Unexpected token in trait method parameter list" ErrorKind::UnexpectedToken raise_error
         fi
 
         cursor tc_peek = next_opt
@@ -1078,7 +1078,7 @@ fn parse_trait_method_signature cursor:TokenCursor -> Signature {
 
 fn parse_trait cursor:TokenCursor -> CasaTrait {
     "trait" cursor expect_token_value drop
-    TokenKind::Identifier (int) cursor expect_token_kind = name_token
+    TokenKind::Identifier cursor expect_token_kind = name_token
 
     List::new (List[TraitMethod]) = methods
     "{" cursor expect_token_value drop
@@ -1086,7 +1086,7 @@ fn parse_trait cursor:TokenCursor -> CasaTrait {
     while true do
         cursor tc_peek = next_opt
         if next_opt .is_none then
-            name_token Token::location "Unclosed trait block" ErrorKind::UnmatchedBlock (int) raise_error
+            name_token Token::location "Unclosed trait block" ErrorKind::UnmatchedBlock raise_error
             break
         fi
         if "}" next_opt .unwrap Token::value == then
@@ -1094,11 +1094,11 @@ fn parse_trait cursor:TokenCursor -> CasaTrait {
             break
         fi
         if "fn" next_opt .unwrap Token::value != then
-            next_opt .unwrap Token::location "Expected method declaration in trait" ErrorKind::UnexpectedToken (int) raise_error
+            next_opt .unwrap Token::location "Expected method declaration in trait" ErrorKind::UnexpectedToken raise_error
             break
         fi
         cursor tc_pop drop  # consume fn
-        TokenKind::Identifier (int) cursor expect_token_kind = method_name
+        TokenKind::Identifier cursor expect_token_kind = method_name
         cursor parse_trait_method_signature = method_sig
         method_sig method_name Token::value TraitMethod methods .push
     done
@@ -1152,7 +1152,7 @@ fn inject_impl_trait_params function:Function type_vars:List[str] trait_bounds:M
                 f"fn[{hidden_sig signature_to_str}]" = hidden_type
                 hidden_name hidden_type make_named_param hidden_params .push
                 hidden_name make_variable function Function::variables .push
-                function Function::location OpKind::OpAssignVar (int) hidden_name make_op_str = assign_op
+                function Function::location OpKind::OpAssignVar hidden_name make_op_str = assign_op
                 insert_pos assign_op function Function::ops .insert
                 1 += insert_pos
                 1 += method_index
@@ -1209,7 +1209,7 @@ fn parse_impl_block cursor:TokenCursor {
             trait_bounds type_vars function inject_impl_trait_params
         fi
         if fn_name GLOBAL_FUNCTIONS .get .is_some then
-            function Function::location f"Identifier `{fn_name}` is already defined" ErrorKind::DuplicateName (int) raise_error
+            function Function::location f"Identifier `{fn_name}` is already defined" ErrorKind::DuplicateName raise_error
         fi
         fn_name function GLOBAL_FUNCTIONS .set = GLOBAL_FUNCTIONS
     done
@@ -1238,10 +1238,10 @@ fn is_match_arm_boundary cursor:TokenCursor -> bool {
         true return
     fi
     # literal =>
-    if TokenKind::Literal (int) token Token::kind == "=>" next_token Token::value == && then
+    if TokenKind::Literal token Token::kind == "=>" next_token Token::value == && then
         true return
     fi
-    if TokenKind::Identifier (int) token Token::kind != then false return fi
+    if TokenKind::Identifier token Token::kind != then false return fi
     # Identifier =>
     if "=>" next_token Token::value == then true return fi
     # StructName { ... } =>
@@ -1273,22 +1273,22 @@ fn parse_struct_match_pattern name_token:Token cursor:TokenCursor -> StructPatte
     "{" cursor expect_token_value drop
     name_token Token::value GLOBAL_STRUCTS .get = struct_opt
     if struct_opt .is_none then
-        name_token Token::location f"Struct `{name_token Token::value}` is not defined" ErrorKind::UndefinedName (int) raise_error
+        name_token Token::location f"Struct `{name_token Token::value}` is not defined" ErrorKind::UndefinedName raise_error
     fi
     Map::new (Map[str str]) = bindings
 
     while true do
         cursor tc_peek = next_opt
         if next_opt .is_none then
-            name_token Token::location "Unexpected end of input in struct pattern" ErrorKind::UnexpectedToken (int) raise_error
+            name_token Token::location "Unexpected end of input in struct pattern" ErrorKind::UnexpectedToken raise_error
         fi
         if "}" next_opt .unwrap Token::value == then
             cursor tc_pop drop
             break
         fi
-        TokenKind::Identifier (int) cursor expect_token_kind = field_token
+        TokenKind::Identifier cursor expect_token_kind = field_token
         ":" cursor expect_token_value drop
-        TokenKind::Identifier (int) cursor expect_token_kind = var_token
+        TokenKind::Identifier cursor expect_token_kind = var_token
         field_token Token::value var_token Token::value bindings .set = bindings
     done
 
@@ -1316,21 +1316,21 @@ fn parse_literal_match_pattern token:Token -> LiteralPattern {
     if '"' 0 value .at == '"' value .length 1 - value .at == && then
         value "str" value 1 value .length 2 - str::substring (int) LiteralPattern return
     fi
-    token Token::location f"Unsupported literal in match arm: `{value}`" ErrorKind::UnexpectedToken (int) raise_error
+    token Token::location f"Unsupported literal in match arm: `{value}`" ErrorKind::UnexpectedToken raise_error
     # Unreachable
     "" "int" 0 LiteralPattern
 }
 
 fn handle_keyword_match token:Token cursor:TokenCursor function_name:str -> List[Op] {
     List::new (List[Op]) = ops
-    token Token::location OpKind::OpMatchStart (int) 0 make_op ops .push
+    token Token::location OpKind::OpMatchStart 0 make_op ops .push
 
     while true do
         cursor expect_token = arm_token
 
         # end keyword
         if "end" arm_token Token::value == then
-            arm_token Token::location OpKind::OpMatchEnd (int) 0 make_op ops .push
+            arm_token Token::location OpKind::OpMatchEnd 0 make_op ops .push
             break
         fi
 
@@ -1338,23 +1338,23 @@ fn handle_keyword_match token:Token cursor:TokenCursor function_name:str -> List
         if MATCH_WILDCARD arm_token Token::value == then
             "=>" cursor expect_token_value drop
             Option::None MATCH_WILDCARD "" make_enum_variant = wildcard
-            "enum_variant" arm_token Token::location OpKind::OpMatchArm (int) wildcard (int) make_op_annotated ops .push
-        elif TokenKind::Literal (int) arm_token Token::kind == then
+            "enum_variant" arm_token Token::location OpKind::OpMatchArm wildcard (int) make_op_annotated ops .push
+        elif TokenKind::Literal arm_token Token::kind == then
             "=>" cursor expect_token_value drop
             arm_token parse_literal_match_pattern = literal_pattern
-            "literal_pattern" arm_token Token::location OpKind::OpMatchArm (int) literal_pattern (int) make_op_annotated = literal_op
+            "literal_pattern" arm_token Token::location OpKind::OpMatchArm literal_pattern (int) make_op_annotated = literal_op
             literal_op ops .push
-        elif TokenKind::Identifier (int) arm_token Token::kind != then
-            arm_token Token::location "Expected match pattern or `_`" ErrorKind::UnexpectedToken (int) raise_error
+        elif TokenKind::Identifier arm_token Token::kind != then
+            arm_token Token::location "Expected match pattern or `_`" ErrorKind::UnexpectedToken raise_error
         elif cursor tc_peek .is_some "{" cursor tc_peek .unwrap Token::value == && then
             # Struct pattern
             cursor arm_token parse_struct_match_pattern = struct_pattern
-            "struct_pattern" arm_token Token::location OpKind::OpMatchArm (int) struct_pattern (int) make_op_annotated ops .push
+            "struct_pattern" arm_token Token::location OpKind::OpMatchArm struct_pattern (int) make_op_annotated ops .push
         elif arm_token Token::value "::" str::find 0 > then
             # Bare identifier
             "=>" cursor expect_token_value drop
             Option::None arm_token Token::value "" make_enum_variant = bare_variant
-            "enum_variant" arm_token Token::location OpKind::OpMatchArm (int) bare_variant (int) make_op_annotated ops .push
+            "enum_variant" arm_token Token::location OpKind::OpMatchArm bare_variant (int) make_op_annotated ops .push
         else
             # Enum::Variant pattern
             arm_token Token::value "::" str::find = separator
@@ -1369,13 +1369,13 @@ fn handle_keyword_match token:Token cursor:TokenCursor function_name:str -> List
                 while true do
                     cursor tc_peek = inner_opt
                     if inner_opt .is_none then
-                        arm_token Token::location "Unexpected end of input in match arm bindings" ErrorKind::UnexpectedToken (int) raise_error
+                        arm_token Token::location "Unexpected end of input in match arm bindings" ErrorKind::UnexpectedToken raise_error
                     fi
                     if ")" inner_opt .unwrap Token::value == then
                         cursor tc_pop drop
                         break
                     fi
-                    TokenKind::Identifier (int) cursor expect_token_kind = binding_token
+                    TokenKind::Identifier cursor expect_token_kind = binding_token
                     binding_token Token::value bindings .push
                 done
             fi
@@ -1383,7 +1383,7 @@ fn handle_keyword_match token:Token cursor:TokenCursor function_name:str -> List
             "=>" cursor expect_token_value drop
             Option::None variant_name enum_name make_enum_variant = variant
             bindings variant EnumVariant::set_bindings
-            "enum_variant" arm_token Token::location OpKind::OpMatchArm (int) variant (int) make_op_annotated ops .push
+            "enum_variant" arm_token Token::location OpKind::OpMatchArm variant (int) make_op_annotated ops .push
         fi
 
         # Parse arm body
@@ -1406,7 +1406,7 @@ fn handle_keyword_match token:Token cursor:TokenCursor function_name:str -> List
                 cursor tc_pop = body_token_opt
                 if body_token_opt .is_none then break fi
                 body_token_opt .unwrap = body_token
-                if TokenKind::FstringStart (int) body_token Token::kind == then
+                if TokenKind::FstringStart body_token Token::kind == then
                     ops function_name cursor body_token handle_fstring
                     continue
                 fi
@@ -1474,10 +1474,10 @@ fn normalize_path path:str -> str {
 }
 
 fn handle_keyword_include token:Token cursor:TokenCursor -> Op {
-    TokenKind::Literal (int) cursor expect_token_kind = path_token
+    TokenKind::Literal cursor expect_token_kind = path_token
     path_token get_op_literal = literal_op
-    if OpKind::OpPushStr (int) literal_op Op::kind != then
-        path_token Token::location "Expected string literal for include path" ErrorKind::UnexpectedToken (int) raise_error
+    if OpKind::OpPushStr literal_op Op::kind != then
+        path_token Token::location "Expected string literal for include path" ErrorKind::UnexpectedToken raise_error
     fi
     literal_op op_str_value = path
 
@@ -1504,7 +1504,7 @@ fn handle_keyword_include token:Token cursor:TokenCursor -> Op {
         f"{directory}{path}" normalize_path = resolved
     fi
 
-    path_token Token::location OpKind::OpIncludeFile (int) resolved make_op_str
+    path_token Token::location OpKind::OpIncludeFile resolved make_op_str
 }
 
 # ============================================================================
@@ -1514,7 +1514,7 @@ fn handle_keyword_include token:Token cursor:TokenCursor -> Op {
 fn get_op_keyword token:Token cursor:TokenCursor function_name:str ops:List[Op] {
     token Token::value keyword_from_str = keyword_opt
     if keyword_opt .is_none then
-        token Token::location f"Token `{token Token::value}` is not a keyword" ErrorKind::Syntax (int) raise_error
+        token Token::location f"Token `{token Token::value}` is not a keyword" ErrorKind::Syntax raise_error
     fi
     keyword_opt .unwrap = keyword
 
@@ -1526,36 +1526,36 @@ fn get_op_keyword token:Token cursor:TokenCursor function_name:str ops:List[Op] 
     fi
 
     # end without match
-    if KeywordKind::End (int) keyword == then
-        token Token::location "`end` without matching `match`" ErrorKind::UnmatchedBlock (int) raise_error
+    if KeywordKind::End keyword == then
+        token Token::location "`end` without matching `match`" ErrorKind::UnmatchedBlock raise_error
     fi
 
     # enum
-    if KeywordKind::EnumKw (int) keyword == then
+    if KeywordKind::EnumKw keyword == then
         token Token::location "Enums" function_name require_global_scope
         cursor tc_retreat
         cursor parse_enum = casa_enum
         if casa_enum CasaEnum::name GLOBAL_ENUMS .get .is_some then
-            casa_enum CasaEnum::location f"Enum `{casa_enum CasaEnum::name}` is already defined" ErrorKind::DuplicateName (int) raise_error
+            casa_enum CasaEnum::location f"Enum `{casa_enum CasaEnum::name}` is already defined" ErrorKind::DuplicateName raise_error
         fi
         casa_enum CasaEnum::name casa_enum GLOBAL_ENUMS .set = GLOBAL_ENUMS
         return
     fi
 
     # fn
-    if KeywordKind::Fn (int) keyword == then
+    if KeywordKind::Fn keyword == then
         token Token::location "Functions" function_name require_global_scope
         cursor tc_retreat
         cursor parse_function = function
         if function Function::name GLOBAL_FUNCTIONS .get .is_some then
-            function Function::location f"Identifier `{function Function::name}` is already defined" ErrorKind::DuplicateName (int) raise_error
+            function Function::location f"Identifier `{function Function::name}` is already defined" ErrorKind::DuplicateName raise_error
         fi
         function Function::name function GLOBAL_FUNCTIONS .set = GLOBAL_FUNCTIONS
         return
     fi
 
     # impl
-    if KeywordKind::Impl (int) keyword == then
+    if KeywordKind::Impl keyword == then
         token Token::location "Implementation blocks" function_name require_global_scope
         cursor tc_retreat
         cursor parse_impl_block
@@ -1563,18 +1563,18 @@ fn get_op_keyword token:Token cursor:TokenCursor function_name:str ops:List[Op] 
     fi
 
     # include
-    if KeywordKind::Include (int) keyword == then
+    if KeywordKind::Include keyword == then
         cursor token handle_keyword_include ops .push
         return
     fi
 
     # is (standalone is error)
-    if KeywordKind::Is (int) keyword == then
-        token Token::location "`is` requires a preceding enum variant" ErrorKind::Syntax (int) raise_error
+    if KeywordKind::Is keyword == then
+        token Token::location "`is` requires a preceding enum variant" ErrorKind::Syntax raise_error
     fi
 
     # match
-    if KeywordKind::Match (int) keyword == then
+    if KeywordKind::Match keyword == then
         function_name cursor token handle_keyword_match = match_ops
         0 = match_index
         while match_index match_ops .length > do
@@ -1585,7 +1585,7 @@ fn get_op_keyword token:Token cursor:TokenCursor function_name:str ops:List[Op] 
     fi
 
     # struct
-    if KeywordKind::StructKw (int) keyword == then
+    if KeywordKind::StructKw keyword == then
         token Token::location "Structs" function_name require_global_scope
         cursor tc_retreat
         cursor parse_struct = casa_struct
@@ -1594,12 +1594,12 @@ fn get_op_keyword token:Token cursor:TokenCursor function_name:str ops:List[Op] 
     fi
 
     # trait
-    if KeywordKind::TraitKw (int) keyword == then
+    if KeywordKind::TraitKw keyword == then
         token Token::location "Traits" function_name require_global_scope
         cursor tc_retreat
         cursor parse_trait = casa_trait
         if casa_trait CasaTrait::name GLOBAL_TRAITS .get .is_some then
-            casa_trait CasaTrait::location f"Trait `{casa_trait CasaTrait::name}` is already defined" ErrorKind::DuplicateName (int) raise_error
+            casa_trait CasaTrait::location f"Trait `{casa_trait CasaTrait::name}` is already defined" ErrorKind::DuplicateName raise_error
         fi
         casa_trait CasaTrait::name casa_trait GLOBAL_TRAITS .set = GLOBAL_TRAITS
         return
@@ -1615,7 +1615,7 @@ fn is_struct_field_boundary cursor:TokenCursor member_names:List[str] -> bool {
     cursor TokenCursor::tokens = token_list
     if pos 1 + token_list .length < then false return fi
     pos token_list .get = token
-    if TokenKind::Identifier (int) token Token::kind != then false return fi
+    if TokenKind::Identifier token Token::kind != then false return fi
     if token Token::value member_names string_list_contains ! then false return fi
     ":" pos 1 + token_list .get Token::value ==
 }
@@ -1629,7 +1629,7 @@ fn parse_struct_field_value cursor:TokenCursor struct_name:str member_names:List
         cursor tc_pop = value_opt
         if value_opt .is_none then break fi
         value_opt .unwrap = value_token
-        if TokenKind::FstringStart (int) value_token Token::kind == then
+        if TokenKind::FstringStart value_token Token::kind == then
             all_ops function_name cursor value_token handle_fstring
             continue
         fi
@@ -1654,19 +1654,19 @@ fn parse_struct_literal name_token:Token cursor:TokenCursor function_name:str ->
     while true do
         cursor tc_peek = next_opt
         if next_opt .is_none then
-            name_token Token::location "Unexpected end of input in struct literal" ErrorKind::UnexpectedToken (int) raise_error
+            name_token Token::location "Unexpected end of input in struct literal" ErrorKind::UnexpectedToken raise_error
         fi
         if "}" next_opt .unwrap Token::value == then
             cursor tc_pop drop
             break
         fi
 
-        TokenKind::Identifier (int) cursor expect_token_kind = field_token
+        TokenKind::Identifier cursor expect_token_kind = field_token
         if field_token Token::value member_names string_list_contains ! then
-            field_token Token::location f"Struct `{name_token Token::value}` has no field `{field_token Token::value}`" ErrorKind::UndefinedName (int) raise_error
+            field_token Token::location f"Struct `{name_token Token::value}` has no field `{field_token Token::value}`" ErrorKind::UndefinedName raise_error
         fi
         if field_token Token::value seen .has then
-            field_token Token::location f"Duplicate field `{field_token Token::value}` in struct literal" ErrorKind::DuplicateName (int) raise_error
+            field_token Token::location f"Duplicate field `{field_token Token::value}` in struct literal" ErrorKind::DuplicateName raise_error
         fi
         field_token Token::value seen .add = seen
         field_token Token::value field_order .push
@@ -1676,12 +1676,12 @@ fn parse_struct_literal name_token:Token cursor:TokenCursor function_name:str ->
         all_ops .length = ops_before
         all_ops function_name member_names name_token Token::value cursor parse_struct_field_value
         if ops_before all_ops .length == then
-            field_token Token::location f"Missing value for field `{field_token Token::value}`" ErrorKind::Syntax (int) raise_error
+            field_token Token::location f"Missing value for field `{field_token Token::value}`" ErrorKind::Syntax raise_error
         fi
     done
 
     field_order name_token Token::value StructLiteral = literal
-    name_token Token::location OpKind::OpStructLiteral (int) literal (int) make_op all_ops .push
+    name_token Token::location OpKind::OpStructLiteral literal (int) make_op all_ops .push
     all_ops
 }
 
@@ -1692,34 +1692,34 @@ fn parse_struct_literal name_token:Token cursor:TokenCursor function_name:str ->
 fn token_to_op token:Token cursor:TokenCursor function_name:str ops:List[Op] {
     token Token::kind = kind
 
-    if TokenKind::Eof (int) kind == then return fi
+    if TokenKind::Eof kind == then return fi
 
-    if TokenKind::Delimiter (int) kind == then
+    if TokenKind::Delimiter kind == then
         ops function_name cursor token get_op_delimiter
         return
     fi
 
-    if TokenKind::Literal (int) kind == then
+    if TokenKind::Literal kind == then
         token get_op_literal ops .push
         return
     fi
 
-    if TokenKind::Intrinsic (int) kind == then
+    if TokenKind::Intrinsic kind == then
         token get_op_intrinsic ops .push
         return
     fi
 
-    if TokenKind::Keyword (int) kind == then
+    if TokenKind::Keyword kind == then
         ops function_name cursor token get_op_keyword
         return
     fi
 
-    if TokenKind::Operator (int) kind == then
+    if TokenKind::Operator kind == then
         function_name cursor token get_op_operator ops .push
         return
     fi
 
-    if TokenKind::Identifier (int) kind == then
+    if TokenKind::Identifier kind == then
         # Check for struct literal: StructName { ... }
         cursor tc_peek = next_opt
         if next_opt .is_some then
@@ -1746,19 +1746,19 @@ fn token_to_op token:Token cursor:TokenCursor function_name:str ops:List[Op] {
         fi
 
         # Plain identifier
-        token Token::location OpKind::OpIdentifier (int) token Token::value make_op_str ops .push
+        token Token::location OpKind::OpIdentifier token Token::value make_op_str ops .push
         return
     fi
 
     # F-string tokens should be handled by handle_fstring
     if
-        TokenKind::FstringStart (int) kind ==
-        TokenKind::FstringEnd (int) kind == ||
-        TokenKind::FstringExprStart (int) kind == ||
-        TokenKind::FstringExprEnd (int) kind == ||
-        TokenKind::FstringText (int) kind == ||
+        TokenKind::FstringStart kind ==
+        TokenKind::FstringEnd kind == ||
+        TokenKind::FstringExprStart kind == ||
+        TokenKind::FstringExprEnd kind == ||
+        TokenKind::FstringText kind == ||
     then
-        token Token::location "F-string token should be handled by handle_fstring" ErrorKind::Syntax (int) raise_error
+        token Token::location "F-string token should be handled by handle_fstring" ErrorKind::Syntax raise_error
     fi
 }
 
@@ -1773,7 +1773,7 @@ fn parse_ops tokens:List[Token] -> List[Op] {
         cursor tc_pop = token_opt
         if token_opt .is_none then break fi
         token_opt .unwrap = token
-        if TokenKind::FstringStart (int) token Token::kind == then
+        if TokenKind::FstringStart token Token::kind == then
             ops GLOBAL_SCOPE_LABEL cursor token handle_fstring
             continue
         fi
@@ -1790,7 +1790,7 @@ fn gather_captures lambda_function:Function function:Function {
     0 = index
     while index lambda_function Function::ops .length > do
         index lambda_function Function::ops .get = op
-        if OpKind::OpIdentifier (int) op Op::kind != then
+        if OpKind::OpIdentifier op Op::kind != then
             1 += index
             continue
         fi
@@ -1823,18 +1823,18 @@ fn resolve_array_identifiers items:List[Op] function:Function errors:List[CasaEr
     0 = rai_i
     while rai_i items .length > do
         rai_i items .get = rai_item
-        if OpKind::OpPushArray (int) rai_item Op::kind == then
+        if OpKind::OpPushArray rai_item Op::kind == then
             errors function rai_item Op::value (List[Op]) resolve_array_identifiers
-        elif OpKind::OpIdentifier (int) rai_item Op::kind == then
+        elif OpKind::OpIdentifier rai_item Op::kind == then
             rai_item op_str_value = rai_name
             if rai_name function Function::variables variable_list_contains then
-                OpKind::OpPushVar (int) rai_item Op::set_kind
+                OpKind::OpPushVar rai_item Op::set_kind
             elif rai_name function Function::captures variable_list_contains then
-                OpKind::OpPushCapture (int) rai_item Op::set_kind
+                OpKind::OpPushCapture rai_item Op::set_kind
             elif rai_name GLOBAL_VARIABLES .get .is_some then
-                OpKind::OpPushVar (int) rai_item Op::set_kind
+                OpKind::OpPushVar rai_item Op::set_kind
             else
-                rai_item Op::location f"Identifier `{rai_name}` is not defined" ErrorKind::UndefinedName (int) make_error errors .push
+                rai_item Op::location f"Identifier `{rai_name}` is not defined" ErrorKind::UndefinedName make_error errors .push
             fi
         fi
         1 += rai_i
@@ -1846,12 +1846,12 @@ fn resolve_enum_variant variant:EnumVariant op:Op function:Function errors:List[
     if variant EnumVariant::enum_name .length 0 != variant EnumVariant::ordinal .is_none && then
         variant EnumVariant::enum_name GLOBAL_ENUMS .get = rev_enum_opt
         if rev_enum_opt .is_none then
-            op Op::location f"Enum `{variant EnumVariant::enum_name}` is not defined" ErrorKind::UndefinedName (int) make_error errors .push
+            op Op::location f"Enum `{variant EnumVariant::enum_name}` is not defined" ErrorKind::UndefinedName make_error errors .push
         else
             rev_enum_opt .unwrap = rev_enum
             variant EnumVariant::variant_name rev_enum CasaEnum::variants string_list_index = rev_ordinal
             if 0 rev_ordinal < then
-                op Op::location f"Variant `{variant EnumVariant::variant_name}` is not defined in enum `{variant EnumVariant::enum_name}`" ErrorKind::UndefinedName (int) make_error errors .push
+                op Op::location f"Variant `{variant EnumVariant::variant_name}` is not defined in enum `{variant EnumVariant::enum_name}`" ErrorKind::UndefinedName make_error errors .push
             else
                 rev_ordinal Option::Some variant EnumVariant::set_ordinal
             fi
@@ -1894,7 +1894,7 @@ fn resolve_identifiers_fn ops:List[Op] function:Function -> List[Op] {
         ri_op Op::kind = ri_kind
 
         # ASSIGN_VARIABLE: register variable
-        if OpKind::OpAssignVar (int) ri_kind == then
+        if OpKind::OpAssignVar ri_kind == then
             ri_op op_str_value = ri_var_name
             ri_var_name make_variable = ri_var
             # Global scope: store in GLOBAL_VARIABLES
@@ -1912,7 +1912,7 @@ fn resolve_identifiers_fn ops:List[Op] function:Function -> List[Op] {
         fi
 
         # FN_PUSH: resolve lambda captures and identifiers
-        if OpKind::OpFnPush (int) ri_kind == then
+        if OpKind::OpFnPush ri_kind == then
             ri_op op_str_value = ri_fn_name
             ri_fn_name GLOBAL_FUNCTIONS .get = ri_lambda_opt
             if ri_lambda_opt .is_some then
@@ -1926,20 +1926,20 @@ fn resolve_identifiers_fn ops:List[Op] function:Function -> List[Op] {
         fi
 
         # PUSH_ARRAY: resolve identifiers inside array literals
-        if OpKind::OpPushArray (int) ri_kind == then
+        if OpKind::OpPushArray ri_kind == then
             ri_errors function ri_op Op::value (List[Op]) resolve_array_identifiers
             continue
         fi
 
         # IDENTIFIER: resolve to specific op kinds
-        if OpKind::OpIdentifier (int) ri_kind == then
+        if OpKind::OpIdentifier ri_kind == then
             ri_op op_str_value = ri_ident
             # Function reference: &name
             if '&' 0 ri_ident .at == then
                 ri_ident 1 ri_ident .length 1 - str::substring = ri_ref_name
                 # Empty & validation
                 if 0 ri_ref_name .length == then
-                    ri_op Op::location "Expected function name after `&`" ErrorKind::Syntax (int) make_error ri_errors .push
+                    ri_op Op::location "Expected function name after `&`" ErrorKind::Syntax make_error ri_errors .push
                     continue
                 fi
                 # Check trait bound reference: &K::method
@@ -1950,7 +1950,7 @@ fn resolve_identifiers_fn ops:List[Op] function:Function -> List[Op] {
                     if ri_ref_tb_opt .is_some then
                         ri_ref_name ri_ref_name "::" str::find 2 + ri_ref_name .length ri_ref_name "::" str::find - 2 - str::substring = ri_ref_tmethod
                         f"__trait_{ri_ref_tv}_{ri_ref_tmethod}" = ri_ref_hidden
-                        OpKind::OpPushVar (int) ri_op Op::set_kind
+                        OpKind::OpPushVar ri_op Op::set_kind
                         ri_ref_hidden (int) ri_op Op::set_value
                         true = ri_ref_is_trait
                     fi
@@ -1958,11 +1958,11 @@ fn resolve_identifiers_fn ops:List[Op] function:Function -> List[Op] {
                 if ri_ref_is_trait ! then
                     ri_ref_name GLOBAL_FUNCTIONS .get = ri_ref_fn_opt
                     if ri_ref_fn_opt .is_some then
-                        OpKind::OpFnPush (int) ri_op Op::set_kind
+                        OpKind::OpFnPush ri_op Op::set_kind
                         ri_ref_name (int) ri_op Op::set_value
                         true ri_ref_fn_opt .unwrap Function::set_is_used
                     else
-                        ri_op Op::location f"Function `{ri_ref_name}` is not defined" ErrorKind::UndefinedName (int) make_error ri_errors .push
+                        ri_op Op::location f"Function `{ri_ref_name}` is not defined" ErrorKind::UndefinedName make_error ri_errors .push
                     fi
                 fi
                 continue
@@ -1977,9 +1977,9 @@ fn resolve_identifiers_fn ops:List[Op] function:Function -> List[Op] {
                     ri_ident ri_sep 2 + ri_ident .length ri_sep - 2 - str::substring = ri_vname
                     ri_vname ri_enum_opt .unwrap CasaEnum::variants string_list_index = ri_ordinal
                     if 0 ri_ordinal < then
-                        ri_op Op::location f"Variant `{ri_vname}` is not defined in enum `{ri_enum_name}`" ErrorKind::UndefinedName (int) make_error ri_errors .push
+                        ri_op Op::location f"Variant `{ri_vname}` is not defined in enum `{ri_enum_name}`" ErrorKind::UndefinedName make_error ri_errors .push
                     else
-                        OpKind::OpPushEnumVariant (int) ri_op Op::set_kind
+                        OpKind::OpPushEnumVariant ri_op Op::set_kind
                         ri_ordinal Option::Some ri_vname ri_enum_name make_enum_variant = ri_ev
                         ri_ev (int) ri_op Op::set_value
                     fi
@@ -1996,7 +1996,7 @@ fn resolve_identifiers_fn ops:List[Op] function:Function -> List[Op] {
                     if ri_hidden_var function Function::variables variable_list_contains ! then
                         ri_hidden_var make_variable function Function::variables .push
                     fi
-                    OpKind::OpPushVar (int) ri_op Op::set_kind
+                    OpKind::OpPushVar ri_op Op::set_kind
                     ri_hidden_var (int) ri_op Op::set_value
                     # Mark for exec: bytecode compiler emits FN_EXEC after push
                     "trait_exec" ri_op Op::set_type_annotation
@@ -2006,34 +2006,34 @@ fn resolve_identifiers_fn ops:List[Op] function:Function -> List[Op] {
 
             # Local variable
             if ri_ident function Function::variables variable_list_contains then
-                OpKind::OpPushVar (int) ri_op Op::set_kind
+                OpKind::OpPushVar ri_op Op::set_kind
                 continue
             fi
 
             # Global function
             ri_ident GLOBAL_FUNCTIONS .get = ri_gfn_opt
             if ri_gfn_opt .is_some then
-                OpKind::OpFnCall (int) ri_op Op::set_kind
+                OpKind::OpFnCall ri_op Op::set_kind
                 true ri_gfn_opt .unwrap Function::set_is_used
                 continue
             fi
 
             # Captured variable
             if ri_ident function Function::captures variable_list_contains then
-                OpKind::OpPushCapture (int) ri_op Op::set_kind
+                OpKind::OpPushCapture ri_op Op::set_kind
                 continue
             fi
 
             # Global variable
             if ri_ident GLOBAL_VARIABLES .get .is_some then
-                OpKind::OpPushVar (int) ri_op Op::set_kind
+                OpKind::OpPushVar ri_op Op::set_kind
                 continue
             fi
 
             # Struct constructor
             ri_ident GLOBAL_STRUCTS .get = ri_struct_opt
             if ri_struct_opt .is_some then
-                OpKind::OpStructNew (int) ri_op Op::set_kind
+                OpKind::OpStructNew ri_op Op::set_kind
                 ri_struct_opt .unwrap (int) ri_op Op::set_value
                 continue
             fi
@@ -2041,17 +2041,17 @@ fn resolve_identifiers_fn ops:List[Op] function:Function -> List[Op] {
             # Enum name -> variant count
             ri_ident GLOBAL_ENUMS .get = ri_enum2_opt
             if ri_enum2_opt .is_some then
-                OpKind::OpPushInt (int) ri_op Op::set_kind
+                OpKind::OpPushInt ri_op Op::set_kind
                 ri_enum2_opt .unwrap CasaEnum::variants .length ri_op Op::set_value
                 continue
             fi
 
-            ri_op Op::location f"Identifier `{ri_ident}` is not defined" ErrorKind::UndefinedName (int) make_error ri_errors .push
+            ri_op Op::location f"Identifier `{ri_ident}` is not defined" ErrorKind::UndefinedName make_error ri_errors .push
             continue
         fi
 
         # MATCH_ARM: resolve enum variants and struct patterns
-        if OpKind::OpMatchArm (int) ri_kind == then
+        if OpKind::OpMatchArm ri_kind == then
             ri_op Op::type_annotation = ri_ma_tag
             if "struct_pattern" ri_ma_tag == then
                 # StructPattern: register field bindings as variables
@@ -2080,14 +2080,14 @@ fn resolve_identifiers_fn ops:List[Op] function:Function -> List[Op] {
         fi
 
         # IS_CHECK: resolve enum variant
-        if OpKind::OpIsCheck (int) ri_kind == then
+        if OpKind::OpIsCheck ri_kind == then
             ri_op Op::value (EnumVariant) = ri_is_ev
             ri_errors function ri_op ri_is_ev resolve_enum_variant
             continue
         fi
 
         # INCLUDE_FILE: process included file
-        if OpKind::OpIncludeFile (int) ri_kind == then
+        if OpKind::OpIncludeFile ri_kind == then
             ri_op op_str_value = ri_inc_path
             if ri_inc_path INCLUDED_FILES .has ! then
                 ri_inc_path INCLUDED_FILES .add = INCLUDED_FILES

--- a/self_hosted/typechecker.casa
+++ b/self_hosted/typechecker.casa
@@ -135,7 +135,7 @@ fn expect_type tc:TypeChecker expected:str -> str {
     if "" tc TypeChecker::current_op_context != then
         f"Type mismatch in {tc TypeChecker::current_op_context}" = et_message
     fi
-    et_actual expected tc TypeChecker::current_location et_message ErrorKind::TypeMismatch (int) add_error_expected
+    et_actual expected tc TypeChecker::current_location et_message ErrorKind::TypeMismatch add_error_expected
     expected
 }
 
@@ -393,7 +393,7 @@ fn bind_type_var tc:TypeChecker bindings:Map[str str] type_var:str actual:str ->
         ANY_TYPE bound != &&
         actual is_enum_type_var ! &&
     then
-        tc TypeChecker::current_location f"Type variable `{type_var}` bound to `{bound}` but got `{actual}`" ErrorKind::TypeMismatch (int) raise_error
+        tc TypeChecker::current_location f"Type variable `{type_var}` bound to `{bound}` but got `{actual}`" ErrorKind::TypeMismatch raise_error
     fi
     bindings
 }
@@ -445,7 +445,7 @@ fn bind_generic_param tc:TypeChecker bindings:Map[str str] expected:Parameter si
                     true return
                 fi
             fi
-            tc TypeChecker::current_location "Type mismatch" ErrorKind::TypeMismatch (int) raise_error
+            tc TypeChecker::current_location "Type mismatch" ErrorKind::TypeMismatch raise_error
         fi
     fi
     if base actual == ANY_TYPE actual == || then
@@ -459,7 +459,7 @@ fn bind_generic_param tc:TypeChecker bindings:Map[str str] expected:Parameter si
         done
         true return
     fi
-    tc TypeChecker::current_location "Type mismatch" ErrorKind::TypeMismatch (int) raise_error
+    tc TypeChecker::current_location "Type mismatch" ErrorKind::TypeMismatch raise_error
     true
 }
 
@@ -494,7 +494,7 @@ fn bind_fn_param tc:TypeChecker bindings:Map[str str] expected:Parameter sig:Sig
         true return
     fi
     if actual is_fn_type ! then
-        tc TypeChecker::current_location "Type mismatch" ErrorKind::TypeMismatch (int) raise_error
+        tc TypeChecker::current_location "Type mismatch" ErrorKind::TypeMismatch raise_error
         true return
     fi
     actual extract_fn_signature_str = actual_sig_opt
@@ -597,8 +597,8 @@ fn apply_signature tc:TypeChecker sig:Signature name:str {
 fn check_arithmetic tc:TypeChecker op:Op {
     op Op::kind = ca_kind
     if
-        OpKind::OpAdd (int) ca_kind ==
-        OpKind::OpSub (int) ca_kind == ||
+        OpKind::OpAdd ca_kind ==
+        OpKind::OpSub ca_kind == ||
     then
         "int" tc expect_type drop
         tc stack_pop = ca_top
@@ -623,13 +623,7 @@ fn check_comparison tc:TypeChecker op:Op {
     base2 GLOBAL_ENUMS .get .is_some = is_enum2
     if is_enum1 is_enum2 || then
         if type1 type2 != then
-            tc TypeChecker::current_location f"Cannot compare `{type2}` with `{type1}`" ErrorKind::TypeMismatch (int) raise_error
-        fi
-        if
-            OpKind::OpEq (int) op Op::kind !=
-            OpKind::OpNe (int) op Op::kind != &&
-        then
-            tc TypeChecker::current_location f"Enum type `{type1}` only supports `==` and `!=` comparison" ErrorKind::TypeMismatch (int) raise_error
+            tc TypeChecker::current_location f"Cannot compare `{type2}` with `{type1}`" ErrorKind::TypeMismatch raise_error
         fi
         # Annotate for bytecode: data-carrying enums need heap tag comparison
         if is_enum1 then
@@ -640,13 +634,13 @@ fn check_comparison tc:TypeChecker op:Op {
         fi
     elif "str" type1 == "str" type2 == || then
         if type1 type2 != then
-            tc TypeChecker::current_location f"Cannot compare `{type2}` with `{type1}`" ErrorKind::TypeMismatch (int) raise_error
+            tc TypeChecker::current_location f"Cannot compare `{type2}` with `{type1}`" ErrorKind::TypeMismatch raise_error
         fi
         if
-            OpKind::OpEq (int) op Op::kind !=
-            OpKind::OpNe (int) op Op::kind != &&
+            OpKind::OpEq op Op::kind !=
+            OpKind::OpNe op Op::kind != &&
         then
-            tc TypeChecker::current_location "Type `str` only supports `==` and `!=` comparison" ErrorKind::TypeMismatch (int) raise_error
+            tc TypeChecker::current_location "Type `str` only supports `==` and `!=` comparison" ErrorKind::TypeMismatch raise_error
         fi
         "str" op Op::set_type_annotation
     fi
@@ -658,7 +652,7 @@ fn check_comparison tc:TypeChecker op:Op {
 # ============================================================================
 
 fn check_boolean tc:TypeChecker op:Op {
-    if OpKind::OpNot (int) op Op::kind == then
+    if OpKind::OpNot op Op::kind == then
         tc stack_pop drop
     else
         tc stack_pop drop
@@ -673,12 +667,12 @@ fn check_boolean tc:TypeChecker op:Op {
 
 fn check_bitwise tc:TypeChecker op:Op {
     op Op::kind = cb_kind
-    if OpKind::OpBitNot (int) cb_kind == then
+    if OpKind::OpBitNot cb_kind == then
         "int" tc expect_type drop
         "int" tc stack_push
     elif
-        OpKind::OpShl (int) cb_kind ==
-        OpKind::OpShr (int) cb_kind == ||
+        OpKind::OpShl cb_kind ==
+        OpKind::OpShr cb_kind == ||
     then
         "int" tc expect_type drop
         tc stack_pop = cb_top
@@ -696,24 +690,24 @@ fn check_bitwise tc:TypeChecker op:Op {
 
 fn check_stack_ops tc:TypeChecker op:Op {
     op Op::kind = kind
-    if OpKind::OpDrop (int) kind == then
+    if OpKind::OpDrop kind == then
         tc stack_pop drop
-    elif OpKind::OpDup (int) kind == then
+    elif OpKind::OpDup kind == then
         tc stack_pop = typ
         typ tc stack_push
         typ tc stack_push
-    elif OpKind::OpSwap (int) kind == then
+    elif OpKind::OpSwap kind == then
         tc stack_pop = type1
         tc stack_pop = type2
         type1 tc stack_push
         type2 tc stack_push
-    elif OpKind::OpOver (int) kind == then
+    elif OpKind::OpOver kind == then
         tc stack_pop = type1
         tc stack_pop = type2
         type2 tc stack_push
         type1 tc stack_push
         type2 tc stack_push
-    elif OpKind::OpRot (int) kind == then
+    elif OpKind::OpRot kind == then
         tc stack_pop = type1
         tc stack_pop = type2
         tc stack_pop = type3
@@ -730,22 +724,22 @@ fn check_stack_ops tc:TypeChecker op:Op {
 fn check_memory tc:TypeChecker op:Op {
     op Op::kind = kind
     if
-        OpKind::OpLoad8 (int) kind ==
-        OpKind::OpLoad16 (int) kind == ||
-        OpKind::OpLoad32 (int) kind == ||
-        OpKind::OpLoad64 (int) kind == ||
+        OpKind::OpLoad8 kind ==
+        OpKind::OpLoad16 kind == ||
+        OpKind::OpLoad32 kind == ||
+        OpKind::OpLoad64 kind == ||
     then
         "ptr" tc expect_type drop
         "int" tc stack_push
     elif
-        OpKind::OpStore8 (int) kind ==
-        OpKind::OpStore16 (int) kind == ||
-        OpKind::OpStore32 (int) kind == ||
-        OpKind::OpStore64 (int) kind == ||
+        OpKind::OpStore8 kind ==
+        OpKind::OpStore16 kind == ||
+        OpKind::OpStore32 kind == ||
+        OpKind::OpStore64 kind == ||
     then
         "ptr" tc expect_type drop
         tc stack_pop drop
-    elif OpKind::OpHeapAlloc (int) kind == then
+    elif OpKind::OpHeapAlloc kind == then
         "int" tc expect_type drop
         "ptr" tc stack_push
     fi
@@ -757,8 +751,8 @@ fn check_memory tc:TypeChecker op:Op {
 
 fn check_assignment tc:TypeChecker op:Op function_opt:Option[Function] {
     if
-        OpKind::OpAssignDec (int) op Op::kind ==
-        OpKind::OpAssignInc (int) op Op::kind == ||
+        OpKind::OpAssignDec op Op::kind ==
+        OpKind::OpAssignInc op Op::kind == ||
     then
         "int" tc expect_type drop
         return
@@ -785,7 +779,7 @@ fn check_assignment tc:TypeChecker op:Op function_opt:Option[Function] {
             fi
             local_var Variable::typ effective_type unify_type = unified
             if "" unified == then
-                op Op::location f"Cannot override local variable `{var_name}` of type `{local_var Variable::typ}` with other type `{effective_type}`" ErrorKind::InvalidVariable (int) add_error
+                op Op::location f"Cannot override local variable `{var_name}` of type `{local_var Variable::typ}` with other type `{effective_type}`" ErrorKind::InvalidVariable add_error
             else
                 unified local_var Variable::set_typ
             fi
@@ -806,7 +800,7 @@ fn check_assignment tc:TypeChecker op:Op function_opt:Option[Function] {
         fi
         global_var Variable::typ effective_type unify_type = unified
         if "" unified == then
-            op Op::location f"Cannot override global variable `{var_name}` of type `{global_var Variable::typ}` with other type `{effective_type}`" ErrorKind::InvalidVariable (int) add_error
+            op Op::location f"Cannot override global variable `{var_name}` of type `{global_var Variable::typ}` with other type `{effective_type}`" ErrorKind::InvalidVariable add_error
         else
             unified global_var Variable::set_typ
         fi
@@ -821,7 +815,7 @@ fn check_assignment tc:TypeChecker op:Op function_opt:Option[Function] {
 # ============================================================================
 
 fn check_push_var tc:TypeChecker op:Op function_opt:Option[Function] {
-    if OpKind::OpPushCapture (int) op Op::kind == then
+    if OpKind::OpPushCapture op Op::kind == then
         op op_str_value = capture_name
         if function_opt .is_some then
             function_opt .unwrap = function
@@ -868,7 +862,7 @@ fn check_push_var tc:TypeChecker op:Op function_opt:Option[Function] {
         return
     fi
 
-    op Op::location f"Variable `{var_name}` is not defined" ErrorKind::UndefinedName (int) raise_error
+    op Op::location f"Variable `{var_name}` is not defined" ErrorKind::UndefinedName raise_error
 }
 
 # ============================================================================
@@ -877,12 +871,12 @@ fn check_push_var tc:TypeChecker op:Op function_opt:Option[Function] {
 
 fn check_if_block tc:TypeChecker op:Op {
     op Op::kind = kind
-    if OpKind::OpIfStart (int) kind == then
+    if OpKind::OpIfStart kind == then
         tc TypeChecker::stack_origins tc TypeChecker::stack make_branched_stack = branched
         op Op::location branched BranchedStack::set_current_branch_location
         branched tc TypeChecker::branched_stacks .push
         true tc TypeChecker::set_in_branch_condition
-    elif OpKind::OpIfCondition (int) kind == then
+    elif OpKind::OpIfCondition kind == then
         false tc TypeChecker::set_in_branch_condition
         "bool" tc expect_type drop
         if 0 tc TypeChecker::branched_stacks .length == then return fi
@@ -896,12 +890,12 @@ fn check_if_block tc:TypeChecker op:Op {
             "if" branched_stack BranchedStack::set_current_branch_label
         fi
     elif
-        OpKind::OpIfElif (int) kind ==
-        OpKind::OpIfElse (int) kind == ||
+        OpKind::OpIfElif kind ==
+        OpKind::OpIfElse kind == ||
     then
         if 0 tc TypeChecker::branched_stacks .length == then return fi
         tc TypeChecker::branched_stacks .length 1 - tc TypeChecker::branched_stacks .get = branched_stack
-        if OpKind::OpIfElse (int) kind == then
+        if OpKind::OpIfElse kind == then
             true branched_stack BranchedStack::set_default_present
             false tc TypeChecker::set_in_branch_condition
         else
@@ -929,8 +923,8 @@ fn check_if_block tc:TypeChecker op:Op {
             op Op::location branched_stack BranchedStack::set_current_branch_location
             return
         fi
-        op Op::location "Branches have incompatible stack effects" ErrorKind::StackMismatch (int) add_error
-    elif OpKind::OpIfEnd (int) kind == then
+        op Op::location "Branches have incompatible stack effects" ErrorKind::StackMismatch add_error
+    elif OpKind::OpIfEnd kind == then
         tc TypeChecker::branched_stacks .pop = branched_stack
         branched_stack BranchedStack::before = before
         branched_stack BranchedStack::after = after
@@ -949,7 +943,7 @@ fn check_if_block tc:TypeChecker op:Op {
             branched_stack BranchedStack::before_origins copy_location_list tc TypeChecker::set_stack_origins
             return
         fi
-        op Op::location "Branches have incompatible stack effects" ErrorKind::StackMismatch (int) add_error
+        op Op::location "Branches have incompatible stack effects" ErrorKind::StackMismatch add_error
     fi
 }
 
@@ -959,20 +953,20 @@ fn check_if_block tc:TypeChecker op:Op {
 
 fn check_while_block tc:TypeChecker op:Op {
     op Op::kind = kind
-    if OpKind::OpWhileStart (int) kind == then
+    if OpKind::OpWhileStart kind == then
         tc TypeChecker::stack_origins tc TypeChecker::stack make_branched_stack = branched
         branched tc TypeChecker::branched_stacks .push
-    elif OpKind::OpWhileCondition (int) kind == then
+    elif OpKind::OpWhileCondition kind == then
         "bool" tc expect_type drop
         if 0 tc TypeChecker::branched_stacks .length == then return fi
         tc TypeChecker::branched_stacks .length 1 - tc TypeChecker::branched_stacks .get = branched_stack
         true branched_stack BranchedStack::set_condition_present
     elif
-        OpKind::OpWhileBreak (int) kind ==
-        OpKind::OpWhileContinue (int) kind == ||
+        OpKind::OpWhileBreak kind ==
+        OpKind::OpWhileContinue kind == ||
     then
         if 0 tc TypeChecker::branched_stacks .length == then return fi
-    elif OpKind::OpWhileEnd (int) kind == then
+    elif OpKind::OpWhileEnd kind == then
         tc TypeChecker::branched_stacks .pop drop
     fi
 }
@@ -1100,7 +1094,7 @@ fn inject_trait_fn_ptrs tc:TypeChecker sig:Signature ops:List[Op] op_index:int l
     # Check TYPE_CAST lookahead for return type binding
     if op_index ops .length > then
         op_index ops .get Op::kind = next_kind
-        if OpKind::OpTypeCast (int) next_kind == then
+        if OpKind::OpTypeCast next_kind == then
             op_index ops .get op_str_value = cast_type
             0 = return_index
             while return_index sig Signature::return_types .length > do
@@ -1120,7 +1114,7 @@ fn inject_trait_fn_ptrs tc:TypeChecker sig:Signature ops:List[Op] op_index:int l
         type_var sig Signature::trait_bounds .get .unwrap = trait_name
         type_var bindings .get = concrete_opt
         if concrete_opt .is_none then
-            location f"Cannot determine concrete type for type variable `{type_var}`" ErrorKind::TypeMismatch (int) raise_error
+            location f"Cannot determine concrete type for type variable `{type_var}`" ErrorKind::TypeMismatch raise_error
             1 += type_index
             continue
         fi
@@ -1145,7 +1139,7 @@ fn inject_trait_fn_ptrs tc:TypeChecker sig:Signature ops:List[Op] op_index:int l
             while 0 method_index >= do
                 method_index trait_def CasaTrait::methods .get = method
                 f"__trait_{concrete}_{method TraitMethod::name}" = hidden_var
-                location OpKind::OpPushVar (int) hidden_var make_op_str = push_op
+                location OpKind::OpPushVar hidden_var make_op_str = push_op
                 insert_pos push_op ops .insert
                 1 += insert_pos
                 1 += inserted
@@ -1156,7 +1150,7 @@ fn inject_trait_fn_ptrs tc:TypeChecker sig:Signature ops:List[Op] op_index:int l
         else
             # Verify structural satisfaction
             if function_opt trait_name concrete type_satisfies_trait ! then
-                location f"Type `{concrete}` does not satisfy trait `{trait_name}`" ErrorKind::TypeMismatch (int) raise_error
+                location f"Type `{concrete}` does not satisfy trait `{trait_name}`" ErrorKind::TypeMismatch raise_error
             fi
             # Inject FN_PUSH for each method (reversed)
             trait_def CasaTrait::methods .length 1 - = method_index
@@ -1165,7 +1159,7 @@ fn inject_trait_fn_ptrs tc:TypeChecker sig:Signature ops:List[Op] op_index:int l
                 f"{concrete}::{method TraitMethod::name}" = fn_name
                 fn_name GLOBAL_FUNCTIONS .get = global_fn_opt
                 if global_fn_opt .is_none then
-                    location f"Function `{fn_name}` required by trait `{trait_name}` not found" ErrorKind::TypeMismatch (int) raise_error
+                    location f"Function `{fn_name}` required by trait `{trait_name}` not found" ErrorKind::TypeMismatch raise_error
                     method_index 1 - = method_index
                     continue
                 fi
@@ -1175,7 +1169,7 @@ fn inject_trait_fn_ptrs tc:TypeChecker sig:Signature ops:List[Op] op_index:int l
                     global_fn global_fn Function::ops resolve_identifiers global_fn Function::set_ops
                 fi
                 global_fn ensure_typechecked
-                location OpKind::OpFnPush (int) fn_name make_op_str = push_op
+                location OpKind::OpFnPush fn_name make_op_str = push_op
                 insert_pos push_op ops .insert
                 1 += insert_pos
                 1 += inserted
@@ -1194,7 +1188,7 @@ fn inject_trait_fn_ptrs tc:TypeChecker sig:Signature ops:List[Op] op_index:int l
 
 fn check_function_ops tc:TypeChecker op:Op ops:List[Op] op_index:int function_opt:Option[Function] -> int {
     op Op::kind = kind
-    if OpKind::OpFnCall (int) kind == then
+    if OpKind::OpFnCall kind == then
         op op_str_value = fn_name
         fn_name GLOBAL_FUNCTIONS .get = fn_opt
         if fn_opt .is_some then
@@ -1207,7 +1201,7 @@ fn check_function_ops tc:TypeChecker op:Op ops:List[Op] op_index:int function_op
             fi
             fn_name sig tc apply_signature
         fi
-    elif OpKind::OpFnExec (int) kind == then
+    elif OpKind::OpFnExec kind == then
         tc stack_peek = fn_ptr_type
         if ANY_TYPE fn_ptr_type == then "fn" = fn_ptr_type fi
         fn_ptr_type tc expect_type drop
@@ -1217,7 +1211,7 @@ fn check_function_ops tc:TypeChecker op:Op ops:List[Op] op_index:int function_op
                 "exec" sig_str_opt .unwrap signature_from_str tc apply_signature
             fi
         fi
-    elif OpKind::OpFnPush (int) kind == then
+    elif OpKind::OpFnPush kind == then
         op op_str_value = push_name
         push_name GLOBAL_FUNCTIONS .get = push_fn_opt
         if push_fn_opt .is_some then
@@ -1227,7 +1221,7 @@ fn check_function_ops tc:TypeChecker op:Op ops:List[Op] op_index:int function_op
         else
             "fn" tc stack_push
         fi
-    elif OpKind::OpFnReturn (int) kind == then
+    elif OpKind::OpFnReturn kind == then
         if tc TypeChecker::has_return_types ! then
             true tc TypeChecker::set_has_return_types
             tc TypeChecker::stack copy_str_list tc TypeChecker::set_return_types
@@ -1247,18 +1241,18 @@ fn check_function_ops tc:TypeChecker op:Op ops:List[Op] op_index:int function_op
 
 fn check_literals tc:TypeChecker op:Op {
     op Op::kind = kind
-    if OpKind::OpPushInt (int) kind == then
+    if OpKind::OpPushInt kind == then
         "int" tc stack_push
-    elif OpKind::OpPushStr (int) kind == then
+    elif OpKind::OpPushStr kind == then
         "str" tc stack_push
-    elif OpKind::OpPushBool (int) kind == then
+    elif OpKind::OpPushBool kind == then
         "bool" tc stack_push
-    elif OpKind::OpPushChar (int) kind == then
+    elif OpKind::OpPushChar kind == then
         "char" tc stack_push
-    elif OpKind::OpPushArray (int) kind == then
+    elif OpKind::OpPushArray kind == then
         # Array literals: pop N items of same type
         "array[any]" tc stack_push
-    elif OpKind::OpFstringConcat (int) kind == then
+    elif OpKind::OpFstringConcat kind == then
         op op_int_value = count
         0 = index
         while index count > do
@@ -1276,15 +1270,15 @@ fn check_literals tc:TypeChecker op:Op {
 fn check_io tc:TypeChecker op:Op {
     tc stack_pop = typ
     if "str" typ == then
-        OpKind::OpPrintStr (int) op Op::set_kind
+        OpKind::OpPrintStr op Op::set_kind
     elif "bool" typ == then
-        OpKind::OpPrintBool (int) op Op::set_kind
+        OpKind::OpPrintBool op Op::set_kind
     elif "char" typ == then
-        OpKind::OpPrintChar (int) op Op::set_kind
+        OpKind::OpPrintChar op Op::set_kind
     elif "cstr" typ == then
-        OpKind::OpPrintCstr (int) op Op::set_kind
+        OpKind::OpPrintCstr op Op::set_kind
     else
-        OpKind::OpPrintInt (int) op Op::set_kind
+        OpKind::OpPrintInt op Op::set_kind
     fi
 }
 
@@ -1306,7 +1300,7 @@ fn check_syscalls tc:TypeChecker op:Op {
     op Op::kind = kind
     # Calculate arg count from syscall variant
     OpKind::OpSyscall0 (int) = base
-    kind base - = arg_count
+    kind (int) base - = arg_count
     "int" tc expect_type drop
     0 = index
     while index arg_count > do
@@ -1392,7 +1386,7 @@ fn check_is tc:TypeChecker op:Op {
     tc stack_pop = typ
     typ resolve_match_type = base
     if base GLOBAL_ENUMS .get .is_none then
-        tc TypeChecker::current_location f"`is` requires an enum type, got `{typ}`" ErrorKind::TypeMismatch (int) raise_error
+        tc TypeChecker::current_location f"`is` requires an enum type, got `{typ}`" ErrorKind::TypeMismatch raise_error
         "bool" tc stack_push
         return
     fi
@@ -1401,7 +1395,7 @@ fn check_is tc:TypeChecker op:Op {
     # Validate the variant belongs to the correct enum
     if "" variant EnumVariant::enum_name != then
         if variant EnumVariant::enum_name casa_enum CasaEnum::name != then
-            tc TypeChecker::current_location f"Cannot check `{variant EnumVariant::enum_name}::{variant EnumVariant::variant_name}` on value of type `{typ}`" ErrorKind::TypeMismatch (int) raise_error
+            tc TypeChecker::current_location f"Cannot check `{variant EnumVariant::enum_name}::{variant EnumVariant::variant_name}` on value of type `{typ}`" ErrorKind::TypeMismatch raise_error
         fi
     fi
     # Validate binding count for data-carrying variants
@@ -1410,7 +1404,7 @@ fn check_is tc:TypeChecker op:Op {
         if inner_opt .is_some then
             inner_opt .unwrap = inner_types
             if variant EnumVariant::bindings .length inner_types .length != then
-                tc TypeChecker::current_location f"Variant `{variant EnumVariant::enum_name}::{variant EnumVariant::variant_name}` has {inner_types .length .to_str} inner value(s), but {variant EnumVariant::bindings .length .to_str} binding(s) provided" ErrorKind::TypeMismatch (int) raise_error
+                tc TypeChecker::current_location f"Variant `{variant EnumVariant::enum_name}::{variant EnumVariant::variant_name}` has {inner_types .length .to_str} inner value(s), but {variant EnumVariant::bindings .length .to_str} binding(s) provided" ErrorKind::TypeMismatch raise_error
             fi
         fi
     fi
@@ -1454,13 +1448,13 @@ fn set_binding_type var_name:str field_type:str function_opt:Option[Function] {
 
 fn check_match tc:TypeChecker op:Op function_opt:Option[Function] {
     op Op::kind = kind
-    if OpKind::OpMatchStart (int) kind == then
+    if OpKind::OpMatchStart kind == then
         tc stack_pop = match_type
         tc TypeChecker::stack_origins tc TypeChecker::stack make_branched_stack = branched
         match_type branched BranchedStack::set_match_type
         true branched BranchedStack::set_default_present
         branched tc TypeChecker::branched_stacks .push
-    elif OpKind::OpMatchArm (int) kind == then
+    elif OpKind::OpMatchArm kind == then
         if 0 tc TypeChecker::branched_stacks .length == then return fi
         tc TypeChecker::branched_stacks .length 1 - tc TypeChecker::branched_stacks .get = branched_stack
         branched_stack BranchedStack::match_type = match_subject_type
@@ -1499,9 +1493,9 @@ fn check_match tc:TypeChecker op:Op function_opt:Option[Function] {
                     # Check if the bare name is a variant of the matched enum
                     bare_name bare_enum CasaEnum::variants string_list_index = bare_index
                     if 0 bare_index >= then
-                        op Op::location f"Unqualified enum variant `{bare_name}`. Did you mean `{arm_base}::{bare_name}`?" ErrorKind::TypeMismatch (int) raise_error
+                        op Op::location f"Unqualified enum variant `{bare_name}`. Did you mean `{arm_base}::{bare_name}`?" ErrorKind::TypeMismatch raise_error
                     else
-                        op Op::location f"Expected qualified enum variant (e.g. `{arm_base}::{0 bare_enum CasaEnum::variants .get}`) or `_`, got `{bare_name}`" ErrorKind::TypeMismatch (int) raise_error
+                        op Op::location f"Expected qualified enum variant (e.g. `{arm_base}::{0 bare_enum CasaEnum::variants .get}`) or `_`, got `{bare_name}`" ErrorKind::TypeMismatch raise_error
                     fi
                 fi
             fi
@@ -1513,12 +1507,12 @@ fn check_match tc:TypeChecker op:Op function_opt:Option[Function] {
             while dup_index branched_stack BranchedStack::branch_records .length > do
                 dup_index branched_stack BranchedStack::branch_records .get = record
                 if covered_key record == then
-                    op Op::location f"Duplicate match arm for `{covered_key}`" ErrorKind::DuplicateName (int) raise_error
+                    op Op::location f"Duplicate match arm for `{covered_key}`" ErrorKind::DuplicateName raise_error
                 fi
                 1 += dup_index
             done
             if covered_key branched_stack BranchedStack::current_branch_label == then
-                op Op::location f"Duplicate match arm for `{covered_key}`" ErrorKind::DuplicateName (int) raise_error
+                op Op::location f"Duplicate match arm for `{covered_key}`" ErrorKind::DuplicateName raise_error
             fi
         fi
 
@@ -1541,7 +1535,7 @@ fn check_match tc:TypeChecker op:Op function_opt:Option[Function] {
                     tc TypeChecker::stack copy_str_list branched_stack BranchedStack::set_after
                     tc TypeChecker::stack_origins copy_location_list branched_stack BranchedStack::set_after_origins
                 else
-                    op Op::location "Match arms have incompatible stack effects" ErrorKind::StackMismatch (int) add_error
+                    op Op::location "Match arms have incompatible stack effects" ErrorKind::StackMismatch add_error
                 fi
             fi
             branched_stack BranchedStack::before copy_str_list tc TypeChecker::set_stack
@@ -1623,7 +1617,7 @@ fn check_match tc:TypeChecker op:Op function_opt:Option[Function] {
         covered_key branched_stack BranchedStack::set_current_branch_label
         op Op::location branched_stack BranchedStack::set_current_branch_location
 
-    elif OpKind::OpMatchEnd (int) kind == then
+    elif OpKind::OpMatchEnd kind == then
         tc TypeChecker::branched_stacks .pop = branched_stack
         # Record last arm label
         if "" branched_stack BranchedStack::current_branch_label != then
@@ -1644,7 +1638,7 @@ fn check_match tc:TypeChecker op:Op function_opt:Option[Function] {
                     tc TypeChecker::stack copy_str_list branched_stack BranchedStack::set_after
                     tc TypeChecker::stack_origins copy_location_list branched_stack BranchedStack::set_after_origins
                 else
-                    op Op::location "Match arms have incompatible stack effects" ErrorKind::StackMismatch (int) add_error
+                    op Op::location "Match arms have incompatible stack effects" ErrorKind::StackMismatch add_error
                 fi
             fi
             branched_stack BranchedStack::before copy_str_list tc TypeChecker::set_stack
@@ -1686,12 +1680,12 @@ fn check_match tc:TypeChecker op:Op function_opt:Option[Function] {
                     f"`{end_base}::{missing_index missing .get}`" missing_builder .append
                     1 += missing_index
                 done
-                op Op::location f"Non-exhaustive match, missing arms: {missing_builder .build}" ErrorKind::TypeMismatch (int) raise_error
+                op Op::location f"Non-exhaustive match, missing arms: {missing_builder .build}" ErrorKind::TypeMismatch raise_error
             fi
         fi
         if end_base GLOBAL_STRUCTS .get .is_some has_wildcard ! && then
             if end_base covered_set .has ! then
-                op Op::location f"Non-exhaustive match on struct `{end_match_type}`" ErrorKind::TypeMismatch (int) raise_error
+                op Op::location f"Non-exhaustive match on struct `{end_match_type}`" ErrorKind::TypeMismatch raise_error
             fi
         fi
         # Literal exhaustiveness
@@ -1707,10 +1701,10 @@ fn check_match tc:TypeChecker op:Op function_opt:Option[Function] {
                     if "true" covered_set .has ! then "true" bool_missing .push fi
                     if "false" covered_set .has ! then "false" bool_missing .push fi
                     if 0 bool_missing .length != then
-                        op Op::location "Non-exhaustive match on `bool`" ErrorKind::TypeMismatch (int) raise_error
+                        op Op::location "Non-exhaustive match on `bool`" ErrorKind::TypeMismatch raise_error
                     fi
                 else
-                    op Op::location f"Non-exhaustive match on type `{end_base}`. A wildcard `_` arm is required" ErrorKind::TypeMismatch (int) raise_error
+                    op Op::location f"Non-exhaustive match on type `{end_base}`. A wildcard `_` arm is required" ErrorKind::TypeMismatch raise_error
                 fi
             fi
         fi
@@ -1735,7 +1729,7 @@ fn check_match tc:TypeChecker op:Op function_opt:Option[Function] {
             branched_stack BranchedStack::after_origins copy_location_list tc TypeChecker::set_stack_origins
             return
         fi
-        op Op::location "Match arms have incompatible stack effects" ErrorKind::StackMismatch (int) add_error
+        op Op::location "Match arms have incompatible stack effects" ErrorKind::StackMismatch add_error
     fi
 }
 
@@ -1891,10 +1885,10 @@ fn check_method_call tc:TypeChecker op:Op ops:List[Op] op_index:int function_opt
                         resolved_returns resolved_params make_signature = resolved_sig
                         receiver tc stack_push
                         f"{receiver}::{method_name}" resolved_sig tc apply_signature
-                        OpKind::OpPushVar (int) op Op::set_kind
+                        OpKind::OpPushVar op Op::set_kind
                         hidden_var (int) op Op::set_value
                         # Insert FN_EXEC op after the PUSH_VARIABLE
-                        op Op::location OpKind::OpFnExec (int) 0 make_op = exec_op
+                        op Op::location OpKind::OpFnExec 0 make_op = exec_op
                         op_index exec_op ops .insert
                         op_index 1 + return
                     fi
@@ -1941,9 +1935,9 @@ fn check_method_call tc:TypeChecker op:Op ops:List[Op] op_index:int function_opt
         fi
         fn_name sig tc apply_signature
         fn_name (int) op Op::set_value
-        OpKind::OpFnCall (int) op Op::set_kind
+        OpKind::OpFnCall op Op::set_kind
     else
-        op Op::location f"Method `{fn_name}` does not exist" ErrorKind::UndefinedName (int) raise_error
+        op Op::location f"Method `{fn_name}` does not exist" ErrorKind::UndefinedName raise_error
     fi
     op_index
 }
@@ -1979,11 +1973,11 @@ fn type_check_ops ops:List[Op] function_opt:Option[Function] -> Signature {
         current_op Op::kind = op_kind
         # Arithmetic
         if
-            OpKind::OpAdd (int) op_kind ==
-            OpKind::OpSub (int) op_kind == ||
-            OpKind::OpMul (int) op_kind == ||
-            OpKind::OpDiv (int) op_kind == ||
-            OpKind::OpMod (int) op_kind == ||
+            OpKind::OpAdd op_kind ==
+            OpKind::OpSub op_kind == ||
+            OpKind::OpMul op_kind == ||
+            OpKind::OpDiv op_kind == ||
+            OpKind::OpMod op_kind == ||
         then
             current_op checker check_arithmetic
             continue
@@ -1991,12 +1985,12 @@ fn type_check_ops ops:List[Op] function_opt:Option[Function] -> Signature {
 
         # Comparison
         if
-            OpKind::OpEq (int) op_kind ==
-            OpKind::OpNe (int) op_kind == ||
-            OpKind::OpLt (int) op_kind == ||
-            OpKind::OpLe (int) op_kind == ||
-            OpKind::OpGt (int) op_kind == ||
-            OpKind::OpGe (int) op_kind == ||
+            OpKind::OpEq op_kind ==
+            OpKind::OpNe op_kind == ||
+            OpKind::OpLt op_kind == ||
+            OpKind::OpLe op_kind == ||
+            OpKind::OpGt op_kind == ||
+            OpKind::OpGe op_kind == ||
         then
             current_op checker check_comparison
             continue
@@ -2004,9 +1998,9 @@ fn type_check_ops ops:List[Op] function_opt:Option[Function] -> Signature {
 
         # Boolean
         if
-            OpKind::OpAnd (int) op_kind ==
-            OpKind::OpOr (int) op_kind == ||
-            OpKind::OpNot (int) op_kind == ||
+            OpKind::OpAnd op_kind ==
+            OpKind::OpOr op_kind == ||
+            OpKind::OpNot op_kind == ||
         then
             current_op checker check_boolean
             continue
@@ -2014,12 +2008,12 @@ fn type_check_ops ops:List[Op] function_opt:Option[Function] -> Signature {
 
         # Bitwise
         if
-            OpKind::OpBitAnd (int) op_kind ==
-            OpKind::OpBitOr (int) op_kind == ||
-            OpKind::OpBitXor (int) op_kind == ||
-            OpKind::OpBitNot (int) op_kind == ||
-            OpKind::OpShl (int) op_kind == ||
-            OpKind::OpShr (int) op_kind == ||
+            OpKind::OpBitAnd op_kind ==
+            OpKind::OpBitOr op_kind == ||
+            OpKind::OpBitXor op_kind == ||
+            OpKind::OpBitNot op_kind == ||
+            OpKind::OpShl op_kind == ||
+            OpKind::OpShr op_kind == ||
         then
             current_op checker check_bitwise
             continue
@@ -2027,11 +2021,11 @@ fn type_check_ops ops:List[Op] function_opt:Option[Function] -> Signature {
 
         # Stack ops
         if
-            OpKind::OpDrop (int) op_kind ==
-            OpKind::OpDup (int) op_kind == ||
-            OpKind::OpSwap (int) op_kind == ||
-            OpKind::OpOver (int) op_kind == ||
-            OpKind::OpRot (int) op_kind == ||
+            OpKind::OpDrop op_kind ==
+            OpKind::OpDup op_kind == ||
+            OpKind::OpSwap op_kind == ||
+            OpKind::OpOver op_kind == ||
+            OpKind::OpRot op_kind == ||
         then
             current_op checker check_stack_ops
             continue
@@ -2039,15 +2033,15 @@ fn type_check_ops ops:List[Op] function_opt:Option[Function] -> Signature {
 
         # Memory
         if
-            OpKind::OpLoad8 (int) op_kind ==
-            OpKind::OpLoad16 (int) op_kind == ||
-            OpKind::OpLoad32 (int) op_kind == ||
-            OpKind::OpLoad64 (int) op_kind == ||
-            OpKind::OpStore8 (int) op_kind == ||
-            OpKind::OpStore16 (int) op_kind == ||
-            OpKind::OpStore32 (int) op_kind == ||
-            OpKind::OpStore64 (int) op_kind == ||
-            OpKind::OpHeapAlloc (int) op_kind == ||
+            OpKind::OpLoad8 op_kind ==
+            OpKind::OpLoad16 op_kind == ||
+            OpKind::OpLoad32 op_kind == ||
+            OpKind::OpLoad64 op_kind == ||
+            OpKind::OpStore8 op_kind == ||
+            OpKind::OpStore16 op_kind == ||
+            OpKind::OpStore32 op_kind == ||
+            OpKind::OpStore64 op_kind == ||
+            OpKind::OpHeapAlloc op_kind == ||
         then
             current_op checker check_memory
             continue
@@ -2055,9 +2049,9 @@ fn type_check_ops ops:List[Op] function_opt:Option[Function] -> Signature {
 
         # Assignment
         if
-            OpKind::OpAssignVar (int) op_kind ==
-            OpKind::OpAssignDec (int) op_kind == ||
-            OpKind::OpAssignInc (int) op_kind == ||
+            OpKind::OpAssignVar op_kind ==
+            OpKind::OpAssignDec op_kind == ||
+            OpKind::OpAssignInc op_kind == ||
         then
             function_opt current_op checker check_assignment
             continue
@@ -2065,8 +2059,8 @@ fn type_check_ops ops:List[Op] function_opt:Option[Function] -> Signature {
 
         # Push variable / capture
         if
-            OpKind::OpPushVar (int) op_kind ==
-            OpKind::OpPushCapture (int) op_kind == ||
+            OpKind::OpPushVar op_kind ==
+            OpKind::OpPushCapture op_kind == ||
         then
             function_opt current_op checker check_push_var
             continue
@@ -2074,11 +2068,11 @@ fn type_check_ops ops:List[Op] function_opt:Option[Function] -> Signature {
 
         # If block
         if
-            OpKind::OpIfStart (int) op_kind ==
-            OpKind::OpIfCondition (int) op_kind == ||
-            OpKind::OpIfElif (int) op_kind == ||
-            OpKind::OpIfElse (int) op_kind == ||
-            OpKind::OpIfEnd (int) op_kind == ||
+            OpKind::OpIfStart op_kind ==
+            OpKind::OpIfCondition op_kind == ||
+            OpKind::OpIfElif op_kind == ||
+            OpKind::OpIfElse op_kind == ||
+            OpKind::OpIfEnd op_kind == ||
         then
             current_op checker check_if_block
             continue
@@ -2086,11 +2080,11 @@ fn type_check_ops ops:List[Op] function_opt:Option[Function] -> Signature {
 
         # While block
         if
-            OpKind::OpWhileStart (int) op_kind ==
-            OpKind::OpWhileCondition (int) op_kind == ||
-            OpKind::OpWhileBreak (int) op_kind == ||
-            OpKind::OpWhileContinue (int) op_kind == ||
-            OpKind::OpWhileEnd (int) op_kind == ||
+            OpKind::OpWhileStart op_kind ==
+            OpKind::OpWhileCondition op_kind == ||
+            OpKind::OpWhileBreak op_kind == ||
+            OpKind::OpWhileContinue op_kind == ||
+            OpKind::OpWhileEnd op_kind == ||
         then
             current_op checker check_while_block
             continue
@@ -2098,10 +2092,10 @@ fn type_check_ops ops:List[Op] function_opt:Option[Function] -> Signature {
 
         # Function ops
         if
-            OpKind::OpFnCall (int) op_kind ==
-            OpKind::OpFnExec (int) op_kind == ||
-            OpKind::OpFnPush (int) op_kind == ||
-            OpKind::OpFnReturn (int) op_kind == ||
+            OpKind::OpFnCall op_kind ==
+            OpKind::OpFnExec op_kind == ||
+            OpKind::OpFnPush op_kind == ||
+            OpKind::OpFnReturn op_kind == ||
         then
             function_opt op_index ops current_op checker check_function_ops = op_index
             continue
@@ -2109,118 +2103,118 @@ fn type_check_ops ops:List[Op] function_opt:Option[Function] -> Signature {
 
         # Literals
         if
-            OpKind::OpPushInt (int) op_kind ==
-            OpKind::OpPushStr (int) op_kind == ||
-            OpKind::OpPushBool (int) op_kind == ||
-            OpKind::OpPushChar (int) op_kind == ||
-            OpKind::OpPushArray (int) op_kind == ||
-            OpKind::OpFstringConcat (int) op_kind == ||
+            OpKind::OpPushInt op_kind ==
+            OpKind::OpPushStr op_kind == ||
+            OpKind::OpPushBool op_kind == ||
+            OpKind::OpPushChar op_kind == ||
+            OpKind::OpPushArray op_kind == ||
+            OpKind::OpFstringConcat op_kind == ||
         then
             current_op checker check_literals
             continue
         fi
 
         # IO
-        if OpKind::OpPrint (int) op_kind == then
+        if OpKind::OpPrint op_kind == then
             current_op checker check_io
             continue
         fi
 
         # Typeof
-        if OpKind::OpTypeof (int) op_kind == then
+        if OpKind::OpTypeof op_kind == then
             current_op checker check_typeof
             continue
         fi
 
         # Syscalls
         if
-            OpKind::OpSyscall0 (int) op_kind ==
-            OpKind::OpSyscall1 (int) op_kind == ||
-            OpKind::OpSyscall2 (int) op_kind == ||
-            OpKind::OpSyscall3 (int) op_kind == ||
-            OpKind::OpSyscall4 (int) op_kind == ||
-            OpKind::OpSyscall5 (int) op_kind == ||
-            OpKind::OpSyscall6 (int) op_kind == ||
+            OpKind::OpSyscall0 op_kind ==
+            OpKind::OpSyscall1 op_kind == ||
+            OpKind::OpSyscall2 op_kind == ||
+            OpKind::OpSyscall3 op_kind == ||
+            OpKind::OpSyscall4 op_kind == ||
+            OpKind::OpSyscall5 op_kind == ||
+            OpKind::OpSyscall6 op_kind == ||
         then
             current_op checker check_syscalls
             continue
         fi
 
         # Argc / Argv
-        if OpKind::OpArgc (int) op_kind == then
+        if OpKind::OpArgc op_kind == then
             "int" checker stack_push
             continue
         fi
-        if OpKind::OpArgv (int) op_kind == then
+        if OpKind::OpArgv op_kind == then
             "ptr" checker stack_push
             continue
         fi
 
         # Enum variant
-        if OpKind::OpPushEnumVariant (int) op_kind == then
+        if OpKind::OpPushEnumVariant op_kind == then
             current_op checker check_enum_variant
             continue
         fi
 
         # Is check
-        if OpKind::OpIsCheck (int) op_kind == then
+        if OpKind::OpIsCheck op_kind == then
             current_op checker check_is
             continue
         fi
 
         # Match block
         if
-            OpKind::OpMatchStart (int) op_kind ==
-            OpKind::OpMatchArm (int) op_kind == ||
-            OpKind::OpMatchEnd (int) op_kind == ||
+            OpKind::OpMatchStart op_kind ==
+            OpKind::OpMatchArm op_kind == ||
+            OpKind::OpMatchEnd op_kind == ||
         then
             function_opt current_op checker check_match
             continue
         fi
 
         # Struct new
-        if OpKind::OpStructNew (int) op_kind == then
+        if OpKind::OpStructNew op_kind == then
             current_op checker check_struct_new
             continue
         fi
 
         # Struct literal
-        if OpKind::OpStructLiteral (int) op_kind == then
+        if OpKind::OpStructLiteral op_kind == then
             current_op checker check_struct_literal
             continue
         fi
 
         # Method call
-        if OpKind::OpMethodCall (int) op_kind == then
+        if OpKind::OpMethodCall op_kind == then
             function_opt op_index ops current_op checker check_method_call = op_index
             continue
         fi
 
         # Type cast
-        if OpKind::OpTypeCast (int) op_kind == then
+        if OpKind::OpTypeCast op_kind == then
             checker stack_pop drop
             current_op op_str_value checker stack_push
             continue
         fi
 
         # Include file (no-op in typechecker)
-        if OpKind::OpIncludeFile (int) op_kind == then
+        if OpKind::OpIncludeFile op_kind == then
             continue
         fi
 
         # Print variants (already resolved, should not appear)
         if
-            OpKind::OpPrintBool (int) op_kind ==
-            OpKind::OpPrintChar (int) op_kind == ||
-            OpKind::OpPrintCstr (int) op_kind == ||
-            OpKind::OpPrintInt (int) op_kind == ||
-            OpKind::OpPrintStr (int) op_kind == ||
+            OpKind::OpPrintBool op_kind ==
+            OpKind::OpPrintChar op_kind == ||
+            OpKind::OpPrintCstr op_kind == ||
+            OpKind::OpPrintInt op_kind == ||
+            OpKind::OpPrintStr op_kind == ||
         then
             continue
         fi
 
         # Identifier (should be resolved by parser)
-        if OpKind::OpIdentifier (int) op_kind == then
+        if OpKind::OpIdentifier op_kind == then
             continue
         fi
     done
@@ -2238,7 +2232,7 @@ fn type_check_ops ops:List[Op] function_opt:Option[Function] -> Signature {
             0 declared Signature::type_vars .length == &&
         then
             if inferred declared signature_matches ! then
-                declared_function Function::location f"Invalid signature for function `{declared_function Function::name}`" ErrorKind::SignatureMismatch (int) add_error
+                declared_function Function::location f"Invalid signature for function `{declared_function Function::name}`" ErrorKind::SignatureMismatch add_error
             fi
         fi
         # Update inferred signature with declared return types for type var functions

--- a/tests/self_hosted/test_argv.casa
+++ b/tests/self_hosted/test_argv.casa
@@ -46,14 +46,14 @@ fn assert_contains needle:str haystack:str msg:str {
 fn test_lex_argc {
     "lex_argc" test_start
     "test" "argc" lex_source = tokens
-    "argc kind" TokenKind::Intrinsic (int) 0 tokens .get Token::kind assert_eq
+    "argc kind" TokenKind::Intrinsic 0 tokens .get Token::kind == assert_true
     "argc value" "argc" 0 tokens .get Token::value assert_str_eq
 }
 
 fn test_lex_argv {
     "lex_argv" test_start
     "test" "argv" lex_source = tokens
-    "argv kind" TokenKind::Intrinsic (int) 0 tokens .get Token::kind assert_eq
+    "argv kind" TokenKind::Intrinsic 0 tokens .get Token::kind == assert_true
     "argv value" "argv" 0 tokens .get Token::value assert_str_eq
 }
 
@@ -65,14 +65,14 @@ fn test_parse_argc {
     "parse_argc" test_start
     "test" "argc" lex_source = tokens
     tokens parse_ops = ops
-    "argc kind" OpKind::OpArgc (int) 0 ops .get Op::kind assert_eq
+    "argc kind" OpKind::OpArgc 0 ops .get Op::kind == assert_true
 }
 
 fn test_parse_argv {
     "parse_argv" test_start
     "test" "argv" lex_source = tokens
     tokens parse_ops = ops
-    "argv kind" OpKind::OpArgv (int) 0 ops .get Op::kind assert_eq
+    "argv kind" OpKind::OpArgv 0 ops .get Op::kind == assert_true
 }
 
 # ============================================================================
@@ -121,7 +121,7 @@ fn test_typecheck_argv_with_load {
 # Bytecode tests
 # ============================================================================
 
-fn has_inst_kind bytecode:List[Inst] kind:int -> bool {
+fn has_inst_kind bytecode:List[Inst] kind:InstKind -> bool {
     false = found
     0 = index
     while index bytecode .length > do
@@ -136,13 +136,13 @@ fn has_inst_kind bytecode:List[Inst] kind:int -> bool {
 fn test_bytecode_argc {
     "bytecode_argc" test_start
     "argc" compile_string_argv = prog
-    "has ARGC inst" InstKind::InstArgc (int) prog Program::bytecode has_inst_kind assert_true
+    "has ARGC inst" InstKind::InstArgc prog Program::bytecode has_inst_kind assert_true
 }
 
 fn test_bytecode_argv {
     "bytecode_argv" test_start
     "argv" compile_string_argv = prog
-    "has ARGV inst" InstKind::InstArgv (int) prog Program::bytecode has_inst_kind assert_true
+    "has ARGV inst" InstKind::InstArgv prog Program::bytecode has_inst_kind assert_true
 }
 
 fn test_bytecode_argc_no_args {
@@ -150,7 +150,7 @@ fn test_bytecode_argc_no_args {
     "argc" compile_string_argv = prog
     0 = index
     while index prog Program::bytecode .length > do
-        if InstKind::InstArgc (int) index prog Program::bytecode .get Inst::kind == then
+        if InstKind::InstArgc index prog Program::bytecode .get Inst::kind == then
             "argc has no int_arg" 0 index prog Program::bytecode .get Inst::int_arg assert_eq
         fi
         1 += index
@@ -162,7 +162,7 @@ fn test_bytecode_argv_no_args {
     "argv" compile_string_argv = prog
     0 = index
     while index prog Program::bytecode .length > do
-        if InstKind::InstArgv (int) index prog Program::bytecode .get Inst::kind == then
+        if InstKind::InstArgv index prog Program::bytecode .get Inst::kind == then
             "argv has no int_arg" 0 index prog Program::bytecode .get Inst::int_arg assert_eq
         fi
         1 += index

--- a/tests/self_hosted/test_bytecode.casa
+++ b/tests/self_hosted/test_bytecode.casa
@@ -25,21 +25,21 @@ fn make_test_location -> Location {
 # Helper to create an op with int value
 # make_op value:int kind:int location:Location
 # param1=value, param2=kind, param3=location
-fn test_make_op value:int kind:int -> Op {
+fn test_make_op value:int kind:OpKind -> Op {
     make_test_location kind value make_op
 }
 
 # Helper to create an op with str value
-# make_op_str value:str kind:int location:Location
+# make_op_str value:str kind:OpKind location:Location
 # param1=value, param2=kind, param3=location
-fn test_make_op_str value:str kind:int -> Op {
+fn test_make_op_str value:str kind:OpKind -> Op {
     make_test_location kind value make_op_str
 }
 
 # Helper to create an annotated op
-# make_op_annotated value:int kind:int location:Location annotation:str
+# make_op_annotated value:int kind:OpKind location:Location annotation:str
 # param1=value, param2=kind, param3=location, param4=annotation
-fn test_make_op_annotated value:int kind:int annotation:str -> Op {
+fn test_make_op_annotated value:int kind:OpKind annotation:str -> Op {
     annotation make_test_location kind value make_op_annotated
 }
 
@@ -83,7 +83,7 @@ fn test_compile_push_int {
     "compile_push_int" test_start
     reset_labels
     List::new (List[Op]) = ops
-    OpKind::OpPushInt (int) 42 test_make_op ops .push
+    OpKind::OpPushInt 42 test_make_op ops .push
 
     ops make_compiler = compiler
     List::new (List[Inst]) = bytecode
@@ -93,8 +93,8 @@ fn test_compile_push_int {
 
     # Should have: LABEL, PUSH(42)
     "push_int bytecode length" 2 bytecode .length assert_eq
-    "push_int label kind" InstKind::InstLabel (int) 0 bytecode .get Inst::kind assert_eq
-    "push_int inst kind" InstKind::InstPush (int) 1 bytecode .get Inst::kind assert_eq
+    "push_int label kind" InstKind::InstLabel 0 bytecode .get Inst::kind == assert_true
+    "push_int inst kind" InstKind::InstPush 1 bytecode .get Inst::kind == assert_true
     "push_int value" 42 1 bytecode .get Inst::int_arg assert_eq
 }
 
@@ -102,13 +102,13 @@ fn test_compile_push_bool {
     "compile_push_bool" test_start
     reset_labels
     List::new (List[Op]) = ops
-    OpKind::OpPushBool (int) 1 test_make_op ops .push
+    OpKind::OpPushBool 1 test_make_op ops .push
 
     ops make_compiler = compiler
     List::new (List[Inst]) = bytecode
     bytecode compiler compile_ops
 
-    "push_bool inst kind" InstKind::InstPush (int) 1 bytecode .get Inst::kind assert_eq
+    "push_bool inst kind" InstKind::InstPush 1 bytecode .get Inst::kind == assert_true
     "push_bool true value" 1 1 bytecode .get Inst::int_arg assert_eq
 }
 
@@ -116,13 +116,13 @@ fn test_compile_push_str {
     "compile_push_str" test_start
     reset_labels
     List::new (List[Op]) = ops
-    OpKind::OpPushStr (int) "hello" test_make_op_str ops .push
+    OpKind::OpPushStr "hello" test_make_op_str ops .push
 
     ops make_compiler = compiler
     List::new (List[Inst]) = bytecode
     bytecode compiler compile_ops
 
-    "push_str inst kind" InstKind::InstPushStr (int) 1 bytecode .get Inst::kind assert_eq
+    "push_str inst kind" InstKind::InstPushStr 1 bytecode .get Inst::kind == assert_true
     "push_str string index" 0 1 bytecode .get Inst::int_arg assert_eq
     "string table entry" "hello" 0 compiler BytecodeCompiler::string_table .get assert_str_eq
 }
@@ -131,13 +131,13 @@ fn test_compile_push_char {
     "compile_push_char" test_start
     reset_labels
     List::new (List[Op]) = ops
-    OpKind::OpPushChar (int) 'A' (int) test_make_op ops .push
+    OpKind::OpPushChar 'A' (int) test_make_op ops .push
 
     ops make_compiler = compiler
     List::new (List[Inst]) = bytecode
     bytecode compiler compile_ops
 
-    "push_char inst kind" InstKind::InstPushChar (int) 1 bytecode .get Inst::kind assert_eq
+    "push_char inst kind" InstKind::InstPushChar 1 bytecode .get Inst::kind == assert_true
     "push_char value" 65 1 bytecode .get Inst::int_arg assert_eq
 }
 
@@ -145,20 +145,20 @@ fn test_compile_direct_ops {
     "compile_direct_ops" test_start
     reset_labels
     List::new (List[Op]) = ops
-    OpKind::OpAdd (int) 0 test_make_op ops .push
-    OpKind::OpSub (int) 0 test_make_op ops .push
-    OpKind::OpDup (int) 0 test_make_op ops .push
-    OpKind::OpDrop (int) 0 test_make_op ops .push
+    OpKind::OpAdd 0 test_make_op ops .push
+    OpKind::OpSub 0 test_make_op ops .push
+    OpKind::OpDup 0 test_make_op ops .push
+    OpKind::OpDrop 0 test_make_op ops .push
 
     ops make_compiler = compiler
     List::new (List[Inst]) = bytecode
     bytecode compiler compile_ops
 
     # Index 0 is label
-    "add inst" InstKind::InstAdd (int) 1 bytecode .get Inst::kind assert_eq
-    "sub inst" InstKind::InstSub (int) 2 bytecode .get Inst::kind assert_eq
-    "dup inst" InstKind::InstDup (int) 3 bytecode .get Inst::kind assert_eq
-    "drop inst" InstKind::InstDrop (int) 4 bytecode .get Inst::kind assert_eq
+    "add inst" InstKind::InstAdd 1 bytecode .get Inst::kind == assert_true
+    "sub inst" InstKind::InstSub 2 bytecode .get Inst::kind == assert_true
+    "dup inst" InstKind::InstDup 3 bytecode .get Inst::kind == assert_true
+    "drop inst" InstKind::InstDrop 4 bytecode .get Inst::kind == assert_true
 }
 
 fn test_compile_variable_assign_and_push {
@@ -171,16 +171,16 @@ fn test_compile_variable_assign_and_push {
     "x" "" make_variable GLOBAL_VARIABLES .set = GLOBAL_VARIABLES
 
     List::new (List[Op]) = ops
-    OpKind::OpAssignVar (int) "x" test_make_op_str ops .push
-    OpKind::OpPushVar (int) "x" test_make_op_str ops .push
+    OpKind::OpAssignVar "x" test_make_op_str ops .push
+    OpKind::OpPushVar "x" test_make_op_str ops .push
 
     ops make_compiler = compiler
     List::new (List[Inst]) = bytecode
     bytecode compiler compile_ops
 
     # Index 0 is label, 1 is GLOBAL_SET, 2 is GLOBAL_GET
-    "assign var kind" InstKind::InstGlobalSet (int) 1 bytecode .get Inst::kind assert_eq
-    "push var kind" InstKind::InstGlobalGet (int) 2 bytecode .get Inst::kind assert_eq
+    "assign var kind" InstKind::InstGlobalSet 1 bytecode .get Inst::kind == assert_true
+    "push var kind" InstKind::InstGlobalGet 2 bytecode .get Inst::kind == assert_true
 
     # Clean up
     Map::new (Map[str Variable]) = GLOBAL_VARIABLES
@@ -192,8 +192,8 @@ fn test_compile_local_variable {
 
     # Create a function with a variable
     List::new (List[Op]) = fn_ops
-    OpKind::OpAssignVar (int) "y" test_make_op_str fn_ops .push
-    OpKind::OpPushVar (int) "y" test_make_op_str fn_ops .push
+    OpKind::OpAssignVar "y" test_make_op_str fn_ops .push
+    OpKind::OpPushVar "y" test_make_op_str fn_ops .push
 
     # make_function name:str ops:List[Op] location:Location
     # param1=name, param2=ops, param3=location
@@ -210,9 +210,9 @@ fn test_compile_local_variable {
     bytecode compiler compile_ops
 
     # Index 0 is label, 1 is LOCAL_SET, 2 is LOCAL_GET
-    "local assign kind" InstKind::InstLocalSet (int) 1 bytecode .get Inst::kind assert_eq
+    "local assign kind" InstKind::InstLocalSet 1 bytecode .get Inst::kind == assert_true
     "local assign index" 0 1 bytecode .get Inst::int_arg assert_eq
-    "local push kind" InstKind::InstLocalGet (int) 2 bytecode .get Inst::kind assert_eq
+    "local push kind" InstKind::InstLocalGet 2 bytecode .get Inst::kind == assert_true
     "local push index" 0 2 bytecode .get Inst::int_arg assert_eq
 }
 
@@ -220,13 +220,13 @@ fn test_compile_fstring_concat {
     "compile_fstring_concat" test_start
     reset_labels
     List::new (List[Op]) = ops
-    OpKind::OpFstringConcat (int) 3 test_make_op ops .push
+    OpKind::OpFstringConcat 3 test_make_op ops .push
 
     ops make_compiler = compiler
     List::new (List[Inst]) = bytecode
     bytecode compiler compile_ops
 
-    "fstring concat kind" InstKind::InstFstringConcat (int) 1 bytecode .get Inst::kind assert_eq
+    "fstring concat kind" InstKind::InstFstringConcat 1 bytecode .get Inst::kind == assert_true
     "fstring concat count" 3 1 bytecode .get Inst::int_arg assert_eq
 }
 
@@ -234,7 +234,7 @@ fn test_compile_type_cast_no_output {
     "compile_type_cast_no_output" test_start
     reset_labels
     List::new (List[Op]) = ops
-    OpKind::OpTypeCast (int) 0 test_make_op ops .push
+    OpKind::OpTypeCast 0 test_make_op ops .push
 
     ops make_compiler = compiler
     List::new (List[Inst]) = bytecode
@@ -248,7 +248,7 @@ fn test_compile_include_no_output {
     "compile_include_no_output" test_start
     reset_labels
     List::new (List[Op]) = ops
-    OpKind::OpIncludeFile (int) 0 test_make_op ops .push
+    OpKind::OpIncludeFile 0 test_make_op ops .push
 
     ops make_compiler = compiler
     List::new (List[Inst]) = bytecode
@@ -271,13 +271,13 @@ fn test_compile_if_block {
     "compile_if_block" test_start
     reset_labels
     List::new (List[Op]) = ops
-    OpKind::OpIfStart (int) 0 test_make_op ops .push
-    OpKind::OpIfCondition (int) 0 test_make_op ops .push
-    OpKind::OpIfEnd (int) 0 test_make_op ops .push
+    OpKind::OpIfStart 0 test_make_op ops .push
+    OpKind::OpIfCondition 0 test_make_op ops .push
+    OpKind::OpIfEnd 0 test_make_op ops .push
 
     "ops has 3 elements" 3 ops .length assert_eq
-    "op 0 is if_start" OpKind::OpIfStart (int) 0 ops .get Op::kind assert_eq
-    "op 2 is if_end" OpKind::OpIfEnd (int) 2 ops .get Op::kind assert_eq
+    "op 0 is if_start" OpKind::OpIfStart 0 ops .get Op::kind == assert_true
+    "op 2 is if_end" OpKind::OpIfEnd 2 ops .get Op::kind == assert_true
 
     ops make_compiler = compiler
     List::new (List[Inst]) = bytecode
@@ -285,18 +285,18 @@ fn test_compile_if_block {
 
     # Expected: LABEL, JUMP_NE(end_label), LABEL(end_label)
     "if block bytecode length" 3 bytecode .length assert_eq
-    "if block has label" InstKind::InstLabel (int) 0 bytecode .get Inst::kind assert_eq
-    "if condition jump_ne" InstKind::InstJumpNe (int) 1 bytecode .get Inst::kind assert_eq
-    "if end label" InstKind::InstLabel (int) 2 bytecode .get Inst::kind assert_eq
+    "if block has label" InstKind::InstLabel 0 bytecode .get Inst::kind == assert_true
+    "if condition jump_ne" InstKind::InstJumpNe 1 bytecode .get Inst::kind == assert_true
+    "if end label" InstKind::InstLabel 2 bytecode .get Inst::kind == assert_true
 }
 
 fn test_compile_while_block {
     "compile_while_block" test_start
     reset_labels
     List::new (List[Op]) = ops
-    OpKind::OpWhileStart (int) 0 test_make_op ops .push
-    OpKind::OpWhileCondition (int) 0 test_make_op ops .push
-    OpKind::OpWhileEnd (int) 0 test_make_op ops .push
+    OpKind::OpWhileStart 0 test_make_op ops .push
+    OpKind::OpWhileCondition 0 test_make_op ops .push
+    OpKind::OpWhileEnd 0 test_make_op ops .push
 
     ops make_compiler = compiler
     List::new (List[Inst]) = bytecode
@@ -304,11 +304,11 @@ fn test_compile_while_block {
 
     # Expected: LABEL(fn), LABEL(start), JUMP_NE(end), JUMP(start), LABEL(end)
     "while block bytecode length" 5 bytecode .length assert_eq
-    "while fn label" InstKind::InstLabel (int) 0 bytecode .get Inst::kind assert_eq
-    "while start label" InstKind::InstLabel (int) 1 bytecode .get Inst::kind assert_eq
-    "while condition jump_ne" InstKind::InstJumpNe (int) 2 bytecode .get Inst::kind assert_eq
-    "while end jump" InstKind::InstJump (int) 3 bytecode .get Inst::kind assert_eq
-    "while end label" InstKind::InstLabel (int) 4 bytecode .get Inst::kind assert_eq
+    "while fn label" InstKind::InstLabel 0 bytecode .get Inst::kind == assert_true
+    "while start label" InstKind::InstLabel 1 bytecode .get Inst::kind == assert_true
+    "while condition jump_ne" InstKind::InstJumpNe 2 bytecode .get Inst::kind == assert_true
+    "while end jump" InstKind::InstJump 3 bytecode .get Inst::kind == assert_true
+    "while end label" InstKind::InstLabel 4 bytecode .get Inst::kind == assert_true
 }
 
 fn test_compile_string_eq {
@@ -316,28 +316,28 @@ fn test_compile_string_eq {
     reset_labels
     List::new (List[Op]) = ops
     # make_op_annotated value:int kind:int location:Location annotation:str
-    "str" OpKind::OpEq (int) 0 test_make_op_annotated ops .push
+    "str" OpKind::OpEq 0 test_make_op_annotated ops .push
 
     ops make_compiler = compiler
     List::new (List[Inst]) = bytecode
     bytecode compiler compile_ops
 
-    "str_eq inst" InstKind::InstStrEq (int) 1 bytecode .get Inst::kind assert_eq
+    "str_eq inst" InstKind::InstStrEq 1 bytecode .get Inst::kind == assert_true
 }
 
 fn test_compile_string_ne {
     "compile_string_ne" test_start
     reset_labels
     List::new (List[Op]) = ops
-    "str" OpKind::OpNe (int) 0 test_make_op_annotated ops .push
+    "str" OpKind::OpNe 0 test_make_op_annotated ops .push
 
     ops make_compiler = compiler
     List::new (List[Inst]) = bytecode
     bytecode compiler compile_ops
 
     # Should emit STR_EQ + NOT
-    "str_ne has str_eq" InstKind::InstStrEq (int) 1 bytecode .get Inst::kind assert_eq
-    "str_ne has not" InstKind::InstNot (int) 2 bytecode .get Inst::kind assert_eq
+    "str_ne has str_eq" InstKind::InstStrEq 1 bytecode .get Inst::kind == assert_true
+    "str_ne has not" InstKind::InstNot 2 bytecode .get Inst::kind == assert_true
 }
 
 fn test_compile_assign_increment {
@@ -346,7 +346,7 @@ fn test_compile_assign_increment {
     "counter" "" make_variable GLOBAL_VARIABLES .set = GLOBAL_VARIABLES
 
     List::new (List[Op]) = ops
-    OpKind::OpAssignInc (int) "counter" test_make_op_str ops .push
+    OpKind::OpAssignInc "counter" test_make_op_str ops .push
 
     ops make_compiler = compiler
     List::new (List[Inst]) = bytecode
@@ -354,9 +354,9 @@ fn test_compile_assign_increment {
 
     # Expected: LABEL, GLOBAL_GET, ADD, GLOBAL_SET
     "inc bytecode length" 4 bytecode .length assert_eq
-    "inc get" InstKind::InstGlobalGet (int) 1 bytecode .get Inst::kind assert_eq
-    "inc add" InstKind::InstAdd (int) 2 bytecode .get Inst::kind assert_eq
-    "inc set" InstKind::InstGlobalSet (int) 3 bytecode .get Inst::kind assert_eq
+    "inc get" InstKind::InstGlobalGet 1 bytecode .get Inst::kind == assert_true
+    "inc add" InstKind::InstAdd 2 bytecode .get Inst::kind == assert_true
+    "inc set" InstKind::InstGlobalSet 3 bytecode .get Inst::kind == assert_true
 
     Map::new (Map[str Variable]) = GLOBAL_VARIABLES
 }
@@ -367,7 +367,7 @@ fn test_compile_assign_decrement {
     "counter" "" make_variable GLOBAL_VARIABLES .set = GLOBAL_VARIABLES
 
     List::new (List[Op]) = ops
-    OpKind::OpAssignDec (int) "counter" test_make_op_str ops .push
+    OpKind::OpAssignDec "counter" test_make_op_str ops .push
 
     ops make_compiler = compiler
     List::new (List[Inst]) = bytecode
@@ -375,10 +375,10 @@ fn test_compile_assign_decrement {
 
     # Expected: LABEL, GLOBAL_GET, SWAP, SUB, GLOBAL_SET
     "dec bytecode length" 5 bytecode .length assert_eq
-    "dec get" InstKind::InstGlobalGet (int) 1 bytecode .get Inst::kind assert_eq
-    "dec swap" InstKind::InstSwap (int) 2 bytecode .get Inst::kind assert_eq
-    "dec sub" InstKind::InstSub (int) 3 bytecode .get Inst::kind assert_eq
-    "dec set" InstKind::InstGlobalSet (int) 4 bytecode .get Inst::kind assert_eq
+    "dec get" InstKind::InstGlobalGet 1 bytecode .get Inst::kind == assert_true
+    "dec swap" InstKind::InstSwap 2 bytecode .get Inst::kind == assert_true
+    "dec sub" InstKind::InstSub 3 bytecode .get Inst::kind == assert_true
+    "dec set" InstKind::InstGlobalSet 4 bytecode .get Inst::kind == assert_true
 
     Map::new (Map[str Variable]) = GLOBAL_VARIABLES
 }
@@ -387,13 +387,13 @@ fn test_compile_push_bool_false {
     "compile_push_bool_false" test_start
     reset_labels
     List::new (List[Op]) = ops
-    OpKind::OpPushBool (int) 0 test_make_op ops .push
+    OpKind::OpPushBool 0 test_make_op ops .push
 
     ops make_compiler = compiler
     List::new (List[Inst]) = bytecode
     bytecode compiler compile_ops
 
-    "push_bool_false inst kind" InstKind::InstPush (int) 1 bytecode .get Inst::kind assert_eq
+    "push_bool_false inst kind" InstKind::InstPush 1 bytecode .get Inst::kind == assert_true
     "push_bool_false value" 0 1 bytecode .get Inst::int_arg assert_eq
 }
 
@@ -401,155 +401,155 @@ fn test_compile_more_direct_ops {
     "compile_more_direct_ops" test_start
     reset_labels
     List::new (List[Op]) = ops
-    OpKind::OpMul (int) 0 test_make_op ops .push
-    OpKind::OpDiv (int) 0 test_make_op ops .push
-    OpKind::OpMod (int) 0 test_make_op ops .push
-    OpKind::OpShl (int) 0 test_make_op ops .push
-    OpKind::OpShr (int) 0 test_make_op ops .push
-    OpKind::OpAnd (int) 0 test_make_op ops .push
-    OpKind::OpOr (int) 0 test_make_op ops .push
-    OpKind::OpNot (int) 0 test_make_op ops .push
-    OpKind::OpEq (int) 0 test_make_op ops .push
-    OpKind::OpNe (int) 0 test_make_op ops .push
-    OpKind::OpGt (int) 0 test_make_op ops .push
-    OpKind::OpGe (int) 0 test_make_op ops .push
-    OpKind::OpLt (int) 0 test_make_op ops .push
-    OpKind::OpLe (int) 0 test_make_op ops .push
-    OpKind::OpSwap (int) 0 test_make_op ops .push
-    OpKind::OpOver (int) 0 test_make_op ops .push
-    OpKind::OpRot (int) 0 test_make_op ops .push
+    OpKind::OpMul 0 test_make_op ops .push
+    OpKind::OpDiv 0 test_make_op ops .push
+    OpKind::OpMod 0 test_make_op ops .push
+    OpKind::OpShl 0 test_make_op ops .push
+    OpKind::OpShr 0 test_make_op ops .push
+    OpKind::OpAnd 0 test_make_op ops .push
+    OpKind::OpOr 0 test_make_op ops .push
+    OpKind::OpNot 0 test_make_op ops .push
+    OpKind::OpEq 0 test_make_op ops .push
+    OpKind::OpNe 0 test_make_op ops .push
+    OpKind::OpGt 0 test_make_op ops .push
+    OpKind::OpGe 0 test_make_op ops .push
+    OpKind::OpLt 0 test_make_op ops .push
+    OpKind::OpLe 0 test_make_op ops .push
+    OpKind::OpSwap 0 test_make_op ops .push
+    OpKind::OpOver 0 test_make_op ops .push
+    OpKind::OpRot 0 test_make_op ops .push
 
     ops make_compiler = compiler
     List::new (List[Inst]) = bytecode
     bytecode compiler compile_ops
 
     # Index 0 is label
-    "mul inst" InstKind::InstMul (int) 1 bytecode .get Inst::kind assert_eq
-    "div inst" InstKind::InstDiv (int) 2 bytecode .get Inst::kind assert_eq
-    "mod inst" InstKind::InstMod (int) 3 bytecode .get Inst::kind assert_eq
-    "shl inst" InstKind::InstShl (int) 4 bytecode .get Inst::kind assert_eq
-    "shr inst" InstKind::InstShr (int) 5 bytecode .get Inst::kind assert_eq
-    "and inst" InstKind::InstAnd (int) 6 bytecode .get Inst::kind assert_eq
-    "or inst" InstKind::InstOr (int) 7 bytecode .get Inst::kind assert_eq
-    "not inst" InstKind::InstNot (int) 8 bytecode .get Inst::kind assert_eq
-    "eq inst" InstKind::InstEq (int) 9 bytecode .get Inst::kind assert_eq
-    "ne inst" InstKind::InstNe (int) 10 bytecode .get Inst::kind assert_eq
-    "gt inst" InstKind::InstGt (int) 11 bytecode .get Inst::kind assert_eq
-    "ge inst" InstKind::InstGe (int) 12 bytecode .get Inst::kind assert_eq
-    "lt inst" InstKind::InstLt (int) 13 bytecode .get Inst::kind assert_eq
-    "le inst" InstKind::InstLe (int) 14 bytecode .get Inst::kind assert_eq
-    "swap inst" InstKind::InstSwap (int) 15 bytecode .get Inst::kind assert_eq
-    "over inst" InstKind::InstOver (int) 16 bytecode .get Inst::kind assert_eq
-    "rot inst" InstKind::InstRot (int) 17 bytecode .get Inst::kind assert_eq
+    "mul inst" InstKind::InstMul 1 bytecode .get Inst::kind == assert_true
+    "div inst" InstKind::InstDiv 2 bytecode .get Inst::kind == assert_true
+    "mod inst" InstKind::InstMod 3 bytecode .get Inst::kind == assert_true
+    "shl inst" InstKind::InstShl 4 bytecode .get Inst::kind == assert_true
+    "shr inst" InstKind::InstShr 5 bytecode .get Inst::kind == assert_true
+    "and inst" InstKind::InstAnd 6 bytecode .get Inst::kind == assert_true
+    "or inst" InstKind::InstOr 7 bytecode .get Inst::kind == assert_true
+    "not inst" InstKind::InstNot 8 bytecode .get Inst::kind == assert_true
+    "eq inst" InstKind::InstEq 9 bytecode .get Inst::kind == assert_true
+    "ne inst" InstKind::InstNe 10 bytecode .get Inst::kind == assert_true
+    "gt inst" InstKind::InstGt 11 bytecode .get Inst::kind == assert_true
+    "ge inst" InstKind::InstGe 12 bytecode .get Inst::kind == assert_true
+    "lt inst" InstKind::InstLt 13 bytecode .get Inst::kind == assert_true
+    "le inst" InstKind::InstLe 14 bytecode .get Inst::kind == assert_true
+    "swap inst" InstKind::InstSwap 15 bytecode .get Inst::kind == assert_true
+    "over inst" InstKind::InstOver 16 bytecode .get Inst::kind == assert_true
+    "rot inst" InstKind::InstRot 17 bytecode .get Inst::kind == assert_true
 }
 
 fn test_compile_direct_ops_bitwise {
     "compile_direct_ops_bitwise" test_start
     reset_labels
     List::new (List[Op]) = ops
-    OpKind::OpBitAnd (int) 0 test_make_op ops .push
-    OpKind::OpBitOr (int) 0 test_make_op ops .push
-    OpKind::OpBitXor (int) 0 test_make_op ops .push
-    OpKind::OpBitNot (int) 0 test_make_op ops .push
+    OpKind::OpBitAnd 0 test_make_op ops .push
+    OpKind::OpBitOr 0 test_make_op ops .push
+    OpKind::OpBitXor 0 test_make_op ops .push
+    OpKind::OpBitNot 0 test_make_op ops .push
 
     ops make_compiler = compiler
     List::new (List[Inst]) = bytecode
     bytecode compiler compile_ops
 
-    "bit_and inst" InstKind::InstBitAnd (int) 1 bytecode .get Inst::kind assert_eq
-    "bit_or inst" InstKind::InstBitOr (int) 2 bytecode .get Inst::kind assert_eq
-    "bit_xor inst" InstKind::InstBitXor (int) 3 bytecode .get Inst::kind assert_eq
-    "bit_not inst" InstKind::InstBitNot (int) 4 bytecode .get Inst::kind assert_eq
+    "bit_and inst" InstKind::InstBitAnd 1 bytecode .get Inst::kind == assert_true
+    "bit_or inst" InstKind::InstBitOr 2 bytecode .get Inst::kind == assert_true
+    "bit_xor inst" InstKind::InstBitXor 3 bytecode .get Inst::kind == assert_true
+    "bit_not inst" InstKind::InstBitNot 4 bytecode .get Inst::kind == assert_true
 }
 
 fn test_compile_direct_ops_memory {
     "compile_direct_ops_memory" test_start
     reset_labels
     List::new (List[Op]) = ops
-    OpKind::OpHeapAlloc (int) 0 test_make_op ops .push
-    OpKind::OpLoad8 (int) 0 test_make_op ops .push
-    OpKind::OpLoad16 (int) 0 test_make_op ops .push
-    OpKind::OpLoad32 (int) 0 test_make_op ops .push
-    OpKind::OpLoad64 (int) 0 test_make_op ops .push
-    OpKind::OpStore8 (int) 0 test_make_op ops .push
-    OpKind::OpStore16 (int) 0 test_make_op ops .push
-    OpKind::OpStore32 (int) 0 test_make_op ops .push
-    OpKind::OpStore64 (int) 0 test_make_op ops .push
+    OpKind::OpHeapAlloc 0 test_make_op ops .push
+    OpKind::OpLoad8 0 test_make_op ops .push
+    OpKind::OpLoad16 0 test_make_op ops .push
+    OpKind::OpLoad32 0 test_make_op ops .push
+    OpKind::OpLoad64 0 test_make_op ops .push
+    OpKind::OpStore8 0 test_make_op ops .push
+    OpKind::OpStore16 0 test_make_op ops .push
+    OpKind::OpStore32 0 test_make_op ops .push
+    OpKind::OpStore64 0 test_make_op ops .push
 
     ops make_compiler = compiler
     List::new (List[Inst]) = bytecode
     bytecode compiler compile_ops
 
-    "heap_alloc inst" InstKind::InstHeapAlloc (int) 1 bytecode .get Inst::kind assert_eq
-    "load8 inst" InstKind::InstLoad8 (int) 2 bytecode .get Inst::kind assert_eq
-    "load16 inst" InstKind::InstLoad16 (int) 3 bytecode .get Inst::kind assert_eq
-    "load32 inst" InstKind::InstLoad32 (int) 4 bytecode .get Inst::kind assert_eq
-    "load64 inst" InstKind::InstLoad64 (int) 5 bytecode .get Inst::kind assert_eq
-    "store8 inst" InstKind::InstStore8 (int) 6 bytecode .get Inst::kind assert_eq
-    "store16 inst" InstKind::InstStore16 (int) 7 bytecode .get Inst::kind assert_eq
-    "store32 inst" InstKind::InstStore32 (int) 8 bytecode .get Inst::kind assert_eq
-    "store64 inst" InstKind::InstStore64 (int) 9 bytecode .get Inst::kind assert_eq
+    "heap_alloc inst" InstKind::InstHeapAlloc 1 bytecode .get Inst::kind == assert_true
+    "load8 inst" InstKind::InstLoad8 2 bytecode .get Inst::kind == assert_true
+    "load16 inst" InstKind::InstLoad16 3 bytecode .get Inst::kind == assert_true
+    "load32 inst" InstKind::InstLoad32 4 bytecode .get Inst::kind == assert_true
+    "load64 inst" InstKind::InstLoad64 5 bytecode .get Inst::kind == assert_true
+    "store8 inst" InstKind::InstStore8 6 bytecode .get Inst::kind == assert_true
+    "store16 inst" InstKind::InstStore16 7 bytecode .get Inst::kind == assert_true
+    "store32 inst" InstKind::InstStore32 8 bytecode .get Inst::kind == assert_true
+    "store64 inst" InstKind::InstStore64 9 bytecode .get Inst::kind == assert_true
 }
 
 fn test_compile_direct_ops_syscall {
     "compile_direct_ops_syscall" test_start
     reset_labels
     List::new (List[Op]) = ops
-    OpKind::OpSyscall0 (int) 0 test_make_op ops .push
-    OpKind::OpSyscall1 (int) 0 test_make_op ops .push
-    OpKind::OpSyscall2 (int) 0 test_make_op ops .push
-    OpKind::OpSyscall3 (int) 0 test_make_op ops .push
-    OpKind::OpSyscall4 (int) 0 test_make_op ops .push
-    OpKind::OpSyscall5 (int) 0 test_make_op ops .push
-    OpKind::OpSyscall6 (int) 0 test_make_op ops .push
+    OpKind::OpSyscall0 0 test_make_op ops .push
+    OpKind::OpSyscall1 0 test_make_op ops .push
+    OpKind::OpSyscall2 0 test_make_op ops .push
+    OpKind::OpSyscall3 0 test_make_op ops .push
+    OpKind::OpSyscall4 0 test_make_op ops .push
+    OpKind::OpSyscall5 0 test_make_op ops .push
+    OpKind::OpSyscall6 0 test_make_op ops .push
 
     ops make_compiler = compiler
     List::new (List[Inst]) = bytecode
     bytecode compiler compile_ops
 
-    "syscall0 inst" InstKind::InstSyscall0 (int) 1 bytecode .get Inst::kind assert_eq
-    "syscall1 inst" InstKind::InstSyscall1 (int) 2 bytecode .get Inst::kind assert_eq
-    "syscall2 inst" InstKind::InstSyscall2 (int) 3 bytecode .get Inst::kind assert_eq
-    "syscall3 inst" InstKind::InstSyscall3 (int) 4 bytecode .get Inst::kind assert_eq
-    "syscall4 inst" InstKind::InstSyscall4 (int) 5 bytecode .get Inst::kind assert_eq
-    "syscall5 inst" InstKind::InstSyscall5 (int) 6 bytecode .get Inst::kind assert_eq
-    "syscall6 inst" InstKind::InstSyscall6 (int) 7 bytecode .get Inst::kind assert_eq
+    "syscall0 inst" InstKind::InstSyscall0 1 bytecode .get Inst::kind == assert_true
+    "syscall1 inst" InstKind::InstSyscall1 2 bytecode .get Inst::kind == assert_true
+    "syscall2 inst" InstKind::InstSyscall2 3 bytecode .get Inst::kind == assert_true
+    "syscall3 inst" InstKind::InstSyscall3 4 bytecode .get Inst::kind == assert_true
+    "syscall4 inst" InstKind::InstSyscall4 5 bytecode .get Inst::kind == assert_true
+    "syscall5 inst" InstKind::InstSyscall5 6 bytecode .get Inst::kind == assert_true
+    "syscall6 inst" InstKind::InstSyscall6 7 bytecode .get Inst::kind == assert_true
 }
 
 fn test_compile_direct_ops_print {
     "compile_direct_ops_print" test_start
     reset_labels
     List::new (List[Op]) = ops
-    OpKind::OpPrintInt (int) 0 test_make_op ops .push
-    OpKind::OpPrintStr (int) 0 test_make_op ops .push
-    OpKind::OpPrintChar (int) 0 test_make_op ops .push
-    OpKind::OpPrintCstr (int) 0 test_make_op ops .push
-    OpKind::OpPrintBool (int) 0 test_make_op ops .push
+    OpKind::OpPrintInt 0 test_make_op ops .push
+    OpKind::OpPrintStr 0 test_make_op ops .push
+    OpKind::OpPrintChar 0 test_make_op ops .push
+    OpKind::OpPrintCstr 0 test_make_op ops .push
+    OpKind::OpPrintBool 0 test_make_op ops .push
 
     ops make_compiler = compiler
     List::new (List[Inst]) = bytecode
     bytecode compiler compile_ops
 
-    "print_int inst" InstKind::InstPrintInt (int) 1 bytecode .get Inst::kind assert_eq
-    "print_str inst" InstKind::InstPrintStr (int) 2 bytecode .get Inst::kind assert_eq
-    "print_char inst" InstKind::InstPrintChar (int) 3 bytecode .get Inst::kind assert_eq
-    "print_cstr inst" InstKind::InstPrintCstr (int) 4 bytecode .get Inst::kind assert_eq
-    "print_bool inst" InstKind::InstPrintBool (int) 5 bytecode .get Inst::kind assert_eq
+    "print_int inst" InstKind::InstPrintInt 1 bytecode .get Inst::kind == assert_true
+    "print_str inst" InstKind::InstPrintStr 2 bytecode .get Inst::kind == assert_true
+    "print_char inst" InstKind::InstPrintChar 3 bytecode .get Inst::kind == assert_true
+    "print_cstr inst" InstKind::InstPrintCstr 4 bytecode .get Inst::kind == assert_true
+    "print_bool inst" InstKind::InstPrintBool 5 bytecode .get Inst::kind == assert_true
 }
 
 fn test_compile_direct_ops_fn {
     "compile_direct_ops_fn" test_start
     reset_labels
     List::new (List[Op]) = ops
-    OpKind::OpFnExec (int) 0 test_make_op ops .push
-    OpKind::OpFnReturn (int) 0 test_make_op ops .push
+    OpKind::OpFnExec 0 test_make_op ops .push
+    OpKind::OpFnReturn 0 test_make_op ops .push
 
     ops make_compiler = compiler
     List::new (List[Inst]) = bytecode
     bytecode compiler compile_ops
 
-    "fn_exec inst" InstKind::InstFnExec (int) 1 bytecode .get Inst::kind assert_eq
-    "fn_return inst" InstKind::InstFnReturn (int) 2 bytecode .get Inst::kind assert_eq
+    "fn_exec inst" InstKind::InstFnExec 1 bytecode .get Inst::kind == assert_true
+    "fn_return inst" InstKind::InstFnReturn 2 bytecode .get Inst::kind == assert_true
 }
 
 fn test_compile_push_array {
@@ -558,13 +558,13 @@ fn test_compile_push_array {
 
     # Create array items: [1, 2, 3]
     List::new (List[Op]) = items
-    OpKind::OpPushInt (int) 1 test_make_op items .push
-    OpKind::OpPushInt (int) 2 test_make_op items .push
-    OpKind::OpPushInt (int) 3 test_make_op items .push
+    OpKind::OpPushInt 1 test_make_op items .push
+    OpKind::OpPushInt 2 test_make_op items .push
+    OpKind::OpPushInt 3 test_make_op items .push
 
     # Create a PushArray op with the items list as value
     List::new (List[Op]) = ops
-    make_test_location OpKind::OpPushArray (int) items (int) make_op ops .push
+    make_test_location OpKind::OpPushArray items (int) make_op ops .push
 
     ops make_compiler = compiler
     List::new (List[Inst]) = bytecode
@@ -580,15 +580,15 @@ fn test_compile_push_array {
     0 = i
     while i bytecode .length > do
         i bytecode .get Inst::kind = kind
-        if InstKind::InstHeapAlloc (int) kind == then
+        if InstKind::InstHeapAlloc kind == then
             1 = has_alloc
-        elif InstKind::InstStore64 (int) kind == then
+        elif InstKind::InstStore64 kind == then
             1 = has_store
-        elif InstKind::InstLabel (int) kind == then
+        elif InstKind::InstLabel kind == then
             1 = has_label
-        elif InstKind::InstJump (int) kind == then
+        elif InstKind::InstJump kind == then
             1 = has_jump
-        elif InstKind::InstJumpNe (int) kind == then
+        elif InstKind::InstJumpNe kind == then
             1 = has_jump_ne
         fi
         1 += i
@@ -605,12 +605,12 @@ fn test_compile_if_elif_else {
     reset_labels
     List::new (List[Op]) = ops
     # if ... then ... elif ... then ... else ... fi
-    OpKind::OpIfStart (int) 0 test_make_op ops .push
-    OpKind::OpIfCondition (int) 0 test_make_op ops .push
-    OpKind::OpIfElif (int) 0 test_make_op ops .push
-    OpKind::OpIfCondition (int) 0 test_make_op ops .push
-    OpKind::OpIfElse (int) 0 test_make_op ops .push
-    OpKind::OpIfEnd (int) 0 test_make_op ops .push
+    OpKind::OpIfStart 0 test_make_op ops .push
+    OpKind::OpIfCondition 0 test_make_op ops .push
+    OpKind::OpIfElif 0 test_make_op ops .push
+    OpKind::OpIfCondition 0 test_make_op ops .push
+    OpKind::OpIfElse 0 test_make_op ops .push
+    OpKind::OpIfEnd 0 test_make_op ops .push
 
     ops make_compiler = compiler
     List::new (List[Inst]) = bytecode
@@ -626,14 +626,14 @@ fn test_compile_if_elif_else {
     # 6: LABEL (else label)
     # 7: LABEL (fi label)
     "elif bytecode length" 8 bytecode .length assert_eq
-    "elif fn label" InstKind::InstLabel (int) 0 bytecode .get Inst::kind assert_eq
-    "elif if jump_ne" InstKind::InstJumpNe (int) 1 bytecode .get Inst::kind assert_eq
-    "elif jump to fi" InstKind::InstJump (int) 2 bytecode .get Inst::kind assert_eq
-    "elif label" InstKind::InstLabel (int) 3 bytecode .get Inst::kind assert_eq
-    "elif cond jump_ne" InstKind::InstJumpNe (int) 4 bytecode .get Inst::kind assert_eq
-    "else jump to fi" InstKind::InstJump (int) 5 bytecode .get Inst::kind assert_eq
-    "else label" InstKind::InstLabel (int) 6 bytecode .get Inst::kind assert_eq
-    "fi label" InstKind::InstLabel (int) 7 bytecode .get Inst::kind assert_eq
+    "elif fn label" InstKind::InstLabel 0 bytecode .get Inst::kind == assert_true
+    "elif if jump_ne" InstKind::InstJumpNe 1 bytecode .get Inst::kind == assert_true
+    "elif jump to fi" InstKind::InstJump 2 bytecode .get Inst::kind == assert_true
+    "elif label" InstKind::InstLabel 3 bytecode .get Inst::kind == assert_true
+    "elif cond jump_ne" InstKind::InstJumpNe 4 bytecode .get Inst::kind == assert_true
+    "else jump to fi" InstKind::InstJump 5 bytecode .get Inst::kind == assert_true
+    "else label" InstKind::InstLabel 6 bytecode .get Inst::kind == assert_true
+    "fi label" InstKind::InstLabel 7 bytecode .get Inst::kind == assert_true
 }
 
 fn test_compile_fn_call {
@@ -646,7 +646,7 @@ fn test_compile_fn_call {
     "greet" func GLOBAL_FUNCTIONS .set = GLOBAL_FUNCTIONS
 
     List::new (List[Op]) = ops
-    OpKind::OpFnCall (int) "greet" test_make_op_str ops .push
+    OpKind::OpFnCall "greet" test_make_op_str ops .push
 
     ops make_compiler = compiler
     List::new (List[Inst]) = bytecode
@@ -654,7 +654,7 @@ fn test_compile_fn_call {
 
     # Should have: LABEL, FN_CALL
     "fn_call bytecode length" 2 bytecode .length assert_eq
-    "fn_call inst kind" InstKind::InstFnCall (int) 1 bytecode .get Inst::kind assert_eq
+    "fn_call inst kind" InstKind::InstFnCall 1 bytecode .get Inst::kind == assert_true
 
     # Clean up
     Map::new (Map[str Function]) = GLOBAL_FUNCTIONS
@@ -666,12 +666,12 @@ fn test_compile_fn_push {
 
     # Register a function in GLOBAL_FUNCTIONS with has_deferred_methods = 0
     List::new (List[Op]) = fn_ops
-    OpKind::OpPushInt (int) 1 test_make_op fn_ops .push
+    OpKind::OpPushInt 1 test_make_op fn_ops .push
     make_test_location fn_ops "adder" make_function = func
     "adder" func GLOBAL_FUNCTIONS .set = GLOBAL_FUNCTIONS
 
     List::new (List[Op]) = ops
-    OpKind::OpFnPush (int) "adder" test_make_op_str ops .push
+    OpKind::OpFnPush "adder" test_make_op_str ops .push
 
     ops make_compiler = compiler
     List::new (List[Inst]) = bytecode

--- a/tests/self_hosted/test_common.casa
+++ b/tests/self_hosted/test_common.casa
@@ -49,34 +49,34 @@ fn test_extract_fn_signature_str {
 fn test_keyword_lookup {
     "keyword_lookup" test_start
     "fn is keyword" "fn" keyword_from_str .is_some assert_true
-    "fn ordinal" KeywordKind::Fn (int) "fn" keyword_from_str .unwrap assert_eq
-    "while ordinal" KeywordKind::While (int) "while" keyword_from_str .unwrap assert_eq
+    "fn ordinal" KeywordKind::Fn "fn" keyword_from_str .unwrap == assert_true
+    "while ordinal" KeywordKind::While "while" keyword_from_str .unwrap == assert_true
     "hello not keyword" "hello" keyword_from_str .is_none assert_true
 }
 
 fn test_operator_lookup {
     "operator_lookup" test_start
-    "plus" OperatorKind::Plus (int) "+" operator_from_str .unwrap assert_eq
-    "eq" OperatorKind::Eq (int) "==" operator_from_str .unwrap assert_eq
-    "assign" OperatorKind::Assign (int) "=" operator_from_str .unwrap assert_eq
+    "plus" OperatorKind::Plus "+" operator_from_str .unwrap == assert_true
+    "eq" OperatorKind::Eq "==" operator_from_str .unwrap == assert_true
+    "assign" OperatorKind::Assign "=" operator_from_str .unwrap == assert_true
     "abc not operator" "abc" operator_from_str .is_none assert_true
 }
 
 fn test_intrinsic_lookup {
     "intrinsic_lookup" test_start
-    "drop" IntrinsicKind::Drop (int) "drop" intrinsic_from_str .unwrap assert_eq
-    "dup" IntrinsicKind::Dup (int) "dup" intrinsic_from_str .unwrap assert_eq
-    "syscall3" IntrinsicKind::Syscall3 (int) "syscall3" intrinsic_from_str .unwrap assert_eq
+    "drop" IntrinsicKind::Drop "drop" intrinsic_from_str .unwrap == assert_true
+    "dup" IntrinsicKind::Dup "dup" intrinsic_from_str .unwrap == assert_true
+    "syscall3" IntrinsicKind::Syscall3 "syscall3" intrinsic_from_str .unwrap == assert_true
     "xyz not intrinsic" "xyz" intrinsic_from_str .is_none assert_true
 }
 
 fn test_delimiter_lookup {
     "delimiter_lookup" test_start
-    "arrow" DelimiterKind::Arrow (int) "->" delimiter_from_str .unwrap assert_eq
-    "fat arrow" DelimiterKind::FatArrow (int) "=>" delimiter_from_str .unwrap assert_eq
-    "colon" DelimiterKind::Colon (int) ":" delimiter_from_str .unwrap assert_eq
-    "dot char" DelimiterKind::Dot (int) '.' delimiter_from_char .unwrap assert_eq
-    "open brace char" DelimiterKind::OpenBrace (int) '{' delimiter_from_char .unwrap assert_eq
+    "arrow" DelimiterKind::Arrow "->" delimiter_from_str .unwrap == assert_true
+    "fat arrow" DelimiterKind::FatArrow "=>" delimiter_from_str .unwrap == assert_true
+    "colon" DelimiterKind::Colon ":" delimiter_from_str .unwrap == assert_true
+    "dot char" DelimiterKind::Dot '.' delimiter_from_char .unwrap == assert_true
+    "open brace char" DelimiterKind::OpenBrace '{' delimiter_from_char .unwrap == assert_true
 }
 
 fn test_signature_to_str {

--- a/tests/self_hosted/test_emitter.casa
+++ b/tests/self_hosted/test_emitter.casa
@@ -101,7 +101,7 @@ fn test_emit_data {
 fn test_emit_push {
     "emit_push" test_start
     List::new (List[Inst]) = bytecode
-    42 InstKind::InstPush (int) make_inst_int bytecode .push
+    42 InstKind::InstPush make_inst_int bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -115,7 +115,7 @@ fn test_emit_push {
 fn test_emit_push_str {
     "emit_push_str" test_start
     List::new (List[Inst]) = bytecode
-    0 InstKind::InstPushStr (int) make_inst_int bytecode .push
+    0 InstKind::InstPushStr make_inst_int bytecode .push
 
     List::new (List[str]) = strings
     "test" strings .push
@@ -132,7 +132,7 @@ fn test_emit_push_str {
 fn test_emit_add {
     "emit_add" test_start
     List::new (List[Inst]) = bytecode
-    InstKind::InstAdd (int) make_inst bytecode .push
+    InstKind::InstAdd make_inst bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -146,8 +146,8 @@ fn test_emit_add {
 fn test_emit_label_and_jump {
     "emit_label_and_jump" test_start
     List::new (List[Inst]) = bytecode
-    7 InstKind::InstLabel (int) make_inst_int bytecode .push
-    7 InstKind::InstJump (int) make_inst_int bytecode .push
+    7 InstKind::InstLabel make_inst_int bytecode .push
+    7 InstKind::InstJump make_inst_int bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -162,7 +162,7 @@ fn test_emit_label_and_jump {
 fn test_emit_fn_call {
     "emit_fn_call" test_start
     List::new (List[Inst]) = bytecode
-    "my_func" InstKind::InstFnCall (int) make_inst_str bytecode .push
+    "my_func" InstKind::InstFnCall make_inst_str bytecode .push
 
     List::new (List[Inst]) = fn_bytecode
 
@@ -178,7 +178,7 @@ fn test_emit_fn_call {
 fn test_emit_fn_call_sanitized {
     "emit_fn_call_sanitized" test_start
     List::new (List[Inst]) = bytecode
-    "Foo::bar" InstKind::InstFnCall (int) make_inst_str bytecode .push
+    "Foo::bar" InstKind::InstFnCall make_inst_str bytecode .push
 
     List::new (List[Inst]) = fn_bytecode
     Map::new (Map[str List[Inst]]) = functions
@@ -210,7 +210,7 @@ fn test_emit_helpers_present {
 fn test_emit_comparison {
     "emit_comparison" test_start
     List::new (List[Inst]) = bytecode
-    InstKind::InstEq (int) make_inst bytecode .push
+    InstKind::InstEq make_inst bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -225,7 +225,7 @@ fn test_emit_comparison {
 fn test_emit_syscall {
     "emit_syscall" test_start
     List::new (List[Inst]) = bytecode
-    InstKind::InstSyscall3 (int) make_inst bytecode .push
+    InstKind::InstSyscall3 make_inst bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -244,10 +244,10 @@ fn test_emit_syscall {
 fn test_emit_local_ops {
     "emit_local_ops" test_start
     List::new (List[Inst]) = bytecode
-    3 InstKind::InstLocalsInit (int) make_inst_int bytecode .push
-    0 InstKind::InstLocalGet (int) make_inst_int bytecode .push
-    1 InstKind::InstLocalSet (int) make_inst_int bytecode .push
-    3 InstKind::InstLocalsUninit (int) make_inst_int bytecode .push
+    3 InstKind::InstLocalsInit make_inst_int bytecode .push
+    0 InstKind::InstLocalGet make_inst_int bytecode .push
+    1 InstKind::InstLocalSet make_inst_int bytecode .push
+    3 InstKind::InstLocalsUninit make_inst_int bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -265,8 +265,8 @@ fn test_emit_local_ops {
 fn test_emit_global_ops {
     "emit_global_ops" test_start
     List::new (List[Inst]) = bytecode
-    2 InstKind::InstGlobalGet (int) make_inst_int bytecode .push
-    3 InstKind::InstGlobalSet (int) make_inst_int bytecode .push
+    2 InstKind::InstGlobalGet make_inst_int bytecode .push
+    3 InstKind::InstGlobalSet make_inst_int bytecode .push
 
     5 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -281,8 +281,8 @@ fn test_emit_global_ops {
 fn test_emit_memory_ops {
     "emit_memory_ops" test_start
     List::new (List[Inst]) = bytecode
-    InstKind::InstLoad64 (int) make_inst bytecode .push
-    InstKind::InstStore64 (int) make_inst bytecode .push
+    InstKind::InstLoad64 make_inst bytecode .push
+    InstKind::InstStore64 make_inst bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -298,7 +298,7 @@ fn test_emit_full_program {
     "emit_full_program" test_start
     # Emit a program with one PUSH instruction
     List::new (List[Inst]) = bytecode
-    99 InstKind::InstPush (int) make_inst_int bytecode .push
+    99 InstKind::InstPush make_inst_int bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -319,7 +319,7 @@ fn test_emit_full_program {
 fn test_emit_drop {
     "emit_drop" test_start
     List::new (List[Inst]) = bytecode
-    InstKind::InstDrop (int) make_inst bytecode .push
+    InstKind::InstDrop make_inst bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -333,7 +333,7 @@ fn test_emit_drop {
 fn test_emit_dup {
     "emit_dup" test_start
     List::new (List[Inst]) = bytecode
-    InstKind::InstDup (int) make_inst bytecode .push
+    InstKind::InstDup make_inst bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -347,7 +347,7 @@ fn test_emit_dup {
 fn test_emit_swap {
     "emit_swap" test_start
     List::new (List[Inst]) = bytecode
-    InstKind::InstSwap (int) make_inst bytecode .push
+    InstKind::InstSwap make_inst bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -364,7 +364,7 @@ fn test_emit_swap {
 fn test_emit_over {
     "emit_over" test_start
     List::new (List[Inst]) = bytecode
-    InstKind::InstOver (int) make_inst bytecode .push
+    InstKind::InstOver make_inst bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -378,7 +378,7 @@ fn test_emit_over {
 fn test_emit_rot {
     "emit_rot" test_start
     List::new (List[Inst]) = bytecode
-    InstKind::InstRot (int) make_inst bytecode .push
+    InstKind::InstRot make_inst bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -401,7 +401,7 @@ fn test_emit_rot {
 fn test_emit_push_char {
     "emit_push_char" test_start
     List::new (List[Inst]) = bytecode
-    97 InstKind::InstPushChar (int) make_inst_int bytecode .push
+    97 InstKind::InstPushChar make_inst_int bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -415,7 +415,7 @@ fn test_emit_push_char {
 fn test_emit_push_large_int {
     "emit_push_large_int" test_start
     List::new (List[Inst]) = bytecode
-    4294967296 InstKind::InstPush (int) make_inst_int bytecode .push
+    4294967296 InstKind::InstPush make_inst_int bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -429,7 +429,7 @@ fn test_emit_push_large_int {
 fn test_emit_push_negative_int {
     "emit_push_negative_int" test_start
     List::new (List[Inst]) = bytecode
-    0 42 - InstKind::InstPush (int) make_inst_int bytecode .push
+    0 42 - InstKind::InstPush make_inst_int bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -447,7 +447,7 @@ fn test_emit_push_negative_int {
 fn test_emit_sub {
     "emit_sub" test_start
     List::new (List[Inst]) = bytecode
-    InstKind::InstSub (int) make_inst bytecode .push
+    InstKind::InstSub make_inst bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -461,7 +461,7 @@ fn test_emit_sub {
 fn test_emit_mul {
     "emit_mul" test_start
     List::new (List[Inst]) = bytecode
-    InstKind::InstMul (int) make_inst bytecode .push
+    InstKind::InstMul make_inst bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -475,7 +475,7 @@ fn test_emit_mul {
 fn test_emit_div {
     "emit_div" test_start
     List::new (List[Inst]) = bytecode
-    InstKind::InstDiv (int) make_inst bytecode .push
+    InstKind::InstDiv make_inst bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -489,7 +489,7 @@ fn test_emit_div {
 fn test_emit_mod {
     "emit_mod" test_start
     List::new (List[Inst]) = bytecode
-    InstKind::InstMod (int) make_inst bytecode .push
+    InstKind::InstMod make_inst bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -508,7 +508,7 @@ fn test_emit_mod {
 fn test_emit_shl {
     "emit_shl" test_start
     List::new (List[Inst]) = bytecode
-    InstKind::InstShl (int) make_inst bytecode .push
+    InstKind::InstShl make_inst bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -522,7 +522,7 @@ fn test_emit_shl {
 fn test_emit_shr {
     "emit_shr" test_start
     List::new (List[Inst]) = bytecode
-    InstKind::InstShr (int) make_inst bytecode .push
+    InstKind::InstShr make_inst bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -540,7 +540,7 @@ fn test_emit_shr {
 fn test_emit_bit_and {
     "emit_bit_and" test_start
     List::new (List[Inst]) = bytecode
-    InstKind::InstBitAnd (int) make_inst bytecode .push
+    InstKind::InstBitAnd make_inst bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -554,7 +554,7 @@ fn test_emit_bit_and {
 fn test_emit_bit_or {
     "emit_bit_or" test_start
     List::new (List[Inst]) = bytecode
-    InstKind::InstBitOr (int) make_inst bytecode .push
+    InstKind::InstBitOr make_inst bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -568,7 +568,7 @@ fn test_emit_bit_or {
 fn test_emit_bit_xor {
     "emit_bit_xor" test_start
     List::new (List[Inst]) = bytecode
-    InstKind::InstBitXor (int) make_inst bytecode .push
+    InstKind::InstBitXor make_inst bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -582,7 +582,7 @@ fn test_emit_bit_xor {
 fn test_emit_bit_not {
     "emit_bit_not" test_start
     List::new (List[Inst]) = bytecode
-    InstKind::InstBitNot (int) make_inst bytecode .push
+    InstKind::InstBitNot make_inst bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -600,7 +600,7 @@ fn test_emit_bit_not {
 fn test_emit_bool_and {
     "emit_bool_and" test_start
     List::new (List[Inst]) = bytecode
-    InstKind::InstAnd (int) make_inst bytecode .push
+    InstKind::InstAnd make_inst bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -614,7 +614,7 @@ fn test_emit_bool_and {
 fn test_emit_bool_or {
     "emit_bool_or" test_start
     List::new (List[Inst]) = bytecode
-    InstKind::InstOr (int) make_inst bytecode .push
+    InstKind::InstOr make_inst bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -628,7 +628,7 @@ fn test_emit_bool_or {
 fn test_emit_bool_not {
     "emit_bool_not" test_start
     List::new (List[Inst]) = bytecode
-    InstKind::InstNot (int) make_inst bytecode .push
+    InstKind::InstNot make_inst bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -646,7 +646,7 @@ fn test_emit_bool_not {
 fn test_emit_ne {
     "emit_ne" test_start
     List::new (List[Inst]) = bytecode
-    InstKind::InstNe (int) make_inst bytecode .push
+    InstKind::InstNe make_inst bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -661,7 +661,7 @@ fn test_emit_ne {
 fn test_emit_lt {
     "emit_lt" test_start
     List::new (List[Inst]) = bytecode
-    InstKind::InstLt (int) make_inst bytecode .push
+    InstKind::InstLt make_inst bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -675,7 +675,7 @@ fn test_emit_lt {
 fn test_emit_le {
     "emit_le" test_start
     List::new (List[Inst]) = bytecode
-    InstKind::InstLe (int) make_inst bytecode .push
+    InstKind::InstLe make_inst bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -689,7 +689,7 @@ fn test_emit_le {
 fn test_emit_gt {
     "emit_gt" test_start
     List::new (List[Inst]) = bytecode
-    InstKind::InstGt (int) make_inst bytecode .push
+    InstKind::InstGt make_inst bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -703,7 +703,7 @@ fn test_emit_gt {
 fn test_emit_ge {
     "emit_ge" test_start
     List::new (List[Inst]) = bytecode
-    InstKind::InstGe (int) make_inst bytecode .push
+    InstKind::InstGe make_inst bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -721,7 +721,7 @@ fn test_emit_ge {
 fn test_emit_heap_alloc {
     "emit_heap_alloc" test_start
     List::new (List[Inst]) = bytecode
-    InstKind::InstHeapAlloc (int) make_inst bytecode .push
+    InstKind::InstHeapAlloc make_inst bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -736,7 +736,7 @@ fn test_emit_heap_alloc {
 fn test_emit_load8 {
     "emit_load8" test_start
     List::new (List[Inst]) = bytecode
-    InstKind::InstLoad8 (int) make_inst bytecode .push
+    InstKind::InstLoad8 make_inst bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -750,7 +750,7 @@ fn test_emit_load8 {
 fn test_emit_load16 {
     "emit_load16" test_start
     List::new (List[Inst]) = bytecode
-    InstKind::InstLoad16 (int) make_inst bytecode .push
+    InstKind::InstLoad16 make_inst bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -764,7 +764,7 @@ fn test_emit_load16 {
 fn test_emit_load32 {
     "emit_load32" test_start
     List::new (List[Inst]) = bytecode
-    InstKind::InstLoad32 (int) make_inst bytecode .push
+    InstKind::InstLoad32 make_inst bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -778,7 +778,7 @@ fn test_emit_load32 {
 fn test_emit_store8 {
     "emit_store8" test_start
     List::new (List[Inst]) = bytecode
-    InstKind::InstStore8 (int) make_inst bytecode .push
+    InstKind::InstStore8 make_inst bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -792,7 +792,7 @@ fn test_emit_store8 {
 fn test_emit_store16 {
     "emit_store16" test_start
     List::new (List[Inst]) = bytecode
-    InstKind::InstStore16 (int) make_inst bytecode .push
+    InstKind::InstStore16 make_inst bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -806,7 +806,7 @@ fn test_emit_store16 {
 fn test_emit_store32 {
     "emit_store32" test_start
     List::new (List[Inst]) = bytecode
-    InstKind::InstStore32 (int) make_inst bytecode .push
+    InstKind::InstStore32 make_inst bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -824,7 +824,7 @@ fn test_emit_store32 {
 fn test_emit_syscall0 {
     "emit_syscall0" test_start
     List::new (List[Inst]) = bytecode
-    InstKind::InstSyscall0 (int) make_inst bytecode .push
+    InstKind::InstSyscall0 make_inst bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -840,7 +840,7 @@ fn test_emit_syscall0 {
 fn test_emit_syscall1 {
     "emit_syscall1" test_start
     List::new (List[Inst]) = bytecode
-    InstKind::InstSyscall1 (int) make_inst bytecode .push
+    InstKind::InstSyscall1 make_inst bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -857,7 +857,7 @@ fn test_emit_syscall1 {
 fn test_emit_syscall2 {
     "emit_syscall2" test_start
     List::new (List[Inst]) = bytecode
-    InstKind::InstSyscall2 (int) make_inst bytecode .push
+    InstKind::InstSyscall2 make_inst bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -875,7 +875,7 @@ fn test_emit_syscall2 {
 fn test_emit_syscall4 {
     "emit_syscall4" test_start
     List::new (List[Inst]) = bytecode
-    InstKind::InstSyscall4 (int) make_inst bytecode .push
+    InstKind::InstSyscall4 make_inst bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -895,7 +895,7 @@ fn test_emit_syscall4 {
 fn test_emit_syscall5 {
     "emit_syscall5" test_start
     List::new (List[Inst]) = bytecode
-    InstKind::InstSyscall5 (int) make_inst bytecode .push
+    InstKind::InstSyscall5 make_inst bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -916,7 +916,7 @@ fn test_emit_syscall5 {
 fn test_emit_syscall6 {
     "emit_syscall6" test_start
     List::new (List[Inst]) = bytecode
-    InstKind::InstSyscall6 (int) make_inst bytecode .push
+    InstKind::InstSyscall6 make_inst bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -943,10 +943,10 @@ fn test_emit_fn_return {
     "emit_fn_return" test_start
     # In a non-global context, fn_return emits jmpq *(%r14)
     List::new (List[Inst]) = bytecode
-    InstKind::InstFnReturn (int) make_inst bytecode .push
+    InstKind::InstFnReturn make_inst bytecode .push
 
     List::new (List[Inst]) = fn_bytecode
-    InstKind::InstFnReturn (int) make_inst fn_bytecode .push
+    InstKind::InstFnReturn make_inst fn_bytecode .push
 
     Map::new (Map[str List[Inst]]) = functions
     "test_fn" fn_bytecode functions .set = functions
@@ -959,7 +959,7 @@ fn test_emit_fn_return {
 fn test_emit_fn_exec {
     "emit_fn_exec" test_start
     List::new (List[Inst]) = bytecode
-    InstKind::InstFnExec (int) make_inst bytecode .push
+    InstKind::InstFnExec make_inst bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -973,7 +973,7 @@ fn test_emit_fn_exec {
 fn test_emit_fn_push {
     "emit_fn_push" test_start
     List::new (List[Inst]) = bytecode
-    "my_lambda" InstKind::InstFnPush (int) make_inst_str bytecode .push
+    "my_lambda" InstKind::InstFnPush make_inst_str bytecode .push
 
     List::new (List[Inst]) = fn_bytecode
     Map::new (Map[str List[Inst]]) = functions
@@ -991,7 +991,7 @@ fn test_emit_fn_push {
 fn test_emit_print_int {
     "emit_print_int" test_start
     List::new (List[Inst]) = bytecode
-    InstKind::InstPrintInt (int) make_inst bytecode .push
+    InstKind::InstPrintInt make_inst bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -1005,7 +1005,7 @@ fn test_emit_print_int {
 fn test_emit_print_str {
     "emit_print_str" test_start
     List::new (List[Inst]) = bytecode
-    InstKind::InstPrintStr (int) make_inst bytecode .push
+    InstKind::InstPrintStr make_inst bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -1019,7 +1019,7 @@ fn test_emit_print_str {
 fn test_emit_print_bool {
     "emit_print_bool" test_start
     List::new (List[Inst]) = bytecode
-    InstKind::InstPrintBool (int) make_inst bytecode .push
+    InstKind::InstPrintBool make_inst bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -1034,7 +1034,7 @@ fn test_emit_print_bool {
 fn test_emit_print_char {
     "emit_print_char" test_start
     List::new (List[Inst]) = bytecode
-    InstKind::InstPrintChar (int) make_inst bytecode .push
+    InstKind::InstPrintChar make_inst bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -1048,7 +1048,7 @@ fn test_emit_print_char {
 fn test_emit_print_cstr {
     "emit_print_cstr" test_start
     List::new (List[Inst]) = bytecode
-    InstKind::InstPrintCstr (int) make_inst bytecode .push
+    InstKind::InstPrintCstr make_inst bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -1066,7 +1066,7 @@ fn test_emit_print_cstr {
 fn test_emit_str_eq {
     "emit_str_eq" test_start
     List::new (List[Inst]) = bytecode
-    InstKind::InstStrEq (int) make_inst bytecode .push
+    InstKind::InstStrEq make_inst bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -1080,7 +1080,7 @@ fn test_emit_str_eq {
 fn test_emit_fstring_concat {
     "emit_fstring_concat" test_start
     List::new (List[Inst]) = bytecode
-    3 InstKind::InstFstringConcat (int) make_inst_int bytecode .push
+    3 InstKind::InstFstringConcat make_inst_int bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -1099,7 +1099,7 @@ fn test_emit_fstring_concat {
 fn test_emit_constant_load {
     "emit_constant_load" test_start
     List::new (List[Inst]) = bytecode
-    0 InstKind::InstConstantLoad (int) make_inst_int bytecode .push
+    0 InstKind::InstConstantLoad make_inst_int bytecode .push
 
     0 1 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -1113,7 +1113,7 @@ fn test_emit_constant_load {
 fn test_emit_constant_store {
     "emit_constant_store" test_start
     List::new (List[Inst]) = bytecode
-    1 InstKind::InstConstantStore (int) make_inst_int bytecode .push
+    1 InstKind::InstConstantStore make_inst_int bytecode .push
 
     0 2 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -1131,7 +1131,7 @@ fn test_emit_constant_store {
 fn test_emit_jump_ne {
     "emit_jump_ne" test_start
     List::new (List[Inst]) = bytecode
-    5 InstKind::InstJumpNe (int) make_inst_int bytecode .push
+    5 InstKind::InstJumpNe make_inst_int bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -1150,7 +1150,7 @@ fn test_emit_jump_ne {
 fn test_emit_argc {
     "emit_argc" test_start
     List::new (List[Inst]) = bytecode
-    InstKind::InstArgc (int) make_inst bytecode .push
+    InstKind::InstArgc make_inst bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -1164,7 +1164,7 @@ fn test_emit_argc {
 fn test_emit_argv {
     "emit_argv" test_start
     List::new (List[Inst]) = bytecode
-    InstKind::InstArgv (int) make_inst bytecode .push
+    InstKind::InstArgv make_inst bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -1193,8 +1193,8 @@ fn test_emit_exit_syscall {
 fn test_emit_globals_init {
     "emit_globals_init" test_start
     List::new (List[Inst]) = bytecode
-    5 InstKind::InstGlobalsInit (int) make_inst_int bytecode .push
-    42 InstKind::InstPush (int) make_inst_int bytecode .push
+    5 InstKind::InstGlobalsInit make_inst_int bytecode .push
+    42 InstKind::InstPush make_inst_int bytecode .push
 
     0 5 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -1216,11 +1216,11 @@ fn test_emit_while_loop_pattern {
     "emit_while_loop_pattern" test_start
     List::new (List[Inst]) = bytecode
     # while loop: label 10, condition check, jump_ne 11, body, jump 10, label 11
-    10 InstKind::InstLabel (int) make_inst_int bytecode .push
-    1 InstKind::InstPush (int) make_inst_int bytecode .push
-    11 InstKind::InstJumpNe (int) make_inst_int bytecode .push
-    10 InstKind::InstJump (int) make_inst_int bytecode .push
-    11 InstKind::InstLabel (int) make_inst_int bytecode .push
+    10 InstKind::InstLabel make_inst_int bytecode .push
+    1 InstKind::InstPush make_inst_int bytecode .push
+    11 InstKind::InstJumpNe make_inst_int bytecode .push
+    10 InstKind::InstJump make_inst_int bytecode .push
+    11 InstKind::InstLabel make_inst_int bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -1264,8 +1264,8 @@ fn test_emit_data_escape_sequences {
 fn test_emit_locals_rep_stosq {
     "emit_locals_rep_stosq" test_start
     List::new (List[Inst]) = bytecode
-    4 InstKind::InstLocalsInit (int) make_inst_int bytecode .push
-    4 InstKind::InstLocalsUninit (int) make_inst_int bytecode .push
+    4 InstKind::InstLocalsInit make_inst_int bytecode .push
+    4 InstKind::InstLocalsUninit make_inst_int bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -1285,7 +1285,7 @@ fn test_emit_locals_rep_stosq {
 fn test_emit_load64 {
     "emit_load64" test_start
     List::new (List[Inst]) = bytecode
-    InstKind::InstLoad64 (int) make_inst bytecode .push
+    InstKind::InstLoad64 make_inst bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -1305,7 +1305,7 @@ fn test_emit_load64 {
 fn test_emit_store64 {
     "emit_store64" test_start
     List::new (List[Inst]) = bytecode
-    InstKind::InstStore64 (int) make_inst bytecode .push
+    InstKind::InstStore64 make_inst bytecode .push
 
     0 0 List::new (List[str])
     Map::new (Map[str List[Inst]])
@@ -1325,15 +1325,15 @@ fn test_emit_store64 {
 fn test_emit_fn_with_body {
     "emit_fn_with_body" test_start
     List::new (List[Inst]) = bytecode
-    "adder" InstKind::InstFnCall (int) make_inst_str bytecode .push
+    "adder" InstKind::InstFnCall make_inst_str bytecode .push
 
     List::new (List[Inst]) = fn_bytecode
-    2 InstKind::InstLocalsInit (int) make_inst_int fn_bytecode .push
-    0 InstKind::InstLocalGet (int) make_inst_int fn_bytecode .push
-    1 InstKind::InstLocalGet (int) make_inst_int fn_bytecode .push
-    InstKind::InstAdd (int) make_inst fn_bytecode .push
-    2 InstKind::InstLocalsUninit (int) make_inst_int fn_bytecode .push
-    InstKind::InstFnReturn (int) make_inst fn_bytecode .push
+    2 InstKind::InstLocalsInit make_inst_int fn_bytecode .push
+    0 InstKind::InstLocalGet make_inst_int fn_bytecode .push
+    1 InstKind::InstLocalGet make_inst_int fn_bytecode .push
+    InstKind::InstAdd make_inst fn_bytecode .push
+    2 InstKind::InstLocalsUninit make_inst_int fn_bytecode .push
+    InstKind::InstFnReturn make_inst fn_bytecode .push
 
     Map::new (Map[str List[Inst]]) = functions
     "adder" fn_bytecode functions .set = functions
@@ -1353,14 +1353,14 @@ fn test_emit_fn_with_body {
 fn test_emit_multiple_functions {
     "emit_multiple_functions" test_start
     List::new (List[Inst]) = bytecode
-    "alpha" InstKind::InstFnCall (int) make_inst_str bytecode .push
-    "beta" InstKind::InstFnCall (int) make_inst_str bytecode .push
+    "alpha" InstKind::InstFnCall make_inst_str bytecode .push
+    "beta" InstKind::InstFnCall make_inst_str bytecode .push
 
     List::new (List[Inst]) = alpha_bytecode
-    InstKind::InstFnReturn (int) make_inst alpha_bytecode .push
+    InstKind::InstFnReturn make_inst alpha_bytecode .push
 
     List::new (List[Inst]) = beta_bytecode
-    InstKind::InstFnReturn (int) make_inst beta_bytecode .push
+    InstKind::InstFnReturn make_inst beta_bytecode .push
 
     Map::new (Map[str List[Inst]]) = functions
     "alpha" alpha_bytecode functions .set = functions

--- a/tests/self_hosted/test_enum.casa
+++ b/tests/self_hosted/test_enum.casa
@@ -52,7 +52,7 @@ fn compile_enum code:str -> Program {
     ops compile_bytecode
 }
 
-fn count_ops ops:List[Op] kind:int -> int {
+fn count_ops ops:List[Op] kind:OpKind -> int {
     0 = count
     0 = index
     while index ops .length > do
@@ -64,7 +64,7 @@ fn count_ops ops:List[Op] kind:int -> int {
     count
 }
 
-fn count_insts bytecode:List[Inst] kind:int -> int {
+fn count_insts bytecode:List[Inst] kind:InstKind -> int {
     0 = count
     0 = index
     while index bytecode .length > do
@@ -76,7 +76,7 @@ fn count_insts bytecode:List[Inst] kind:int -> int {
     count
 }
 
-fn has_inst_kind bytecode:List[Inst] kind:int -> bool {
+fn has_inst_kind bytecode:List[Inst] kind:InstKind -> bool {
     0 kind bytecode count_insts !=
 }
 
@@ -86,7 +86,7 @@ fn has_push_value bytecode:List[Inst] value:int -> bool {
     while index bytecode .length > do
         index bytecode .get = inst
         if
-            InstKind::InstPush (int) inst Inst::kind ==
+            InstKind::InstPush inst Inst::kind ==
             value inst Inst::int_arg == &&
         then
             true = found
@@ -196,7 +196,7 @@ fn test_parse_duplicate_enum_raises {
     clear_errors
     "enum Color { Red Green Blue }\nenum Color { Cyan Magenta Yellow }\n" test_parse_code drop
     "has errors" assert_has_errors
-    "duplicate name error" ErrorKind::DuplicateName (int) assert_error_kind
+    "duplicate name error" ErrorKind::DuplicateName assert_error_kind
     clear_errors
     disable_test_mode
 }
@@ -219,7 +219,7 @@ fn test_parse_duplicate_variant_raises {
     clear_errors
     "enum Dup { A B A }\n" test_parse_code drop
     "has errors" assert_has_errors
-    "duplicate name error" ErrorKind::DuplicateName (int) assert_error_kind
+    "duplicate name error" ErrorKind::DuplicateName assert_error_kind
     clear_errors
     disable_test_mode
 }
@@ -253,7 +253,7 @@ fn test_parse_duplicate_type_var_raises {
 fn test_resolve_enum_variant {
     "resolve_enum_variant" test_start
     "enum Color { Red Green Blue }\nColor::Red" resolve_enum = ops
-    "has variant op" 0 OpKind::OpPushEnumVariant (int) ops count_ops != assert_true
+    "has variant op" 0 OpKind::OpPushEnumVariant ops count_ops != assert_true
 }
 
 fn test_resolve_enum_variant_ordinal_first {
@@ -261,7 +261,7 @@ fn test_resolve_enum_variant_ordinal_first {
     "enum Color { Red Green Blue }\nColor::Red" resolve_enum = ops
     0 = index
     while index ops .length > do
-        if OpKind::OpPushEnumVariant (int) index ops .get Op::kind == then
+        if OpKind::OpPushEnumVariant index ops .get Op::kind == then
             index ops .get Op::value (EnumVariant) = variant
             "ordinal 0" 0 variant EnumVariant::ordinal .unwrap assert_eq
             "enum name" "Color" variant EnumVariant::enum_name assert_str_eq
@@ -276,7 +276,7 @@ fn test_resolve_enum_variant_ordinal_second {
     "enum Color { Red Green Blue }\nColor::Green" resolve_enum = ops
     0 = index
     while index ops .length > do
-        if OpKind::OpPushEnumVariant (int) index ops .get Op::kind == then
+        if OpKind::OpPushEnumVariant index ops .get Op::kind == then
             index ops .get Op::value (EnumVariant) = variant
             "ordinal 1" 1 variant EnumVariant::ordinal .unwrap assert_eq
             "variant name" "Green" variant EnumVariant::variant_name assert_str_eq
@@ -290,7 +290,7 @@ fn test_resolve_enum_variant_ordinal_third {
     "enum Color { Red Green Blue }\nColor::Blue" resolve_enum = ops
     0 = index
     while index ops .length > do
-        if OpKind::OpPushEnumVariant (int) index ops .get Op::kind == then
+        if OpKind::OpPushEnumVariant index ops .get Op::kind == then
             index ops .get Op::value (EnumVariant) = variant
             "ordinal 2" 2 variant EnumVariant::ordinal .unwrap assert_eq
             "variant name" "Blue" variant EnumVariant::variant_name assert_str_eq
@@ -302,7 +302,7 @@ fn test_resolve_enum_variant_ordinal_third {
 fn test_resolve_multiple_variants {
     "resolve_multiple_variants" test_start
     "enum Color { Red Green Blue }\nColor::Red Color::Green Color::Blue\n" resolve_enum = ops
-    "three variants" 3 OpKind::OpPushEnumVariant (int) ops count_ops assert_eq
+    "three variants" 3 OpKind::OpPushEnumVariant ops count_ops == assert_true
 }
 
 fn test_resolve_undefined_enum_raises {
@@ -312,7 +312,7 @@ fn test_resolve_undefined_enum_raises {
     clear_errors
     "Nonexistent::Foo" resolve_enum drop
     "has errors" assert_has_errors
-    "undefined name" ErrorKind::UndefinedName (int) assert_error_kind
+    "undefined name" ErrorKind::UndefinedName assert_error_kind
     clear_errors
     disable_test_mode
 }
@@ -324,7 +324,7 @@ fn test_resolve_undefined_variant_raises {
     clear_errors
     "enum Color { Red Green Blue }\nColor::Yellow" resolve_enum drop
     "has errors" assert_has_errors
-    "undefined name" ErrorKind::UndefinedName (int) assert_error_kind
+    "undefined name" ErrorKind::UndefinedName assert_error_kind
     clear_errors
     disable_test_mode
 }
@@ -492,27 +492,27 @@ fn test_enum_variant_compiles_to_push_ordinal_2 {
 fn test_match_compiles_to_dup_eq_jump_pattern {
     "match_compiles_to_dup_eq_jump_pattern" test_start
     "enum Color { Red Green Blue }\nColor::Red match\n    Color::Red => 1 drop\n    Color::Green => 2 drop\n    Color::Blue => 3 drop\nend\n" compile_enum = prog
-    "has DUP" 0 InstKind::InstDup (int) prog Program::bytecode count_insts != assert_true
-    "has EQ" 0 InstKind::InstEq (int) prog Program::bytecode count_insts != assert_true
-    "has JUMP_NE" 0 InstKind::InstJumpNe (int) prog Program::bytecode count_insts != assert_true
+    "has DUP" 0 InstKind::InstDup prog Program::bytecode count_insts != assert_true
+    "has EQ" 0 InstKind::InstEq prog Program::bytecode count_insts != assert_true
+    "has JUMP_NE" 0 InstKind::InstJumpNe prog Program::bytecode count_insts != assert_true
 }
 
 fn test_enum_print_compiles_to_print_int {
     "enum_print_compiles_to_print_int" test_start
     "enum Color { Red Green Blue }\nColor::Red print\n" compile_enum = prog
-    "has PRINT_INT" InstKind::InstPrintInt (int) prog Program::bytecode has_inst_kind assert_true
+    "has PRINT_INT" InstKind::InstPrintInt prog Program::bytecode has_inst_kind assert_true
 }
 
 fn test_data_enum_variant_compiles_to_heap_alloc {
     "data_enum_variant_compiles_to_heap_alloc" test_start
     "enum Shape { Circle(int) Rectangle(int int) Point }\n10 Shape::Circle\n" compile_enum = prog
-    "has HEAP_ALLOC" InstKind::InstHeapAlloc (int) prog Program::bytecode has_inst_kind assert_true
+    "has HEAP_ALLOC" InstKind::InstHeapAlloc prog Program::bytecode has_inst_kind assert_true
 }
 
 fn test_data_enum_stores_ordinal {
     "data_enum_stores_ordinal" test_start
     "enum Shape { Circle(int) Rectangle(int int) Point }\n10 Shape::Circle\n" compile_enum = prog
-    "has STORE64" InstKind::InstStore64 (int) prog Program::bytecode has_inst_kind assert_true
+    "has STORE64" InstKind::InstStore64 prog Program::bytecode has_inst_kind assert_true
 }
 
 # ============================================================================
@@ -522,27 +522,27 @@ fn test_data_enum_stores_ordinal {
 fn test_parse_match_produces_match_ops {
     "parse_match_produces_match_ops" test_start
     "enum Color { Red Green Blue }\nColor::Red match\n    Color::Red => 1\n    Color::Green => 2\n    Color::Blue => 3\nend\n" test_parse_code = ops
-    "has MATCH_START" 0 OpKind::OpMatchStart (int) ops count_ops != assert_true
-    "has MATCH_ARM" 0 OpKind::OpMatchArm (int) ops count_ops != assert_true
-    "has MATCH_END" 0 OpKind::OpMatchEnd (int) ops count_ops != assert_true
+    "has MATCH_START" 0 OpKind::OpMatchStart ops count_ops != assert_true
+    "has MATCH_ARM" 0 OpKind::OpMatchArm ops count_ops != assert_true
+    "has MATCH_END" 0 OpKind::OpMatchEnd ops count_ops != assert_true
 }
 
 fn test_parse_match_arm_count {
     "parse_match_arm_count" test_start
     "enum Color { Red Green Blue }\nColor::Red match\n    Color::Red => 1\n    Color::Green => 2\n    Color::Blue => 3\nend\n" test_parse_code = ops
-    "three arms" 3 OpKind::OpMatchArm (int) ops count_ops assert_eq
+    "three arms" 3 OpKind::OpMatchArm ops count_ops == assert_true
 }
 
 fn test_parse_braced_arm {
     "parse_braced_arm" test_start
     "enum Color { Red Green Blue }\nColor::Red match\n    Color::Red => { 1 }\n    Color::Green => { 2 }\n    Color::Blue => { 3 }\nend\n" test_parse_code = ops
-    "three arms" 3 OpKind::OpMatchArm (int) ops count_ops assert_eq
+    "three arms" 3 OpKind::OpMatchArm ops count_ops == assert_true
 }
 
 fn test_parse_empty_braced_arm {
     "parse_empty_braced_arm" test_start
     "enum Color { Red Green Blue }\nColor::Red match\n    Color::Red => {}\n    Color::Green => {}\n    Color::Blue => {}\nend\n" test_parse_code = ops
-    "three arms" 3 OpKind::OpMatchArm (int) ops count_ops assert_eq
+    "three arms" 3 OpKind::OpMatchArm ops count_ops == assert_true
 }
 
 # ============================================================================
@@ -579,7 +579,7 @@ fn test_enum_eq_different_types_raises {
     clear_errors
     "enum Color { Red Green Blue }\nenum Shape { Circle Square }\nColor::Red Shape::Circle ==\n" tc_enum drop
     "has errors" assert_has_errors
-    "type mismatch" ErrorKind::TypeMismatch (int) assert_error_kind
+    "type mismatch" ErrorKind::TypeMismatch assert_error_kind
     clear_errors
     disable_test_mode
 }
@@ -591,7 +591,7 @@ fn test_enum_int_comparison_raises {
     clear_errors
     "enum Color { Red Green Blue }\nColor::Red 42 ==\n" tc_enum drop
     "has errors" assert_has_errors
-    "type mismatch" ErrorKind::TypeMismatch (int) assert_error_kind
+    "type mismatch" ErrorKind::TypeMismatch assert_error_kind
     clear_errors
     disable_test_mode
 }
@@ -614,7 +614,7 @@ fn test_match_duplicate_arm_raises {
     clear_errors
     "enum Color { Red Green Blue }\nColor::Red match\n    Color::Red => 1\n    Color::Red => 2\n    Color::Green => 3\n    Color::Blue => 4\nend\ndrop\n" tc_enum drop
     "has errors" assert_has_errors
-    "duplicate name" ErrorKind::DuplicateName (int) assert_error_kind
+    "duplicate name" ErrorKind::DuplicateName assert_error_kind
     clear_errors
     disable_test_mode
 }
@@ -652,7 +652,7 @@ fn test_duplicate_literal_arm_raises {
     clear_errors
     "42 match\n    1 => \"one\"\n    1 => \"one again\"\n    _ => \"other\"\nend\ndrop\n" tc_enum drop
     "has errors" assert_has_errors
-    "duplicate name" ErrorKind::DuplicateName (int) assert_error_kind
+    "duplicate name" ErrorKind::DuplicateName assert_error_kind
     clear_errors
     disable_test_mode
 }
@@ -701,19 +701,19 @@ fn test_parse_generic_enum_type_var_order_preserved {
 fn test_parse_braced_arm_multiline_body {
     "parse_braced_arm_multiline_body" test_start
     "enum Color { Red Green Blue }\nColor::Red match\n    Color::Red => {\n        \"red\" print\n        \"\\n\" print\n    }\n    Color::Green => \"green\"\n    Color::Blue => \"blue\"\nend\n" test_parse_code = ops
-    "three arms" 3 OpKind::OpMatchArm (int) ops count_ops assert_eq
+    "three arms" 3 OpKind::OpMatchArm ops count_ops == assert_true
 }
 
 fn test_parse_mixed_braced_and_unbraced_arms {
     "parse_mixed_braced_and_unbraced_arms" test_start
     "enum Color { Red Green Blue }\nColor::Green match\n    Color::Red => 0\n    Color::Green => {\n        1\n    }\n    Color::Blue => 2\nend\n" test_parse_code = ops
-    "three arms" 3 OpKind::OpMatchArm (int) ops count_ops assert_eq
+    "three arms" 3 OpKind::OpMatchArm ops count_ops == assert_true
 }
 
 fn test_parse_braced_arm_with_destructuring {
     "parse_braced_arm_with_destructuring" test_start
     "enum Shape { Circle(int) Rectangle(int int) Point }\n10 Shape::Circle match\n    Shape::Circle(radius) => {\n        \"r=\" print\n        radius print\n    }\n    Shape::Rectangle(width height) => {\n        width height * print\n    }\n    Shape::Point => \"point\" print\nend\n" test_parse_code = ops
-    "three arms" 3 OpKind::OpMatchArm (int) ops count_ops assert_eq
+    "three arms" 3 OpKind::OpMatchArm ops count_ops == assert_true
 }
 
 # ============================================================================
@@ -755,7 +755,7 @@ fn test_wrong_enum_type_in_function_raises {
     clear_errors
     "enum Color { Red Green Blue }\nenum Direction { North South East West }\nfn is_red c:Color -> bool { c Color::Red == }\nDirection::North is_red\n" tc_enum drop
     "has errors" assert_has_errors
-    "type mismatch" ErrorKind::TypeMismatch (int) assert_error_kind
+    "type mismatch" ErrorKind::TypeMismatch assert_error_kind
     clear_errors
     disable_test_mode
 }
@@ -789,7 +789,7 @@ fn test_data_enum_wrong_inner_type_raises {
     clear_errors
     "enum Shape { Circle(int) Rectangle(int int) Point }\n\"hello\" Shape::Circle" tc_enum drop
     "has errors" assert_has_errors
-    "type mismatch" ErrorKind::TypeMismatch (int) assert_error_kind
+    "type mismatch" ErrorKind::TypeMismatch assert_error_kind
     clear_errors
     disable_test_mode
 }
@@ -849,7 +849,7 @@ fn test_is_different_enum_type_raises {
     clear_errors
     "enum Color { Red Green Blue }\nenum Direction { North South East West }\nColor::Red = c\nc Direction::North is\n" tc_enum drop
     "has errors" assert_has_errors
-    "type mismatch" ErrorKind::TypeMismatch (int) assert_error_kind
+    "type mismatch" ErrorKind::TypeMismatch assert_error_kind
     clear_errors
     disable_test_mode
 }
@@ -861,7 +861,7 @@ fn test_is_non_enum_type_raises {
     clear_errors
     "enum Color { Red Green Blue }\n42 Color::Red is\n" tc_enum drop
     "has errors" assert_has_errors
-    "type mismatch" ErrorKind::TypeMismatch (int) assert_error_kind
+    "type mismatch" ErrorKind::TypeMismatch assert_error_kind
     clear_errors
     disable_test_mode
 }
@@ -873,7 +873,7 @@ fn test_is_wrong_binding_count_raises {
     clear_errors
     "enum Shape { Circle(int) Rectangle(int int) Point }\n10 Shape::Circle = s\nif s Shape::Circle(a b) is then\na print\nfi\n" tc_enum drop
     "has errors" assert_has_errors
-    "type mismatch" ErrorKind::TypeMismatch (int) assert_error_kind
+    "type mismatch" ErrorKind::TypeMismatch assert_error_kind
     clear_errors
     disable_test_mode
 }
@@ -885,7 +885,7 @@ fn test_is_bindings_on_plain_variant_raises {
     clear_errors
     "enum Color { Red Green Blue }\nColor::Red = c\nif c Color::Red(x) is then\nx print\nfi\n" tc_enum drop
     "has errors" assert_has_errors
-    "type mismatch" ErrorKind::TypeMismatch (int) assert_error_kind
+    "type mismatch" ErrorKind::TypeMismatch assert_error_kind
     clear_errors
     disable_test_mode
 }
@@ -907,7 +907,7 @@ fn test_is_check_resolves_ordinal {
     "enum Color { Red Green Blue }\nColor::Blue = c\nc Color::Blue is\n" resolve_enum = ops
     0 = index
     while index ops .length > do
-        if OpKind::OpIsCheck (int) index ops .get Op::kind == then
+        if OpKind::OpIsCheck index ops .get Op::kind == then
             index ops .get Op::value (EnumVariant) = variant
             "ordinal 2" 2 variant EnumVariant::ordinal .unwrap assert_eq
         fi
@@ -920,7 +920,7 @@ fn test_is_check_with_bindings_parsed {
     "enum Shape { Circle(int) Rectangle(int int) Point }\n10 Shape::Circle = s\nif s Shape::Circle(r) is then\nr print\nfi\n" resolve_enum = ops
     0 = index
     while index ops .length > do
-        if OpKind::OpIsCheck (int) index ops .get Op::kind == then
+        if OpKind::OpIsCheck index ops .get Op::kind == then
             index ops .get Op::value (EnumVariant) = variant
             "has binding" 1 variant EnumVariant::bindings .length assert_eq
             "binding name" "r" 0 variant EnumVariant::bindings .get assert_str_eq
@@ -934,7 +934,7 @@ fn test_is_check_multiple_bindings_parsed {
     "enum Shape { Circle(int) Rectangle(int int) Point }\n3 4 Shape::Rectangle = s\nif s Shape::Rectangle(w h) is then\nw print\nfi\n" resolve_enum = ops
     0 = index
     while index ops .length > do
-        if OpKind::OpIsCheck (int) index ops .get Op::kind == then
+        if OpKind::OpIsCheck index ops .get Op::kind == then
             index ops .get Op::value (EnumVariant) = variant
             "has bindings" 2 variant EnumVariant::bindings .length assert_eq
             "binding w" "w" 0 variant EnumVariant::bindings .get assert_str_eq
@@ -951,7 +951,7 @@ fn test_is_check_multiple_bindings_parsed {
 fn test_data_enum_match_loads_ordinal {
     "data_enum_match_loads_ordinal" test_start
     "enum Shape { Circle(int) Rectangle(int int) Point }\n10 Shape::Circle match\n    Shape::Circle(r) => r drop\n    Shape::Rectangle(w h) => w drop\n    Shape::Point => 0 drop\nend\n" compile_enum = prog
-    "has LOAD64" InstKind::InstLoad64 (int) prog Program::bytecode has_inst_kind assert_true
+    "has LOAD64" InstKind::InstLoad64 prog Program::bytecode has_inst_kind assert_true
 }
 
 fn test_braced_arm_as_expression_typechecks {

--- a/tests/self_hosted/test_enum_variant_hint.casa
+++ b/tests/self_hosted/test_enum_variant_hint.casa
@@ -32,7 +32,7 @@ fn test_bare_variant_produces_type_mismatch {
     clear_errors
     "enum Color { Red Green Blue }\nColor::Green match\n    Color::Red => 1\n    Green => 2\n    Color::Blue => 3\nend\n" tc_evh drop
     "has errors" assert_has_errors
-    "type mismatch" ErrorKind::TypeMismatch (int) assert_error_kind
+    "type mismatch" ErrorKind::TypeMismatch assert_error_kind
     clear_errors
     disable_test_mode
 }
@@ -54,7 +54,7 @@ fn test_bare_variant_first_arm {
     clear_global_state
     clear_errors
     "enum Color { Red Green Blue }\nColor::Red match\n    Red => 1\n    Color::Green => 2\n    Color::Blue => 3\nend\n" tc_evh drop
-    "has type mismatch" ErrorKind::TypeMismatch (int) assert_error_kind
+    "has type mismatch" ErrorKind::TypeMismatch assert_error_kind
     "has hint" "Did you mean `Color::Red`?" assert_error_contains
     clear_errors
     disable_test_mode
@@ -66,7 +66,7 @@ fn test_bare_variant_last_arm {
     clear_global_state
     clear_errors
     "enum Color { Red Green Blue }\nColor::Red match\n    Color::Red => 1\n    Color::Green => 2\n    Blue => 3\nend\n" tc_evh drop
-    "has type mismatch" ErrorKind::TypeMismatch (int) assert_error_kind
+    "has type mismatch" ErrorKind::TypeMismatch assert_error_kind
     "has hint" "Did you mean `Color::Blue`?" assert_error_contains
     clear_errors
     disable_test_mode
@@ -100,7 +100,7 @@ fn test_all_bare_variants_errors_on_first {
     clear_global_state
     clear_errors
     "enum Color { Red Green Blue }\nColor::Red match\n    Red => 1\n    Green => 2\n    Blue => 3\nend\n" tc_evh drop
-    "has type mismatch" ErrorKind::TypeMismatch (int) assert_error_kind
+    "has type mismatch" ErrorKind::TypeMismatch assert_error_kind
     "has hint for Red" "Did you mean `Color::Red`?" assert_error_contains
     clear_errors
     disable_test_mode

--- a/tests/self_hosted/test_error.casa
+++ b/tests/self_hosted/test_error.casa
@@ -53,21 +53,21 @@ fn test_offset_to_source_line {
 
 fn test_error_kind_name {
     "error_kind_name" test_start
-    "syntax" "SYNTAX" ErrorKind::Syntax (int) error_kind_name assert_str_eq
-    "type mismatch" "TYPE_MISMATCH" ErrorKind::TypeMismatch (int) error_kind_name assert_str_eq
-    "undefined" "UNDEFINED_NAME" ErrorKind::UndefinedName (int) error_kind_name assert_str_eq
+    "syntax" "SYNTAX" ErrorKind::Syntax error_kind_name assert_str_eq
+    "type mismatch" "TYPE_MISMATCH" ErrorKind::TypeMismatch error_kind_name assert_str_eq
+    "undefined" "UNDEFINED_NAME" ErrorKind::UndefinedName error_kind_name assert_str_eq
 }
 
 fn test_format_error_no_location {
     "format_error_no_location" test_start
-    empty_location "bad token" ErrorKind::Syntax (int) make_error = err
+    empty_location "bad token" ErrorKind::Syntax make_error = err
     err format_error = formatted
     "exact format" "error[SYNTAX]: bad token" formatted assert_str_eq
 }
 
 fn test_format_error_with_location_no_source {
     "format_error_with_location_no_source" test_start
-    3 0 "test.casa" make_location "not found" ErrorKind::UndefinedName (int) make_error = err
+    3 0 "test.casa" make_location "not found" ErrorKind::UndefinedName make_error = err
     err format_error = formatted
     "has error kind" formatted "error[UNDEFINED_NAME]" str::find 0 1 - swap > assert_true
 }
@@ -75,7 +75,7 @@ fn test_format_error_with_location_no_source {
 fn test_format_error_with_source {
     "format_error_with_source" test_start
     "test_src.casa" "foo bar baz" SOURCE_CACHE .set = SOURCE_CACHE
-    3 4 "test_src.casa" make_location "`bar` is not defined" ErrorKind::UndefinedName (int) make_error = err
+    3 4 "test_src.casa" make_location "`bar` is not defined" ErrorKind::UndefinedName make_error = err
     err format_error = formatted
     "has error kind" formatted "error[UNDEFINED_NAME]" str::find 0 1 - swap > assert_true
     "has location" formatted "test_src.casa:1:5" str::find 0 1 - swap > assert_true
@@ -86,7 +86,7 @@ fn test_format_error_with_source {
 fn test_format_error_multiline_source {
     "format_error_multiline_source" test_start
     "test_multi.casa" "10 = x\nfoo\n20 = y" SOURCE_CACHE .set = SOURCE_CACHE
-    3 7 "test_multi.casa" make_location "`foo` is not defined" ErrorKind::UndefinedName (int) make_error = err
+    3 7 "test_multi.casa" make_location "`foo` is not defined" ErrorKind::UndefinedName make_error = err
     err format_error = formatted
     "has location" formatted "test_multi.casa:2:1" str::find 0 1 - swap > assert_true
     "has foo" formatted "foo" str::find 0 1 - swap > assert_true
@@ -95,7 +95,7 @@ fn test_format_error_multiline_source {
 
 fn test_format_error_with_expected_got {
     "format_error_with_expected_got" test_start
-    "`str`" "`int`" empty_location "Type mismatch" ErrorKind::TypeMismatch (int) make_error_expected = err
+    "`str`" "`int`" empty_location "Type mismatch" ErrorKind::TypeMismatch make_error_expected = err
     err format_error = formatted
     "has expected" formatted "Expected: `int`" str::find 0 1 - swap > assert_true
     "has got" formatted "Got: `str`" str::find 0 1 - swap > assert_true
@@ -104,7 +104,7 @@ fn test_format_error_with_expected_got {
 fn test_format_error_with_note {
     "format_error_with_note" test_start
     "test_note.casa" "\"hello\" 42 +" SOURCE_CACHE .set = SOURCE_CACHE
-    2 8 "test_note.casa" make_location "Type mismatch" ErrorKind::TypeMismatch (int) make_error = err
+    2 8 "test_note.casa" make_location "Type mismatch" ErrorKind::TypeMismatch make_error = err
     7 0 "test_note.casa" make_location "value of type `str` pushed here" CasaNote = note
     note err CasaError::notes .push
     err format_error = formatted
@@ -115,7 +115,7 @@ fn test_format_error_with_note {
 fn test_format_error_with_multiple_notes {
     "format_error_with_multiple_notes" test_start
     "test_notes.casa" "if true then\n    1 2\nelse\n    3\nfi" SOURCE_CACHE .set = SOURCE_CACHE
-    2 30 "test_notes.casa" make_location "Branches have incompatible stack effects" ErrorKind::StackMismatch (int) make_error = err
+    2 30 "test_notes.casa" make_location "Branches have incompatible stack effects" ErrorKind::StackMismatch make_error = err
     2 0 "test_notes.casa" make_location "`if` branch has signature `None -> int int`" CasaNote = note1
     4 21 "test_notes.casa" make_location "`else` branch has signature `None -> int`" CasaNote = note2
     note1 err CasaError::notes .push
@@ -134,7 +134,7 @@ fn test_format_error_with_multiple_notes {
 fn test_format_error_note_without_source {
     "format_error_note_without_source" test_start
     "present.casa" "foo" SOURCE_CACHE .set = SOURCE_CACHE
-    3 0 "present.casa" make_location "Type mismatch" ErrorKind::TypeMismatch (int) make_error = err
+    3 0 "present.casa" make_location "Type mismatch" ErrorKind::TypeMismatch make_error = err
     5 0 "missing.casa" make_location "value pushed here" CasaNote = note
     note err CasaError::notes .push
     err format_error = formatted

--- a/tests/self_hosted/test_generic_structs.casa
+++ b/tests/self_hosted/test_generic_structs.casa
@@ -186,11 +186,11 @@ fn test_typecheck_generic_struct_in_function {
 fn test_resolve_generic_struct_new {
     "resolve_generic_struct_new" test_start
     "struct Box[T] { value: T }\n42 Box" resolve_gs = ops
-    OpKind::OpStructNew (int) ops find_ops_by_kind = struct_new_ops
+    OpKind::OpStructNew ops find_ops_by_kind = struct_new_ops
     "has struct new op" 1 struct_new_ops .length assert_eq
 }
 
-fn find_ops_by_kind ops:List[Op] kind:int -> List[Op] {
+fn find_ops_by_kind ops:List[Op] kind:OpKind -> List[Op] {
     List::new (List[Op]) = result
     0 = index
     while index ops .length > do

--- a/tests/self_hosted/test_lexer.casa
+++ b/tests/self_hosted/test_lexer.casa
@@ -8,29 +8,29 @@ fn test_integer_literal {
     "test" "42" lex_source = tokens
     "token count" 2 tokens .length assert_eq
     "value" "42" 0 tokens .get Token::value assert_str_eq
-    "kind" TokenKind::Literal (int) 0 tokens .get Token::kind assert_eq
+    "kind" TokenKind::Literal 0 tokens .get Token::kind == assert_true
 }
 
 fn test_keywords {
     "keywords" test_start
     "test" "fn if while" lex_source = tokens
-    "fn kind" TokenKind::Keyword (int) 0 tokens .get Token::kind assert_eq
+    "fn kind" TokenKind::Keyword 0 tokens .get Token::kind == assert_true
     "fn value" "fn" 0 tokens .get Token::value assert_str_eq
-    "if kind" TokenKind::Keyword (int) 1 tokens .get Token::kind assert_eq
-    "while kind" TokenKind::Keyword (int) 2 tokens .get Token::kind assert_eq
+    "if kind" TokenKind::Keyword 1 tokens .get Token::kind == assert_true
+    "while kind" TokenKind::Keyword 2 tokens .get Token::kind == assert_true
 }
 
 fn test_operators {
     "operators" test_start
     "test" "1 2 +" lex_source = tokens
-    "plus kind" TokenKind::Operator (int) 2 tokens .get Token::kind assert_eq
+    "plus kind" TokenKind::Operator 2 tokens .get Token::kind == assert_true
     "plus value" "+" 2 tokens .get Token::value assert_str_eq
 }
 
 fn test_identifiers {
     "identifiers" test_start
     "test" "foo bar" lex_source = tokens
-    "foo kind" TokenKind::Identifier (int) 0 tokens .get Token::kind assert_eq
+    "foo kind" TokenKind::Identifier 0 tokens .get Token::kind == assert_true
     "foo value" "foo" 0 tokens .get Token::value assert_str_eq
     "bar value" "bar" 1 tokens .get Token::value assert_str_eq
 }
@@ -38,51 +38,51 @@ fn test_identifiers {
 fn test_string_literal {
     "string_literal" test_start
     "test" "\"hello\"" lex_source = tokens
-    "kind" TokenKind::Literal (int) 0 tokens .get Token::kind assert_eq
+    "kind" TokenKind::Literal 0 tokens .get Token::kind == assert_true
     "value" "\"hello\"" 0 tokens .get Token::value assert_str_eq
 }
 
 fn test_char_literal {
     "char_literal" test_start
     "test" "'A'" lex_source = tokens
-    "kind" TokenKind::Literal (int) 0 tokens .get Token::kind assert_eq
+    "kind" TokenKind::Literal 0 tokens .get Token::kind == assert_true
     "value" "'A'" 0 tokens .get Token::value assert_str_eq
 }
 
 fn test_boolean_literal {
     "boolean_literal" test_start
     "test" "true false" lex_source = tokens
-    "true kind" TokenKind::Literal (int) 0 tokens .get Token::kind assert_eq
+    "true kind" TokenKind::Literal 0 tokens .get Token::kind == assert_true
     "true value" "true" 0 tokens .get Token::value assert_str_eq
-    "false kind" TokenKind::Literal (int) 1 tokens .get Token::kind assert_eq
+    "false kind" TokenKind::Literal 1 tokens .get Token::kind == assert_true
 }
 
 fn test_negative_integer {
     "negative_integer" test_start
     "test" "-42" lex_source = tokens
-    "kind" TokenKind::Literal (int) 0 tokens .get Token::kind assert_eq
+    "kind" TokenKind::Literal 0 tokens .get Token::kind == assert_true
     "value" "-42" 0 tokens .get Token::value assert_str_eq
 }
 
 fn test_delimiters {
     "delimiters" test_start
     "test" "{ }" lex_source = tokens
-    "open kind" TokenKind::Delimiter (int) 0 tokens .get Token::kind assert_eq
-    "close kind" TokenKind::Delimiter (int) 1 tokens .get Token::kind assert_eq
+    "open kind" TokenKind::Delimiter 0 tokens .get Token::kind == assert_true
+    "close kind" TokenKind::Delimiter 1 tokens .get Token::kind == assert_true
 }
 
 fn test_intrinsics {
     "intrinsics" test_start
     "test" "drop dup swap" lex_source = tokens
-    "drop kind" TokenKind::Intrinsic (int) 0 tokens .get Token::kind assert_eq
-    "dup kind" TokenKind::Intrinsic (int) 1 tokens .get Token::kind assert_eq
-    "swap kind" TokenKind::Intrinsic (int) 2 tokens .get Token::kind assert_eq
+    "drop kind" TokenKind::Intrinsic 0 tokens .get Token::kind == assert_true
+    "dup kind" TokenKind::Intrinsic 1 tokens .get Token::kind == assert_true
+    "swap kind" TokenKind::Intrinsic 2 tokens .get Token::kind == assert_true
 }
 
 fn test_coloncolon {
     "coloncolon" test_start
     "test" "Foo::bar" lex_source = tokens
-    "kind" TokenKind::Identifier (int) 0 tokens .get Token::kind assert_eq
+    "kind" TokenKind::Identifier 0 tokens .get Token::kind == assert_true
     "value" "Foo::bar" 0 tokens .get Token::value assert_str_eq
 }
 
@@ -97,158 +97,158 @@ fn test_comments_skipped {
 fn test_eof {
     "eof" test_start
     "test" "" lex_source = tokens
-    "eof kind" TokenKind::Eof (int) 0 tokens .get Token::kind assert_eq
+    "eof kind" TokenKind::Eof 0 tokens .get Token::kind == assert_true
 }
 
 fn test_fstring_basic {
     "fstring_basic" test_start
     "test" "f\"hello\"" lex_source = tokens
-    "start" TokenKind::FstringStart (int) 0 tokens .get Token::kind assert_eq
-    "text" TokenKind::FstringText (int) 1 tokens .get Token::kind assert_eq
+    "start" TokenKind::FstringStart 0 tokens .get Token::kind == assert_true
+    "text" TokenKind::FstringText 1 tokens .get Token::kind == assert_true
     "text value" "hello" 1 tokens .get Token::value assert_str_eq
-    "end" TokenKind::FstringEnd (int) 2 tokens .get Token::kind assert_eq
+    "end" TokenKind::FstringEnd 2 tokens .get Token::kind == assert_true
 }
 
 fn test_all_keywords {
     "all_keywords" test_start
     "test" "fn" lex_source = tokens
-    "fn" TokenKind::Keyword (int) 0 tokens .get Token::kind assert_eq
+    "fn" TokenKind::Keyword 0 tokens .get Token::kind == assert_true
     "test" "impl" lex_source = tokens
-    "impl" TokenKind::Keyword (int) 0 tokens .get Token::kind assert_eq
+    "impl" TokenKind::Keyword 0 tokens .get Token::kind == assert_true
     "test" "return" lex_source = tokens
-    "return" TokenKind::Keyword (int) 0 tokens .get Token::kind assert_eq
+    "return" TokenKind::Keyword 0 tokens .get Token::kind == assert_true
     "test" "while" lex_source = tokens
-    "while" TokenKind::Keyword (int) 0 tokens .get Token::kind assert_eq
+    "while" TokenKind::Keyword 0 tokens .get Token::kind == assert_true
     "test" "do" lex_source = tokens
-    "do" TokenKind::Keyword (int) 0 tokens .get Token::kind assert_eq
+    "do" TokenKind::Keyword 0 tokens .get Token::kind == assert_true
     "test" "break" lex_source = tokens
-    "break" TokenKind::Keyword (int) 0 tokens .get Token::kind assert_eq
+    "break" TokenKind::Keyword 0 tokens .get Token::kind == assert_true
     "test" "continue" lex_source = tokens
-    "continue" TokenKind::Keyword (int) 0 tokens .get Token::kind assert_eq
+    "continue" TokenKind::Keyword 0 tokens .get Token::kind == assert_true
     "test" "done" lex_source = tokens
-    "done" TokenKind::Keyword (int) 0 tokens .get Token::kind assert_eq
+    "done" TokenKind::Keyword 0 tokens .get Token::kind == assert_true
     "test" "if" lex_source = tokens
-    "if" TokenKind::Keyword (int) 0 tokens .get Token::kind assert_eq
+    "if" TokenKind::Keyword 0 tokens .get Token::kind == assert_true
     "test" "then" lex_source = tokens
-    "then" TokenKind::Keyword (int) 0 tokens .get Token::kind assert_eq
+    "then" TokenKind::Keyword 0 tokens .get Token::kind == assert_true
     "test" "elif" lex_source = tokens
-    "elif" TokenKind::Keyword (int) 0 tokens .get Token::kind assert_eq
+    "elif" TokenKind::Keyword 0 tokens .get Token::kind == assert_true
     "test" "else" lex_source = tokens
-    "else" TokenKind::Keyword (int) 0 tokens .get Token::kind assert_eq
+    "else" TokenKind::Keyword 0 tokens .get Token::kind == assert_true
     "test" "fi" lex_source = tokens
-    "fi" TokenKind::Keyword (int) 0 tokens .get Token::kind assert_eq
+    "fi" TokenKind::Keyword 0 tokens .get Token::kind == assert_true
     "test" "end" lex_source = tokens
-    "end" TokenKind::Keyword (int) 0 tokens .get Token::kind assert_eq
+    "end" TokenKind::Keyword 0 tokens .get Token::kind == assert_true
     "test" "enum" lex_source = tokens
-    "enum" TokenKind::Keyword (int) 0 tokens .get Token::kind assert_eq
+    "enum" TokenKind::Keyword 0 tokens .get Token::kind == assert_true
     "test" "struct" lex_source = tokens
-    "struct" TokenKind::Keyword (int) 0 tokens .get Token::kind assert_eq
+    "struct" TokenKind::Keyword 0 tokens .get Token::kind == assert_true
     "test" "trait" lex_source = tokens
-    "trait" TokenKind::Keyword (int) 0 tokens .get Token::kind assert_eq
+    "trait" TokenKind::Keyword 0 tokens .get Token::kind == assert_true
     "test" "match" lex_source = tokens
-    "match" TokenKind::Keyword (int) 0 tokens .get Token::kind assert_eq
+    "match" TokenKind::Keyword 0 tokens .get Token::kind == assert_true
     "test" "is" lex_source = tokens
-    "is" TokenKind::Keyword (int) 0 tokens .get Token::kind assert_eq
+    "is" TokenKind::Keyword 0 tokens .get Token::kind == assert_true
     "test" "include" lex_source = tokens
-    "include" TokenKind::Keyword (int) 0 tokens .get Token::kind assert_eq
+    "include" TokenKind::Keyword 0 tokens .get Token::kind == assert_true
 }
 
 fn test_all_operators {
     "all_operators" test_start
     "test" "+" lex_source = tokens
-    "+" TokenKind::Operator (int) 0 tokens .get Token::kind assert_eq
+    "+" TokenKind::Operator 0 tokens .get Token::kind == assert_true
     "test" "-" lex_source = tokens
-    "-" TokenKind::Operator (int) 0 tokens .get Token::kind assert_eq
+    "-" TokenKind::Operator 0 tokens .get Token::kind == assert_true
     "test" "*" lex_source = tokens
-    "*" TokenKind::Operator (int) 0 tokens .get Token::kind assert_eq
+    "*" TokenKind::Operator 0 tokens .get Token::kind == assert_true
     "test" "/" lex_source = tokens
-    "/" TokenKind::Operator (int) 0 tokens .get Token::kind assert_eq
+    "/" TokenKind::Operator 0 tokens .get Token::kind == assert_true
     "test" "%" lex_source = tokens
-    "%" TokenKind::Operator (int) 0 tokens .get Token::kind assert_eq
+    "%" TokenKind::Operator 0 tokens .get Token::kind == assert_true
     "test" "<<" lex_source = tokens
-    "<<" TokenKind::Operator (int) 0 tokens .get Token::kind assert_eq
+    "<<" TokenKind::Operator 0 tokens .get Token::kind == assert_true
     "test" ">>" lex_source = tokens
-    ">>" TokenKind::Operator (int) 0 tokens .get Token::kind assert_eq
+    ">>" TokenKind::Operator 0 tokens .get Token::kind == assert_true
     "test" "&&" lex_source = tokens
-    "&&" TokenKind::Operator (int) 0 tokens .get Token::kind assert_eq
+    "&&" TokenKind::Operator 0 tokens .get Token::kind == assert_true
     "test" "||" lex_source = tokens
-    "||" TokenKind::Operator (int) 0 tokens .get Token::kind assert_eq
+    "||" TokenKind::Operator 0 tokens .get Token::kind == assert_true
     "test" "!" lex_source = tokens
-    "!" TokenKind::Operator (int) 0 tokens .get Token::kind assert_eq
+    "!" TokenKind::Operator 0 tokens .get Token::kind == assert_true
     "test" "==" lex_source = tokens
-    "==" TokenKind::Operator (int) 0 tokens .get Token::kind assert_eq
+    "==" TokenKind::Operator 0 tokens .get Token::kind == assert_true
     "test" ">=" lex_source = tokens
-    ">=" TokenKind::Operator (int) 0 tokens .get Token::kind assert_eq
+    ">=" TokenKind::Operator 0 tokens .get Token::kind == assert_true
     "test" ">" lex_source = tokens
-    ">" TokenKind::Operator (int) 0 tokens .get Token::kind assert_eq
+    ">" TokenKind::Operator 0 tokens .get Token::kind == assert_true
     "test" "<=" lex_source = tokens
-    "<=" TokenKind::Operator (int) 0 tokens .get Token::kind assert_eq
+    "<=" TokenKind::Operator 0 tokens .get Token::kind == assert_true
     "test" "<" lex_source = tokens
-    "<" TokenKind::Operator (int) 0 tokens .get Token::kind assert_eq
+    "<" TokenKind::Operator 0 tokens .get Token::kind == assert_true
     "test" "!=" lex_source = tokens
-    "!=" TokenKind::Operator (int) 0 tokens .get Token::kind assert_eq
+    "!=" TokenKind::Operator 0 tokens .get Token::kind == assert_true
     "test" "=" lex_source = tokens
-    "=" TokenKind::Operator (int) 0 tokens .get Token::kind assert_eq
+    "=" TokenKind::Operator 0 tokens .get Token::kind == assert_true
     "test" "-=" lex_source = tokens
-    "-=" TokenKind::Operator (int) 0 tokens .get Token::kind assert_eq
+    "-=" TokenKind::Operator 0 tokens .get Token::kind == assert_true
     "test" "+=" lex_source = tokens
-    "+=" TokenKind::Operator (int) 0 tokens .get Token::kind assert_eq
+    "+=" TokenKind::Operator 0 tokens .get Token::kind == assert_true
     "test" "&" lex_source = tokens
-    "&" TokenKind::Operator (int) 0 tokens .get Token::kind assert_eq
+    "&" TokenKind::Operator 0 tokens .get Token::kind == assert_true
     "test" "|" lex_source = tokens
-    "|" TokenKind::Operator (int) 0 tokens .get Token::kind assert_eq
+    "|" TokenKind::Operator 0 tokens .get Token::kind == assert_true
     "test" "^" lex_source = tokens
-    "^" TokenKind::Operator (int) 0 tokens .get Token::kind assert_eq
+    "^" TokenKind::Operator 0 tokens .get Token::kind == assert_true
     "test" "~" lex_source = tokens
-    "~" TokenKind::Operator (int) 0 tokens .get Token::kind assert_eq
+    "~" TokenKind::Operator 0 tokens .get Token::kind == assert_true
 }
 
 fn test_identifier_capitalized {
     "identifier_capitalized" test_start
     "test" "Person" lex_source = tokens
-    "kind" TokenKind::Identifier (int) 0 tokens .get Token::kind assert_eq
+    "kind" TokenKind::Identifier 0 tokens .get Token::kind == assert_true
     "value" "Person" 0 tokens .get Token::value assert_str_eq
 }
 
 fn test_empty_string_literal {
     "empty_string_literal" test_start
     "test" "\"\"" lex_source = tokens
-    "kind" TokenKind::Literal (int) 0 tokens .get Token::kind assert_eq
+    "kind" TokenKind::Literal 0 tokens .get Token::kind == assert_true
     "value" "\"\"" 0 tokens .get Token::value assert_str_eq
 }
 
 fn test_char_literal_escape_newline {
     "char_literal_escape_newline" test_start
     "test" "'\\n'" lex_source = tokens
-    "kind" TokenKind::Literal (int) 0 tokens .get Token::kind assert_eq
+    "kind" TokenKind::Literal 0 tokens .get Token::kind == assert_true
     "value" "'\n'" 0 tokens .get Token::value assert_str_eq
 }
 
 fn test_char_literal_escape_tab {
     "char_literal_escape_tab" test_start
     "test" "'\\t'" lex_source = tokens
-    "kind" TokenKind::Literal (int) 0 tokens .get Token::kind assert_eq
+    "kind" TokenKind::Literal 0 tokens .get Token::kind == assert_true
     "value" "'\t'" 0 tokens .get Token::value assert_str_eq
 }
 
 fn test_char_literal_escape_backslash {
     "char_literal_escape_backslash" test_start
     "test" "'\\\\'" lex_source = tokens
-    "kind" TokenKind::Literal (int) 0 tokens .get Token::kind assert_eq
+    "kind" TokenKind::Literal 0 tokens .get Token::kind == assert_true
     "value" "'\\'" 0 tokens .get Token::value assert_str_eq
 }
 
 fn test_char_literal_escape_null {
     "char_literal_escape_null" test_start
     "test" "'\\0'" lex_source = tokens
-    "kind" TokenKind::Literal (int) 0 tokens .get Token::kind assert_eq
+    "kind" TokenKind::Literal 0 tokens .get Token::kind == assert_true
     "value" "'\0'" 0 tokens .get Token::value assert_str_eq
 }
 
 fn test_char_literal_escape_single_quote {
     "char_literal_escape_single_quote" test_start
     "test" "'\\''" lex_source = tokens
-    "kind" TokenKind::Literal (int) 0 tokens .get Token::kind assert_eq
+    "kind" TokenKind::Literal 0 tokens .get Token::kind == assert_true
     "value" "'''" 0 tokens .get Token::value assert_str_eq
 }
 
@@ -256,113 +256,113 @@ fn test_char_literal_in_expression {
     "char_literal_in_expression" test_start
     "test" "'a' print" lex_source = tokens
     "count" 3 tokens .length assert_eq
-    "char kind" TokenKind::Literal (int) 0 tokens .get Token::kind assert_eq
-    "print kind" TokenKind::Intrinsic (int) 1 tokens .get Token::kind assert_eq
+    "char kind" TokenKind::Literal 0 tokens .get Token::kind == assert_true
+    "print kind" TokenKind::Intrinsic 1 tokens .get Token::kind == assert_true
 }
 
 fn test_minus_operator_with_space {
     "minus_operator_with_space" test_start
     "test" "- 42" lex_source = tokens
-    "minus kind" TokenKind::Operator (int) 0 tokens .get Token::kind assert_eq
+    "minus kind" TokenKind::Operator 0 tokens .get Token::kind == assert_true
     "minus value" "-" 0 tokens .get Token::value assert_str_eq
-    "42 kind" TokenKind::Literal (int) 1 tokens .get Token::kind assert_eq
+    "42 kind" TokenKind::Literal 1 tokens .get Token::kind == assert_true
     "42 value" "42" 1 tokens .get Token::value assert_str_eq
 }
 
 fn test_negative_after_int_no_space {
     "negative_after_int_no_space" test_start
     "test" "10-3" lex_source = tokens
-    "10 kind" TokenKind::Literal (int) 0 tokens .get Token::kind assert_eq
+    "10 kind" TokenKind::Literal 0 tokens .get Token::kind == assert_true
     "10 value" "10" 0 tokens .get Token::value assert_str_eq
-    "-3 kind" TokenKind::Identifier (int) 1 tokens .get Token::kind assert_eq
+    "-3 kind" TokenKind::Identifier 1 tokens .get Token::kind == assert_true
     "-3 value" "-3" 1 tokens .get Token::value assert_str_eq
 }
 
 fn test_all_delimiters {
     "all_delimiters" test_start
     "test" "->" lex_source = tokens
-    "-> kind" TokenKind::Delimiter (int) 0 tokens .get Token::kind assert_eq
+    "-> kind" TokenKind::Delimiter 0 tokens .get Token::kind == assert_true
     "-> value" "->" 0 tokens .get Token::value assert_str_eq
     "test" "," lex_source = tokens
-    ", kind" TokenKind::Delimiter (int) 0 tokens .get Token::kind assert_eq
+    ", kind" TokenKind::Delimiter 0 tokens .get Token::kind == assert_true
     "test" ":" lex_source = tokens
-    ": kind" TokenKind::Delimiter (int) 0 tokens .get Token::kind assert_eq
+    ": kind" TokenKind::Delimiter 0 tokens .get Token::kind == assert_true
     "test" "." lex_source = tokens
-    ". kind" TokenKind::Delimiter (int) 0 tokens .get Token::kind assert_eq
+    ". kind" TokenKind::Delimiter 0 tokens .get Token::kind == assert_true
     "test" "{" lex_source = tokens
-    "{ kind" TokenKind::Delimiter (int) 0 tokens .get Token::kind assert_eq
+    "{ kind" TokenKind::Delimiter 0 tokens .get Token::kind == assert_true
     "test" "}" lex_source = tokens
-    "} kind" TokenKind::Delimiter (int) 0 tokens .get Token::kind assert_eq
+    "} kind" TokenKind::Delimiter 0 tokens .get Token::kind == assert_true
     "test" "[" lex_source = tokens
-    "[ kind" TokenKind::Delimiter (int) 0 tokens .get Token::kind assert_eq
+    "[ kind" TokenKind::Delimiter 0 tokens .get Token::kind == assert_true
     "test" "]" lex_source = tokens
-    "] kind" TokenKind::Delimiter (int) 0 tokens .get Token::kind assert_eq
+    "] kind" TokenKind::Delimiter 0 tokens .get Token::kind == assert_true
     "test" "(" lex_source = tokens
-    "( kind" TokenKind::Delimiter (int) 0 tokens .get Token::kind assert_eq
+    "( kind" TokenKind::Delimiter 0 tokens .get Token::kind == assert_true
     "test" ")" lex_source = tokens
-    ") kind" TokenKind::Delimiter (int) 0 tokens .get Token::kind assert_eq
+    ") kind" TokenKind::Delimiter 0 tokens .get Token::kind == assert_true
 }
 
 fn test_all_intrinsics {
     "all_intrinsics" test_start
     "test" "drop" lex_source = tokens
-    "drop" TokenKind::Intrinsic (int) 0 tokens .get Token::kind assert_eq
+    "drop" TokenKind::Intrinsic 0 tokens .get Token::kind == assert_true
     "test" "dup" lex_source = tokens
-    "dup" TokenKind::Intrinsic (int) 0 tokens .get Token::kind assert_eq
+    "dup" TokenKind::Intrinsic 0 tokens .get Token::kind == assert_true
     "test" "over" lex_source = tokens
-    "over" TokenKind::Intrinsic (int) 0 tokens .get Token::kind assert_eq
+    "over" TokenKind::Intrinsic 0 tokens .get Token::kind == assert_true
     "test" "rot" lex_source = tokens
-    "rot" TokenKind::Intrinsic (int) 0 tokens .get Token::kind assert_eq
+    "rot" TokenKind::Intrinsic 0 tokens .get Token::kind == assert_true
     "test" "swap" lex_source = tokens
-    "swap" TokenKind::Intrinsic (int) 0 tokens .get Token::kind assert_eq
+    "swap" TokenKind::Intrinsic 0 tokens .get Token::kind == assert_true
     "test" "alloc" lex_source = tokens
-    "alloc" TokenKind::Intrinsic (int) 0 tokens .get Token::kind assert_eq
+    "alloc" TokenKind::Intrinsic 0 tokens .get Token::kind == assert_true
     "test" "load8" lex_source = tokens
-    "load8" TokenKind::Intrinsic (int) 0 tokens .get Token::kind assert_eq
+    "load8" TokenKind::Intrinsic 0 tokens .get Token::kind == assert_true
     "test" "load16" lex_source = tokens
-    "load16" TokenKind::Intrinsic (int) 0 tokens .get Token::kind assert_eq
+    "load16" TokenKind::Intrinsic 0 tokens .get Token::kind == assert_true
     "test" "load32" lex_source = tokens
-    "load32" TokenKind::Intrinsic (int) 0 tokens .get Token::kind assert_eq
+    "load32" TokenKind::Intrinsic 0 tokens .get Token::kind == assert_true
     "test" "load64" lex_source = tokens
-    "load64" TokenKind::Intrinsic (int) 0 tokens .get Token::kind assert_eq
+    "load64" TokenKind::Intrinsic 0 tokens .get Token::kind == assert_true
     "test" "store8" lex_source = tokens
-    "store8" TokenKind::Intrinsic (int) 0 tokens .get Token::kind assert_eq
+    "store8" TokenKind::Intrinsic 0 tokens .get Token::kind == assert_true
     "test" "store16" lex_source = tokens
-    "store16" TokenKind::Intrinsic (int) 0 tokens .get Token::kind assert_eq
+    "store16" TokenKind::Intrinsic 0 tokens .get Token::kind == assert_true
     "test" "store32" lex_source = tokens
-    "store32" TokenKind::Intrinsic (int) 0 tokens .get Token::kind assert_eq
+    "store32" TokenKind::Intrinsic 0 tokens .get Token::kind == assert_true
     "test" "store64" lex_source = tokens
-    "store64" TokenKind::Intrinsic (int) 0 tokens .get Token::kind assert_eq
+    "store64" TokenKind::Intrinsic 0 tokens .get Token::kind == assert_true
     "test" "print" lex_source = tokens
-    "print" TokenKind::Intrinsic (int) 0 tokens .get Token::kind assert_eq
+    "print" TokenKind::Intrinsic 0 tokens .get Token::kind == assert_true
     "test" "typeof" lex_source = tokens
-    "typeof" TokenKind::Intrinsic (int) 0 tokens .get Token::kind assert_eq
+    "typeof" TokenKind::Intrinsic 0 tokens .get Token::kind == assert_true
     "test" "exec" lex_source = tokens
-    "exec" TokenKind::Intrinsic (int) 0 tokens .get Token::kind assert_eq
+    "exec" TokenKind::Intrinsic 0 tokens .get Token::kind == assert_true
     "test" "syscall0" lex_source = tokens
-    "syscall0" TokenKind::Intrinsic (int) 0 tokens .get Token::kind assert_eq
+    "syscall0" TokenKind::Intrinsic 0 tokens .get Token::kind == assert_true
     "test" "syscall1" lex_source = tokens
-    "syscall1" TokenKind::Intrinsic (int) 0 tokens .get Token::kind assert_eq
+    "syscall1" TokenKind::Intrinsic 0 tokens .get Token::kind == assert_true
     "test" "syscall2" lex_source = tokens
-    "syscall2" TokenKind::Intrinsic (int) 0 tokens .get Token::kind assert_eq
+    "syscall2" TokenKind::Intrinsic 0 tokens .get Token::kind == assert_true
     "test" "syscall3" lex_source = tokens
-    "syscall3" TokenKind::Intrinsic (int) 0 tokens .get Token::kind assert_eq
+    "syscall3" TokenKind::Intrinsic 0 tokens .get Token::kind == assert_true
     "test" "syscall4" lex_source = tokens
-    "syscall4" TokenKind::Intrinsic (int) 0 tokens .get Token::kind assert_eq
+    "syscall4" TokenKind::Intrinsic 0 tokens .get Token::kind == assert_true
     "test" "syscall5" lex_source = tokens
-    "syscall5" TokenKind::Intrinsic (int) 0 tokens .get Token::kind assert_eq
+    "syscall5" TokenKind::Intrinsic 0 tokens .get Token::kind == assert_true
     "test" "syscall6" lex_source = tokens
-    "syscall6" TokenKind::Intrinsic (int) 0 tokens .get Token::kind assert_eq
+    "syscall6" TokenKind::Intrinsic 0 tokens .get Token::kind == assert_true
     "test" "argc" lex_source = tokens
-    "argc" TokenKind::Intrinsic (int) 0 tokens .get Token::kind assert_eq
+    "argc" TokenKind::Intrinsic 0 tokens .get Token::kind == assert_true
     "test" "argv" lex_source = tokens
-    "argv" TokenKind::Intrinsic (int) 0 tokens .get Token::kind assert_eq
+    "argv" TokenKind::Intrinsic 0 tokens .get Token::kind == assert_true
 }
 
 fn test_namespace_chained {
     "namespace_chained" test_start
     "test" "A::B::c" lex_source = tokens
-    "kind" TokenKind::Identifier (int) 0 tokens .get Token::kind assert_eq
+    "kind" TokenKind::Identifier 0 tokens .get Token::kind == assert_true
     "value" "A::B::c" 0 tokens .get Token::value assert_str_eq
 }
 
@@ -370,8 +370,8 @@ fn test_namespace_in_expression {
     "namespace_in_expression" test_start
     "test" "42 Foo::bar" lex_source = tokens
     "count" 3 tokens .length assert_eq
-    "42 kind" TokenKind::Literal (int) 0 tokens .get Token::kind assert_eq
-    "Foo::bar kind" TokenKind::Identifier (int) 1 tokens .get Token::kind assert_eq
+    "42 kind" TokenKind::Literal 0 tokens .get Token::kind == assert_true
+    "Foo::bar kind" TokenKind::Identifier 1 tokens .get Token::kind == assert_true
     "Foo::bar value" "Foo::bar" 1 tokens .get Token::value assert_str_eq
 }
 
@@ -379,7 +379,7 @@ fn test_hashtag_comment_skips {
     "hashtag_comment_skips" test_start
     "test" "# this is a comment" lex_source = tokens
     "count" 1 tokens .length assert_eq
-    "eof kind" TokenKind::Eof (int) 0 tokens .get Token::kind assert_eq
+    "eof kind" TokenKind::Eof 0 tokens .get Token::kind == assert_true
 }
 
 fn test_comment_at_end_of_file {
@@ -393,7 +393,7 @@ fn test_empty_comment {
     "empty_comment" test_start
     "test" "#" lex_source = tokens
     "count" 1 tokens .length assert_eq
-    "eof kind" TokenKind::Eof (int) 0 tokens .get Token::kind assert_eq
+    "eof kind" TokenKind::Eof 0 tokens .get Token::kind == assert_true
 }
 
 fn test_multiple_comment_lines {
@@ -409,7 +409,7 @@ fn test_whitespace_only {
     "whitespace_only" test_start
     "test" "   \t\n  " lex_source = tokens
     "count" 1 tokens .length assert_eq
-    "eof kind" TokenKind::Eof (int) 0 tokens .get Token::kind assert_eq
+    "eof kind" TokenKind::Eof 0 tokens .get Token::kind == assert_true
 }
 
 fn test_multiple_whitespace_between_tokens {
@@ -440,11 +440,11 @@ fn test_full_expression {
     "full_expression" test_start
     "test" "34 35 + print" lex_source = tokens
     "count" 5 tokens .length assert_eq
-    "34 kind" TokenKind::Literal (int) 0 tokens .get Token::kind assert_eq
-    "35 kind" TokenKind::Literal (int) 1 tokens .get Token::kind assert_eq
-    "+ kind" TokenKind::Operator (int) 2 tokens .get Token::kind assert_eq
-    "print kind" TokenKind::Intrinsic (int) 3 tokens .get Token::kind assert_eq
-    "eof kind" TokenKind::Eof (int) 4 tokens .get Token::kind assert_eq
+    "34 kind" TokenKind::Literal 0 tokens .get Token::kind == assert_true
+    "35 kind" TokenKind::Literal 1 tokens .get Token::kind == assert_true
+    "+ kind" TokenKind::Operator 2 tokens .get Token::kind == assert_true
+    "print kind" TokenKind::Intrinsic 3 tokens .get Token::kind == assert_true
+    "eof kind" TokenKind::Eof 4 tokens .get Token::kind == assert_true
     "34 value" "34" 0 tokens .get Token::value assert_str_eq
     "35 value" "35" 1 tokens .get Token::value assert_str_eq
     "+ value" "+" 2 tokens .get Token::value assert_str_eq
@@ -454,77 +454,77 @@ fn test_full_expression {
 fn test_fstring_empty {
     "fstring_empty" test_start
     "test" "f\"\"" lex_source = tokens
-    "start" TokenKind::FstringStart (int) 0 tokens .get Token::kind assert_eq
-    "end" TokenKind::FstringEnd (int) 1 tokens .get Token::kind assert_eq
+    "start" TokenKind::FstringStart 0 tokens .get Token::kind == assert_true
+    "end" TokenKind::FstringEnd 1 tokens .get Token::kind == assert_true
     "count" 3 tokens .length assert_eq
 }
 
 fn test_fstring_expression_only {
     "fstring_expression_only" test_start
     "test" "f\"{x}\"" lex_source = tokens
-    "start" TokenKind::FstringStart (int) 0 tokens .get Token::kind assert_eq
-    "expr_start" TokenKind::FstringExprStart (int) 1 tokens .get Token::kind assert_eq
-    "identifier" TokenKind::Identifier (int) 2 tokens .get Token::kind assert_eq
+    "start" TokenKind::FstringStart 0 tokens .get Token::kind == assert_true
+    "expr_start" TokenKind::FstringExprStart 1 tokens .get Token::kind == assert_true
+    "identifier" TokenKind::Identifier 2 tokens .get Token::kind == assert_true
     "id value" "x" 2 tokens .get Token::value assert_str_eq
-    "expr_end" TokenKind::FstringExprEnd (int) 3 tokens .get Token::kind assert_eq
-    "end" TokenKind::FstringEnd (int) 4 tokens .get Token::kind assert_eq
+    "expr_end" TokenKind::FstringExprEnd 3 tokens .get Token::kind == assert_true
+    "end" TokenKind::FstringEnd 4 tokens .get Token::kind == assert_true
 }
 
 fn test_fstring_text_and_expression {
     "fstring_text_and_expression" test_start
     "test" "f\"hello {x} world\"" lex_source = tokens
-    "start" TokenKind::FstringStart (int) 0 tokens .get Token::kind assert_eq
-    "text1" TokenKind::FstringText (int) 1 tokens .get Token::kind assert_eq
+    "start" TokenKind::FstringStart 0 tokens .get Token::kind == assert_true
+    "text1" TokenKind::FstringText 1 tokens .get Token::kind == assert_true
     "text1 value" "hello " 1 tokens .get Token::value assert_str_eq
-    "expr_start" TokenKind::FstringExprStart (int) 2 tokens .get Token::kind assert_eq
-    "identifier" TokenKind::Identifier (int) 3 tokens .get Token::kind assert_eq
-    "expr_end" TokenKind::FstringExprEnd (int) 4 tokens .get Token::kind assert_eq
-    "text2" TokenKind::FstringText (int) 5 tokens .get Token::kind assert_eq
+    "expr_start" TokenKind::FstringExprStart 2 tokens .get Token::kind == assert_true
+    "identifier" TokenKind::Identifier 3 tokens .get Token::kind == assert_true
+    "expr_end" TokenKind::FstringExprEnd 4 tokens .get Token::kind == assert_true
+    "text2" TokenKind::FstringText 5 tokens .get Token::kind == assert_true
     "text2 value" " world" 5 tokens .get Token::value assert_str_eq
-    "end" TokenKind::FstringEnd (int) 6 tokens .get Token::kind assert_eq
+    "end" TokenKind::FstringEnd 6 tokens .get Token::kind == assert_true
 }
 
 fn test_fstring_escaped_braces {
     "fstring_escaped_braces" test_start
     "test" "f\"\\{braces\\}\"" lex_source = tokens
-    "start" TokenKind::FstringStart (int) 0 tokens .get Token::kind assert_eq
-    "text" TokenKind::FstringText (int) 1 tokens .get Token::kind assert_eq
+    "start" TokenKind::FstringStart 0 tokens .get Token::kind == assert_true
+    "text" TokenKind::FstringText 1 tokens .get Token::kind == assert_true
     "text value" "{braces}" 1 tokens .get Token::value assert_str_eq
-    "end" TokenKind::FstringEnd (int) 2 tokens .get Token::kind assert_eq
+    "end" TokenKind::FstringEnd 2 tokens .get Token::kind == assert_true
 }
 
 fn test_fstring_escape_sequences {
     "fstring_escape_sequences" test_start
     "test" "f\"hello\\nworld\"" lex_source = tokens
-    "text" TokenKind::FstringText (int) 1 tokens .get Token::kind assert_eq
+    "text" TokenKind::FstringText 1 tokens .get Token::kind == assert_true
     "text value" "hello\nworld" 1 tokens .get Token::value assert_str_eq
 }
 
 fn test_fstring_multiple_expressions {
     "fstring_multiple_expressions" test_start
     "test" "f\"{a} and {b}\"" lex_source = tokens
-    "start" TokenKind::FstringStart (int) 0 tokens .get Token::kind assert_eq
-    "expr_start1" TokenKind::FstringExprStart (int) 1 tokens .get Token::kind assert_eq
-    "id1" TokenKind::Identifier (int) 2 tokens .get Token::kind assert_eq
-    "expr_end1" TokenKind::FstringExprEnd (int) 3 tokens .get Token::kind assert_eq
-    "text" TokenKind::FstringText (int) 4 tokens .get Token::kind assert_eq
+    "start" TokenKind::FstringStart 0 tokens .get Token::kind == assert_true
+    "expr_start1" TokenKind::FstringExprStart 1 tokens .get Token::kind == assert_true
+    "id1" TokenKind::Identifier 2 tokens .get Token::kind == assert_true
+    "expr_end1" TokenKind::FstringExprEnd 3 tokens .get Token::kind == assert_true
+    "text" TokenKind::FstringText 4 tokens .get Token::kind == assert_true
     "text value" " and " 4 tokens .get Token::value assert_str_eq
-    "expr_start2" TokenKind::FstringExprStart (int) 5 tokens .get Token::kind assert_eq
-    "id2" TokenKind::Identifier (int) 6 tokens .get Token::kind assert_eq
-    "expr_end2" TokenKind::FstringExprEnd (int) 7 tokens .get Token::kind assert_eq
-    "end" TokenKind::FstringEnd (int) 8 tokens .get Token::kind assert_eq
+    "expr_start2" TokenKind::FstringExprStart 5 tokens .get Token::kind == assert_true
+    "id2" TokenKind::Identifier 6 tokens .get Token::kind == assert_true
+    "expr_end2" TokenKind::FstringExprEnd 7 tokens .get Token::kind == assert_true
+    "end" TokenKind::FstringEnd 8 tokens .get Token::kind == assert_true
 }
 
 fn test_fstring_complex_expression {
     "fstring_complex_expression" test_start
     "test" "f\"{1 2 +}\"" lex_source = tokens
-    "start" TokenKind::FstringStart (int) 0 tokens .get Token::kind assert_eq
-    "expr_start" TokenKind::FstringExprStart (int) 1 tokens .get Token::kind assert_eq
-    "lit1" TokenKind::Literal (int) 2 tokens .get Token::kind assert_eq
-    "lit2" TokenKind::Literal (int) 3 tokens .get Token::kind assert_eq
-    "op" TokenKind::Operator (int) 4 tokens .get Token::kind assert_eq
-    "expr_end" TokenKind::FstringExprEnd (int) 5 tokens .get Token::kind assert_eq
-    "end" TokenKind::FstringEnd (int) 6 tokens .get Token::kind assert_eq
+    "start" TokenKind::FstringStart 0 tokens .get Token::kind == assert_true
+    "expr_start" TokenKind::FstringExprStart 1 tokens .get Token::kind == assert_true
+    "lit1" TokenKind::Literal 2 tokens .get Token::kind == assert_true
+    "lit2" TokenKind::Literal 3 tokens .get Token::kind == assert_true
+    "op" TokenKind::Operator 4 tokens .get Token::kind == assert_true
+    "expr_end" TokenKind::FstringExprEnd 5 tokens .get Token::kind == assert_true
+    "end" TokenKind::FstringEnd 6 tokens .get Token::kind == assert_true
 }
 
 fn test_locations {
@@ -552,7 +552,7 @@ fn test_escape_span_multiple_escapes {
 fn test_arrow_standalone {
     "arrow_standalone" test_start
     "test" "->" lex_source = tokens
-    "kind" TokenKind::Delimiter (int) 0 tokens .get Token::kind assert_eq
+    "kind" TokenKind::Delimiter 0 tokens .get Token::kind == assert_true
     "value" "->" 0 tokens .get Token::value assert_str_eq
 }
 
@@ -561,7 +561,7 @@ fn test_arrow_with_spaces {
     "test" "a -> b" lex_source = tokens
     "count" 4 tokens .length assert_eq
     "a value" "a" 0 tokens .get Token::value assert_str_eq
-    "arrow kind" TokenKind::Delimiter (int) 1 tokens .get Token::kind assert_eq
+    "arrow kind" TokenKind::Delimiter 1 tokens .get Token::kind == assert_true
     "arrow value" "->" 1 tokens .get Token::value assert_str_eq
     "b value" "b" 2 tokens .get Token::value assert_str_eq
 }
@@ -570,27 +570,27 @@ fn test_arrow_after_identifier {
     "arrow_after_identifier" test_start
     "test" "a->b" lex_source = tokens
     "a value" "a" 0 tokens .get Token::value assert_str_eq
-    "a kind" TokenKind::Identifier (int) 0 tokens .get Token::kind assert_eq
-    "arrow kind" TokenKind::Delimiter (int) 1 tokens .get Token::kind assert_eq
+    "a kind" TokenKind::Identifier 0 tokens .get Token::kind == assert_true
+    "arrow kind" TokenKind::Delimiter 1 tokens .get Token::kind == assert_true
     "arrow value" "->" 1 tokens .get Token::value assert_str_eq
     "b value" "b" 2 tokens .get Token::value assert_str_eq
-    "b kind" TokenKind::Identifier (int) 2 tokens .get Token::kind assert_eq
+    "b kind" TokenKind::Identifier 2 tokens .get Token::kind == assert_true
 }
 
 fn test_arrow_in_function_signature {
     "arrow_in_function_signature" test_start
     "test" "fn foo x:int -> int" lex_source = tokens
-    "arrow kind" TokenKind::Delimiter (int) 5 tokens .get Token::kind assert_eq
+    "arrow kind" TokenKind::Delimiter 5 tokens .get Token::kind == assert_true
     "arrow value" "->" 5 tokens .get Token::value assert_str_eq
 }
 
 fn test_arrow_setter_syntax {
     "arrow_setter_syntax" test_start
     "test" "\"Jane\" person->name" lex_source = tokens
-    "jane kind" TokenKind::Literal (int) 0 tokens .get Token::kind assert_eq
+    "jane kind" TokenKind::Literal 0 tokens .get Token::kind == assert_true
     "jane value" "\"Jane\"" 0 tokens .get Token::value assert_str_eq
     "person value" "person" 1 tokens .get Token::value assert_str_eq
-    "arrow kind" TokenKind::Delimiter (int) 2 tokens .get Token::kind assert_eq
+    "arrow kind" TokenKind::Delimiter 2 tokens .get Token::kind == assert_true
     "arrow value" "->" 2 tokens .get Token::value assert_str_eq
     "name value" "name" 3 tokens .get Token::value assert_str_eq
 }
@@ -598,7 +598,7 @@ fn test_arrow_setter_syntax {
 fn test_function_reference {
     "function_reference" test_start
     "test" "&foo" lex_source = tokens
-    "kind" TokenKind::Identifier (int) 0 tokens .get Token::kind assert_eq
+    "kind" TokenKind::Identifier 0 tokens .get Token::kind == assert_true
     "value" "&foo" 0 tokens .get Token::value assert_str_eq
 }
 
@@ -606,11 +606,11 @@ fn test_struct_instantiation {
     "struct_instantiation" test_start
     "test" "18 \"John\" Person" lex_source = tokens
     "count" 4 tokens .length assert_eq
-    "18 kind" TokenKind::Literal (int) 0 tokens .get Token::kind assert_eq
+    "18 kind" TokenKind::Literal 0 tokens .get Token::kind == assert_true
     "18 value" "18" 0 tokens .get Token::value assert_str_eq
-    "john kind" TokenKind::Literal (int) 1 tokens .get Token::kind assert_eq
+    "john kind" TokenKind::Literal 1 tokens .get Token::kind == assert_true
     "john value" "\"John\"" 1 tokens .get Token::value assert_str_eq
-    "person kind" TokenKind::Identifier (int) 2 tokens .get Token::kind assert_eq
+    "person kind" TokenKind::Identifier 2 tokens .get Token::kind == assert_true
     "person value" "Person" 2 tokens .get Token::value assert_str_eq
 }
 
@@ -618,7 +618,7 @@ fn test_dot_accessor {
     "dot_accessor" test_start
     "test" "person.name" lex_source = tokens
     "person value" "person" 0 tokens .get Token::value assert_str_eq
-    "dot kind" TokenKind::Delimiter (int) 1 tokens .get Token::kind assert_eq
+    "dot kind" TokenKind::Delimiter 1 tokens .get Token::kind == assert_true
     "dot value" "." 1 tokens .get Token::value assert_str_eq
     "name value" "name" 2 tokens .get Token::value assert_str_eq
 }
@@ -626,11 +626,11 @@ fn test_dot_accessor {
 fn test_type_cast {
     "type_cast" test_start
     "test" "(SomeType)" lex_source = tokens
-    "open kind" TokenKind::Delimiter (int) 0 tokens .get Token::kind assert_eq
+    "open kind" TokenKind::Delimiter 0 tokens .get Token::kind == assert_true
     "open value" "(" 0 tokens .get Token::value assert_str_eq
-    "type kind" TokenKind::Identifier (int) 1 tokens .get Token::kind assert_eq
+    "type kind" TokenKind::Identifier 1 tokens .get Token::kind == assert_true
     "type value" "SomeType" 1 tokens .get Token::value assert_str_eq
-    "close kind" TokenKind::Delimiter (int) 2 tokens .get Token::kind assert_eq
+    "close kind" TokenKind::Delimiter 2 tokens .get Token::kind == assert_true
     "close value" ")" 2 tokens .get Token::value assert_str_eq
 }
 
@@ -649,65 +649,65 @@ fn test_array_literal {
 fn test_lambda_block {
     "lambda_block" test_start
     "test" "{ 2 * }" lex_source = tokens
-    "open kind" TokenKind::Delimiter (int) 0 tokens .get Token::kind assert_eq
+    "open kind" TokenKind::Delimiter 0 tokens .get Token::kind == assert_true
     "open value" "{" 0 tokens .get Token::value assert_str_eq
-    "close kind" TokenKind::Delimiter (int) 3 tokens .get Token::kind assert_eq
+    "close kind" TokenKind::Delimiter 3 tokens .get Token::kind == assert_true
     "close value" "}" 3 tokens .get Token::value assert_str_eq
 }
 
 fn test_none_is_identifier {
     "none_is_identifier" test_start
     "test" "none" lex_source = tokens
-    "kind" TokenKind::Identifier (int) 0 tokens .get Token::kind assert_eq
+    "kind" TokenKind::Identifier 0 tokens .get Token::kind == assert_true
     "value" "none" 0 tokens .get Token::value assert_str_eq
 }
 
 fn test_some_is_identifier {
     "some_is_identifier" test_start
     "test" "some" lex_source = tokens
-    "kind" TokenKind::Identifier (int) 0 tokens .get Token::kind assert_eq
+    "kind" TokenKind::Identifier 0 tokens .get Token::kind == assert_true
     "value" "some" 0 tokens .get Token::value assert_str_eq
 }
 
 fn test_string_escape_newline {
     "string_escape_newline" test_start
     "test" "\"hello\\nworld\"" lex_source = tokens
-    "kind" TokenKind::Literal (int) 0 tokens .get Token::kind assert_eq
+    "kind" TokenKind::Literal 0 tokens .get Token::kind == assert_true
     "value" "\"hello\nworld\"" 0 tokens .get Token::value assert_str_eq
 }
 
 fn test_string_escape_tab {
     "string_escape_tab" test_start
     "test" "\"hello\\tworld\"" lex_source = tokens
-    "kind" TokenKind::Literal (int) 0 tokens .get Token::kind assert_eq
+    "kind" TokenKind::Literal 0 tokens .get Token::kind == assert_true
     "value" "\"hello\tworld\"" 0 tokens .get Token::value assert_str_eq
 }
 
 fn test_string_escape_backslash {
     "string_escape_backslash" test_start
     "test" "\"hello\\\\world\"" lex_source = tokens
-    "kind" TokenKind::Literal (int) 0 tokens .get Token::kind assert_eq
+    "kind" TokenKind::Literal 0 tokens .get Token::kind == assert_true
     "value" "\"hello\\world\"" 0 tokens .get Token::value assert_str_eq
 }
 
 fn test_string_escape_quote {
     "string_escape_quote" test_start
     "test" "\"hello\\\"world\"" lex_source = tokens
-    "kind" TokenKind::Literal (int) 0 tokens .get Token::kind assert_eq
+    "kind" TokenKind::Literal 0 tokens .get Token::kind == assert_true
     "value" "\"hello\"world\"" 0 tokens .get Token::value assert_str_eq
 }
 
 fn test_string_escape_null {
     "string_escape_null" test_start
     "test" "\"hello\\0world\"" lex_source = tokens
-    "kind" TokenKind::Literal (int) 0 tokens .get Token::kind assert_eq
+    "kind" TokenKind::Literal 0 tokens .get Token::kind == assert_true
     "value" "\"hello\0world\"" 0 tokens .get Token::value assert_str_eq
 }
 
 fn test_string_escape_carriage_return {
     "string_escape_carriage_return" test_start
     "test" "\"hello\\rworld\"" lex_source = tokens
-    "kind" TokenKind::Literal (int) 0 tokens .get Token::kind assert_eq
+    "kind" TokenKind::Literal 0 tokens .get Token::kind == assert_true
     "value" "\"hello\rworld\"" 0 tokens .get Token::value assert_str_eq
 }
 
@@ -720,7 +720,7 @@ fn test_string_multiple_escapes {
 fn test_string_escaped_quote_does_not_terminate {
     "string_escaped_quote_does_not_terminate" test_start
     "test" "\"say \\\"hi\\\"\"" lex_source = tokens
-    "kind" TokenKind::Literal (int) 0 tokens .get Token::kind assert_eq
+    "kind" TokenKind::Literal 0 tokens .get Token::kind == assert_true
     "value" "\"say \"hi\"\"" 0 tokens .get Token::value assert_str_eq
 }
 
@@ -755,17 +755,17 @@ fn test_string_adjacent_backslash_then_n {
 fn test_fat_arrow_delimiter {
     "fat_arrow_delimiter" test_start
     "test" "=>" lex_source = tokens
-    "kind" TokenKind::Delimiter (int) 0 tokens .get Token::kind assert_eq
+    "kind" TokenKind::Delimiter 0 tokens .get Token::kind == assert_true
     "value" "=>" 0 tokens .get Token::value assert_str_eq
 }
 
 fn test_fat_arrow_in_match {
     "fat_arrow_in_match" test_start
     "test" "Up => 1" lex_source = tokens
-    "Up kind" TokenKind::Identifier (int) 0 tokens .get Token::kind assert_eq
-    "arrow kind" TokenKind::Delimiter (int) 1 tokens .get Token::kind assert_eq
+    "Up kind" TokenKind::Identifier 0 tokens .get Token::kind == assert_true
+    "arrow kind" TokenKind::Delimiter 1 tokens .get Token::kind == assert_true
     "arrow value" "=>" 1 tokens .get Token::value assert_str_eq
-    "1 kind" TokenKind::Literal (int) 2 tokens .get Token::kind assert_eq
+    "1 kind" TokenKind::Literal 2 tokens .get Token::kind == assert_true
 }
 
 # ============================================================================
@@ -775,28 +775,28 @@ fn test_fat_arrow_in_match {
 fn test_typeof_intrinsic {
     "typeof_intrinsic" test_start
     "test" "typeof" lex_source = tokens
-    "kind" TokenKind::Intrinsic (int) 0 tokens .get Token::kind assert_eq
+    "kind" TokenKind::Intrinsic 0 tokens .get Token::kind == assert_true
     "value" "typeof" 0 tokens .get Token::value assert_str_eq
 }
 
 fn test_argc_intrinsic {
     "argc_intrinsic" test_start
     "test" "argc" lex_source = tokens
-    "kind" TokenKind::Intrinsic (int) 0 tokens .get Token::kind assert_eq
+    "kind" TokenKind::Intrinsic 0 tokens .get Token::kind == assert_true
     "value" "argc" 0 tokens .get Token::value assert_str_eq
 }
 
 fn test_argv_intrinsic {
     "argv_intrinsic" test_start
     "test" "argv" lex_source = tokens
-    "kind" TokenKind::Intrinsic (int) 0 tokens .get Token::kind assert_eq
+    "kind" TokenKind::Intrinsic 0 tokens .get Token::kind == assert_true
     "value" "argv" 0 tokens .get Token::value assert_str_eq
 }
 
 fn test_exec_intrinsic {
     "exec_intrinsic" test_start
     "test" "exec" lex_source = tokens
-    "kind" TokenKind::Intrinsic (int) 0 tokens .get Token::kind assert_eq
+    "kind" TokenKind::Intrinsic 0 tokens .get Token::kind == assert_true
     "value" "exec" 0 tokens .get Token::value assert_str_eq
 }
 
@@ -807,42 +807,42 @@ fn test_exec_intrinsic {
 fn test_enum_keyword {
     "enum_keyword" test_start
     "test" "enum" lex_source = tokens
-    "kind" TokenKind::Keyword (int) 0 tokens .get Token::kind assert_eq
+    "kind" TokenKind::Keyword 0 tokens .get Token::kind == assert_true
     "value" "enum" 0 tokens .get Token::value assert_str_eq
 }
 
 fn test_struct_keyword {
     "struct_keyword" test_start
     "test" "struct" lex_source = tokens
-    "kind" TokenKind::Keyword (int) 0 tokens .get Token::kind assert_eq
+    "kind" TokenKind::Keyword 0 tokens .get Token::kind == assert_true
     "value" "struct" 0 tokens .get Token::value assert_str_eq
 }
 
 fn test_trait_keyword {
     "trait_keyword" test_start
     "test" "trait" lex_source = tokens
-    "kind" TokenKind::Keyword (int) 0 tokens .get Token::kind assert_eq
+    "kind" TokenKind::Keyword 0 tokens .get Token::kind == assert_true
     "value" "trait" 0 tokens .get Token::value assert_str_eq
 }
 
 fn test_match_keyword {
     "match_keyword" test_start
     "test" "match" lex_source = tokens
-    "kind" TokenKind::Keyword (int) 0 tokens .get Token::kind assert_eq
+    "kind" TokenKind::Keyword 0 tokens .get Token::kind == assert_true
     "value" "match" 0 tokens .get Token::value assert_str_eq
 }
 
 fn test_is_keyword {
     "is_keyword" test_start
     "test" "is" lex_source = tokens
-    "kind" TokenKind::Keyword (int) 0 tokens .get Token::kind assert_eq
+    "kind" TokenKind::Keyword 0 tokens .get Token::kind == assert_true
     "value" "is" 0 tokens .get Token::value assert_str_eq
 }
 
 fn test_include_keyword {
     "include_keyword" test_start
     "test" "include" lex_source = tokens
-    "kind" TokenKind::Keyword (int) 0 tokens .get Token::kind assert_eq
+    "kind" TokenKind::Keyword 0 tokens .get Token::kind == assert_true
     "value" "include" 0 tokens .get Token::value assert_str_eq
 }
 

--- a/tests/self_hosted/test_parser.casa
+++ b/tests/self_hosted/test_parser.casa
@@ -13,7 +13,7 @@ fn test_parse_integer {
     "test" "42" lex_source = tokens
     tokens parse_ops = ops
     "count" 1 ops .length assert_eq
-    "kind" OpKind::OpPushInt (int) 0 ops .get Op::kind assert_eq
+    "kind" OpKind::OpPushInt 0 ops .get Op::kind == assert_true
     "value" 42 0 ops .get Op::value assert_eq
 }
 
@@ -22,7 +22,7 @@ fn test_parse_negative_integer {
     "test" "-7" lex_source = tokens
     tokens parse_ops = ops
     "count" 1 ops .length assert_eq
-    "kind" OpKind::OpPushInt (int) 0 ops .get Op::kind assert_eq
+    "kind" OpKind::OpPushInt 0 ops .get Op::kind == assert_true
     "value" 0 7 - 0 ops .get Op::value assert_eq
 }
 
@@ -31,7 +31,7 @@ fn test_parse_bool_true {
     "test" "true" lex_source = tokens
     tokens parse_ops = ops
     "count" 1 ops .length assert_eq
-    "kind" OpKind::OpPushBool (int) 0 ops .get Op::kind assert_eq
+    "kind" OpKind::OpPushBool 0 ops .get Op::kind == assert_true
     "value" 1 0 ops .get Op::value assert_eq
 }
 
@@ -40,7 +40,7 @@ fn test_parse_bool_false {
     "test" "false" lex_source = tokens
     tokens parse_ops = ops
     "count" 1 ops .length assert_eq
-    "kind" OpKind::OpPushBool (int) 0 ops .get Op::kind assert_eq
+    "kind" OpKind::OpPushBool 0 ops .get Op::kind == assert_true
     "value" 0 0 ops .get Op::value assert_eq
 }
 
@@ -49,7 +49,7 @@ fn test_parse_string {
     "test" "\"hello\"" lex_source = tokens
     tokens parse_ops = ops
     "count" 1 ops .length assert_eq
-    "kind" OpKind::OpPushStr (int) 0 ops .get Op::kind assert_eq
+    "kind" OpKind::OpPushStr 0 ops .get Op::kind == assert_true
     "value" "hello" 0 ops .get op_str_value assert_str_eq
 }
 
@@ -58,7 +58,7 @@ fn test_parse_char {
     "test" "'A'" lex_source = tokens
     tokens parse_ops = ops
     "count" 1 ops .length assert_eq
-    "kind" OpKind::OpPushChar (int) 0 ops .get Op::kind assert_eq
+    "kind" OpKind::OpPushChar 0 ops .get Op::kind == assert_true
     "value" 65 0 ops .get Op::value assert_eq
 }
 
@@ -70,56 +70,56 @@ fn test_parse_keyword_if {
     "parse_keyword_if" test_start
     "test" "if" lex_source = tokens
     tokens parse_ops = ops
-    "kind" OpKind::OpIfStart (int) 0 ops .get Op::kind assert_eq
+    "kind" OpKind::OpIfStart 0 ops .get Op::kind == assert_true
 }
 
 fn test_parse_keyword_then {
     "parse_keyword_then" test_start
     "test" "then" lex_source = tokens
     tokens parse_ops = ops
-    "kind" OpKind::OpIfCondition (int) 0 ops .get Op::kind assert_eq
+    "kind" OpKind::OpIfCondition 0 ops .get Op::kind == assert_true
 }
 
 fn test_parse_keyword_else {
     "parse_keyword_else" test_start
     "test" "else" lex_source = tokens
     tokens parse_ops = ops
-    "kind" OpKind::OpIfElse (int) 0 ops .get Op::kind assert_eq
+    "kind" OpKind::OpIfElse 0 ops .get Op::kind == assert_true
 }
 
 fn test_parse_keyword_fi {
     "parse_keyword_fi" test_start
     "test" "fi" lex_source = tokens
     tokens parse_ops = ops
-    "kind" OpKind::OpIfEnd (int) 0 ops .get Op::kind assert_eq
+    "kind" OpKind::OpIfEnd 0 ops .get Op::kind == assert_true
 }
 
 fn test_parse_keyword_while {
     "parse_keyword_while" test_start
     "test" "while" lex_source = tokens
     tokens parse_ops = ops
-    "kind" OpKind::OpWhileStart (int) 0 ops .get Op::kind assert_eq
+    "kind" OpKind::OpWhileStart 0 ops .get Op::kind == assert_true
 }
 
 fn test_parse_keyword_do {
     "parse_keyword_do" test_start
     "test" "do" lex_source = tokens
     tokens parse_ops = ops
-    "kind" OpKind::OpWhileCondition (int) 0 ops .get Op::kind assert_eq
+    "kind" OpKind::OpWhileCondition 0 ops .get Op::kind == assert_true
 }
 
 fn test_parse_keyword_done {
     "parse_keyword_done" test_start
     "test" "done" lex_source = tokens
     tokens parse_ops = ops
-    "kind" OpKind::OpWhileEnd (int) 0 ops .get Op::kind assert_eq
+    "kind" OpKind::OpWhileEnd 0 ops .get Op::kind == assert_true
 }
 
 fn test_parse_keyword_return {
     "parse_keyword_return" test_start
     "test" "return" lex_source = tokens
     tokens parse_ops = ops
-    "kind" OpKind::OpFnReturn (int) 0 ops .get Op::kind assert_eq
+    "kind" OpKind::OpFnReturn 0 ops .get Op::kind == assert_true
 }
 
 # ============================================================================
@@ -130,42 +130,42 @@ fn test_parse_operator_add {
     "parse_operator_add" test_start
     "test" "+" lex_source = tokens
     tokens parse_ops = ops
-    "kind" OpKind::OpAdd (int) 0 ops .get Op::kind assert_eq
+    "kind" OpKind::OpAdd 0 ops .get Op::kind == assert_true
 }
 
 fn test_parse_operator_sub {
     "parse_operator_sub" test_start
     "test" "1 -" lex_source = tokens
     tokens parse_ops = ops
-    "kind" OpKind::OpSub (int) 1 ops .get Op::kind assert_eq
+    "kind" OpKind::OpSub 1 ops .get Op::kind == assert_true
 }
 
 fn test_parse_operator_eq {
     "parse_operator_eq" test_start
     "test" "==" lex_source = tokens
     tokens parse_ops = ops
-    "kind" OpKind::OpEq (int) 0 ops .get Op::kind assert_eq
+    "kind" OpKind::OpEq 0 ops .get Op::kind == assert_true
 }
 
 fn test_parse_operator_not {
     "parse_operator_not" test_start
     "test" "!" lex_source = tokens
     tokens parse_ops = ops
-    "kind" OpKind::OpNot (int) 0 ops .get Op::kind assert_eq
+    "kind" OpKind::OpNot 0 ops .get Op::kind == assert_true
 }
 
 fn test_parse_operator_and {
     "parse_operator_and" test_start
     "test" "&&" lex_source = tokens
     tokens parse_ops = ops
-    "kind" OpKind::OpAnd (int) 0 ops .get Op::kind assert_eq
+    "kind" OpKind::OpAnd 0 ops .get Op::kind == assert_true
 }
 
 fn test_parse_operator_or {
     "parse_operator_or" test_start
     "test" "||" lex_source = tokens
     tokens parse_ops = ops
-    "kind" OpKind::OpOr (int) 0 ops .get Op::kind assert_eq
+    "kind" OpKind::OpOr 0 ops .get Op::kind == assert_true
 }
 
 # ============================================================================
@@ -176,28 +176,28 @@ fn test_parse_intrinsic_drop {
     "parse_intrinsic_drop" test_start
     "test" "drop" lex_source = tokens
     tokens parse_ops = ops
-    "kind" OpKind::OpDrop (int) 0 ops .get Op::kind assert_eq
+    "kind" OpKind::OpDrop 0 ops .get Op::kind == assert_true
 }
 
 fn test_parse_intrinsic_dup {
     "parse_intrinsic_dup" test_start
     "test" "dup" lex_source = tokens
     tokens parse_ops = ops
-    "kind" OpKind::OpDup (int) 0 ops .get Op::kind assert_eq
+    "kind" OpKind::OpDup 0 ops .get Op::kind == assert_true
 }
 
 fn test_parse_intrinsic_swap {
     "parse_intrinsic_swap" test_start
     "test" "swap" lex_source = tokens
     tokens parse_ops = ops
-    "kind" OpKind::OpSwap (int) 0 ops .get Op::kind assert_eq
+    "kind" OpKind::OpSwap 0 ops .get Op::kind == assert_true
 }
 
 fn test_parse_intrinsic_print {
     "parse_intrinsic_print" test_start
     "test" "print" lex_source = tokens
     tokens parse_ops = ops
-    "kind" OpKind::OpPrint (int) 0 ops .get Op::kind assert_eq
+    "kind" OpKind::OpPrint 0 ops .get Op::kind == assert_true
 }
 
 # ============================================================================
@@ -209,7 +209,7 @@ fn test_parse_type_cast {
     "test" "(int)" lex_source = tokens
     tokens parse_ops = ops
     "count" 1 ops .length assert_eq
-    "kind" OpKind::OpTypeCast (int) 0 ops .get Op::kind assert_eq
+    "kind" OpKind::OpTypeCast 0 ops .get Op::kind == assert_true
     "value" "int" 0 ops .get op_str_value assert_str_eq
 }
 
@@ -217,7 +217,7 @@ fn test_parse_type_cast_str {
     "parse_type_cast_str" test_start
     "test" "(str)" lex_source = tokens
     tokens parse_ops = ops
-    "kind" OpKind::OpTypeCast (int) 0 ops .get Op::kind assert_eq
+    "kind" OpKind::OpTypeCast 0 ops .get Op::kind == assert_true
     "value" "str" 0 ops .get op_str_value assert_str_eq
 }
 
@@ -230,8 +230,8 @@ fn test_parse_variable_assign {
     "test" "42 = foo" lex_source = tokens
     tokens parse_ops = ops
     "count" 2 ops .length assert_eq
-    "push kind" OpKind::OpPushInt (int) 0 ops .get Op::kind assert_eq
-    "assign kind" OpKind::OpAssignVar (int) 1 ops .get Op::kind assert_eq
+    "push kind" OpKind::OpPushInt 0 ops .get Op::kind == assert_true
+    "assign kind" OpKind::OpAssignVar 1 ops .get Op::kind == assert_true
     "assign name" "foo" 1 ops .get op_str_value assert_str_eq
 }
 
@@ -239,8 +239,8 @@ fn test_parse_variable_inc {
     "parse_variable_inc" test_start
     "test" "1 += counter" lex_source = tokens
     tokens parse_ops = ops
-    "push kind" OpKind::OpPushInt (int) 0 ops .get Op::kind assert_eq
-    "inc kind" OpKind::OpAssignInc (int) 1 ops .get Op::kind assert_eq
+    "push kind" OpKind::OpPushInt 0 ops .get Op::kind == assert_true
+    "inc kind" OpKind::OpAssignInc 1 ops .get Op::kind == assert_true
     "inc name" "counter" 1 ops .get op_str_value assert_str_eq
 }
 
@@ -252,7 +252,7 @@ fn test_parse_method_call {
     "parse_method_call" test_start
     "test" ".length" lex_source = tokens
     tokens parse_ops = ops
-    "kind" OpKind::OpMethodCall (int) 0 ops .get Op::kind assert_eq
+    "kind" OpKind::OpMethodCall 0 ops .get Op::kind == assert_true
     "value" "length" 0 ops .get op_str_value assert_str_eq
 }
 
@@ -260,7 +260,7 @@ fn test_parse_setter_call {
     "parse_setter_call" test_start
     "test" "->name" lex_source = tokens
     tokens parse_ops = ops
-    "kind" OpKind::OpMethodCall (int) 0 ops .get Op::kind assert_eq
+    "kind" OpKind::OpMethodCall 0 ops .get Op::kind == assert_true
     "value" "set_name" 0 ops .get op_str_value assert_str_eq
 }
 
@@ -272,7 +272,7 @@ fn test_parse_identifier {
     "parse_identifier" test_start
     "test" "foo" lex_source = tokens
     tokens parse_ops = ops
-    "kind" OpKind::OpIdentifier (int) 0 ops .get Op::kind assert_eq
+    "kind" OpKind::OpIdentifier 0 ops .get Op::kind == assert_true
     "value" "foo" 0 ops .get op_str_value assert_str_eq
 }
 
@@ -334,24 +334,24 @@ fn test_parse_if_construct {
     "parse_if_construct" test_start
     "test" "if true then 42 else 0 fi" lex_source = tokens
     tokens parse_ops = ops
-    "if" OpKind::OpIfStart (int) 0 ops .get Op::kind assert_eq
-    "true" OpKind::OpPushBool (int) 1 ops .get Op::kind assert_eq
-    "then" OpKind::OpIfCondition (int) 2 ops .get Op::kind assert_eq
-    "42" OpKind::OpPushInt (int) 3 ops .get Op::kind assert_eq
-    "else" OpKind::OpIfElse (int) 4 ops .get Op::kind assert_eq
-    "0" OpKind::OpPushInt (int) 5 ops .get Op::kind assert_eq
-    "fi" OpKind::OpIfEnd (int) 6 ops .get Op::kind assert_eq
+    "if" OpKind::OpIfStart 0 ops .get Op::kind == assert_true
+    "true" OpKind::OpPushBool 1 ops .get Op::kind == assert_true
+    "then" OpKind::OpIfCondition 2 ops .get Op::kind == assert_true
+    "42" OpKind::OpPushInt 3 ops .get Op::kind == assert_true
+    "else" OpKind::OpIfElse 4 ops .get Op::kind == assert_true
+    "0" OpKind::OpPushInt 5 ops .get Op::kind == assert_true
+    "fi" OpKind::OpIfEnd 6 ops .get Op::kind == assert_true
 }
 
 fn test_parse_while_construct {
     "parse_while_construct" test_start
     "test" "while true do break done" lex_source = tokens
     tokens parse_ops = ops
-    "while" OpKind::OpWhileStart (int) 0 ops .get Op::kind assert_eq
-    "true" OpKind::OpPushBool (int) 1 ops .get Op::kind assert_eq
-    "do" OpKind::OpWhileCondition (int) 2 ops .get Op::kind assert_eq
-    "break" OpKind::OpWhileBreak (int) 3 ops .get Op::kind assert_eq
-    "done" OpKind::OpWhileEnd (int) 4 ops .get Op::kind assert_eq
+    "while" OpKind::OpWhileStart 0 ops .get Op::kind == assert_true
+    "true" OpKind::OpPushBool 1 ops .get Op::kind == assert_true
+    "do" OpKind::OpWhileCondition 2 ops .get Op::kind == assert_true
+    "break" OpKind::OpWhileBreak 3 ops .get Op::kind == assert_true
+    "done" OpKind::OpWhileEnd 4 ops .get Op::kind == assert_true
 }
 
 # ============================================================================
@@ -362,7 +362,7 @@ fn test_parse_match_construct {
     "parse_match_construct" test_start
     "test" "enum Dir { Up Down }\nmatch Up => 1 Down => 2 end" lex_source = tokens
     tokens parse_ops = ops
-    "match start" OpKind::OpMatchStart (int) 0 ops .get Op::kind assert_eq
+    "match start" OpKind::OpMatchStart 0 ops .get Op::kind == assert_true
 }
 
 # ============================================================================
@@ -374,10 +374,10 @@ fn test_parse_multiple_ops {
     "test" "1 2 + = result" lex_source = tokens
     tokens parse_ops = ops
     "count" 4 ops .length assert_eq
-    "push 1" OpKind::OpPushInt (int) 0 ops .get Op::kind assert_eq
-    "push 2" OpKind::OpPushInt (int) 1 ops .get Op::kind assert_eq
-    "add" OpKind::OpAdd (int) 2 ops .get Op::kind assert_eq
-    "assign" OpKind::OpAssignVar (int) 3 ops .get Op::kind assert_eq
+    "push 1" OpKind::OpPushInt 0 ops .get Op::kind == assert_true
+    "push 2" OpKind::OpPushInt 1 ops .get Op::kind == assert_true
+    "add" OpKind::OpAdd 2 ops .get Op::kind == assert_true
+    "assign" OpKind::OpAssignVar 3 ops .get Op::kind == assert_true
 }
 
 # ============================================================================
@@ -388,63 +388,63 @@ fn test_parse_operator_mul {
     "parse_operator_mul" test_start
     "test" "1 2 *" lex_source = tokens
     tokens parse_ops = ops
-    "kind" OpKind::OpMul (int) 2 ops .get Op::kind assert_eq
+    "kind" OpKind::OpMul 2 ops .get Op::kind == assert_true
 }
 
 fn test_parse_operator_div {
     "parse_operator_div" test_start
     "test" "1 2 /" lex_source = tokens
     tokens parse_ops = ops
-    "kind" OpKind::OpDiv (int) 2 ops .get Op::kind assert_eq
+    "kind" OpKind::OpDiv 2 ops .get Op::kind == assert_true
 }
 
 fn test_parse_operator_mod {
     "parse_operator_mod" test_start
     "test" "1 2 %" lex_source = tokens
     tokens parse_ops = ops
-    "kind" OpKind::OpMod (int) 2 ops .get Op::kind assert_eq
+    "kind" OpKind::OpMod 2 ops .get Op::kind == assert_true
 }
 
 fn test_parse_operator_lt {
     "parse_operator_lt" test_start
     "test" "1 2 <" lex_source = tokens
     tokens parse_ops = ops
-    "kind" OpKind::OpLt (int) 2 ops .get Op::kind assert_eq
+    "kind" OpKind::OpLt 2 ops .get Op::kind == assert_true
 }
 
 fn test_parse_operator_gt {
     "parse_operator_gt" test_start
     "test" "1 2 >" lex_source = tokens
     tokens parse_ops = ops
-    "kind" OpKind::OpGt (int) 2 ops .get Op::kind assert_eq
+    "kind" OpKind::OpGt 2 ops .get Op::kind == assert_true
 }
 
 fn test_parse_operator_le {
     "parse_operator_le" test_start
     "test" "1 2 <=" lex_source = tokens
     tokens parse_ops = ops
-    "kind" OpKind::OpLe (int) 2 ops .get Op::kind assert_eq
+    "kind" OpKind::OpLe 2 ops .get Op::kind == assert_true
 }
 
 fn test_parse_operator_ge {
     "parse_operator_ge" test_start
     "test" "1 2 >=" lex_source = tokens
     tokens parse_ops = ops
-    "kind" OpKind::OpGe (int) 2 ops .get Op::kind assert_eq
+    "kind" OpKind::OpGe 2 ops .get Op::kind == assert_true
 }
 
 fn test_parse_operator_ne {
     "parse_operator_ne" test_start
     "test" "1 2 !=" lex_source = tokens
     tokens parse_ops = ops
-    "kind" OpKind::OpNe (int) 2 ops .get Op::kind assert_eq
+    "kind" OpKind::OpNe 2 ops .get Op::kind == assert_true
 }
 
 fn test_parse_operator_bit_not {
     "parse_operator_bit_not" test_start
     "test" "1 ~" lex_source = tokens
     tokens parse_ops = ops
-    "kind" OpKind::OpBitNot (int) 1 ops .get Op::kind assert_eq
+    "kind" OpKind::OpBitNot 1 ops .get Op::kind == assert_true
 }
 
 # ============================================================================
@@ -455,28 +455,28 @@ fn test_parse_intrinsic_over {
     "parse_intrinsic_over" test_start
     "test" "over" lex_source = tokens
     tokens parse_ops = ops
-    "kind" OpKind::OpOver (int) 0 ops .get Op::kind assert_eq
+    "kind" OpKind::OpOver 0 ops .get Op::kind == assert_true
 }
 
 fn test_parse_intrinsic_rot {
     "parse_intrinsic_rot" test_start
     "test" "rot" lex_source = tokens
     tokens parse_ops = ops
-    "kind" OpKind::OpRot (int) 0 ops .get Op::kind assert_eq
+    "kind" OpKind::OpRot 0 ops .get Op::kind == assert_true
 }
 
 fn test_parse_intrinsic_typeof {
     "parse_intrinsic_typeof" test_start
     "test" "typeof" lex_source = tokens
     tokens parse_ops = ops
-    "kind" OpKind::OpTypeof (int) 0 ops .get Op::kind assert_eq
+    "kind" OpKind::OpTypeof 0 ops .get Op::kind == assert_true
 }
 
 fn test_parse_intrinsic_alloc {
     "parse_intrinsic_alloc" test_start
     "test" "alloc" lex_source = tokens
     tokens parse_ops = ops
-    "kind" OpKind::OpHeapAlloc (int) 0 ops .get Op::kind assert_eq
+    "kind" OpKind::OpHeapAlloc 0 ops .get Op::kind == assert_true
 }
 
 # ============================================================================
@@ -487,8 +487,8 @@ fn test_parse_variable_dec {
     "parse_variable_dec" test_start
     "test" "1 -= counter" lex_source = tokens
     tokens parse_ops = ops
-    "push kind" OpKind::OpPushInt (int) 0 ops .get Op::kind assert_eq
-    "dec kind" OpKind::OpAssignDec (int) 1 ops .get Op::kind assert_eq
+    "push kind" OpKind::OpPushInt 0 ops .get Op::kind == assert_true
+    "dec kind" OpKind::OpAssignDec 1 ops .get Op::kind == assert_true
     "dec name" "counter" 1 ops .get op_str_value assert_str_eq
 }
 
@@ -500,7 +500,7 @@ fn test_parse_keyword_elif {
     "parse_keyword_elif" test_start
     "test" "elif" lex_source = tokens
     tokens parse_ops = ops
-    "kind" OpKind::OpIfElif (int) 0 ops .get Op::kind assert_eq
+    "kind" OpKind::OpIfElif 0 ops .get Op::kind == assert_true
 }
 
 # ============================================================================
@@ -511,14 +511,14 @@ fn test_parse_keyword_break {
     "parse_keyword_break" test_start
     "test" "break" lex_source = tokens
     tokens parse_ops = ops
-    "kind" OpKind::OpWhileBreak (int) 0 ops .get Op::kind assert_eq
+    "kind" OpKind::OpWhileBreak 0 ops .get Op::kind == assert_true
 }
 
 fn test_parse_keyword_continue {
     "parse_keyword_continue" test_start
     "test" "continue" lex_source = tokens
     tokens parse_ops = ops
-    "kind" OpKind::OpWhileContinue (int) 0 ops .get Op::kind assert_eq
+    "kind" OpKind::OpWhileContinue 0 ops .get Op::kind == assert_true
 }
 
 # ============================================================================
@@ -530,7 +530,7 @@ fn test_parse_string_with_escapes {
     "test" "\"hello\\nworld\"" lex_source = tokens
     tokens parse_ops = ops
     "count" 1 ops .length assert_eq
-    "kind" OpKind::OpPushStr (int) 0 ops .get Op::kind assert_eq
+    "kind" OpKind::OpPushStr 0 ops .get Op::kind == assert_true
     "value" "hello\nworld" 0 ops .get op_str_value assert_str_eq
 }
 

--- a/tests/self_hosted/test_struct_literal.casa
+++ b/tests/self_hosted/test_struct_literal.casa
@@ -42,7 +42,7 @@ fn sl_compile code:str -> Program {
     ops compile_bytecode
 }
 
-fn sl_count_ops ops:List[Op] kind:int -> int {
+fn sl_count_ops ops:List[Op] kind:OpKind -> int {
     0 = count
     0 = index
     while index ops .length > do
@@ -54,7 +54,7 @@ fn sl_count_ops ops:List[Op] kind:int -> int {
     count
 }
 
-fn sl_count_insts bytecode:List[Inst] kind:int -> int {
+fn sl_count_insts bytecode:List[Inst] kind:InstKind -> int {
     0 = count
     0 = index
     while index bytecode .length > do
@@ -66,7 +66,7 @@ fn sl_count_insts bytecode:List[Inst] kind:int -> int {
     count
 }
 
-fn sl_has_inst_kind bytecode:List[Inst] kind:int -> bool {
+fn sl_has_inst_kind bytecode:List[Inst] kind:InstKind -> bool {
     0 kind bytecode sl_count_insts !=
 }
 
@@ -77,11 +77,11 @@ fn sl_has_inst_kind bytecode:List[Inst] kind:int -> bool {
 fn test_basic_struct_literal {
     "basic_struct_literal" test_start
     "struct Point { x: int y: int }\nPoint { x: 1 y: 2 }" sl_parse = ops
-    "has struct literal op" 1 OpKind::OpStructLiteral (int) ops sl_count_ops assert_eq
+    "has struct literal op" 1 OpKind::OpStructLiteral ops sl_count_ops == assert_true
     # Check the StructLiteral value
     0 = index
     while index ops .length > do
-        if OpKind::OpStructLiteral (int) index ops .get Op::kind == then
+        if OpKind::OpStructLiteral index ops .get Op::kind == then
             index ops .get Op::value (StructLiteral) = literal
             "struct name" "Point" literal StructLiteral::struct_name assert_str_eq
             "field count" 2 literal StructLiteral::field_order .length assert_eq
@@ -97,7 +97,7 @@ fn test_reverse_field_order {
     "struct Point { x: int y: int }\nPoint { y: 2 x: 1 }" sl_parse = ops
     0 = index
     while index ops .length > do
-        if OpKind::OpStructLiteral (int) index ops .get Op::kind == then
+        if OpKind::OpStructLiteral index ops .get Op::kind == then
             index ops .get Op::value (StructLiteral) = literal
             "field 0" "y" 0 literal StructLiteral::field_order .get assert_str_eq
             "field 1" "x" 1 literal StructLiteral::field_order .get assert_str_eq
@@ -109,10 +109,10 @@ fn test_reverse_field_order {
 fn test_struct_match_pattern {
     "struct_match_pattern" test_start
     "struct Point { x: int y: int }\n1 2 Point = p\np match\n    Point { x: px y: py } => px py +\nend" sl_parse = ops
-    "has match arm" 0 OpKind::OpMatchArm (int) ops sl_count_ops != assert_true
+    "has match arm" 0 OpKind::OpMatchArm ops sl_count_ops != assert_true
     0 = index
     while index ops .length > do
-        if OpKind::OpMatchArm (int) index ops .get Op::kind == then
+        if OpKind::OpMatchArm index ops .get Op::kind == then
             index ops .get Op::value (StructPattern) = pattern
             "struct name" "Point" pattern StructPattern::struct_name assert_str_eq
             "binding x" "px" "x" pattern StructPattern::bindings .get .unwrap assert_str_eq
@@ -127,7 +127,7 @@ fn test_partial_binding {
     "struct Point { x: int y: int }\n1 2 Point = p\np match\n    Point { x: px } => px\nend" sl_parse = ops
     0 = index
     while index ops .length > do
-        if OpKind::OpMatchArm (int) index ops .get Op::kind == then
+        if OpKind::OpMatchArm index ops .get Op::kind == then
             index ops .get Op::value (StructPattern) = pattern
             "binding x" "px" "x" pattern StructPattern::bindings .get .unwrap assert_str_eq
             "no y binding" "y" pattern StructPattern::bindings .get .is_none assert_true
@@ -139,7 +139,7 @@ fn test_partial_binding {
 fn test_field_value_with_expression {
     "field_value_with_expression" test_start
     "struct Point { x: int y: int }\nPoint { x: 1 2 + y: 3 }" sl_parse = ops
-    "has struct literal op" 1 OpKind::OpStructLiteral (int) ops sl_count_ops assert_eq
+    "has struct literal op" 1 OpKind::OpStructLiteral ops sl_count_ops == assert_true
 }
 
 # ============================================================================
@@ -155,7 +155,7 @@ fn test_unknown_field_error {
     clear_errors
     "struct Point { x: int y: int }\nPoint { z: 1 y: 2 }" sl_parse drop
     "has errors" assert_has_errors
-    "undefined name" ErrorKind::UndefinedName (int) assert_error_kind
+    "undefined name" ErrorKind::UndefinedName assert_error_kind
     clear_errors
     disable_test_mode
 }
@@ -167,7 +167,7 @@ fn test_duplicate_field_error {
     clear_errors
     "struct Point { x: int y: int }\nPoint { x: 1 x: 2 y: 3 }" sl_parse drop
     "has errors" assert_has_errors
-    "duplicate name" ErrorKind::DuplicateName (int) assert_error_kind
+    "duplicate name" ErrorKind::DuplicateName assert_error_kind
     clear_errors
     disable_test_mode
 }
@@ -219,7 +219,7 @@ fn test_unknown_struct_in_pattern_error {
     clear_errors
     "struct Point { x: int y: int }\n1 2 Point = p\np match\n    Rect { x: px } => px\nend" sl_parse drop
     "has errors" assert_has_errors
-    "undefined name" ErrorKind::UndefinedName (int) assert_error_kind
+    "undefined name" ErrorKind::UndefinedName assert_error_kind
     clear_errors
     disable_test_mode
 }
@@ -271,7 +271,7 @@ fn test_field_type_mismatch_error {
     clear_errors
     "struct Point { x: int y: int }\nPoint { x: \"hello\" y: 2 }" sl_typecheck drop
     "has errors" assert_has_errors
-    "type mismatch" ErrorKind::TypeMismatch (int) assert_error_kind
+    "type mismatch" ErrorKind::TypeMismatch assert_error_kind
     clear_errors
     disable_test_mode
 }
@@ -336,15 +336,15 @@ fn test_stack_and_literal_coexist {
 fn test_compile_struct_literal {
     "compile_struct_literal" test_start
     "struct Point { x: int y: int }\nPoint { x: 1 y: 2 } = p\np.x drop" sl_compile = prog
-    "has HEAP_ALLOC" InstKind::InstHeapAlloc (int) prog Program::bytecode sl_has_inst_kind assert_true
-    "has STORE64" InstKind::InstStore64 (int) prog Program::bytecode sl_has_inst_kind assert_true
+    "has HEAP_ALLOC" InstKind::InstHeapAlloc prog Program::bytecode sl_has_inst_kind assert_true
+    "has STORE64" InstKind::InstStore64 prog Program::bytecode sl_has_inst_kind assert_true
 }
 
 fn test_compile_struct_literal_reverse_order {
     "compile_struct_literal_reverse_order" test_start
     "struct Point { x: int y: int }\nPoint { y: 99 x: 42 } = p\np.x drop" sl_compile = prog
-    "has HEAP_ALLOC" InstKind::InstHeapAlloc (int) prog Program::bytecode sl_has_inst_kind assert_true
-    "has STORE64" InstKind::InstStore64 (int) prog Program::bytecode sl_has_inst_kind assert_true
+    "has HEAP_ALLOC" InstKind::InstHeapAlloc prog Program::bytecode sl_has_inst_kind assert_true
+    "has STORE64" InstKind::InstStore64 prog Program::bytecode sl_has_inst_kind assert_true
 }
 
 fn test_compile_struct_match {

--- a/tests/self_hosted/test_traits.casa
+++ b/tests/self_hosted/test_traits.casa
@@ -149,7 +149,7 @@ fn test_trait_unexpected_token_raises {
     clear_errors
     "trait Foo { 42 }" trait_test_parse drop
     "has errors" assert_has_errors
-    "unexpected token" ErrorKind::UnexpectedToken (int) assert_error_kind
+    "unexpected token" ErrorKind::UnexpectedToken assert_error_kind
     clear_errors
     disable_test_mode
 }
@@ -161,7 +161,7 @@ fn test_trait_duplicate_raises {
     clear_errors
     "trait Foo { fn bar self:self -> int }\ntrait Foo { fn baz self:self -> int }\n" trait_test_parse drop
     "has errors" assert_has_errors
-    "duplicate name" ErrorKind::DuplicateName (int) assert_error_kind
+    "duplicate name" ErrorKind::DuplicateName assert_error_kind
     clear_errors
     disable_test_mode
 }
@@ -203,7 +203,7 @@ fn test_trait_bound_undefined_raises {
     clear_errors
     "fn tbtest[K: Nonexistent] K -> int { 0 }" trait_test_parse drop
     "has errors" assert_has_errors
-    "undefined name" ErrorKind::UndefinedName (int) assert_error_kind
+    "undefined name" ErrorKind::UndefinedName assert_error_kind
     clear_errors
     disable_test_mode
 }
@@ -320,7 +320,7 @@ fn test_trait_hidden_params_creates_assign_ops {
     while index func Function::ops .length > do
         index func Function::ops .get = current_op
         if
-            OpKind::OpAssignVar (int) current_op Op::kind ==
+            OpKind::OpAssignVar current_op Op::kind ==
             "__trait_K_hash" current_op Op::value (str) == &&
         then
             true = found
@@ -606,7 +606,7 @@ fn test_k_coloncolon_method_resolved_as_push_variable_exec {
     while index func Function::ops .length > do
         index func Function::ops .get = current_op
         if
-            OpKind::OpPushVar (int) current_op Op::kind ==
+            OpKind::OpPushVar current_op Op::kind ==
             "__trait_K_hash" current_op Op::value (str) == &&
         then
             true = found_push_var
@@ -634,7 +634,7 @@ fn test_ampersand_k_coloncolon_method_resolved_as_push_variable {
     while index func Function::ops .length > do
         index func Function::ops .get = current_op
         if
-            OpKind::OpPushVar (int) current_op Op::kind ==
+            OpKind::OpPushVar current_op Op::kind ==
             "__trait_K_hash" current_op Op::value (str) == &&
         then
             true = found_push_var
@@ -656,7 +656,7 @@ fn test_trait_bounded_fn_with_non_satisfying_type_raises {
     clear_errors
     HASHABLE_TRAIT "struct NoHash { val: int }\nfn get_hash[K: Hashable] k:K -> int { k .hash }\n42 NoHash = m\nm get_hash\n" str::concat trait_test_typecheck drop
     "has errors" assert_has_errors
-    "type mismatch for unsatisfied trait" ErrorKind::TypeMismatch (int) assert_error_kind
+    "type mismatch for unsatisfied trait" ErrorKind::TypeMismatch assert_error_kind
     clear_errors
     disable_test_mode
 }

--- a/tests/self_hosted/test_type_annotations.casa
+++ b/tests/self_hosted/test_type_annotations.casa
@@ -35,7 +35,7 @@ fn find_assign_ops ops:List[Op] -> List[Op] {
     0 = index
     while index ops .length > do
         index ops .get = op
-        if OpKind::OpAssignVar (int) op Op::kind == then
+        if OpKind::OpAssignVar op Op::kind == then
             op result .push
         fi
         1 += index
@@ -43,7 +43,7 @@ fn find_assign_ops ops:List[Op] -> List[Op] {
     result
 }
 
-fn find_ops_by_kind ops:List[Op] kind:int -> List[Op] {
+fn find_ops_by_kind ops:List[Op] kind:OpKind -> List[Op] {
     List::new (List[Op]) = result
     0 = index
     while index ops .length > do
@@ -157,7 +157,7 @@ fn test_annotation_char {
 fn test_no_annotation_on_increment {
     "no_annotation_on_increment" test_start
     "42 = x 1 += x" test_parse = ops
-    OpKind::OpAssignInc (int) ops find_ops_by_kind = inc_ops
+    OpKind::OpAssignInc ops find_ops_by_kind = inc_ops
     "count" 1 inc_ops .length assert_eq
     "annotation empty" "" 0 inc_ops .get Op::type_annotation assert_str_eq
 }
@@ -165,7 +165,7 @@ fn test_no_annotation_on_increment {
 fn test_no_annotation_on_decrement {
     "no_annotation_on_decrement" test_start
     "42 = x 1 -= x" test_parse = ops
-    OpKind::OpAssignDec (int) ops find_ops_by_kind = dec_ops
+    OpKind::OpAssignDec ops find_ops_by_kind = dec_ops
     "count" 1 dec_ops .length assert_eq
     "annotation empty" "" 0 dec_ops .get Op::type_annotation assert_str_eq
 }

--- a/tests/self_hosted/test_typechecker.casa
+++ b/tests/self_hosted/test_typechecker.casa
@@ -18,97 +18,97 @@ fn tc_check ops:List[Op] -> TypeChecker {
         helper_op Op::kind = helper_kind
 
         # Literals
-        if OpKind::OpPushInt (int) helper_kind == then
+        if OpKind::OpPushInt helper_kind == then
             "int" helper_tc stack_push
-        elif OpKind::OpPushStr (int) helper_kind == then
+        elif OpKind::OpPushStr helper_kind == then
             "str" helper_tc stack_push
-        elif OpKind::OpPushBool (int) helper_kind == then
+        elif OpKind::OpPushBool helper_kind == then
             "bool" helper_tc stack_push
-        elif OpKind::OpPushChar (int) helper_kind == then
+        elif OpKind::OpPushChar helper_kind == then
             "char" helper_tc stack_push
         # Arithmetic
         elif
-            OpKind::OpAdd (int) helper_kind ==
-            OpKind::OpSub (int) helper_kind == ||
-            OpKind::OpMul (int) helper_kind == ||
-            OpKind::OpDiv (int) helper_kind == ||
-            OpKind::OpMod (int) helper_kind == ||
+            OpKind::OpAdd helper_kind ==
+            OpKind::OpSub helper_kind == ||
+            OpKind::OpMul helper_kind == ||
+            OpKind::OpDiv helper_kind == ||
+            OpKind::OpMod helper_kind == ||
         then
             helper_op helper_tc check_arithmetic
         # Comparison
         elif
-            OpKind::OpEq (int) helper_kind ==
-            OpKind::OpNe (int) helper_kind == ||
-            OpKind::OpLt (int) helper_kind == ||
-            OpKind::OpLe (int) helper_kind == ||
-            OpKind::OpGt (int) helper_kind == ||
-            OpKind::OpGe (int) helper_kind == ||
+            OpKind::OpEq helper_kind ==
+            OpKind::OpNe helper_kind == ||
+            OpKind::OpLt helper_kind == ||
+            OpKind::OpLe helper_kind == ||
+            OpKind::OpGt helper_kind == ||
+            OpKind::OpGe helper_kind == ||
         then
             helper_op helper_tc check_comparison
         # Boolean
         elif
-            OpKind::OpAnd (int) helper_kind ==
-            OpKind::OpOr (int) helper_kind == ||
-            OpKind::OpNot (int) helper_kind == ||
+            OpKind::OpAnd helper_kind ==
+            OpKind::OpOr helper_kind == ||
+            OpKind::OpNot helper_kind == ||
         then
             helper_op helper_tc check_boolean
         # Bitwise
         elif
-            OpKind::OpBitAnd (int) helper_kind ==
-            OpKind::OpBitOr (int) helper_kind == ||
-            OpKind::OpBitXor (int) helper_kind == ||
-            OpKind::OpBitNot (int) helper_kind == ||
-            OpKind::OpShl (int) helper_kind == ||
-            OpKind::OpShr (int) helper_kind == ||
+            OpKind::OpBitAnd helper_kind ==
+            OpKind::OpBitOr helper_kind == ||
+            OpKind::OpBitXor helper_kind == ||
+            OpKind::OpBitNot helper_kind == ||
+            OpKind::OpShl helper_kind == ||
+            OpKind::OpShr helper_kind == ||
         then
             helper_op helper_tc check_bitwise
         # Stack ops
         elif
-            OpKind::OpDrop (int) helper_kind ==
-            OpKind::OpDup (int) helper_kind == ||
-            OpKind::OpSwap (int) helper_kind == ||
-            OpKind::OpOver (int) helper_kind == ||
-            OpKind::OpRot (int) helper_kind == ||
+            OpKind::OpDrop helper_kind ==
+            OpKind::OpDup helper_kind == ||
+            OpKind::OpSwap helper_kind == ||
+            OpKind::OpOver helper_kind == ||
+            OpKind::OpRot helper_kind == ||
         then
             helper_op helper_tc check_stack_ops
         # Memory
         elif
-            OpKind::OpLoad8 (int) helper_kind ==
-            OpKind::OpLoad16 (int) helper_kind == ||
-            OpKind::OpLoad32 (int) helper_kind == ||
-            OpKind::OpLoad64 (int) helper_kind == ||
-            OpKind::OpStore8 (int) helper_kind == ||
-            OpKind::OpStore16 (int) helper_kind == ||
-            OpKind::OpStore32 (int) helper_kind == ||
-            OpKind::OpStore64 (int) helper_kind == ||
-            OpKind::OpHeapAlloc (int) helper_kind == ||
+            OpKind::OpLoad8 helper_kind ==
+            OpKind::OpLoad16 helper_kind == ||
+            OpKind::OpLoad32 helper_kind == ||
+            OpKind::OpLoad64 helper_kind == ||
+            OpKind::OpStore8 helper_kind == ||
+            OpKind::OpStore16 helper_kind == ||
+            OpKind::OpStore32 helper_kind == ||
+            OpKind::OpStore64 helper_kind == ||
+            OpKind::OpHeapAlloc helper_kind == ||
         then
             helper_op helper_tc check_memory
         # Print
-        elif OpKind::OpPrint (int) helper_kind == then
+        elif OpKind::OpPrint helper_kind == then
             helper_op helper_tc check_io
         # Typeof
-        elif OpKind::OpTypeof (int) helper_kind == then
+        elif OpKind::OpTypeof helper_kind == then
             helper_op helper_tc check_typeof
         # Type cast
-        elif OpKind::OpTypeCast (int) helper_kind == then
+        elif OpKind::OpTypeCast helper_kind == then
             helper_tc stack_pop drop
             helper_op op_str_value helper_tc stack_push
         # Syscalls
         elif
-            OpKind::OpSyscall0 (int) helper_kind ==
-            OpKind::OpSyscall1 (int) helper_kind == ||
-            OpKind::OpSyscall2 (int) helper_kind == ||
-            OpKind::OpSyscall3 (int) helper_kind == ||
-            OpKind::OpSyscall4 (int) helper_kind == ||
-            OpKind::OpSyscall5 (int) helper_kind == ||
-            OpKind::OpSyscall6 (int) helper_kind == ||
+            OpKind::OpSyscall0 helper_kind ==
+            OpKind::OpSyscall1 helper_kind == ||
+            OpKind::OpSyscall2 helper_kind == ||
+            OpKind::OpSyscall3 helper_kind == ||
+            OpKind::OpSyscall4 helper_kind == ||
+            OpKind::OpSyscall5 helper_kind == ||
+            OpKind::OpSyscall6 helper_kind == ||
         then
             helper_op helper_tc check_syscalls
         # Argc / Argv
-        elif OpKind::OpArgc (int) helper_kind == then
+        elif OpKind::OpArgc helper_kind == then
             "int" helper_tc stack_push
-        elif OpKind::OpArgv (int) helper_kind == then
+        elif OpKind::OpArgv helper_kind == then
             "ptr" helper_tc stack_push
         fi
 
@@ -124,7 +124,7 @@ fn tc_check ops:List[Op] -> TypeChecker {
 fn test_push_int_stack {
     "push_int_stack" test_start
     List::new (List[Op]) = ops
-    empty_location OpKind::OpPushInt (int) 42 make_op ops .push
+    empty_location OpKind::OpPushInt 42 make_op ops .push
     ops tc_check = result_tc
     "stack has one item" 1 result_tc TypeChecker::stack .length assert_eq
     "type is int" "int" 0 result_tc TypeChecker::stack .get assert_str_eq
@@ -137,9 +137,9 @@ fn test_push_int_stack {
 fn test_add_stack_effect {
     "add_stack_effect" test_start
     List::new (List[Op]) = ops
-    empty_location OpKind::OpPushInt (int) 10 make_op ops .push
-    empty_location OpKind::OpPushInt (int) 20 make_op ops .push
-    empty_location OpKind::OpAdd (int) 0 make_op ops .push
+    empty_location OpKind::OpPushInt 10 make_op ops .push
+    empty_location OpKind::OpPushInt 20 make_op ops .push
+    empty_location OpKind::OpAdd 0 make_op ops .push
     ops tc_check = result_tc
     "stack has one item after add" 1 result_tc TypeChecker::stack .length assert_eq
     "result type is int" "int" 0 result_tc TypeChecker::stack .get assert_str_eq
@@ -154,34 +154,34 @@ fn test_arithmetic_ops {
 
     # Sub
     List::new (List[Op]) = ops_sub
-    empty_location OpKind::OpPushInt (int) 5 make_op ops_sub .push
-    empty_location OpKind::OpPushInt (int) 3 make_op ops_sub .push
-    empty_location OpKind::OpSub (int) 0 make_op ops_sub .push
+    empty_location OpKind::OpPushInt 5 make_op ops_sub .push
+    empty_location OpKind::OpPushInt 3 make_op ops_sub .push
+    empty_location OpKind::OpSub 0 make_op ops_sub .push
     ops_sub tc_check = tc_sub
     "sub result" 1 tc_sub TypeChecker::stack .length assert_eq
     "sub type" "int" 0 tc_sub TypeChecker::stack .get assert_str_eq
 
     # Mul
     List::new (List[Op]) = ops_mul
-    empty_location OpKind::OpPushInt (int) 2 make_op ops_mul .push
-    empty_location OpKind::OpPushInt (int) 3 make_op ops_mul .push
-    empty_location OpKind::OpMul (int) 0 make_op ops_mul .push
+    empty_location OpKind::OpPushInt 2 make_op ops_mul .push
+    empty_location OpKind::OpPushInt 3 make_op ops_mul .push
+    empty_location OpKind::OpMul 0 make_op ops_mul .push
     ops_mul tc_check = tc_mul
     "mul type" "int" 0 tc_mul TypeChecker::stack .get assert_str_eq
 
     # Div
     List::new (List[Op]) = ops_div
-    empty_location OpKind::OpPushInt (int) 10 make_op ops_div .push
-    empty_location OpKind::OpPushInt (int) 2 make_op ops_div .push
-    empty_location OpKind::OpDiv (int) 0 make_op ops_div .push
+    empty_location OpKind::OpPushInt 10 make_op ops_div .push
+    empty_location OpKind::OpPushInt 2 make_op ops_div .push
+    empty_location OpKind::OpDiv 0 make_op ops_div .push
     ops_div tc_check = tc_div
     "div type" "int" 0 tc_div TypeChecker::stack .get assert_str_eq
 
     # Mod
     List::new (List[Op]) = ops_mod
-    empty_location OpKind::OpPushInt (int) 10 make_op ops_mod .push
-    empty_location OpKind::OpPushInt (int) 3 make_op ops_mod .push
-    empty_location OpKind::OpMod (int) 0 make_op ops_mod .push
+    empty_location OpKind::OpPushInt 10 make_op ops_mod .push
+    empty_location OpKind::OpPushInt 3 make_op ops_mod .push
+    empty_location OpKind::OpMod 0 make_op ops_mod .push
     ops_mod tc_check = tc_mod
     "mod type" "int" 0 tc_mod TypeChecker::stack .get assert_str_eq
 }
@@ -193,9 +193,9 @@ fn test_arithmetic_ops {
 fn test_comparison_produces_bool {
     "comparison_produces_bool" test_start
     List::new (List[Op]) = ops
-    empty_location OpKind::OpPushInt (int) 1 make_op ops .push
-    empty_location OpKind::OpPushInt (int) 2 make_op ops .push
-    empty_location OpKind::OpLt (int) 0 make_op ops .push
+    empty_location OpKind::OpPushInt 1 make_op ops .push
+    empty_location OpKind::OpPushInt 2 make_op ops .push
+    empty_location OpKind::OpLt 0 make_op ops .push
     ops tc_check = result_tc
     "stack after lt" 1 result_tc TypeChecker::stack .length assert_eq
     "lt result is bool" "bool" 0 result_tc TypeChecker::stack .get assert_str_eq
@@ -209,24 +209,24 @@ fn test_boolean_ops {
     "boolean_ops" test_start
     # AND
     List::new (List[Op]) = ops_and
-    empty_location OpKind::OpPushBool (int) 1 make_op ops_and .push
-    empty_location OpKind::OpPushBool (int) 0 make_op ops_and .push
-    empty_location OpKind::OpAnd (int) 0 make_op ops_and .push
+    empty_location OpKind::OpPushBool 1 make_op ops_and .push
+    empty_location OpKind::OpPushBool 0 make_op ops_and .push
+    empty_location OpKind::OpAnd 0 make_op ops_and .push
     ops_and tc_check = tc_and
     "and result" "bool" 0 tc_and TypeChecker::stack .get assert_str_eq
 
     # OR
     List::new (List[Op]) = ops_or
-    empty_location OpKind::OpPushBool (int) 1 make_op ops_or .push
-    empty_location OpKind::OpPushBool (int) 0 make_op ops_or .push
-    empty_location OpKind::OpOr (int) 0 make_op ops_or .push
+    empty_location OpKind::OpPushBool 1 make_op ops_or .push
+    empty_location OpKind::OpPushBool 0 make_op ops_or .push
+    empty_location OpKind::OpOr 0 make_op ops_or .push
     ops_or tc_check = tc_or
     "or result" "bool" 0 tc_or TypeChecker::stack .get assert_str_eq
 
     # NOT
     List::new (List[Op]) = ops_not
-    empty_location OpKind::OpPushBool (int) 1 make_op ops_not .push
-    empty_location OpKind::OpNot (int) 0 make_op ops_not .push
+    empty_location OpKind::OpPushBool 1 make_op ops_not .push
+    empty_location OpKind::OpNot 0 make_op ops_not .push
     ops_not tc_check = tc_not
     "not result" "bool" 0 tc_not TypeChecker::stack .get assert_str_eq
 }
@@ -238,8 +238,8 @@ fn test_boolean_ops {
 fn test_dup_stack_effect {
     "dup_stack_effect" test_start
     List::new (List[Op]) = ops
-    empty_location OpKind::OpPushInt (int) 42 make_op ops .push
-    empty_location OpKind::OpDup (int) 0 make_op ops .push
+    empty_location OpKind::OpPushInt 42 make_op ops .push
+    empty_location OpKind::OpDup 0 make_op ops .push
     ops tc_check = result_tc
     "stack after dup" 2 result_tc TypeChecker::stack .length assert_eq
     "first is int" "int" 0 result_tc TypeChecker::stack .get assert_str_eq
@@ -253,9 +253,9 @@ fn test_dup_stack_effect {
 fn test_swap_stack_effect {
     "swap_stack_effect" test_start
     List::new (List[Op]) = ops
-    empty_location OpKind::OpPushInt (int) 42 make_op ops .push
-    empty_location OpKind::OpPushStr (int) "hello" (int) make_op ops .push
-    empty_location OpKind::OpSwap (int) 0 make_op ops .push
+    empty_location OpKind::OpPushInt 42 make_op ops .push
+    empty_location OpKind::OpPushStr "hello" (int) make_op ops .push
+    empty_location OpKind::OpSwap 0 make_op ops .push
     ops tc_check = result_tc
     "stack after swap" 2 result_tc TypeChecker::stack .length assert_eq
     "bottom is str" "str" 0 result_tc TypeChecker::stack .get assert_str_eq
@@ -269,9 +269,9 @@ fn test_swap_stack_effect {
 fn test_over_stack_effect {
     "over_stack_effect" test_start
     List::new (List[Op]) = ops
-    empty_location OpKind::OpPushInt (int) 42 make_op ops .push
-    empty_location OpKind::OpPushStr (int) "hello" (int) make_op ops .push
-    empty_location OpKind::OpOver (int) 0 make_op ops .push
+    empty_location OpKind::OpPushInt 42 make_op ops .push
+    empty_location OpKind::OpPushStr "hello" (int) make_op ops .push
+    empty_location OpKind::OpOver 0 make_op ops .push
     ops tc_check = result_tc
     "stack after over" 3 result_tc TypeChecker::stack .length assert_eq
     "bottom is int" "int" 0 result_tc TypeChecker::stack .get assert_str_eq
@@ -286,9 +286,9 @@ fn test_over_stack_effect {
 fn test_drop_stack_effect {
     "drop_stack_effect" test_start
     List::new (List[Op]) = ops
-    empty_location OpKind::OpPushInt (int) 42 make_op ops .push
-    empty_location OpKind::OpPushStr (int) "hello" (int) make_op ops .push
-    empty_location OpKind::OpDrop (int) 0 make_op ops .push
+    empty_location OpKind::OpPushInt 42 make_op ops .push
+    empty_location OpKind::OpPushStr "hello" (int) make_op ops .push
+    empty_location OpKind::OpDrop 0 make_op ops .push
     ops tc_check = result_tc
     "stack after drop" 1 result_tc TypeChecker::stack .length assert_eq
     "remaining is int" "int" 0 result_tc TypeChecker::stack .get assert_str_eq
@@ -301,10 +301,10 @@ fn test_drop_stack_effect {
 fn test_rot_stack_effect {
     "rot_stack_effect" test_start
     List::new (List[Op]) = ops
-    empty_location OpKind::OpPushInt (int) 42 make_op ops .push
-    empty_location OpKind::OpPushStr (int) "hello" (int) make_op ops .push
-    empty_location OpKind::OpPushBool (int) 1 make_op ops .push
-    empty_location OpKind::OpRot (int) 0 make_op ops .push
+    empty_location OpKind::OpPushInt 42 make_op ops .push
+    empty_location OpKind::OpPushStr "hello" (int) make_op ops .push
+    empty_location OpKind::OpPushBool 1 make_op ops .push
+    empty_location OpKind::OpRot 0 make_op ops .push
     ops tc_check = result_tc
     "stack after rot" 3 result_tc TypeChecker::stack .length assert_eq
     # ROT: pop t1(bool), t2(str), t3(int) -> push t2(str), t1(bool), t3(int)
@@ -320,8 +320,8 @@ fn test_rot_stack_effect {
 fn test_type_cast {
     "type_cast" test_start
     List::new (List[Op]) = ops
-    empty_location OpKind::OpPushInt (int) 42 make_op ops .push
-    empty_location OpKind::OpTypeCast (int) "str" (int) make_op ops .push
+    empty_location OpKind::OpPushInt 42 make_op ops .push
+    empty_location OpKind::OpTypeCast "str" (int) make_op ops .push
     ops tc_check = result_tc
     "stack after cast" 1 result_tc TypeChecker::stack .length assert_eq
     "cast to str" "str" 0 result_tc TypeChecker::stack .get assert_str_eq
@@ -334,10 +334,10 @@ fn test_type_cast {
 fn test_push_literals {
     "push_literals" test_start
     List::new (List[Op]) = ops
-    empty_location OpKind::OpPushInt (int) 42 make_op ops .push
-    empty_location OpKind::OpPushStr (int) "hi" (int) make_op ops .push
-    empty_location OpKind::OpPushBool (int) 1 make_op ops .push
-    empty_location OpKind::OpPushChar (int) 65 make_op ops .push
+    empty_location OpKind::OpPushInt 42 make_op ops .push
+    empty_location OpKind::OpPushStr "hi" (int) make_op ops .push
+    empty_location OpKind::OpPushBool 1 make_op ops .push
+    empty_location OpKind::OpPushChar 65 make_op ops .push
     ops tc_check = result_tc
     "four items on stack" 4 result_tc TypeChecker::stack .length assert_eq
     "int" "int" 0 result_tc TypeChecker::stack .get assert_str_eq
@@ -355,24 +355,24 @@ fn test_print_dispatch {
 
     # print str -> OpPrintStr
     List::new (List[Op]) = ops_str
-    empty_location OpKind::OpPushStr (int) "hello" (int) make_op ops_str .push
-    empty_location OpKind::OpPrint (int) 0 make_op ops_str .push
+    empty_location OpKind::OpPushStr "hello" (int) make_op ops_str .push
+    empty_location OpKind::OpPrint 0 make_op ops_str .push
     ops_str tc_check drop
-    "print str resolved" OpKind::OpPrintStr (int) 1 ops_str .get Op::kind assert_eq
+    "print str resolved" OpKind::OpPrintStr 1 ops_str .get Op::kind == assert_true
 
     # print int -> OpPrintInt
     List::new (List[Op]) = ops_int
-    empty_location OpKind::OpPushInt (int) 42 make_op ops_int .push
-    empty_location OpKind::OpPrint (int) 0 make_op ops_int .push
+    empty_location OpKind::OpPushInt 42 make_op ops_int .push
+    empty_location OpKind::OpPrint 0 make_op ops_int .push
     ops_int tc_check drop
-    "print int resolved" OpKind::OpPrintInt (int) 1 ops_int .get Op::kind assert_eq
+    "print int resolved" OpKind::OpPrintInt 1 ops_int .get Op::kind == assert_true
 
     # print bool -> OpPrintBool
     List::new (List[Op]) = ops_bool
-    empty_location OpKind::OpPushBool (int) 1 make_op ops_bool .push
-    empty_location OpKind::OpPrint (int) 0 make_op ops_bool .push
+    empty_location OpKind::OpPushBool 1 make_op ops_bool .push
+    empty_location OpKind::OpPrint 0 make_op ops_bool .push
     ops_bool tc_check drop
-    "print bool resolved" OpKind::OpPrintBool (int) 1 ops_bool .get Op::kind assert_eq
+    "print bool resolved" OpKind::OpPrintBool 1 ops_bool .get Op::kind == assert_true
 }
 
 # ============================================================================
@@ -382,8 +382,8 @@ fn test_print_dispatch {
 fn test_typeof_effect {
     "typeof_effect" test_start
     List::new (List[Op]) = ops
-    empty_location OpKind::OpPushInt (int) 42 make_op ops .push
-    empty_location OpKind::OpTypeof (int) 0 make_op ops .push
+    empty_location OpKind::OpPushInt 42 make_op ops .push
+    empty_location OpKind::OpTypeof 0 make_op ops .push
     ops tc_check = result_tc
     "stack after typeof" 1 result_tc TypeChecker::stack .length assert_eq
     "typeof result is str" "str" 0 result_tc TypeChecker::stack .get assert_str_eq
@@ -398,24 +398,24 @@ fn test_bitwise_ops {
 
     # BIT_NOT
     List::new (List[Op]) = ops_bnot
-    empty_location OpKind::OpPushInt (int) 42 make_op ops_bnot .push
-    empty_location OpKind::OpBitNot (int) 0 make_op ops_bnot .push
+    empty_location OpKind::OpPushInt 42 make_op ops_bnot .push
+    empty_location OpKind::OpBitNot 0 make_op ops_bnot .push
     ops_bnot tc_check = tc_bnot
     "bitnot result" "int" 0 tc_bnot TypeChecker::stack .get assert_str_eq
 
     # SHL
     List::new (List[Op]) = ops_shl
-    empty_location OpKind::OpPushInt (int) 1 make_op ops_shl .push
-    empty_location OpKind::OpPushInt (int) 3 make_op ops_shl .push
-    empty_location OpKind::OpShl (int) 0 make_op ops_shl .push
+    empty_location OpKind::OpPushInt 1 make_op ops_shl .push
+    empty_location OpKind::OpPushInt 3 make_op ops_shl .push
+    empty_location OpKind::OpShl 0 make_op ops_shl .push
     ops_shl tc_check = tc_shl
     "shl result" "int" 0 tc_shl TypeChecker::stack .get assert_str_eq
 
     # BIT_AND
     List::new (List[Op]) = ops_band
-    empty_location OpKind::OpPushInt (int) 0 make_op ops_band .push
-    empty_location OpKind::OpPushInt (int) 1 make_op ops_band .push
-    empty_location OpKind::OpBitAnd (int) 0 make_op ops_band .push
+    empty_location OpKind::OpPushInt 0 make_op ops_band .push
+    empty_location OpKind::OpPushInt 1 make_op ops_band .push
+    empty_location OpKind::OpBitAnd 0 make_op ops_band .push
     ops_band tc_check = tc_band
     "bitand result" "int" 0 tc_band TypeChecker::stack .get assert_str_eq
 }
@@ -429,8 +429,8 @@ fn test_memory_ops {
 
     # heap_alloc: int -> ptr
     List::new (List[Op]) = ops_alloc
-    empty_location OpKind::OpPushInt (int) 100 make_op ops_alloc .push
-    empty_location OpKind::OpHeapAlloc (int) 0 make_op ops_alloc .push
+    empty_location OpKind::OpPushInt 100 make_op ops_alloc .push
+    empty_location OpKind::OpHeapAlloc 0 make_op ops_alloc .push
     ops_alloc tc_check = tc_alloc
     "alloc result is ptr" "ptr" 0 tc_alloc TypeChecker::stack .get assert_str_eq
 }
@@ -442,8 +442,8 @@ fn test_memory_ops {
 fn test_argc_argv {
     "argc_argv" test_start
     List::new (List[Op]) = ops
-    empty_location OpKind::OpArgc (int) 0 make_op ops .push
-    empty_location OpKind::OpArgv (int) 0 make_op ops .push
+    empty_location OpKind::OpArgc 0 make_op ops .push
+    empty_location OpKind::OpArgv 0 make_op ops .push
     ops tc_check = result_tc
     "stack count" 2 result_tc TypeChecker::stack .length assert_eq
     "argc is int" "int" 0 result_tc TypeChecker::stack .get assert_str_eq
@@ -603,20 +603,20 @@ fn test_tc_pipeline_memory {
 fn test_print_dispatch_char {
     "print_dispatch_char" test_start
     List::new (List[Op]) = ops
-    empty_location OpKind::OpPushChar (int) 65 make_op ops .push
-    empty_location OpKind::OpPrint (int) 0 make_op ops .push
+    empty_location OpKind::OpPushChar 65 make_op ops .push
+    empty_location OpKind::OpPrint 0 make_op ops .push
     ops tc_check drop
-    "print char resolved" OpKind::OpPrintChar (int) 1 ops .get Op::kind assert_eq
+    "print char resolved" OpKind::OpPrintChar 1 ops .get Op::kind == assert_true
 }
 
 fn test_print_dispatch_cstr {
     "print_dispatch_cstr" test_start
     List::new (List[Op]) = ops
-    empty_location OpKind::OpPushInt (int) 42 make_op ops .push
-    empty_location OpKind::OpTypeCast (int) "cstr" (int) make_op ops .push
-    empty_location OpKind::OpPrint (int) 0 make_op ops .push
+    empty_location OpKind::OpPushInt 42 make_op ops .push
+    empty_location OpKind::OpTypeCast "cstr" (int) make_op ops .push
+    empty_location OpKind::OpPrint 0 make_op ops .push
     ops tc_check drop
-    "print cstr resolved" OpKind::OpPrintCstr (int) 2 ops .get Op::kind assert_eq
+    "print cstr resolved" OpKind::OpPrintCstr 2 ops .get Op::kind == assert_true
 }
 
 # ============================================================================
@@ -626,8 +626,8 @@ fn test_print_dispatch_cstr {
 fn test_print_pops_stack {
     "print_pops_stack" test_start
     List::new (List[Op]) = ops
-    empty_location OpKind::OpPushInt (int) 42 make_op ops .push
-    empty_location OpKind::OpPrint (int) 0 make_op ops .push
+    empty_location OpKind::OpPushInt 42 make_op ops .push
+    empty_location OpKind::OpPrint 0 make_op ops .push
     ops tc_check = result_tc
     "stack empty after print" 0 result_tc TypeChecker::stack .length assert_eq
 }
@@ -639,8 +639,8 @@ fn test_print_pops_stack {
 fn test_typeof_str {
     "typeof_str" test_start
     List::new (List[Op]) = ops
-    empty_location OpKind::OpPushStr (int) "hi" (int) make_op ops .push
-    empty_location OpKind::OpTypeof (int) 0 make_op ops .push
+    empty_location OpKind::OpPushStr "hi" (int) make_op ops .push
+    empty_location OpKind::OpTypeof 0 make_op ops .push
     ops tc_check = result_tc
     "typeof str result" "str" 0 result_tc TypeChecker::stack .get assert_str_eq
 }
@@ -648,8 +648,8 @@ fn test_typeof_str {
 fn test_typeof_bool {
     "typeof_bool" test_start
     List::new (List[Op]) = ops
-    empty_location OpKind::OpPushBool (int) 1 make_op ops .push
-    empty_location OpKind::OpTypeof (int) 0 make_op ops .push
+    empty_location OpKind::OpPushBool 1 make_op ops .push
+    empty_location OpKind::OpTypeof 0 make_op ops .push
     ops tc_check = result_tc
     "typeof bool result" "str" 0 result_tc TypeChecker::stack .get assert_str_eq
 }
@@ -663,41 +663,41 @@ fn test_all_comparison_ops {
 
     # Eq
     List::new (List[Op]) = ops_eq
-    empty_location OpKind::OpPushInt (int) 1 make_op ops_eq .push
-    empty_location OpKind::OpPushInt (int) 1 make_op ops_eq .push
-    empty_location OpKind::OpEq (int) 0 make_op ops_eq .push
+    empty_location OpKind::OpPushInt 1 make_op ops_eq .push
+    empty_location OpKind::OpPushInt 1 make_op ops_eq .push
+    empty_location OpKind::OpEq 0 make_op ops_eq .push
     ops_eq tc_check = tc_eq
     "eq is bool" "bool" 0 tc_eq TypeChecker::stack .get assert_str_eq
 
     # Ne
     List::new (List[Op]) = ops_ne
-    empty_location OpKind::OpPushInt (int) 1 make_op ops_ne .push
-    empty_location OpKind::OpPushInt (int) 2 make_op ops_ne .push
-    empty_location OpKind::OpNe (int) 0 make_op ops_ne .push
+    empty_location OpKind::OpPushInt 1 make_op ops_ne .push
+    empty_location OpKind::OpPushInt 2 make_op ops_ne .push
+    empty_location OpKind::OpNe 0 make_op ops_ne .push
     ops_ne tc_check = tc_ne
     "ne is bool" "bool" 0 tc_ne TypeChecker::stack .get assert_str_eq
 
     # Le
     List::new (List[Op]) = ops_le
-    empty_location OpKind::OpPushInt (int) 1 make_op ops_le .push
-    empty_location OpKind::OpPushInt (int) 2 make_op ops_le .push
-    empty_location OpKind::OpLe (int) 0 make_op ops_le .push
+    empty_location OpKind::OpPushInt 1 make_op ops_le .push
+    empty_location OpKind::OpPushInt 2 make_op ops_le .push
+    empty_location OpKind::OpLe 0 make_op ops_le .push
     ops_le tc_check = tc_le
     "le is bool" "bool" 0 tc_le TypeChecker::stack .get assert_str_eq
 
     # Ge
     List::new (List[Op]) = ops_ge
-    empty_location OpKind::OpPushInt (int) 1 make_op ops_ge .push
-    empty_location OpKind::OpPushInt (int) 2 make_op ops_ge .push
-    empty_location OpKind::OpGe (int) 0 make_op ops_ge .push
+    empty_location OpKind::OpPushInt 1 make_op ops_ge .push
+    empty_location OpKind::OpPushInt 2 make_op ops_ge .push
+    empty_location OpKind::OpGe 0 make_op ops_ge .push
     ops_ge tc_check = tc_ge
     "ge is bool" "bool" 0 tc_ge TypeChecker::stack .get assert_str_eq
 
     # Gt
     List::new (List[Op]) = ops_gt
-    empty_location OpKind::OpPushInt (int) 5 make_op ops_gt .push
-    empty_location OpKind::OpPushInt (int) 2 make_op ops_gt .push
-    empty_location OpKind::OpGt (int) 0 make_op ops_gt .push
+    empty_location OpKind::OpPushInt 5 make_op ops_gt .push
+    empty_location OpKind::OpPushInt 2 make_op ops_gt .push
+    empty_location OpKind::OpGt 0 make_op ops_gt .push
     ops_gt tc_check = tc_gt
     "gt is bool" "bool" 0 tc_gt TypeChecker::stack .get assert_str_eq
 }
@@ -709,9 +709,9 @@ fn test_all_comparison_ops {
 fn test_string_comparison_annotation {
     "string_comparison_annotation" test_start
     List::new (List[Op]) = ops
-    empty_location OpKind::OpPushStr (int) "a" (int) make_op ops .push
-    empty_location OpKind::OpPushStr (int) "b" (int) make_op ops .push
-    empty_location OpKind::OpEq (int) 0 make_op ops .push
+    empty_location OpKind::OpPushStr "a" (int) make_op ops .push
+    empty_location OpKind::OpPushStr "b" (int) make_op ops .push
+    empty_location OpKind::OpEq 0 make_op ops .push
     ops tc_check = result_tc
     "str cmp is bool" "bool" 0 result_tc TypeChecker::stack .get assert_str_eq
     "annotation is str" "str" 2 ops .get Op::type_annotation assert_str_eq
@@ -724,9 +724,9 @@ fn test_string_comparison_annotation {
 fn test_bitwise_shr {
     "bitwise_shr" test_start
     List::new (List[Op]) = ops
-    empty_location OpKind::OpPushInt (int) 8 make_op ops .push
-    empty_location OpKind::OpPushInt (int) 2 make_op ops .push
-    empty_location OpKind::OpShr (int) 0 make_op ops .push
+    empty_location OpKind::OpPushInt 8 make_op ops .push
+    empty_location OpKind::OpPushInt 2 make_op ops .push
+    empty_location OpKind::OpShr 0 make_op ops .push
     ops tc_check = result_tc
     "shr result" "int" 0 result_tc TypeChecker::stack .get assert_str_eq
 }
@@ -734,9 +734,9 @@ fn test_bitwise_shr {
 fn test_bitwise_or {
     "bitwise_or" test_start
     List::new (List[Op]) = ops
-    empty_location OpKind::OpPushInt (int) 5 make_op ops .push
-    empty_location OpKind::OpPushInt (int) 3 make_op ops .push
-    empty_location OpKind::OpBitOr (int) 0 make_op ops .push
+    empty_location OpKind::OpPushInt 5 make_op ops .push
+    empty_location OpKind::OpPushInt 3 make_op ops .push
+    empty_location OpKind::OpBitOr 0 make_op ops .push
     ops tc_check = result_tc
     "bitor result" "int" 0 result_tc TypeChecker::stack .get assert_str_eq
 }
@@ -744,9 +744,9 @@ fn test_bitwise_or {
 fn test_bitwise_xor {
     "bitwise_xor" test_start
     List::new (List[Op]) = ops
-    empty_location OpKind::OpPushInt (int) 5 make_op ops .push
-    empty_location OpKind::OpPushInt (int) 3 make_op ops .push
-    empty_location OpKind::OpBitXor (int) 0 make_op ops .push
+    empty_location OpKind::OpPushInt 5 make_op ops .push
+    empty_location OpKind::OpPushInt 3 make_op ops .push
+    empty_location OpKind::OpBitXor 0 make_op ops .push
     ops tc_check = result_tc
     "bitxor result" "int" 0 result_tc TypeChecker::stack .get assert_str_eq
 }
@@ -760,25 +760,25 @@ fn test_memory_load_sizes {
 
     # load8
     List::new (List[Op]) = ops8
-    empty_location OpKind::OpPushInt (int) 8 make_op ops8 .push
-    empty_location OpKind::OpHeapAlloc (int) 0 make_op ops8 .push
-    empty_location OpKind::OpLoad8 (int) 0 make_op ops8 .push
+    empty_location OpKind::OpPushInt 8 make_op ops8 .push
+    empty_location OpKind::OpHeapAlloc 0 make_op ops8 .push
+    empty_location OpKind::OpLoad8 0 make_op ops8 .push
     ops8 tc_check = tc8
     "load8 result" "int" 0 tc8 TypeChecker::stack .get assert_str_eq
 
     # load16
     List::new (List[Op]) = ops16
-    empty_location OpKind::OpPushInt (int) 8 make_op ops16 .push
-    empty_location OpKind::OpHeapAlloc (int) 0 make_op ops16 .push
-    empty_location OpKind::OpLoad16 (int) 0 make_op ops16 .push
+    empty_location OpKind::OpPushInt 8 make_op ops16 .push
+    empty_location OpKind::OpHeapAlloc 0 make_op ops16 .push
+    empty_location OpKind::OpLoad16 0 make_op ops16 .push
     ops16 tc_check = tc16
     "load16 result" "int" 0 tc16 TypeChecker::stack .get assert_str_eq
 
     # load32
     List::new (List[Op]) = ops32
-    empty_location OpKind::OpPushInt (int) 8 make_op ops32 .push
-    empty_location OpKind::OpHeapAlloc (int) 0 make_op ops32 .push
-    empty_location OpKind::OpLoad32 (int) 0 make_op ops32 .push
+    empty_location OpKind::OpPushInt 8 make_op ops32 .push
+    empty_location OpKind::OpHeapAlloc 0 make_op ops32 .push
+    empty_location OpKind::OpLoad32 0 make_op ops32 .push
     ops32 tc_check = tc32
     "load32 result" "int" 0 tc32 TypeChecker::stack .get assert_str_eq
 }
@@ -788,28 +788,28 @@ fn test_memory_store_sizes {
 
     # store8: value ptr -> (empty)
     List::new (List[Op]) = ops8
-    empty_location OpKind::OpPushInt (int) 42 make_op ops8 .push
-    empty_location OpKind::OpPushInt (int) 8 make_op ops8 .push
-    empty_location OpKind::OpHeapAlloc (int) 0 make_op ops8 .push
-    empty_location OpKind::OpStore8 (int) 0 make_op ops8 .push
+    empty_location OpKind::OpPushInt 42 make_op ops8 .push
+    empty_location OpKind::OpPushInt 8 make_op ops8 .push
+    empty_location OpKind::OpHeapAlloc 0 make_op ops8 .push
+    empty_location OpKind::OpStore8 0 make_op ops8 .push
     ops8 tc_check = tc8
     "store8 empty" 0 tc8 TypeChecker::stack .length assert_eq
 
     # store16
     List::new (List[Op]) = ops16
-    empty_location OpKind::OpPushInt (int) 42 make_op ops16 .push
-    empty_location OpKind::OpPushInt (int) 8 make_op ops16 .push
-    empty_location OpKind::OpHeapAlloc (int) 0 make_op ops16 .push
-    empty_location OpKind::OpStore16 (int) 0 make_op ops16 .push
+    empty_location OpKind::OpPushInt 42 make_op ops16 .push
+    empty_location OpKind::OpPushInt 8 make_op ops16 .push
+    empty_location OpKind::OpHeapAlloc 0 make_op ops16 .push
+    empty_location OpKind::OpStore16 0 make_op ops16 .push
     ops16 tc_check = tc16
     "store16 empty" 0 tc16 TypeChecker::stack .length assert_eq
 
     # store32
     List::new (List[Op]) = ops32
-    empty_location OpKind::OpPushInt (int) 42 make_op ops32 .push
-    empty_location OpKind::OpPushInt (int) 8 make_op ops32 .push
-    empty_location OpKind::OpHeapAlloc (int) 0 make_op ops32 .push
-    empty_location OpKind::OpStore32 (int) 0 make_op ops32 .push
+    empty_location OpKind::OpPushInt 42 make_op ops32 .push
+    empty_location OpKind::OpPushInt 8 make_op ops32 .push
+    empty_location OpKind::OpHeapAlloc 0 make_op ops32 .push
+    empty_location OpKind::OpStore32 0 make_op ops32 .push
     ops32 tc_check = tc32
     "store32 empty" 0 tc32 TypeChecker::stack .length assert_eq
 }
@@ -1043,7 +1043,7 @@ fn test_error_arithmetic_str_int {
     "error_arithmetic_str_int" test_start
     "\"hello\" 1 *" tc_string_error drop
     "has errors" assert_has_errors
-    "type mismatch" ErrorKind::TypeMismatch (int) assert_error_kind
+    "type mismatch" ErrorKind::TypeMismatch assert_error_kind
     clear_errors
     disable_test_mode
 }
@@ -1052,7 +1052,7 @@ fn test_error_arithmetic_bool_int {
     "error_arithmetic_bool_int" test_start
     "true 1 *" tc_string_error drop
     "has errors" assert_has_errors
-    "type mismatch" ErrorKind::TypeMismatch (int) assert_error_kind
+    "type mismatch" ErrorKind::TypeMismatch assert_error_kind
     clear_errors
     disable_test_mode
 }
@@ -1065,7 +1065,7 @@ fn test_error_bitwise_and_bool {
     "error_bitwise_and_bool" test_start
     "true false &" tc_string_error drop
     "has errors" assert_has_errors
-    "type mismatch" ErrorKind::TypeMismatch (int) assert_error_kind
+    "type mismatch" ErrorKind::TypeMismatch assert_error_kind
     clear_errors
     disable_test_mode
 }
@@ -1074,7 +1074,7 @@ fn test_error_bitwise_or_bool {
     "error_bitwise_or_bool" test_start
     "true false |" tc_string_error drop
     "has errors" assert_has_errors
-    "type mismatch" ErrorKind::TypeMismatch (int) assert_error_kind
+    "type mismatch" ErrorKind::TypeMismatch assert_error_kind
     clear_errors
     disable_test_mode
 }
@@ -1083,7 +1083,7 @@ fn test_error_bitwise_xor_bool {
     "error_bitwise_xor_bool" test_start
     "true false ^" tc_string_error drop
     "has errors" assert_has_errors
-    "type mismatch" ErrorKind::TypeMismatch (int) assert_error_kind
+    "type mismatch" ErrorKind::TypeMismatch assert_error_kind
     clear_errors
     disable_test_mode
 }
@@ -1092,7 +1092,7 @@ fn test_error_bitwise_not_bool {
     "error_bitwise_not_bool" test_start
     "true ~" tc_string_error drop
     "has errors" assert_has_errors
-    "type mismatch" ErrorKind::TypeMismatch (int) assert_error_kind
+    "type mismatch" ErrorKind::TypeMismatch assert_error_kind
     clear_errors
     disable_test_mode
 }
@@ -1105,7 +1105,7 @@ fn test_error_load_non_ptr {
     "error_load_non_ptr" test_start
     "42 load64" tc_string_error drop
     "has errors" assert_has_errors
-    "type mismatch" ErrorKind::TypeMismatch (int) assert_error_kind
+    "type mismatch" ErrorKind::TypeMismatch assert_error_kind
     clear_errors
     disable_test_mode
 }
@@ -1118,7 +1118,7 @@ fn test_error_store_non_ptr {
     "error_store_non_ptr" test_start
     "42 99 store64" tc_string_error drop
     "has errors" assert_has_errors
-    "type mismatch" ErrorKind::TypeMismatch (int) assert_error_kind
+    "type mismatch" ErrorKind::TypeMismatch assert_error_kind
     clear_errors
     disable_test_mode
 }
@@ -1140,10 +1140,10 @@ fn test_store_accepts_any_value_type {
 fn test_memory_store64 {
     "memory_store64" test_start
     List::new (List[Op]) = ops
-    empty_location OpKind::OpPushInt (int) 42 make_op ops .push
-    empty_location OpKind::OpPushInt (int) 8 make_op ops .push
-    empty_location OpKind::OpHeapAlloc (int) 0 make_op ops .push
-    empty_location OpKind::OpStore64 (int) 0 make_op ops .push
+    empty_location OpKind::OpPushInt 42 make_op ops .push
+    empty_location OpKind::OpPushInt 8 make_op ops .push
+    empty_location OpKind::OpHeapAlloc 0 make_op ops .push
+    empty_location OpKind::OpStore64 0 make_op ops .push
     ops tc_check = result_tc
     "store64 empty" 0 result_tc TypeChecker::stack .length assert_eq
 }
@@ -1166,7 +1166,7 @@ fn test_error_syscall_non_int_number {
     "error_syscall_non_int_number" test_start
     "\"not_a_number\" syscall0" tc_string_error drop
     "has errors" assert_has_errors
-    "type mismatch" ErrorKind::TypeMismatch (int) assert_error_kind
+    "type mismatch" ErrorKind::TypeMismatch assert_error_kind
     clear_errors
     disable_test_mode
 }
@@ -1175,7 +1175,7 @@ fn test_error_syscall1_non_int_number {
     "error_syscall1_non_int_number" test_start
     "0 \"not_a_number\" syscall1" tc_string_error drop
     "has errors" assert_has_errors
-    "type mismatch" ErrorKind::TypeMismatch (int) assert_error_kind
+    "type mismatch" ErrorKind::TypeMismatch assert_error_kind
     clear_errors
     disable_test_mode
 }
@@ -1184,7 +1184,7 @@ fn test_error_syscall3_non_int_number {
     "error_syscall3_non_int_number" test_start
     "0 0 0 \"not_a_number\" syscall3" tc_string_error drop
     "has errors" assert_has_errors
-    "type mismatch" ErrorKind::TypeMismatch (int) assert_error_kind
+    "type mismatch" ErrorKind::TypeMismatch assert_error_kind
     clear_errors
     disable_test_mode
 }
@@ -1198,28 +1198,28 @@ fn test_syscall_op_level {
 
     # syscall0: pops 1 (syscall number), pushes int
     List::new (List[Op]) = ops0
-    empty_location OpKind::OpPushInt (int) 60 make_op ops0 .push
-    empty_location OpKind::OpSyscall0 (int) 0 make_op ops0 .push
+    empty_location OpKind::OpPushInt 60 make_op ops0 .push
+    empty_location OpKind::OpSyscall0 0 make_op ops0 .push
     ops0 tc_check = tc0
     "syscall0 result" 1 tc0 TypeChecker::stack .length assert_eq
     "syscall0 type" "int" 0 tc0 TypeChecker::stack .get assert_str_eq
 
     # syscall1: pops 2 (1 arg + syscall number), pushes int
     List::new (List[Op]) = ops1
-    empty_location OpKind::OpPushInt (int) 0 make_op ops1 .push
-    empty_location OpKind::OpPushInt (int) 60 make_op ops1 .push
-    empty_location OpKind::OpSyscall1 (int) 0 make_op ops1 .push
+    empty_location OpKind::OpPushInt 0 make_op ops1 .push
+    empty_location OpKind::OpPushInt 60 make_op ops1 .push
+    empty_location OpKind::OpSyscall1 0 make_op ops1 .push
     ops1 tc_check = tc1
     "syscall1 result" 1 tc1 TypeChecker::stack .length assert_eq
     "syscall1 type" "int" 0 tc1 TypeChecker::stack .get assert_str_eq
 
     # syscall3: pops 4 (3 args + syscall number), pushes int
     List::new (List[Op]) = ops3
-    empty_location OpKind::OpPushInt (int) 0 make_op ops3 .push
-    empty_location OpKind::OpPushInt (int) 0 make_op ops3 .push
-    empty_location OpKind::OpPushInt (int) 0 make_op ops3 .push
-    empty_location OpKind::OpPushInt (int) 1 make_op ops3 .push
-    empty_location OpKind::OpSyscall3 (int) 0 make_op ops3 .push
+    empty_location OpKind::OpPushInt 0 make_op ops3 .push
+    empty_location OpKind::OpPushInt 0 make_op ops3 .push
+    empty_location OpKind::OpPushInt 0 make_op ops3 .push
+    empty_location OpKind::OpPushInt 1 make_op ops3 .push
+    empty_location OpKind::OpSyscall3 0 make_op ops3 .push
     ops3 tc_check = tc3
     "syscall3 result" 1 tc3 TypeChecker::stack .length assert_eq
     "syscall3 type" "int" 0 tc3 TypeChecker::stack .get assert_str_eq
@@ -1232,8 +1232,8 @@ fn test_syscall_op_level {
 fn test_typeof_char {
     "typeof_char" test_start
     List::new (List[Op]) = ops
-    empty_location OpKind::OpPushChar (int) 65 make_op ops .push
-    empty_location OpKind::OpTypeof (int) 0 make_op ops .push
+    empty_location OpKind::OpPushChar 65 make_op ops .push
+    empty_location OpKind::OpTypeof 0 make_op ops .push
     ops tc_check = result_tc
     "typeof char result" "str" 0 result_tc TypeChecker::stack .get assert_str_eq
 }
@@ -1241,9 +1241,9 @@ fn test_typeof_char {
 fn test_typeof_ptr {
     "typeof_ptr" test_start
     List::new (List[Op]) = ops
-    empty_location OpKind::OpPushInt (int) 10 make_op ops .push
-    empty_location OpKind::OpHeapAlloc (int) 0 make_op ops .push
-    empty_location OpKind::OpTypeof (int) 0 make_op ops .push
+    empty_location OpKind::OpPushInt 10 make_op ops .push
+    empty_location OpKind::OpHeapAlloc 0 make_op ops .push
+    empty_location OpKind::OpTypeof 0 make_op ops .push
     ops tc_check = result_tc
     "typeof ptr result" "str" 0 result_tc TypeChecker::stack .get assert_str_eq
 }
@@ -1255,8 +1255,8 @@ fn test_typeof_ptr {
 fn test_dup_preserves_str {
     "dup_preserves_str" test_start
     List::new (List[Op]) = ops
-    empty_location OpKind::OpPushStr (int) "hello" (int) make_op ops .push
-    empty_location OpKind::OpDup (int) 0 make_op ops .push
+    empty_location OpKind::OpPushStr "hello" (int) make_op ops .push
+    empty_location OpKind::OpDup 0 make_op ops .push
     ops tc_check = result_tc
     "dup str count" 2 result_tc TypeChecker::stack .length assert_eq
     "dup str first" "str" 0 result_tc TypeChecker::stack .get assert_str_eq
@@ -1266,8 +1266,8 @@ fn test_dup_preserves_str {
 fn test_dup_preserves_bool {
     "dup_preserves_bool" test_start
     List::new (List[Op]) = ops
-    empty_location OpKind::OpPushBool (int) 1 make_op ops .push
-    empty_location OpKind::OpDup (int) 0 make_op ops .push
+    empty_location OpKind::OpPushBool 1 make_op ops .push
+    empty_location OpKind::OpDup 0 make_op ops .push
     ops tc_check = result_tc
     "dup bool count" 2 result_tc TypeChecker::stack .length assert_eq
     "dup bool first" "bool" 0 result_tc TypeChecker::stack .get assert_str_eq
@@ -1303,7 +1303,7 @@ fn test_error_if_inconsistent {
     "error_if_inconsistent" test_start
     "if true then 1 else \"two\" fi" tc_string_error drop
     "has errors" assert_has_errors
-    "stack mismatch" ErrorKind::StackMismatch (int) assert_error_kind
+    "stack mismatch" ErrorKind::StackMismatch assert_error_kind
     clear_errors
     disable_test_mode
 }
@@ -1316,7 +1316,7 @@ fn test_error_if_no_else_mismatch {
     "error_if_no_else_mismatch" test_start
     "if true then 1 fi" tc_string_error drop
     "has errors" assert_has_errors
-    "stack mismatch" ErrorKind::StackMismatch (int) assert_error_kind
+    "stack mismatch" ErrorKind::StackMismatch assert_error_kind
     clear_errors
     disable_test_mode
 }
@@ -1352,12 +1352,12 @@ fn test_error_fn_signature_mismatch {
     # Build a function with declared sig "int -> str" but body returns int
     "int -> str" signature_from_str = bad_sig
     List::new (List[Op]) = bad_ops
-    empty_location OpKind::OpPushInt (int) 42 make_op bad_ops .push
+    empty_location OpKind::OpPushInt 42 make_op bad_ops .push
     # RPN: sig location ops name make_function_with_sig
     bad_sig empty_location bad_ops "bad_fn" make_function_with_sig = bad_fn
     bad_fn Option::Some bad_ops type_check_ops drop
     "has errors" assert_has_errors
-    "signature mismatch" ErrorKind::SignatureMismatch (int) assert_error_kind
+    "signature mismatch" ErrorKind::SignatureMismatch assert_error_kind
     clear_errors
     disable_test_mode
 }
@@ -1376,7 +1376,7 @@ fn test_error_unused_fn_type_error {
     bad_sig empty_location empty_ops "bad_unused" make_function_with_sig = bad_fn
     bad_fn Option::Some empty_ops type_check_ops drop
     "has errors" assert_has_errors
-    "signature mismatch" ErrorKind::SignatureMismatch (int) assert_error_kind
+    "signature mismatch" ErrorKind::SignatureMismatch assert_error_kind
     clear_errors
     disable_test_mode
 }
@@ -1500,12 +1500,12 @@ fn test_types_match_array_types {
 fn test_print_dispatch_ptr {
     "print_dispatch_ptr" test_start
     List::new (List[Op]) = ops
-    empty_location OpKind::OpPushInt (int) 10 make_op ops .push
-    empty_location OpKind::OpHeapAlloc (int) 0 make_op ops .push
-    empty_location OpKind::OpPrint (int) 0 make_op ops .push
+    empty_location OpKind::OpPushInt 10 make_op ops .push
+    empty_location OpKind::OpHeapAlloc 0 make_op ops .push
+    empty_location OpKind::OpPrint 0 make_op ops .push
     ops tc_check drop
     # ptr falls through to print_int
-    "print ptr resolved" OpKind::OpPrintInt (int) 2 ops .get Op::kind assert_eq
+    "print ptr resolved" OpKind::OpPrintInt 2 ops .get Op::kind == assert_true
 }
 
 # ============================================================================
@@ -1515,8 +1515,8 @@ fn test_print_dispatch_ptr {
 fn test_typeof_annotation {
     "typeof_annotation" test_start
     List::new (List[Op]) = ops
-    empty_location OpKind::OpPushInt (int) 42 make_op ops .push
-    empty_location OpKind::OpTypeof (int) 0 make_op ops .push
+    empty_location OpKind::OpPushInt 42 make_op ops .push
+    empty_location OpKind::OpTypeof 0 make_op ops .push
     ops tc_check drop
     "typeof annotation" "int" 1 ops .get Op::type_annotation assert_str_eq
 }
@@ -1528,8 +1528,8 @@ fn test_typeof_annotation {
 fn test_type_cast_str_to_int {
     "type_cast_str_to_int" test_start
     List::new (List[Op]) = ops
-    empty_location OpKind::OpPushStr (int) "hello" (int) make_op ops .push
-    empty_location OpKind::OpTypeCast (int) "int" (int) make_op ops .push
+    empty_location OpKind::OpPushStr "hello" (int) make_op ops .push
+    empty_location OpKind::OpTypeCast "int" (int) make_op ops .push
     ops tc_check = result_tc
     "cast str to int" 1 result_tc TypeChecker::stack .length assert_eq
     "cast result" "int" 0 result_tc TypeChecker::stack .get assert_str_eq
@@ -1538,8 +1538,8 @@ fn test_type_cast_str_to_int {
 fn test_type_cast_bool_to_int {
     "type_cast_bool_to_int" test_start
     List::new (List[Op]) = ops
-    empty_location OpKind::OpPushBool (int) 1 make_op ops .push
-    empty_location OpKind::OpTypeCast (int) "int" (int) make_op ops .push
+    empty_location OpKind::OpPushBool 1 make_op ops .push
+    empty_location OpKind::OpTypeCast "int" (int) make_op ops .push
     ops tc_check = result_tc
     "cast bool to int" "int" 0 result_tc TypeChecker::stack .get assert_str_eq
 }
@@ -1574,7 +1574,7 @@ fn test_error_str_lt_comparison {
     "error_str_lt_comparison" test_start
     "\"a\" \"b\" <" tc_string_error drop
     "has errors" assert_has_errors
-    "type mismatch" ErrorKind::TypeMismatch (int) assert_error_kind
+    "type mismatch" ErrorKind::TypeMismatch assert_error_kind
     clear_errors
     disable_test_mode
 }

--- a/tests/self_hosted/test_typeof.casa
+++ b/tests/self_hosted/test_typeof.casa
@@ -39,7 +39,7 @@ fn assert_contains needle:str haystack:str msg:str {
     fi
 }
 
-fn has_inst_kind bytecode:List[Inst] kind:int -> bool {
+fn has_inst_kind bytecode:List[Inst] kind:InstKind -> bool {
     false = found
     0 = index
     while index bytecode .length > do
@@ -70,7 +70,7 @@ fn string_table_contains table:List[str] needle:str -> bool {
 fn test_lex_typeof {
     "lex_typeof" test_start
     "test" "typeof" lex_source = tokens
-    "typeof kind" TokenKind::Intrinsic (int) 0 tokens .get Token::kind assert_eq
+    "typeof kind" TokenKind::Intrinsic 0 tokens .get Token::kind == assert_true
     "typeof value" "typeof" 0 tokens .get Token::value assert_str_eq
 }
 
@@ -82,7 +82,7 @@ fn test_parse_typeof {
     "parse_typeof" test_start
     "test" "42 typeof" lex_source = tokens
     tokens parse_ops = ops
-    "typeof kind" OpKind::OpTypeof (int) 1 ops .get Op::kind assert_eq
+    "typeof kind" OpKind::OpTypeof 1 ops .get Op::kind == assert_true
 }
 
 # ============================================================================
@@ -140,9 +140,9 @@ fn test_typecheck_typeof_ptr {
 fn test_bytecode_typeof_int {
     "bytecode_typeof_int" test_start
     "42 typeof" compile_typeof = prog
-    "has DROP" InstKind::InstDrop (int) prog Program::bytecode has_inst_kind assert_true
-    "has PUSH_STR" InstKind::InstPushStr (int) prog Program::bytecode has_inst_kind assert_true
-    "has PRINT_STR" InstKind::InstPrintStr (int) prog Program::bytecode has_inst_kind assert_true
+    "has DROP" InstKind::InstDrop prog Program::bytecode has_inst_kind assert_true
+    "has PUSH_STR" InstKind::InstPushStr prog Program::bytecode has_inst_kind assert_true
+    "has PRINT_STR" InstKind::InstPrintStr prog Program::bytecode has_inst_kind assert_true
     "int in strings" "int" prog Program::strings string_table_contains assert_true
 }
 
@@ -169,9 +169,9 @@ fn test_bytecode_typeof_instruction_sequence {
         index 1 + prog Program::bytecode .get Inst::kind = kind1
         index 2 + prog Program::bytecode .get Inst::kind = kind2
         if
-            InstKind::InstDrop (int) kind0 ==
-            InstKind::InstPushStr (int) kind1 == &&
-            InstKind::InstPrintStr (int) kind2 == &&
+            InstKind::InstDrop kind0 ==
+            InstKind::InstPushStr kind1 == &&
+            InstKind::InstPrintStr kind2 == &&
         then
             true = found_seq
         fi

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -432,6 +432,17 @@ class TestEnumTypeChecking:
         )
         assert sig.return_types == ["bool"]
 
+    @pytest.mark.parametrize("op", ["<", "<=", ">", ">="])
+    def test_enum_ordering_same_type(self, op):
+        sig = typecheck_string(
+            COLOR_ENUM + f"Color::Red Color::Blue {op}"
+        )
+        assert sig.return_types == ["bool"]
+
+    def test_data_enum_ordering(self):
+        sig = typecheck_string(SHAPE_ENUM + "Shape::Point Shape::Point <")
+        assert sig.return_types == ["bool"]
+
     def test_enum_eq_different_types_raises(self):
         with pytest.raises(CasaErrorCollection) as exc_info:
             typecheck_string(
@@ -1037,6 +1048,33 @@ class TestEnumEndToEnd:
 
     def test_data_enum_ne(self, run_casa):
         output = run_casa(SHAPE_ENUM + "10 Shape::Circle Shape::Point != print\n")
+        assert output == "true"
+
+    def test_enum_lt_true(self, run_casa):
+        # RPN: Color::Blue Color::Red < means Red < Blue (0 < 2)
+        output = run_casa(COLOR_ENUM + "Color::Blue Color::Red < print\n")
+        assert output == "true"
+
+    def test_enum_lt_false(self, run_casa):
+        output = run_casa(COLOR_ENUM + "Color::Red Color::Blue < print\n")
+        assert output == "false"
+
+    def test_enum_le_true(self, run_casa):
+        output = run_casa(COLOR_ENUM + "Color::Red Color::Red <= print\n")
+        assert output == "true"
+
+    def test_enum_gt_true(self, run_casa):
+        # RPN: Color::Red Color::Blue > means Blue > Red (2 > 0)
+        output = run_casa(COLOR_ENUM + "Color::Red Color::Blue > print\n")
+        assert output == "true"
+
+    def test_enum_ge_true(self, run_casa):
+        output = run_casa(COLOR_ENUM + "Color::Green Color::Green >= print\n")
+        assert output == "true"
+
+    def test_data_enum_lt(self, run_casa):
+        # RPN: Shape::Point 10 Shape::Circle < means Circle < Point (0 < 2)
+        output = run_casa(SHAPE_ENUM + "Shape::Point 10 Shape::Circle < print\n")
         assert output == "true"
 
 


### PR DESCRIPTION
## Summary
- Enable `<`, `<=`, `>`, `>=` operators on same-type enums (in addition to existing `==` and `!=`), with ordering based on variant declaration order
- Refactor the self-hosted compiler to use proper enum types (`OpKind`, `TokenKind`, `InstKind`, `ErrorKind`, etc.) instead of `int` for struct fields, function parameters, and Map types
- Add `Hashable` trait implementations for enums used as Map keys
- Remove ~1200 unnecessary `(int)` casts from the self-hosted compiler and tests

## Test plan
- [x] All 1202 Python tests pass (`pytest tests/`)
- [x] All 33 example tests pass (`tests/test_examples.sh`)
- [x] All 16 self-hosted test files compile and pass (1508 total assertions)
- [x] Self-hosted compiler compiles successfully
- [x] LSP compiles successfully
- [x] No remaining enum `(int)` casts (only legitimate char/pointer casts and hash impls remain)