### PR TITLE
fix(argparse): derive program name from argv[0]

### DIFF
--- a/casa.casa
+++ b/casa.casa
@@ -18,7 +18,7 @@ include "compiler/build.casa"
 # ============================================================================
 
 fn parse_cli_args -> ParsedArgs {
-    "casa" ArgParser::new = parser
+    ArgParser::new = parser
     "input file" "input" parser .add_positional
     "output binary name" "--output" "-o" "output" parser .add_option
     "keep the .s file after linking" "" "--keep-asm" "keep-asm" parser .add_flag

--- a/docs/standard-library.md
+++ b/docs/standard-library.md
@@ -1299,14 +1299,14 @@ It provides a declarative API for defining and parsing CLI arguments, with auto-
 
 ### `ArgParser::new`
 
-Creates a new argument parser with the given program name (used in help/error output).
+Creates a new argument parser. The program name used in help/error output is derived from `basename(argv[0])`, matching the default behavior of Python's `argparse`.
 
-**Signature:** `ArgParser::new program_name:str -> ArgParser`
+**Signature:** `ArgParser::new -> ArgParser`
 
-**Stack effect:** `str -> ArgParser`
+**Stack effect:** `-> ArgParser`
 
 ```casa
-"myapp" ArgParser::new = parser
+ArgParser::new = parser
 ```
 
 ### `ArgParser::add_positional`
@@ -1387,7 +1387,7 @@ Returns `true` if the flag was set, `false` otherwise.
 ```casa
 include "../lib/argparse.casa"
 
-"myapp" ArgParser::new = parser
+ArgParser::new = parser
 "input file" "input" parser .add_positional
 "output file" "--output" "-o" "output" parser .add_option
 "verbose output" "--verbose" "-v" "verbose" parser .add_flag
@@ -1398,7 +1398,7 @@ parser .parse_args = args
 "verbose" args .get_flag = is_verbose
 ```
 
-Running `./myapp --help` produces:
+Assuming the compiled binary is named `myapp`, running `./myapp --help` produces:
 
 ```
 usage: myapp [-h] [-o OUTPUT] [-v] input

--- a/examples/argparse.casa
+++ b/examples/argparse.casa
@@ -4,7 +4,7 @@
 
 include "../lib/argparse.casa"
 
-"argparse" ArgParser::new = parser
+ArgParser::new = parser
 "name to greet" "--name" "-n" "name" parser .add_option
 "greeting prefix" "--greeting" "-g" "greeting" parser .add_option
 "verbose output" "--verbose" "-v" "verbose" parser .add_flag

--- a/lib/argparse.casa
+++ b/lib/argparse.casa
@@ -33,7 +33,10 @@ struct ParsedArgs {
 # ---------------------------------------------------------------------------
 
 impl ArgParser {
-    fn new program_name:str -> ArgParser {
+    fn new -> ArgParser {
+        # Derive program name from basename of argv[0] (like Python's argparse)
+        0 get_arg "/" str::split = path_parts
+        path_parts.length 1 - path_parts .get = program_name
         List::new (List[ArgDef]) program_name ArgParser
     }
 


### PR DESCRIPTION
## Summary
- `./casac` used to print `usage: casa ...` because `casa.casa` hardcoded `"casa"` when constructing the `ArgParser`.
- `ArgParser::new` now takes no arguments and derives the program name from `basename(argv[0])`, matching Python's `argparse.ArgumentParser()` default. Callers drop the string literal.
- Updated `casa.casa`, `examples/argparse.casa`, and `docs/standard-library.md` to match the new signature.

## Test plan
- [x] `./casac` prints `usage: casac [-h] ...` and `casac: error: ...`
- [x] Invocation via absolute path `/home/agent/git/casa/casac` still shows just `casac` (basename strip)
- [x] `./casac --bogus` prints `casac: error: unrecognized arguments: --bogus`
- [x] `tests/test_examples.sh`: 33/33 passing (includes updated `argparse` example)
- [x] `tests/test_compiler.sh`: 19/19 passing (includes `self_compilation` and `fixed_point`)