### PR TITLE
Drop redundant .to_str in f-strings + expand fstring example

### DIFF
--- a/compiler/build.casa
+++ b/compiler/build.casa
@@ -23,7 +23,7 @@ fn compile_binary asm_source:str output_name:str keep_asm:bool {
     asm_file as_args .push
     as_args run_command = as_result
     if 0 as_result != then
-        f"Assembly failed with exit code {as_result .to_str}" eprintln
+        f"Assembly failed with exit code {as_result}" eprintln
         1 exit
     fi
 
@@ -35,7 +35,7 @@ fn compile_binary asm_source:str output_name:str keep_asm:bool {
     obj_file ld_args .push
     ld_args run_command = ld_result
     if 0 ld_result != then
-        f"Linking failed with exit code {ld_result .to_str}" eprintln
+        f"Linking failed with exit code {ld_result}" eprintln
         1 exit
     fi
 

--- a/compiler/emitter.casa
+++ b/compiler/emitter.casa
@@ -100,13 +100,13 @@ fn escape_string s:str -> str {
 fn emit_bss asm:StringBuilder program:Program {
     ".section .bss" asm emit_line
     if 0 program Program::globals_count > then
-        f"globals: .skip {program Program::globals_count 8 * .to_str}" asm emit_line
+        f"globals: .skip {program Program::globals_count 8 *}" asm emit_line
     fi
     if 0 program Program::constants_count > then
-        f"constants: .skip {program Program::constants_count 8 * .to_str}" asm emit_line
+        f"constants: .skip {program Program::constants_count 8 *}" asm emit_line
     fi
-    f"return_stack: .skip {RETURN_STACK_SIZE .to_str}" asm emit_line
-    f"heap: .skip {HEAP_SIZE .to_str}" asm emit_line
+    f"return_stack: .skip {RETURN_STACK_SIZE}" asm emit_line
+    f"heap: .skip {HEAP_SIZE}" asm emit_line
     "heap_ptr: .skip 8" asm emit_line
     "__argc: .skip 8" asm emit_line
     "__argv: .skip 8" asm emit_line
@@ -125,8 +125,8 @@ fn emit_data asm:StringBuilder program:Program {
         index program Program::strings .get = value
         value escape_string = escaped
         ".align 8" asm emit_line
-        f"str_{index .to_str}:" asm emit_line
-        f".quad {value .length .to_str}" asm emit_line
+        f"str_{index}:" asm emit_line
+        f".quad {value .length}" asm emit_line
         f".asciz \"{escaped}\"" asm emit_line
         1 += index
     done
@@ -333,16 +333,16 @@ fn emit_stack_ops asm:StringBuilder inst:Inst {
             INT32_MIN value >=
             INT32_MAX value <= &&
         then
-            f"pushq ${value .to_str}" asm emit_indent
+            f"pushq ${value}" asm emit_indent
         else
-            f"movabsq ${value .to_str}, %rax" asm emit_indent
+            f"movabsq ${value}, %rax" asm emit_indent
             "pushq %rax" asm emit_indent
         fi
     elif InstKind::InstPushStr kind == then
-        f"leaq str_{inst Inst::int_arg .to_str}(%rip), %rax" asm emit_indent
+        f"leaq str_{inst Inst::int_arg}(%rip), %rax" asm emit_indent
         "pushq %rax" asm emit_indent
     elif InstKind::InstPushChar kind == then
-        f"pushq ${inst Inst::int_arg .to_str}" asm emit_indent
+        f"pushq ${inst Inst::int_arg}" asm emit_indent
     elif InstKind::InstDrop kind == then
         "addq $8, %rsp" asm emit_indent
     elif InstKind::InstDup kind == then
@@ -451,69 +451,69 @@ fn emit_arithmetic asm:StringBuilder inst:Inst {
 fn emit_control_flow asm:StringBuilder inst:Inst is_global:bool {
     inst Inst::kind = kind
     if InstKind::InstLabel kind == then
-        f".L{inst Inst::int_arg .to_str}:" asm emit_line
+        f".L{inst Inst::int_arg}:" asm emit_line
     elif InstKind::InstJump kind == then
-        f"jmp .L{inst Inst::int_arg .to_str}" asm emit_indent
+        f"jmp .L{inst Inst::int_arg}" asm emit_indent
     elif InstKind::InstJumpNe kind == then
         "popq %rax" asm emit_indent
         "testq %rax, %rax" asm emit_indent
-        f"jz .L{inst Inst::int_arg .to_str}" asm emit_indent
+        f"jz .L{inst Inst::int_arg}" asm emit_indent
     elif InstKind::InstGlobalsInit kind == then
         # Nothing needed, BSS handles it
     elif InstKind::InstGlobalGet kind == then
         inst Inst::int_arg 8 * = offset
-        f"movq globals+{offset .to_str}(%rip), %rax" asm emit_indent
+        f"movq globals+{offset}(%rip), %rax" asm emit_indent
         "pushq %rax" asm emit_indent
     elif InstKind::InstGlobalSet kind == then
         inst Inst::int_arg 8 * = offset
         "popq %rax" asm emit_indent
-        f"movq %rax, globals+{offset .to_str}(%rip)" asm emit_indent
+        f"movq %rax, globals+{offset}(%rip)" asm emit_indent
     elif InstKind::InstLocalsInit kind == then
         inst Inst::int_arg = count
         if 0 count != then
             "movq %r14, %rdi" asm emit_indent
-            f"movq ${count .to_str}, %rcx" asm emit_indent
+            f"movq ${count}, %rcx" asm emit_indent
             "xorq %rax, %rax" asm emit_indent
             "rep stosq" asm emit_indent
-            f"addq ${count 8 * .to_str}, %r14" asm emit_indent
+            f"addq ${count 8 *}, %r14" asm emit_indent
         fi
     elif InstKind::InstLocalsUninit kind == then
         inst Inst::int_arg = count
         if 0 count != then
-            f"subq ${count 8 * .to_str}, %r14" asm emit_indent
+            f"subq ${count 8 *}, %r14" asm emit_indent
         fi
     elif InstKind::InstLocalGet kind == then
         inst Inst::int_arg 1 + 8 * = offset
-        f"movq -{offset .to_str}(%r14), %rax" asm emit_indent
+        f"movq -{offset}(%r14), %rax" asm emit_indent
         "pushq %rax" asm emit_indent
     elif InstKind::InstLocalSet kind == then
         inst Inst::int_arg 1 + 8 * = offset
         "popq %rax" asm emit_indent
-        f"movq %rax, -{offset .to_str}(%r14)" asm emit_indent
+        f"movq %rax, -{offset}(%r14)" asm emit_indent
     elif InstKind::InstConstantLoad kind == then
         inst Inst::int_arg 8 * = offset
-        f"movq constants+{offset .to_str}(%rip), %rax" asm emit_indent
+        f"movq constants+{offset}(%rip), %rax" asm emit_indent
         "pushq %rax" asm emit_indent
     elif InstKind::InstConstantStore kind == then
         inst Inst::int_arg 8 * = offset
         "popq %rax" asm emit_indent
-        f"movq %rax, constants+{offset .to_str}(%rip)" asm emit_indent
+        f"movq %rax, constants+{offset}(%rip)" asm emit_indent
     elif InstKind::InstFnCall kind == then
         inst Inst::str_arg sanitize_name = label
         emit_uid = uid
-        f"leaq .Lret_{uid .to_str}(%rip), %rax" asm emit_indent
+        f"leaq .Lret_{uid}(%rip), %rax" asm emit_indent
         "movq %rax, (%r14)" asm emit_indent
         "addq $8, %r14" asm emit_indent
         f"jmp fn_{label}" asm emit_indent
-        f".Lret_{uid .to_str}:" asm emit_line
+        f".Lret_{uid}:" asm emit_line
     elif InstKind::InstFnExec kind == then
         emit_uid = uid
-        f"leaq .Lret_{uid .to_str}(%rip), %rax" asm emit_indent
+        f"leaq .Lret_{uid}(%rip), %rax" asm emit_indent
         "movq %rax, (%r14)" asm emit_indent
         "addq $8, %r14" asm emit_indent
         "popq %rax" asm emit_indent
         "jmpq *%rax" asm emit_indent
-        f".Lret_{uid .to_str}:" asm emit_line
+        f".Lret_{uid}:" asm emit_line
     elif InstKind::InstFnPush kind == then
         inst Inst::str_arg sanitize_name = label
         f"leaq fn_{label}(%rip), %rax" asm emit_indent
@@ -588,34 +588,34 @@ fn emit_io_ops asm:StringBuilder inst:Inst {
     if InstKind::InstPrintInt kind == then
         emit_uid = uid
         "popq %rdi" asm emit_indent
-        f"leaq .Lprint_done_{uid .to_str}(%rip), %rax" asm emit_indent
+        f"leaq .Lprint_done_{uid}(%rip), %rax" asm emit_indent
         "movq %rax, (%r14)" asm emit_indent
         "addq $8, %r14" asm emit_indent
         "jmp print_int" asm emit_indent
-        f".Lprint_done_{uid .to_str}:" asm emit_line
+        f".Lprint_done_{uid}:" asm emit_line
     elif InstKind::InstPrintBool kind == then
         emit_uid = uid
         "popq %rax" asm emit_indent
         "testq %rax, %rax" asm emit_indent
-        f"jz .Lpb_false_{uid .to_str}" asm emit_indent
+        f"jz .Lpb_false_{uid}" asm emit_indent
         "leaq bool_true(%rip), %rsi" asm emit_indent
         "movq $4, %rdx" asm emit_indent
-        f"jmp .Lpb_write_{uid .to_str}" asm emit_indent
-        f".Lpb_false_{uid .to_str}:" asm emit_line
+        f"jmp .Lpb_write_{uid}" asm emit_indent
+        f".Lpb_false_{uid}:" asm emit_line
         "leaq bool_false(%rip), %rsi" asm emit_indent
         "movq $5, %rdx" asm emit_indent
-        f".Lpb_write_{uid .to_str}:" asm emit_line
+        f".Lpb_write_{uid}:" asm emit_line
         "movq $1, %rdi" asm emit_indent
         "movq $1, %rax" asm emit_indent
         "syscall" asm emit_indent
     elif InstKind::InstPrintStr kind == then
         emit_uid = uid
         "popq %rdi" asm emit_indent
-        f"leaq .Lprint_done_{uid .to_str}(%rip), %rax" asm emit_indent
+        f"leaq .Lprint_done_{uid}(%rip), %rax" asm emit_indent
         "movq %rax, (%r14)" asm emit_indent
         "addq $8, %r14" asm emit_indent
         "jmp print_str" asm emit_indent
-        f".Lprint_done_{uid .to_str}:" asm emit_line
+        f".Lprint_done_{uid}:" asm emit_line
     elif InstKind::InstPrintChar kind == then
         "popq %rax" asm emit_indent
         "movb %al, -1(%rsp)" asm emit_indent
@@ -628,12 +628,12 @@ fn emit_io_ops asm:StringBuilder inst:Inst {
         emit_uid = uid
         "popq %rsi" asm emit_indent
         "movq %rsi, %rdi" asm emit_indent
-        f".Lpc_scan_{uid .to_str}:" asm emit_line
+        f".Lpc_scan_{uid}:" asm emit_line
         "cmpb $0, (%rsi)" asm emit_indent
-        f"je .Lpc_done_{uid .to_str}" asm emit_indent
+        f"je .Lpc_done_{uid}" asm emit_indent
         "incq %rsi" asm emit_indent
-        f"jmp .Lpc_scan_{uid .to_str}" asm emit_indent
-        f".Lpc_done_{uid .to_str}:" asm emit_line
+        f"jmp .Lpc_scan_{uid}" asm emit_indent
+        f".Lpc_done_{uid}:" asm emit_line
         "movq %rsi, %rdx" asm emit_indent
         "subq %rdi, %rdx" asm emit_indent
         "movq %rdi, %rsi" asm emit_indent
@@ -642,12 +642,12 @@ fn emit_io_ops asm:StringBuilder inst:Inst {
         "syscall" asm emit_indent
     elif InstKind::InstFstringConcat kind == then
         emit_uid = uid
-        f"movq ${inst Inst::int_arg .to_str}, %rdi" asm emit_indent
-        f"leaq .Lconcat_done_{uid .to_str}(%rip), %rax" asm emit_indent
+        f"movq ${inst Inst::int_arg}, %rdi" asm emit_indent
+        f"leaq .Lconcat_done_{uid}(%rip), %rax" asm emit_indent
         "movq %rax, (%r14)" asm emit_indent
         "addq $8, %r14" asm emit_indent
         "jmp str_concat" asm emit_indent
-        f".Lconcat_done_{uid .to_str}:" asm emit_line
+        f".Lconcat_done_{uid}:" asm emit_line
     fi
 }
 
@@ -661,16 +661,16 @@ fn emit_str_eq asm:StringBuilder {
     "popq %rdi" asm emit_indent
     "movq (%rdi), %rcx" asm emit_indent
     "cmpq (%rsi), %rcx" asm emit_indent
-    f"jne .Lstreq_ne_{uid .to_str}" asm emit_indent
+    f"jne .Lstreq_ne_{uid}" asm emit_indent
     "leaq 8(%rdi), %rdi" asm emit_indent
     "leaq 8(%rsi), %rsi" asm emit_indent
     "repe cmpsb" asm emit_indent
-    f"jne .Lstreq_ne_{uid .to_str}" asm emit_indent
+    f"jne .Lstreq_ne_{uid}" asm emit_indent
     "pushq $1" asm emit_indent
-    f"jmp .Lstreq_done_{uid .to_str}" asm emit_indent
-    f".Lstreq_ne_{uid .to_str}:" asm emit_line
+    f"jmp .Lstreq_done_{uid}" asm emit_indent
+    f".Lstreq_ne_{uid}:" asm emit_line
     "pushq $0" asm emit_indent
-    f".Lstreq_done_{uid .to_str}:" asm emit_line
+    f".Lstreq_done_{uid}:" asm emit_line
 }
 
 # ============================================================================

--- a/compiler/error.casa
+++ b/compiler/error.casa
@@ -257,7 +257,7 @@ fn report_errors errors:List[CasaError] {
         "" eprintln
         1 += index
     done
-    f"Found {errors .length .to_str} error(s)." eprintln
+    f"Found {errors .length} error(s)." eprintln
 }
 
 fn report_warnings {

--- a/compiler/parser.casa
+++ b/compiler/parser.casa
@@ -472,7 +472,7 @@ fn handle_fstring start_token:Token cursor:TokenCursor function_name:str ops:Lis
             1 += part_count
         elif TokenKind::FstringExprStart token Token::kind == then
             function_name cursor parse_fstring_expr = expr_ops
-            f"lambda__{function_name}_o{token Token::location Location::span Span::offset .to_str}" = lambda_name
+            f"lambda__{function_name}_o{token Token::location Location::span Span::offset}" = lambda_name
             token Token::location expr_ops lambda_name make_function = lambda_function
             lambda_name lambda_function GLOBAL_FUNCTIONS .set = GLOBAL_FUNCTIONS
             token Token::location OpKind::OpFnPush lambda_name make_op_str ops .push
@@ -518,7 +518,7 @@ fn get_op_delimiter token:Token cursor:TokenCursor function_name:str ops:List[Op
     if "{" value == then
         cursor tc_retreat
         function_name cursor parse_block_ops = lambda_ops
-        f"lambda__{function_name}_o{token Token::location Location::span Span::offset .to_str}" = lambda_name
+        f"lambda__{function_name}_o{token Token::location Location::span Span::offset}" = lambda_name
         token Token::location lambda_ops lambda_name make_function = lambda_function
         lambda_name lambda_function GLOBAL_FUNCTIONS .set = GLOBAL_FUNCTIONS
         token Token::location OpKind::OpFnPush lambda_name make_op_str ops .push

--- a/compiler/typechecker.casa
+++ b/compiler/typechecker.casa
@@ -532,7 +532,7 @@ fn apply_signature tc:TypeChecker sig:Signature name:str {
         0 = index
         while index sig Signature::parameters .length > do
             if "" name != then
-                f"parameter {index 1 + .to_str} of `{name}`" tc TypeChecker::set_current_expect_ctx
+                f"parameter {index 1 +} of `{name}`" tc TypeChecker::set_current_expect_ctx
             fi
             index sig Signature::parameters .get Parameter::typ tc expect_type drop
             1 += index
@@ -554,7 +554,7 @@ fn apply_signature tc:TypeChecker sig:Signature name:str {
         param Parameter::typ = expected
 
         if "" name != then
-            f"parameter {index 1 + .to_str} of `{name}`" tc TypeChecker::set_current_expect_ctx
+            f"parameter {index 1 +} of `{name}`" tc TypeChecker::set_current_expect_ctx
         fi
 
         # Direct type variable (e.g. T)
@@ -1456,7 +1456,7 @@ fn check_is tc:TypeChecker op:Op {
         if inner_opt .is_some then
             inner_opt .unwrap = inner_types
             if variant EnumVariant::bindings .length inner_types .length != then
-                tc TypeChecker::current_location f"Variant `{variant EnumVariant::enum_name}::{variant EnumVariant::variant_name}` has {inner_types .length .to_str} inner value(s), but {variant EnumVariant::bindings .length .to_str} binding(s) provided" ErrorKind::TypeMismatch raise_error
+                tc TypeChecker::current_location f"Variant `{variant EnumVariant::enum_name}::{variant EnumVariant::variant_name}` has {inner_types .length} inner value(s), but {variant EnumVariant::bindings .length} binding(s) provided" ErrorKind::TypeMismatch raise_error
             fi
         fi
     fi

--- a/examples/command_line_args.casa
+++ b/examples/command_line_args.casa
@@ -6,13 +6,13 @@ include "../lib/std.casa"
 
 # Print number of user arguments (excluding program name)
 argc 1 - = num_args
-f"number of arguments: {num_args .to_str}" print "\n" print
+f"number of arguments: {num_args}" print "\n" print
 
 # Print each user argument
 1 = i
 while i argc > do
     i get_arg = arg
-    f"  arg {i 1 - .to_str}: {arg}" print "\n" print
+    f"  arg {i 1 -}: {arg}" print "\n" print
     1 += i
 done
 

--- a/examples/fstring.casa
+++ b/examples/fstring.casa
@@ -1,5 +1,7 @@
 # F-string interpolation examples
 
+include "../lib/std.casa"
+
 # Basic f-string with a variable
 "world" = greeting
 f"hello {greeting}\n" print
@@ -28,3 +30,14 @@ f"col1\tcol2\n" print
 
 # F-string with no expressions is just a string
 f"plain string\n" print
+
+# Arbitrary types that satisfy the Display trait are auto-converted
+42 = count
+'A' = letter
+true = ready
+f"count={count} letter={letter} ready={ready}\n" print
+
+# Containers and Option[T] also satisfy Display
+[1, 2, 3] (array[int]) = nums
+5 Option::Some = maybe
+f"nums={nums} maybe={maybe}\n" print

--- a/examples/outputs/fstring.out
+++ b/examples/outputs/fstring.out
@@ -5,3 +5,5 @@ hi Bob
 casa supports f-strings
 col1	col2
 plain string
+count=42 letter=A ready=true
+nums=[1, 2, 3] maybe=Some(5)

--- a/examples/run_command.casa
+++ b/examples/run_command.casa
@@ -4,13 +4,13 @@
 include "../lib/std.casa"
 
 # Run echo
-["/usr/bin/env", "echo", "hello", "from", "casa"] List::from_array run_command = exit_code
-f"echo exit code: {exit_code .to_str}" print "\n" print
+["/usr/bin/env", "echo", "hello", "from", "casa"] List::from_array run_command = echo_code
+f"echo exit code: {echo_code}" print "\n" print
 
 # Run true (exits 0)
-["/usr/bin/env", "true"] List::from_array run_command = exit_code
-f"true exit code: {exit_code .to_str}" print "\n" print
+["/usr/bin/env", "true"] List::from_array run_command = true_code
+f"true exit code: {true_code}" print "\n" print
 
 # Run false (exits 1)
-["/usr/bin/env", "false"] List::from_array run_command = exit_code
-f"false exit code: {exit_code .to_str}" print "\n" print
+["/usr/bin/env", "false"] List::from_array run_command = false_code
+f"false exit code: {false_code}" print "\n" print

--- a/lib/std.casa
+++ b/lib/std.casa
@@ -175,11 +175,11 @@ fn digit_to_str d:int -> str {
 impl int {
     fn to_str n:int -> str {
         if 0 n < then
-            f"-{0 n - .to_str}"
+            f"-{0 n -}"
         elif 10 n < then
             n digit_to_str
         else
-            f"{n 10 / .to_str}{n 10 % digit_to_str}"
+            f"{n 10 /}{n 10 % digit_to_str}"
         fi
     }
 }

--- a/lib/test.casa
+++ b/lib/test.casa
@@ -36,7 +36,7 @@ fn assert_eq actual:int expected:int msg:str {
     if expected actual == then
         1 += test_pass_count
     else
-        f"[FAIL] {test_current_name}: {msg} (expected {expected .to_str}, got {actual .to_str})\n" eprint
+        f"[FAIL] {test_current_name}: {msg} (expected {expected}, got {actual})\n" eprint
         1 += test_fail_count
     fi
 }
@@ -51,7 +51,7 @@ fn assert_str_eq actual:str expected:str msg:str {
 }
 
 fn test_summary {
-    f"{test_pass_count .to_str} passed, {test_fail_count .to_str} failed\n" print
+    f"{test_pass_count} passed, {test_fail_count} failed\n" print
     if 0 test_fail_count > then
         1 exit
     fi

--- a/lsp.casa
+++ b/lsp.casa
@@ -263,7 +263,7 @@ fn read_message reader:StdinReader -> Option[JsonValue] {
 
 fn send_json_rpc body:str {
     body .length = body_length
-    f"Content-Length: {body_length .to_str}\r\n\r\n{body}" stdout_write
+    f"Content-Length: {body_length}\r\n\r\n{body}" stdout_write
 }
 
 fn send_response id:JsonValue result:JsonValue {
@@ -992,7 +992,7 @@ fn format_hover op:Op state:DocumentState func:Option[Function] -> Option[str] {
 
     # Literals
     if OpKind::OpPushInt kind == then
-        f"(int) {op op_int_value .to_str}" Option::Some
+        f"(int) {op op_int_value}" Option::Some
         return
     fi
     if OpKind::OpPushStr kind == then


### PR DESCRIPTION
## Summary
- Remove redundant `.to_str` calls inside f-strings across the compiler, stdlib, LSP, and examples — now that v1.1.0 auto-dispatches via the `Display` trait.
- Extend `examples/fstring.casa` to showcase interpolation of `int`, `char`, `bool`, `array[int]`, and `Option[int]`.

Requires the v1.1.0 compiler as the bootstrap binary (older `casac` cannot typecheck the refactored sources).

## Test plan
- [x] `./tests/test_compiler.sh` (20/20 incl. self-compile + fixed-point)
- [x] `./tests/test_examples.sh` (33/33)