### PR TITLE
feat(fstring): auto-convert arbitrary types via Display trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Casa compiles to x86-64 Linux executables via GNU assembly. It features static t
 - **String interpolation** — f-strings with embedded expressions (`f"hello {name}"`)
 - **Compiles to native code** — generates x86-64 assembly with `ld` and `as`
 - **Enums and match** — enum types with exhaustive pattern matching
-- **Traits** — structural trait system with bounded polymorphism (`trait`, `Hashable`)
+- **Traits** — structural trait system with bounded polymorphism (`trait`, `Hashable`, `Display`)
 - **Standard library** — generic `List[T]`, `Map[K V]`, `Set[K]`, arrays with `map`/`filter`/`reduce`, type conversions, and memory utilities
 
 ## Requirements

--- a/compiler/bytecode.casa
+++ b/compiler/bytecode.casa
@@ -896,6 +896,9 @@ fn compile_op compiler:BytecodeCompiler op:Op op_index:int bytecode:List[Inst] {
         bytecode op compiler compile_assignment
     elif OpKind::OpFstringConcat kind == then
         op op_int_value InstKind::InstFstringConcat make_inst_int bytecode .push
+    elif OpKind::OpFstringToStr kind == then
+        # Identity no-op: str expression already left on stack by the preceding lambda.
+        # Non-str cases are rewritten to OpMethodCall during type checking.
     elif OpKind::OpFnCall kind == OpKind::OpFnPush kind == || then
         if OpKind::OpFnPush kind == then
             op op_str_value GLOBAL_FUNCTIONS .get = function_opt

--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -127,7 +127,7 @@ enum OperatorKind {
 }
 
 # ============================================================================
-# OpKind enum (86 variants)
+# OpKind enum (87 variants)
 # ============================================================================
 enum OpKind {
     # Stack
@@ -233,6 +233,7 @@ enum OpKind {
     OpIncludeFile
     # F-strings
     OpFstringConcat
+    OpFstringToStr
     # Command-line arguments
     OpArgc
     OpArgv

--- a/compiler/parser.casa
+++ b/compiler/parser.casa
@@ -477,6 +477,7 @@ fn handle_fstring start_token:Token cursor:TokenCursor function_name:str ops:Lis
             lambda_name lambda_function GLOBAL_FUNCTIONS .set = GLOBAL_FUNCTIONS
             token Token::location OpKind::OpFnPush lambda_name make_op_str ops .push
             token Token::location OpKind::OpFnExec 0 make_op ops .push
+            token Token::location OpKind::OpFstringToStr "" make_op_str ops .push
             1 += part_count
         elif TokenKind::FstringEnd token Token::kind == then
             break
@@ -804,7 +805,7 @@ fn parse_function cursor:TokenCursor -> Function {
                     bound_type_var bound_method TraitMethod::signature resolve_trait_sig = hidden_sig
                     f"fn[{hidden_sig signature_to_str}]" = hidden_type
                     hidden_name hidden_type make_named_param hidden_params .push
-                    hidden_name make_variable variables .push
+                    hidden_type hidden_name Variable variables .push
                     name_token Token::location OpKind::OpAssignVar hidden_name make_op_str ops .push
                     1 += method_index
                 done

--- a/compiler/typechecker.casa
+++ b/compiler/typechecker.casa
@@ -814,6 +814,35 @@ fn check_assignment tc:TypeChecker op:Op function_opt:Option[Function] {
 # Check push variable / capture
 # ============================================================================
 
+# Simulate the FnExec emitted by the bytecode pass for trait-bound namespace calls
+# like `K::hash`. The parser rewrites these to an OpPushVar of the hidden
+# `__trait_{type_var}_{method}` variable, annotated as "trait_exec". At typecheck
+# time we pop the fn-pointer type we just pushed and apply the resolved trait
+# method signature so the correct return type lands on the stack.
+fn simulate_trait_exec tc:TypeChecker function:Function var_name:str {
+    var_name 8 var_name .length 8 - str::substring = trait_suffix
+    trait_suffix "_" str::find = trait_sep
+    if trait_sep 0 >= then return fi
+    trait_suffix 0 trait_sep str::substring = trait_type_var
+    trait_suffix trait_sep 1 + trait_suffix .length trait_sep - 1 - str::substring = trait_method_name
+    trait_type_var function Function::signature Signature::trait_bounds .get = trait_name_opt
+    if trait_name_opt .is_none then return fi
+    trait_name_opt .unwrap GLOBAL_TRAITS .get = trait_def_opt
+    if trait_def_opt .is_none then return fi
+    trait_def_opt .unwrap = trait_def
+    0 = trait_lookup_index
+    while trait_lookup_index trait_def CasaTrait::methods .length > do
+        trait_lookup_index trait_def CasaTrait::methods .get = trait_method_entry
+        if trait_method_name trait_method_entry TraitMethod::name == then
+            tc stack_pop drop
+            trait_type_var trait_method_entry TraitMethod::signature resolve_trait_sig = resolved_exec_sig
+            f"{trait_type_var}::{trait_method_name}" resolved_exec_sig tc apply_signature
+            return
+        fi
+        1 += trait_lookup_index
+    done
+}
+
 fn check_push_var tc:TypeChecker op:Op function_opt:Option[Function] {
     if OpKind::OpPushCapture op Op::kind == then
         op op_str_value = capture_name
@@ -834,6 +863,7 @@ fn check_push_var tc:TypeChecker op:Op function_opt:Option[Function] {
 
     # PUSH_VARIABLE
     op op_str_value = var_name
+    "trait_exec" op Op::type_annotation == = is_trait_exec
 
     # Check local variables first
     if function_opt .is_some then
@@ -845,6 +875,9 @@ fn check_push_var tc:TypeChecker op:Op function_opt:Option[Function] {
                 local_type tc stack_push
             else
                 ANY_TYPE tc stack_push
+            fi
+            if is_trait_exec then
+                var_name function tc simulate_trait_exec
             fi
             return
         fi
@@ -1015,10 +1048,26 @@ fn type_satisfies_trait type_name:str trait_name:str function_opt:Option[Functio
         index trait_def CasaTrait::methods .get = method
         f"{type_name}::{method TraitMethod::name}" = fn_name
         fn_name GLOBAL_FUNCTIONS .get = fn_opt
+        false = via_generic_base
+        # Fall back to the generic base type (e.g. `Option::to_str` for `Option[int]`)
+        if fn_opt .is_none then
+            type_name extract_generic_base = base_opt
+            if base_opt .is_some then
+                f"{base_opt .unwrap}::{method TraitMethod::name}" = fn_name
+                fn_name GLOBAL_FUNCTIONS .get = fn_opt
+                true = via_generic_base
+            fi
+        fi
         if fn_opt .is_none then false return fi
         fn_opt .unwrap = function
         function ensure_typechecked
         if "None -> None" function Function::signature signature_to_str == then false return fi
+        # When satisfying via the generic base, skip strict signature comparison —
+        # the concrete trait bounds are verified at the actual call site.
+        if via_generic_base then
+            1 += index
+            continue
+        fi
         type_name method TraitMethod::signature resolve_trait_sig = resolved
         if function Function::signature Signature::parameters .length resolved Signature::parameters .length != then
             false return
@@ -1104,18 +1153,21 @@ fn inject_trait_fn_ptrs tc:TypeChecker sig:Signature ops:List[Op] op_index:int l
         fi
     fi
 
-    # Inject FN_PUSH ops for each trait bound
+    # Inject FN_PUSH ops for each trait bound.
+    # Iterate type vars in reverse so the first param in the signature (which
+    # the parser prepends in forward key order) ends up on the top of the stack,
+    # matching the order apply_signature pops parameters in.
     0 = inserted
     op_index 1 - = insert_pos
     sig Signature::trait_bounds .keys = type_var_keys
-    0 = type_index
-    while type_index type_var_keys .length > do
+    type_var_keys .length 1 - = type_index
+    while 0 type_index >= do
         type_index type_var_keys .get = type_var
         type_var sig Signature::trait_bounds .get .unwrap = trait_name
         type_var bindings .get = concrete_opt
         if concrete_opt .is_none then
             location f"Cannot determine concrete type for type variable `{type_var}`" ErrorKind::TypeMismatch raise_error
-            1 += type_index
+            type_index 1 - = type_index
             continue
         fi
         concrete_opt .unwrap = concrete
@@ -1177,7 +1229,7 @@ fn inject_trait_fn_ptrs tc:TypeChecker sig:Signature ops:List[Op] op_index:int l
                 method_index 1 - = method_index
             done
         fi
-        1 += type_index
+        type_index 1 - = type_index
     done
     inserted
 }
@@ -1943,6 +1995,26 @@ fn check_method_call tc:TypeChecker op:Op ops:List[Op] op_index:int function_opt
 }
 
 # ============================================================================
+# Check f-string expression conversion (Display trait dispatch)
+# ============================================================================
+
+fn check_fstring_to_str tc:TypeChecker op:Op ops:List[Op] op_index:int function_opt:Option[Function] -> int {
+    tc stack_peek = fstring_type
+    if "str" fstring_type == then
+        op_index return
+    fi
+    if function_opt "Display" fstring_type type_satisfies_trait ! then
+        op Op::location f"Type `{fstring_type}` cannot be used in f-string: does not satisfy trait `Display`" ErrorKind::MissingTraitMethod add_error
+        tc stack_pop drop
+        "str" tc stack_push
+        op_index return
+    fi
+    OpKind::OpMethodCall op Op::set_kind
+    "to_str" (int) op Op::set_value
+    function_opt op_index ops op tc check_method_call
+}
+
+# ============================================================================
 # Ensure a function is typechecked
 # ============================================================================
 
@@ -2187,6 +2259,12 @@ fn type_check_ops ops:List[Op] function_opt:Option[Function] -> Signature {
         # Method call
         if OpKind::OpMethodCall op_kind == then
             function_opt op_index ops current_op checker check_method_call = op_index
+            continue
+        fi
+
+        # F-string expression -> str conversion (Display trait)
+        if OpKind::OpFstringToStr op_kind == then
+            function_opt op_index ops current_op checker check_fstring_to_str = op_index
             continue
         fi
 

--- a/docs/standard-library.md
+++ b/docs/standard-library.md
@@ -832,6 +832,56 @@ Converts a pointer to a string by casting its address to an integer and converti
 buf.to_str print        # prints the address as a decimal number
 ```
 
+### `char::to_str`
+
+Wraps a single character in a one-character string.
+
+**Signature:** `char::to_str c:char -> str`
+
+**Stack effect:** `char -> str`
+
+```casa
+'A'.to_str print    # A
+```
+
+### `array[T]::to_str`
+
+Formats an array as `[elem1, elem2, ...]`. Requires `T` to satisfy the `Display` trait.
+
+**Signature:** `array::to_str self:array[T] -> str` (with `T: Display`)
+
+```casa
+[1, 2, 3] (array[int]) .to_str print    # [1, 2, 3]
+```
+
+### `List[T]::to_str`
+
+Formats a `List` the same way as an array. Requires `T` to satisfy the `Display` trait.
+
+**Signature:** `List::to_str self:List[T] -> str` (with `T: Display`)
+
+### `Option[T]::to_str`
+
+Formats an `Option` as `Some(value)` or `None`. Requires `T` to satisfy the `Display` trait.
+
+**Signature:** `Option::to_str self:Option[T] -> str` (with `T: Display`)
+
+```casa
+5 Option::Some .to_str print                # Some(5)
+Option::None (Option[int]) .to_str print    # None
+```
+
+### `Result[T E]::to_str`
+
+Formats a `Result` as `Ok(value)` or `Error(err)`. Requires both `T` and `E` to satisfy the `Display` trait.
+
+**Signature:** `Result::to_str self:Result[T E] -> str` (with `T: Display, E: Display`)
+
+```casa
+99 Result::Ok (Result[int str]) .to_str print       # Ok(99)
+"oops" Result::Error (Result[int str]) .to_str print # Error(oops)
+```
+
 ## Hash Helpers
 
 Standalone hash functions used by the built-in `Hashable` trait implementations.

--- a/docs/traits.md
+++ b/docs/traits.md
@@ -161,6 +161,33 @@ Built-in implementations:
 - `int::hash` returns the absolute value (via `int_hash`)
 - `int::eq` compares integers with `==`
 
+## Built-in Trait: `Display`
+
+The standard library defines a `Display` trait used by f-string interpolation to convert values to strings:
+
+```casa
+trait Display {
+    fn to_str self:self -> str
+}
+```
+
+Any type with a `to_str self:T -> str` method structurally satisfies `Display`. The standard library provides implementations for `int`, `bool`, `str`, `char`, `cstr`, `ptr`, and generic containers `array[T]`, `List[T]`, `Option[T]`, and `Result[T E]` (the parameter types must themselves satisfy `Display`).
+
+When an expression appears inside an f-string (`f"value: {x}"`), the compiler verifies that its type satisfies `Display` and automatically calls the corresponding `to_str` method. Custom structs and enums become interpolatable simply by providing a `to_str` method:
+
+```casa
+struct Point { x: int y: int }
+
+impl Point {
+    fn to_str self:Point -> str {
+        f"Point({self.x}, {self.y})"
+    }
+}
+
+1 2 Point = origin
+f"origin = {origin}\n" print    # origin = Point(1, 2)
+```
+
 ## Errors
 
 ### `MISSING_TRAIT_METHOD`

--- a/docs/types-and-literals.md
+++ b/docs/types-and-literals.md
@@ -113,13 +113,14 @@ F-strings let you embed expressions inside a string literal. Prefix a string wit
 f"hello {name}" print    # hello world
 ```
 
-Expressions inside `{}` must produce a value of type `str`. Non-string types are not auto-converted.
+Any expression whose type satisfies the [`Display`](traits.md#built-in-trait-display) trait can be interpolated. The compiler automatically calls `to_str` on non-string values, so explicit conversions are no longer required:
 
 ```casa
-# This will NOT work: int expression inside f-string with text
 42 = n
-f"count: {n}"    # TYPE error: expected str, got int
+f"count: {n}"    # count: 42
 ```
+
+Types that do not implement `Display` — for example, custom structs without a `to_str` method — are rejected at compile time with a dedicated f-string error.
 
 Multiple expressions are supported:
 

--- a/lib/std.casa
+++ b/lib/std.casa
@@ -577,6 +577,10 @@ trait Hashable {
     fn eq self:self other:self -> bool
 }
 
+trait Display {
+    fn to_str self:self -> str
+}
+
 # ---------------------------------------------------------------------------
 # Hash helpers
 # ---------------------------------------------------------------------------
@@ -887,3 +891,83 @@ fn run_command args:List[str] -> int {
     # Extract exit code: bits 8-15 of status word
     rc_status load64 8 >> 255 &
 }
+
+# ---------------------------------------------------------------------------
+# Display implementations for container and enum types
+# ---------------------------------------------------------------------------
+impl char {
+    fn to_str c:char -> str {
+        10 alloc (str) = char_buf
+        1 char_buf (ptr) store64
+        c 0 char_buf.set
+        0 (char) 1 char_buf.set
+        char_buf
+    }
+}
+
+impl[T: Display] array[T] {
+    fn to_str self:array[T] -> str {
+        StringBuilder::new = arr_builder
+        "[" arr_builder .append
+        0 = arr_index
+        self.length = arr_length
+        while arr_index arr_length > do
+            if 0 arr_index > then
+                ", " arr_builder .append
+            fi
+            arr_index self.nth T::to_str arr_builder .append
+            1 += arr_index
+        done
+        "]" arr_builder .append
+        arr_builder .build
+    }
+}
+
+impl[T: Display] List[T] {
+    fn to_str self:List[T] -> str {
+        StringBuilder::new = list_builder
+        "[" list_builder .append
+        0 = list_index
+        self.size = list_length
+        while list_index list_length > do
+            if 0 list_index > then
+                ", " list_builder .append
+            fi
+            list_index self.get T::to_str list_builder .append
+            1 += list_index
+        done
+        "]" list_builder .append
+        list_builder .build
+    }
+}
+
+impl[T: Display] Option[T] {
+    fn to_str self:Option[T] -> str {
+        if self.is_some then
+            StringBuilder::new = option_builder
+            "Some(" option_builder .append
+            self.unwrap T::to_str option_builder .append
+            ")" option_builder .append
+            option_builder .build
+            return
+        fi
+        "None"
+    }
+}
+
+impl[T: Display, E: Display] Result[T E] {
+    fn to_str self:Result[T E] -> str {
+        StringBuilder::new = result_builder
+        if self.is_ok then
+            "Ok(" result_builder .append
+            self.unwrap T::to_str result_builder .append
+        else
+            "Error(" result_builder .append
+            self.unwrap_error E::to_str result_builder .append
+        fi
+        ")" result_builder .append
+        result_builder .build
+    }
+}
+
+

--- a/tests/compiler/test_display.casa
+++ b/tests/compiler/test_display.casa
@@ -1,0 +1,251 @@
+include "../../compiler/common.casa"
+include "../../compiler/error.casa"
+include "../../compiler/lexer.casa"
+include "../../compiler/parser.casa"
+include "../../compiler/typechecker.casa"
+include "../../lib/test.casa"
+include "../../lib/test_helpers.casa"
+
+# ============================================================================
+# Constants
+# ============================================================================
+
+"trait Display { fn to_str self:self -> str }\n" = DISPLAY_TRAIT
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+fn display_test_parse code:str -> List[Op] {
+    clear_global_state
+    "test" code lex_source = tokens
+    tokens parse_ops
+}
+
+fn display_test_resolve code:str -> List[Op] {
+    clear_global_state
+    "test" code lex_source = tokens
+    tokens parse_ops = ops
+    ops resolve_identifiers_global
+}
+
+fn display_test_typecheck code:str -> Signature {
+    clear_global_state
+    "test" code lex_source = tokens
+    tokens parse_ops = ops
+    ops resolve_identifiers_global = ops
+    Option::None (Option[Function]) ops type_check_ops
+}
+
+fn display_test_typecheck_error code:str -> Signature {
+    enable_test_mode
+    clear_errors
+    clear_global_state
+    "test" code lex_source = tokens
+    tokens parse_ops = ops
+    ops resolve_identifiers_global = ops
+    Option::None (Option[Function]) ops type_check_ops
+}
+
+fn count_op_kind ops:List[Op] kind:OpKind -> int {
+    0 = count_result
+    0 = count_index
+    while count_index ops .length > do
+        if kind count_index ops .get Op::kind == then
+            1 += count_result
+        fi
+        1 += count_index
+    done
+    count_result
+}
+
+# ============================================================================
+# Parser: OpFstringToStr is emitted for each expression part
+# ============================================================================
+
+fn test_parser_emits_fstring_to_str {
+    "parser_emits_fstring_to_str" test_start
+    "\"x\" = name\nf\"hi {name}\" drop\n" display_test_parse = ops
+    # Find the lambda's enclosing function (global scope) and look for OpFstringToStr
+    # in the top-level ops list.
+    0 = found_count
+    0 = index
+    while index ops .length > do
+        if OpKind::OpFstringToStr index ops .get Op::kind == then
+            1 += found_count
+        fi
+        1 += index
+    done
+    "one OpFstringToStr per expression" 1 found_count assert_eq
+}
+
+fn test_parser_emits_fstring_to_str_multiple {
+    "parser_emits_fstring_to_str_multiple" test_start
+    "\"a\" = a\n\"b\" = b\nf\"{a} and {b}\" drop\n" display_test_parse = ops
+    0 = found_count
+    0 = index
+    while index ops .length > do
+        if OpKind::OpFstringToStr index ops .get Op::kind == then
+            1 += found_count
+        fi
+        1 += index
+    done
+    "two OpFstringToStr ops for two expressions" 2 found_count assert_eq
+}
+
+fn test_parser_no_fstring_to_str_without_expressions {
+    "parser_no_fstring_to_str_without_expressions" test_start
+    "f\"plain text\" drop\n" display_test_parse = ops
+    0 = found_count
+    0 = index
+    while index ops .length > do
+        if OpKind::OpFstringToStr index ops .get Op::kind == then
+            1 += found_count
+        fi
+        1 += index
+    done
+    "no OpFstringToStr for plain f-string" 0 found_count assert_eq
+}
+
+# ============================================================================
+# Typechecker: f-strings with str expressions pass through unchanged
+# ============================================================================
+
+fn test_fstring_str_expression_typechecks {
+    "fstring_str_expression_typechecks" test_start
+    DISPLAY_TRAIT "\"world\" = greeting\nf\"hello {greeting}\" drop\n" str::concat display_test_typecheck drop
+    "no errors for str expression" assert_no_errors
+}
+
+# ============================================================================
+# Typechecker: f-strings with Display-implementing types auto-convert
+# ============================================================================
+
+fn test_fstring_int_with_display {
+    "fstring_int_with_display" test_start
+    DISPLAY_TRAIT "impl int { fn to_str n:int -> str { \"42\" } }\n42 = n\nf\"value {n}\" drop\n" str::concat display_test_typecheck drop
+    "no errors for int with Display" assert_no_errors
+}
+
+fn test_fstring_custom_struct_with_display {
+    "fstring_custom_struct_with_display" test_start
+    DISPLAY_TRAIT "struct Point { x: int }\nimpl Point { fn to_str self:Point -> str { \"Point\" } }\n1 Point = p\nf\"value {p}\" drop\n" str::concat display_test_typecheck drop
+    "no errors for custom struct with Display" assert_no_errors
+}
+
+# ============================================================================
+# Typechecker: types without Display produce the dedicated f-string error
+# ============================================================================
+
+fn test_fstring_missing_display_raises {
+    "fstring_missing_display_raises" test_start
+    DISPLAY_TRAIT "struct NoDisplay { val: int }\n1 NoDisplay = n\nf\"value {n}\" drop\n" str::concat display_test_typecheck_error drop
+    "has errors" assert_has_errors
+    "error contains custom f-string message" "cannot be used in f-string" assert_error_contains
+    "error mentions Display trait" "Display" assert_error_contains
+    "missing trait method error kind" ErrorKind::MissingTraitMethod assert_error_kind
+    clear_errors
+    disable_test_mode
+}
+
+fn test_fstring_missing_display_without_trait_raises {
+    "fstring_missing_display_without_trait_raises" test_start
+    # Display trait not defined at all — int cannot be interpolated
+    "42 = n\nf\"value {n}\" drop\n" display_test_typecheck_error drop
+    "has errors" assert_has_errors
+    clear_errors
+    disable_test_mode
+}
+
+# ============================================================================
+# type_satisfies_trait: generic base fallback
+# ============================================================================
+
+fn test_type_satisfies_trait_generic_base_fallback {
+    "type_satisfies_trait_generic_base_fallback" test_start
+    DISPLAY_TRAIT "enum Box[T] { Boxed(T) }\nimpl Box { fn to_str self:Box -> str { \"boxed\" } }\n" str::concat display_test_resolve drop
+    Option::None (Option[Function]) = no_fn
+    "Box[int] satisfies Display via base" no_fn "Display" "Box[int]" type_satisfies_trait assert_true
+    "Box[str] satisfies Display via base" no_fn "Display" "Box[str]" type_satisfies_trait assert_true
+}
+
+fn test_type_satisfies_trait_no_fallback_method {
+    "type_satisfies_trait_no_fallback_method" test_start
+    DISPLAY_TRAIT "enum Bag[T] { Empty Full(T) }\n" str::concat display_test_resolve drop
+    Option::None (Option[Function]) = no_fn
+    "Bag[int] does not satisfy without to_str" no_fn "Display" "Bag[int]" type_satisfies_trait ! assert_true
+}
+
+# ============================================================================
+# check_push_var: trait_exec annotation simulates the exec
+# ============================================================================
+
+fn test_trait_exec_pushes_return_type {
+    "trait_exec_pushes_return_type" test_start
+    DISPLAY_TRAIT "struct Tag { val: int }\nimpl Tag { fn to_str self:Tag -> str { \"tag\" } }\nfn show[T: Display] x:T -> str { x T::to_str }\n1 Tag = t\nt show drop\n" str::concat display_test_typecheck drop
+    "show" GLOBAL_FUNCTIONS .get .unwrap = func
+    "signature has str return type" "str" 0 func Function::signature Signature::return_types .get assert_str_eq
+    "no errors" assert_no_errors
+}
+
+# ============================================================================
+# inject_trait_fn_ptrs: multi-type-parameter ordering (the Result[T E] bug)
+# ============================================================================
+
+fn test_multi_trait_bound_ordering {
+    "multi_trait_bound_ordering" test_start
+    DISPLAY_TRAIT "fn either[A: Display, B: Display] a:A b:B -> str { a A::to_str }\nimpl int { fn to_str n:int -> str { \"i\" } }\nimpl bool { fn to_str b:bool -> str { \"b\" } }\n1 true either drop\n" str::concat display_test_typecheck drop
+    "no errors for multi-bound call" assert_no_errors
+}
+
+# ============================================================================
+# Integration: explicit .to_str inside an f-string still works (identity path)
+# ============================================================================
+
+fn test_fstring_explicit_to_str_still_works {
+    "fstring_explicit_to_str_still_works" test_start
+    DISPLAY_TRAIT "impl int { fn to_str n:int -> str { \"n\" } }\n42 = n\nf\"value {n .to_str}\" drop\n" str::concat display_test_typecheck drop
+    "no errors with explicit .to_str" assert_no_errors
+}
+
+# ============================================================================
+# Integration: nested f-strings with mixed primitive types
+# ============================================================================
+
+fn test_fstring_mixed_types {
+    "fstring_mixed_types" test_start
+    DISPLAY_TRAIT "impl int { fn to_str n:int -> str { \"i\" } }\nimpl bool { fn to_str b:bool -> str { \"b\" } }\n42 = n\ntrue = flag\nf\"n={n} flag={flag}\" drop\n" str::concat display_test_typecheck drop
+    "no errors for mixed primitive f-string" assert_no_errors
+}
+
+# ============================================================================
+# Run all tests
+# ============================================================================
+
+# Parser
+test_parser_emits_fstring_to_str
+test_parser_emits_fstring_to_str_multiple
+test_parser_no_fstring_to_str_without_expressions
+
+# Typechecker: positive cases
+test_fstring_str_expression_typechecks
+test_fstring_int_with_display
+test_fstring_custom_struct_with_display
+test_fstring_explicit_to_str_still_works
+test_fstring_mixed_types
+
+# Typechecker: error cases
+test_fstring_missing_display_raises
+test_fstring_missing_display_without_trait_raises
+
+# type_satisfies_trait
+test_type_satisfies_trait_generic_base_fallback
+test_type_satisfies_trait_no_fallback_method
+
+# check_push_var trait_exec simulation
+test_trait_exec_pushes_return_type
+
+# Multi-type-parameter trait bound ordering
+test_multi_trait_bound_ordering
+
+test_summary


### PR DESCRIPTION
## Summary

- F-strings now accept any expression whose type satisfies a new `Display` trait; the compiler auto-invokes `to_str` so explicit `.to_str` calls are no longer needed.
- Adds `Display` to `lib/std.casa` with implementations for `char`, `array[T]`, `List[T]`, `Option[T]`, and `Result[T E]` (primitives `int`/`bool`/`str`/`cstr`/`ptr` already provided `to_str`).
- Fixes a latent ordering bug in `inject_trait_fn_ptrs` that broke any trait-bounded signature with multiple type variables, which was required to make `impl[T: Display, E: Display] Result[T E]` work.

## Details

- `compiler/common.casa`: new `OpFstringToStr` op kind.
- `compiler/parser.casa`: `handle_fstring` emits `OpFstringToStr` after each `{...}` expression; hidden `__trait_*` parameter variables now carry their `fn[...]` type.
- `compiler/typechecker.casa`:
  - new `check_fstring_to_str` — no-op for `str`, otherwise verifies `Display` via `type_satisfies_trait` and rewrites the op to `OpMethodCall "to_str"`; emits a dedicated f-string error on failure.
  - `type_satisfies_trait` falls back to the generic base (`Option::to_str` for `Option[int]`) so concrete parameterizations are accepted.
  - new `simulate_trait_exec` helper: when `check_push_var` sees a `trait_exec`-annotated `OpPushVar`, it pops the fn-pointer and applies the resolved trait method signature so the correct return type lands on the type stack.
  - `inject_trait_fn_ptrs` now iterates `trait_bounds.keys` in reverse to match the parameter order the parser prepends and that `apply_signature` pops in.
- `compiler/bytecode.casa`: `OpFstringToStr` is a no-op (the identity-str case).
- `examples/fstring.casa` + regenerated output: demonstrates int, char, bool, array, and Option interpolation.
- Docs: `types-and-literals.md`, `traits.md` (new `Display` section), `standard-library.md` (new `to_str` entries), `README.md`.

## Test plan

- [x] `./tests/test_examples.sh` — 33/33 pass
- [x] `./tests/test_compiler.sh` — 19/19 pass (including `self_compilation` and `fixed_point`)
- [x] Manual: `f"{int} {char} {bool} {array[int]} {Option[int]} {Result[int str]}"` produces expected output
- [x] Manual: a custom struct with a user-written `to_str` method is interpolatable
- [x] Manual: a struct without `to_str` produces the custom f-string error