### PR TITLE
feat(traits): generic trait parameters and generic trait bounds

### DIFF
--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -517,11 +517,11 @@ struct Signature {
     parameters:   List[Parameter]
     return_types: List[str]
     type_vars:    Set[str]
-    trait_bounds:  Map[str str]
+    trait_bounds:  Map[str TraitBound]
 }
 
 fn empty_signature -> Signature {
-    Map::new (Map[str str])
+    Map::new (Map[str TraitBound])
     Set::new (Set[str])
     List::new (List[str])
     List::new (List[Parameter])
@@ -529,7 +529,7 @@ fn empty_signature -> Signature {
 }
 
 fn make_signature params:List[Parameter] returns:List[str] -> Signature {
-    Map::new (Map[str str])
+    Map::new (Map[str TraitBound])
     Set::new (Set[str])
     returns
     params
@@ -649,9 +649,64 @@ struct TraitMethod {
 }
 
 struct CasaTrait {
-    name:     str
-    methods:  List[TraitMethod]
-    location: Location
+    name:        str
+    type_params: List[str]
+    methods:     List[TraitMethod]
+    location:    Location
+}
+
+# Per-method hidden-parameter info produced by build_hidden_trait_methods.
+# Both parse_function and inject_impl_trait_params consume this list to
+# prepend `__trait_{type_var}_{method}` function-pointer parameters.
+struct HiddenTraitMethod {
+    var_name: str  # e.g. "__trait_I_next"
+    fn_type:  str  # e.g. "fn[I -> Option[int]]"
+}
+
+# A generic trait bound attached to a type variable in a function or impl
+# header. For `fn foo[I: Iterator[int]] ...` the bound is
+# TraitBound{name="Iterator", type_args=["int"]}. For non-generic bounds
+# like `K: Hashable` the type_args list is empty.
+struct TraitBound {
+    name:      str
+    type_args: List[str]
+}
+
+fn make_simple_trait_bound name:str -> TraitBound {
+    List::new (List[str]) name TraitBound
+}
+
+fn trait_bound_to_str bound:TraitBound -> str {
+    bound TraitBound::type_args = tbts_args
+    if 0 tbts_args .length == then
+        bound TraitBound::name return
+    fi
+    StringBuilder::new = tbts_sb
+    bound TraitBound::name tbts_sb .append
+    "[" tbts_sb .append
+    0 = tbts_index
+    while tbts_index tbts_args .length > do
+        if 0 tbts_index != then " " tbts_sb .append fi
+        tbts_index tbts_args .get tbts_sb .append
+        1 += tbts_index
+    done
+    "]" tbts_sb .append
+    tbts_sb .build
+}
+
+fn trait_bound_eq a:TraitBound b:TraitBound -> bool {
+    if a TraitBound::name b TraitBound::name != then false return fi
+    a TraitBound::type_args = tbe_a_args
+    b TraitBound::type_args = tbe_b_args
+    if tbe_a_args .length tbe_b_args .length != then false return fi
+    0 = tbe_index
+    while tbe_index tbe_a_args .length > do
+        if tbe_index tbe_a_args .get tbe_index tbe_b_args .get != then
+            false return
+        fi
+        1 += tbe_index
+    done
+    true
 }
 
 # ============================================================================
@@ -980,6 +1035,54 @@ fn signature_matches sig_a:Signature sig_b:Signature -> bool {
     done
 
     true
+}
+
+fn substitute_type_params typ:str subs:Map[str str] -> str {
+    # Replace any occurrence of a substitution key within a type expression.
+    # E.g. with subs {T: int}, "T" -> "int", "Option[T]" -> "Option[int]".
+    if typ subs .get .is_some then
+        typ subs .get .unwrap return
+    fi
+    typ extract_generic_base = base_opt
+    if base_opt .is_none then
+        typ return
+    fi
+    base_opt .unwrap = base
+    typ extract_generic_params = params_opt
+    if params_opt .is_none then
+        typ return
+    fi
+    params_opt .unwrap = params
+    StringBuilder::new = builder
+    base builder .append
+    "[" builder .append
+    0 = stp_index
+    while stp_index params .length > do
+        if 0 stp_index != then " " builder .append fi
+        subs stp_index params .get substitute_type_params builder .append
+        1 += stp_index
+    done
+    "]" builder .append
+    builder .build
+}
+
+fn apply_type_subs_to_sig sig:Signature subs:Map[str str] -> Signature {
+    if 0 subs .length == then sig return fi
+    List::new (List[Parameter]) = params
+    0 = index
+    while index sig Signature::parameters .length > do
+        index sig Signature::parameters .get = param
+        subs param Parameter::typ substitute_type_params = new_typ
+        param Parameter::name new_typ make_named_param params .push
+        1 += index
+    done
+    List::new (List[str]) = returns
+    0 = index
+    while index sig Signature::return_types .length > do
+        subs index sig Signature::return_types .get substitute_type_params returns .push
+        1 += index
+    done
+    returns params make_signature
 }
 
 fn resolve_trait_sig sig:Signature type_var:str -> Signature {

--- a/compiler/parser.casa
+++ b/compiler/parser.casa
@@ -619,13 +619,80 @@ fn require_global_scope function_name:str what:str location:Location {
 # ============================================================================
 
 # Global to pass trait bounds from parse_type_vars (since we can't return tuples)
-Map::new (Map[str str]) = LAST_TRAIT_BOUNDS
+Map::new (Map[str TraitBound]) = LAST_TRAIT_BOUNDS
+
+# Parse the `[arg1 arg2 ...]` type argument list that follows a generic trait
+# name in a trait bound (e.g. `I: Iterator[int]`). The caller has already
+# consumed the trait identifier. If the next token is not `[`, returns an
+# empty list. Otherwise consumes tokens up to the matching closing `]`,
+# splitting args at top-level `,` or whitespace and preserving nested
+# generic structure including the space separators.
+fn parse_bound_type_args cursor:TokenCursor trait_token:Token -> List[str] {
+    List::new (List[str]) = bound_args
+    cursor tc_peek = bracket_opt
+    if bracket_opt .is_none then bound_args return fi
+    if "[" bracket_opt .unwrap Token::value != then bound_args return fi
+    cursor tc_pop drop  # consume [
+    1 = pba_depth
+    StringBuilder::new = pba_current
+    false = pba_need_space
+    while 0 pba_depth > do
+        cursor tc_pop = arg_tok_opt
+        if arg_tok_opt .is_none then
+            trait_token Token::location "Unclosed trait bound type argument list" ErrorKind::Syntax raise_error
+            bound_args return
+        fi
+        arg_tok_opt .unwrap Token::value = arg_val
+        if "[" arg_val == then
+            1 += pba_depth
+            arg_val pba_current .append
+            false = pba_need_space
+            continue
+        fi
+        if "]" arg_val == then
+            pba_depth 1 - = pba_depth
+            if 0 pba_depth == then
+                if 0 pba_current .length != then
+                    pba_current .build bound_args .push
+                fi
+                continue
+            fi
+            arg_val pba_current .append
+            true = pba_need_space
+            continue
+        fi
+        if "," arg_val == 1 pba_depth == && then
+            if 0 pba_current .length != then
+                pba_current .build bound_args .push
+                StringBuilder::new = pba_current
+            fi
+            false = pba_need_space
+            continue
+        fi
+        # Top-level whitespace-separated args: finalize the current arg and
+        # start a new one. Nested args (depth > 1) preserve spacing so that
+        # `Map[str int]` serializes back as the canonical multi-token form.
+        if 1 pba_depth == then
+            if 0 pba_current .length != then
+                pba_current .build bound_args .push
+                StringBuilder::new = pba_current
+            fi
+            arg_val pba_current .append
+            true = pba_need_space
+            continue
+        fi
+        if pba_need_space then " " pba_current .append fi
+        arg_val pba_current .append
+        true = pba_need_space
+    done
+    bound_args
+}
 
 fn parse_type_vars cursor:TokenCursor -> List[str] {
     "[" cursor expect_token_value drop
     List::new (List[str]) = vars
     Set::new (Set[str]) = seen
-    Map::new (Map[str str]) = LAST_TRAIT_BOUNDS
+    Map::new (Map[str TraitBound]) = LAST_TRAIT_BOUNDS
 
     while true do
         cursor tc_pop = token_opt
@@ -649,16 +716,27 @@ fn parse_type_vars cursor:TokenCursor -> List[str] {
             fi
             token Token::value vars .push
             token Token::value seen .add = seen
-            # Check for trait bound: K: Hashable
+            # Check for trait bound: K: Hashable  or  K: Iterator[int]
             cursor tc_peek = colon_opt
             if colon_opt .is_some then
                 if ":" colon_opt .unwrap Token::value == then
                     cursor tc_pop drop  # consume :
                     TokenKind::Identifier cursor expect_token_kind = trait_token
-                    if trait_token Token::value GLOBAL_TRAITS .get .is_none then
-                        trait_token Token::location f"Trait `{trait_token Token::value}` is not defined" ErrorKind::UndefinedName raise_error
+                    trait_token Token::value = bound_trait_name
+                    bound_trait_name GLOBAL_TRAITS .get = bound_trait_def_opt
+                    if bound_trait_def_opt .is_none then
+                        trait_token Token::location f"Trait `{bound_trait_name}` is not defined" ErrorKind::UndefinedName raise_error
                     fi
-                    token Token::value trait_token Token::value LAST_TRAIT_BOUNDS .set = LAST_TRAIT_BOUNDS
+                    trait_token cursor parse_bound_type_args = bound_args
+                    if bound_trait_def_opt .is_some then
+                        # Arity check against trait's declared type_params
+                        bound_trait_def_opt .unwrap CasaTrait::type_params = declared_params
+                        if bound_args .length declared_params .length != then
+                            trait_token Token::location f"Trait `{bound_trait_name}` expects {declared_params .length} type argument(s), got {bound_args .length}" ErrorKind::Syntax raise_error
+                        fi
+                        bound_args bound_trait_name TraitBound = ptv_bound
+                        token Token::value ptv_bound LAST_TRAIT_BOUNDS .set = LAST_TRAIT_BOUNDS
+                    fi
                 fi
             fi
         else
@@ -755,6 +833,52 @@ fn parse_signature cursor:TokenCursor -> Signature {
 }
 
 # ============================================================================
+# build_hidden_trait_methods - shared hidden-param construction
+# ============================================================================
+#
+# Walks the given trait bounds and returns a flat list of (var_name, fn_type)
+# pairs describing each hidden `__trait_{type_var}_{method}` parameter that
+# must be injected. Used by both parse_function and inject_impl_trait_params.
+# Bounds whose trait is not registered in GLOBAL_TRAITS are silently skipped,
+# matching the pre-extraction behavior of both call sites.
+fn build_hidden_trait_methods trait_bounds:Map[str TraitBound] -> List[HiddenTraitMethod] {
+    List::new (List[HiddenTraitMethod]) = result
+    trait_bounds .keys = bound_keys
+    0 = bound_index
+    while bound_index bound_keys .length > do
+        bound_index bound_keys .get = bound_type_var
+        bound_type_var trait_bounds .get .unwrap = bound
+        bound TraitBound::name GLOBAL_TRAITS .get = bound_trait_opt
+        if bound_trait_opt .is_some then
+            bound_trait_opt .unwrap = bound_trait
+            # Build substitution map from trait's declared type_params to the
+            # concrete type_args carried on the bound.
+            Map::new (Map[str str]) = bound_subs
+            bound_trait CasaTrait::type_params = bhtm_params
+            bound TraitBound::type_args = bhtm_args
+            if bhtm_params .length bhtm_args .length == then
+                0 = bhtm_sub_index
+                while bhtm_sub_index bhtm_params .length > do
+                    bhtm_sub_index bhtm_params .get bhtm_sub_index bhtm_args .get bound_subs .set = bound_subs
+                    1 += bhtm_sub_index
+                done
+            fi
+            0 = method_index
+            while method_index bound_trait CasaTrait::methods .length > do
+                method_index bound_trait CasaTrait::methods .get = bound_method
+                f"__trait_{bound_type_var}_{bound_method TraitMethod::name}" = hidden_name
+                bound_subs bound_type_var bound_method TraitMethod::signature resolve_trait_sig apply_type_subs_to_sig = hidden_sig
+                f"fn[{hidden_sig signature_to_str}]" = hidden_type
+                hidden_type hidden_name HiddenTraitMethod result .push
+                1 += method_index
+            done
+        fi
+        1 += bound_index
+    done
+    result
+}
+
+# ============================================================================
 # parse_function - parse function definition
 # ============================================================================
 
@@ -790,27 +914,16 @@ fn parse_function cursor:TokenCursor -> Function {
     # Inject hidden __trait_* parameters for trait-bounded type vars
     if 0 sig Signature::trait_bounds .keys .length != then
         List::new (List[Parameter]) = hidden_params
-        sig Signature::trait_bounds .keys = bound_keys
-        0 = bound_index
-        while bound_index bound_keys .length > do
-            bound_index bound_keys .get = bound_type_var
-            bound_type_var sig Signature::trait_bounds .get .unwrap = bound_trait_name
-            bound_trait_name GLOBAL_TRAITS .get = bound_trait_opt
-            if bound_trait_opt .is_some then
-                bound_trait_opt .unwrap = bound_trait
-                0 = method_index
-                while method_index bound_trait CasaTrait::methods .length > do
-                    method_index bound_trait CasaTrait::methods .get = bound_method
-                    f"__trait_{bound_type_var}_{bound_method TraitMethod::name}" = hidden_name
-                    bound_type_var bound_method TraitMethod::signature resolve_trait_sig = hidden_sig
-                    f"fn[{hidden_sig signature_to_str}]" = hidden_type
-                    hidden_name hidden_type make_named_param hidden_params .push
-                    hidden_type hidden_name Variable variables .push
-                    name_token Token::location OpKind::OpAssignVar hidden_name make_op_str ops .push
-                    1 += method_index
-                done
-            fi
-            1 += bound_index
+        sig Signature::trait_bounds build_hidden_trait_methods = hidden_methods
+        0 = hidden_index
+        while hidden_index hidden_methods .length > do
+            hidden_index hidden_methods .get = hidden
+            hidden HiddenTraitMethod::var_name = hidden_name
+            hidden HiddenTraitMethod::fn_type = hidden_type
+            hidden_name hidden_type make_named_param hidden_params .push
+            hidden_type hidden_name Variable variables .push
+            name_token Token::location OpKind::OpAssignVar hidden_name make_op_str ops .push
+            1 += hidden_index
         done
         # Prepend hidden params to signature parameters
         0 = param_index
@@ -1081,6 +1194,30 @@ fn parse_trait cursor:TokenCursor -> CasaTrait {
     "trait" cursor expect_token_value drop
     TokenKind::Identifier cursor expect_token_kind = name_token
 
+    List::new (List[str]) = type_params
+    cursor tc_peek = bracket_opt
+    if bracket_opt .is_some "[" bracket_opt .unwrap Token::value == && then
+        cursor tc_pop drop  # consume [
+        while true do
+            cursor tc_peek = tp_opt
+            if tp_opt .is_none then
+                name_token Token::location "Unclosed trait type parameter list" ErrorKind::UnmatchedBlock raise_error
+                break
+            fi
+            tp_opt .unwrap = tp_tok
+            if "]" tp_tok Token::value == then
+                cursor tc_pop drop
+                break
+            fi
+            if TokenKind::Identifier tp_tok Token::kind != then
+                tp_tok Token::location "Expected type parameter identifier in trait" ErrorKind::UnexpectedToken raise_error
+                break
+            fi
+            cursor tc_pop drop
+            tp_tok Token::value type_params .push
+        done
+    fi
+
     List::new (List[TraitMethod]) = methods
     "{" cursor expect_token_value drop
 
@@ -1104,14 +1241,14 @@ fn parse_trait cursor:TokenCursor -> CasaTrait {
         method_sig method_name Token::value TraitMethod methods .push
     done
 
-    name_token Token::location methods name_token Token::value CasaTrait
+    name_token Token::location methods type_params name_token Token::value CasaTrait
 }
 
 # ============================================================================
 # parse_impl_block - parse impl Type { fn methods... }
 # ============================================================================
 
-fn inject_impl_trait_params function:Function type_vars:List[str] trait_bounds:Map[str str] {
+fn inject_impl_trait_params function:Function type_vars:List[str] trait_bounds:Map[str TraitBound] {
     function Function::signature = sig
 
     # Merge type vars into function signature
@@ -1138,28 +1275,18 @@ fn inject_impl_trait_params function:Function type_vars:List[str] trait_bounds:M
     # Inject hidden __trait_* parameters
     List::new (List[Parameter]) = hidden_params
     0 = insert_pos
-    0 = bound_iter
-    while bound_iter bound_keys .length > do
-        bound_iter bound_keys .get = bound_type_var
-        bound_type_var sig Signature::trait_bounds .get .unwrap = trait_name
-        trait_name GLOBAL_TRAITS .get = trait_opt
-        if trait_opt .is_some then
-            trait_opt .unwrap = trait_def
-            0 = method_index
-            while method_index trait_def CasaTrait::methods .length > do
-                method_index trait_def CasaTrait::methods .get = method
-                f"__trait_{bound_type_var}_{method TraitMethod::name}" = hidden_name
-                bound_type_var method TraitMethod::signature resolve_trait_sig = hidden_sig
-                f"fn[{hidden_sig signature_to_str}]" = hidden_type
-                hidden_name hidden_type make_named_param hidden_params .push
-                hidden_name make_variable function Function::variables .push
-                function Function::location OpKind::OpAssignVar hidden_name make_op_str = assign_op
-                insert_pos assign_op function Function::ops .insert
-                1 += insert_pos
-                1 += method_index
-            done
-        fi
-        1 += bound_iter
+    sig Signature::trait_bounds build_hidden_trait_methods = hidden_methods
+    0 = hidden_index
+    while hidden_index hidden_methods .length > do
+        hidden_index hidden_methods .get = hidden
+        hidden HiddenTraitMethod::var_name = hidden_name
+        hidden HiddenTraitMethod::fn_type = hidden_type
+        hidden_name hidden_type make_named_param hidden_params .push
+        hidden_name make_variable function Function::variables .push
+        function Function::location OpKind::OpAssignVar hidden_name make_op_str = assign_op
+        insert_pos assign_op function Function::ops .insert
+        1 += insert_pos
+        1 += hidden_index
     done
 
     # Prepend hidden params to existing signature parameters
@@ -1178,7 +1305,7 @@ fn parse_impl_block cursor:TokenCursor {
 
     # Parse optional type parameters with trait bounds
     List::new (List[str]) = type_vars
-    Map::new (Map[str str]) = trait_bounds
+    Map::new (Map[str TraitBound]) = trait_bounds
     cursor tc_peek = tvars_opt
     if tvars_opt .is_some then
         if "[" tvars_opt .unwrap Token::value == then

--- a/compiler/typechecker.casa
+++ b/compiler/typechecker.casa
@@ -825,9 +825,9 @@ fn simulate_trait_exec tc:TypeChecker function:Function var_name:str {
     if trait_sep 0 >= then return fi
     trait_suffix 0 trait_sep str::substring = trait_type_var
     trait_suffix trait_sep 1 + trait_suffix .length trait_sep - 1 - str::substring = trait_method_name
-    trait_type_var function Function::signature Signature::trait_bounds .get = trait_name_opt
-    if trait_name_opt .is_none then return fi
-    trait_name_opt .unwrap GLOBAL_TRAITS .get = trait_def_opt
+    trait_type_var function Function::signature Signature::trait_bounds .get = trait_bound_opt
+    if trait_bound_opt .is_none then return fi
+    trait_bound_opt .unwrap TraitBound::name GLOBAL_TRAITS .get = trait_def_opt
     if trait_def_opt .is_none then return fi
     trait_def_opt .unwrap = trait_def
     0 = trait_lookup_index
@@ -1032,15 +1032,34 @@ fn bind_generic_params_standalone bindings:Map[str str] expected_type:str actual
 }
 
 fn type_satisfies_trait type_name:str trait_name:str function_opt:Option[Function] -> bool {
-    trait_name GLOBAL_TRAITS .get = trait_opt
+    # Accept both bare ("Iterator") and concrete generic ("Iterator[int]") trait names.
+    trait_name extract_generic_base = trait_base_opt
+    if trait_base_opt .is_some then trait_base_opt .unwrap else trait_name fi = trait_lookup_name
+    trait_lookup_name GLOBAL_TRAITS .get = trait_opt
     if trait_opt .is_none then false return fi
     trait_opt .unwrap = trait_def
+    # Build substitution map from trait's type_params to concrete args from trait_name.
+    Map::new (Map[str str]) = trait_subs
+    if trait_base_opt .is_some then
+        trait_name extract_generic_params = trait_args_opt
+        if trait_args_opt .is_some then
+            trait_args_opt .unwrap = trait_args
+            trait_def CasaTrait::type_params = tparams
+            if trait_args .length tparams .length == then
+                0 = tsub_index
+                while tsub_index tparams .length > do
+                    tsub_index tparams .get tsub_index trait_args .get trait_subs .set = trait_subs
+                    1 += tsub_index
+                done
+            fi
+        fi
+    fi
     # Type variable with matching bound satisfies the trait
     if function_opt .is_some then
         function_opt .unwrap Function::signature Signature::trait_bounds = bounds
         type_name bounds .get = bound_opt
         if bound_opt .is_some then
-            if trait_name bound_opt .unwrap == then true return fi
+            if trait_name bound_opt .unwrap trait_bound_to_str == then true return fi
         fi
     fi
     0 = index
@@ -1068,7 +1087,7 @@ fn type_satisfies_trait type_name:str trait_name:str function_opt:Option[Functio
             1 += index
             continue
         fi
-        type_name method TraitMethod::signature resolve_trait_sig = resolved
+        trait_subs type_name method TraitMethod::signature resolve_trait_sig apply_type_subs_to_sig = resolved
         if function Function::signature Signature::parameters .length resolved Signature::parameters .length != then
             false return
         fi
@@ -1106,6 +1125,121 @@ fn type_satisfies_trait type_name:str trait_name:str function_opt:Option[Functio
     true
 }
 
+fn find_tparam_index tparams:List[str] name:str -> int {
+    -1 = ftpi_result
+    0 = ftpi_scan
+    while ftpi_scan tparams .length > do
+        if ftpi_scan tparams .get name == then
+            ftpi_scan = ftpi_result
+        fi
+        1 += ftpi_scan
+    done
+    ftpi_result
+}
+
+fn try_bind_caller_tvar bindings:Map[str str] sig:Signature caller_ref:str concrete:str -> Map[str str] {
+    if caller_ref sig Signature::type_vars .has ! then bindings return fi
+    if caller_ref bindings .get .is_some then bindings return fi
+    caller_ref concrete bindings .set return
+}
+
+# Given a single (trait-side expected type, concrete-side actual type) pair
+# from a method signature diff, if the expected type references a trait
+# type parameter that maps (via the current bound's type args) to an unbound
+# caller type variable, bind it to the actual type. Handles both direct
+# references (`T`) and one-level nested generics (`Option[T]` vs `Option[int]`).
+fn bind_from_type_slot bindings:Map[str str] sig:Signature tparams:List[str] bargs:List[str] expected:str actual:str -> Map[str str] {
+    expected tparams find_tparam_index = direct_tp_idx
+    if 0 direct_tp_idx >= then
+        direct_tp_idx bargs .get = direct_caller_ref
+        actual direct_caller_ref sig bindings try_bind_caller_tvar return
+    fi
+    expected extract_generic_base = expected_base_opt
+    actual extract_generic_base = actual_base_opt
+    if expected_base_opt .is_none then bindings return fi
+    if actual_base_opt .is_none then bindings return fi
+    if expected_base_opt .unwrap actual_base_opt .unwrap != then bindings return fi
+    expected extract_generic_params = expected_params_opt
+    actual extract_generic_params = actual_params_opt
+    if expected_params_opt .is_none then bindings return fi
+    if actual_params_opt .is_none then bindings return fi
+    expected_params_opt .unwrap = expected_params
+    actual_params_opt .unwrap = actual_params
+    0 = slot_index
+    while
+        slot_index expected_params .length >
+        slot_index actual_params .length > &&
+    do
+        slot_index expected_params .get = nested_expected
+        nested_expected tparams find_tparam_index = nested_tp_idx
+        if 0 nested_tp_idx >= then
+            nested_tp_idx bargs .get = nested_caller_ref
+            slot_index actual_params .get nested_caller_ref sig bindings try_bind_caller_tvar = bindings
+        fi
+        1 += slot_index
+    done
+    bindings
+}
+
+fn diff_method_sig bindings:Map[str str] sig:Signature tparams:List[str] bargs:List[str] trait_resolved:Signature impl_sig:Signature -> Map[str str] {
+    0 = param_index
+    while
+        param_index trait_resolved Signature::parameters .length >
+        param_index impl_sig Signature::parameters .length > &&
+    do
+        param_index trait_resolved Signature::parameters .get Parameter::typ = expected_param
+        param_index impl_sig Signature::parameters .get Parameter::typ = actual_param
+        actual_param expected_param bargs tparams sig bindings bind_from_type_slot = bindings
+        1 += param_index
+    done
+    0 = return_index
+    while
+        return_index trait_resolved Signature::return_types .length >
+        return_index impl_sig Signature::return_types .length > &&
+    do
+        return_index trait_resolved Signature::return_types .get = expected_return
+        return_index impl_sig Signature::return_types .get = actual_return
+        actual_return expected_return bargs tparams sig bindings bind_from_type_slot = bindings
+        1 += return_index
+    done
+    bindings
+}
+
+fn method_diff_bind_for_bound bindings:Map[str str] sig:Signature bound:TraitBound concrete:str -> Map[str str] {
+    bound TraitBound::name GLOBAL_TRAITS .get = mdbb_trait_opt
+    if mdbb_trait_opt .is_none then bindings return fi
+    mdbb_trait_opt .unwrap = mdbb_trait
+    mdbb_trait CasaTrait::type_params = mdbb_tparams
+    bound TraitBound::type_args = mdbb_bargs
+    if mdbb_bargs .length mdbb_tparams .length != then bindings return fi
+    0 = mdbb_method_idx
+    while mdbb_method_idx mdbb_trait CasaTrait::methods .length > do
+        mdbb_method_idx mdbb_trait CasaTrait::methods .get = mdbb_method
+        f"{concrete}::{mdbb_method TraitMethod::name}" GLOBAL_FUNCTIONS .get = mdbb_fn_opt
+        if mdbb_fn_opt .is_some then
+            concrete mdbb_method TraitMethod::signature resolve_trait_sig = mdbb_trait_resolved
+            mdbb_fn_opt .unwrap Function::signature mdbb_trait_resolved mdbb_bargs mdbb_tparams sig bindings diff_method_sig = bindings
+        fi
+        1 += mdbb_method_idx
+    done
+    bindings
+}
+
+fn method_diff_bind_all sig:Signature function_opt:Option[Function] bindings:Map[str str] -> Map[str str] {
+    sig Signature::trait_bounds .keys = mdba_bound_keys
+    0 = mdba_idx
+    while mdba_idx mdba_bound_keys .length > do
+        mdba_idx mdba_bound_keys .get = mdba_type_var
+        mdba_type_var sig Signature::trait_bounds .get .unwrap = mdba_bound
+        mdba_type_var bindings .get = mdba_concrete_opt
+        if mdba_concrete_opt .is_some then
+            mdba_concrete_opt .unwrap mdba_bound sig bindings method_diff_bind_for_bound = bindings
+        fi
+        1 += mdba_idx
+    done
+    bindings
+}
+
 fn inject_trait_fn_ptrs tc:TypeChecker sig:Signature ops:List[Op] op_index:int location:Location function_opt:Option[Function] -> int {
     # Bind type variables from the stack (peek at positions)
     Map::new (Map[str str]) = bindings
@@ -1130,8 +1264,12 @@ fn inject_trait_fn_ptrs tc:TypeChecker sig:Signature ops:List[Op] op_index:int l
             index non_hidden .get = stack_param
             stack_index tc TypeChecker::stack .get = actual
             if stack_param Parameter::typ sig Signature::type_vars .has then
-                if stack_param Parameter::typ bindings .get .is_none then
-                    stack_param Parameter::typ actual bindings .set = bindings
+                stack_param Parameter::typ = binding_type_var
+                binding_type_var bindings .get = existing_binding_opt
+                if existing_binding_opt .is_none then
+                    binding_type_var actual bindings .set = bindings
+                elif actual existing_binding_opt .unwrap != then
+                    location f"Type variable `{binding_type_var}` bound to `{existing_binding_opt .unwrap}` but got `{actual}`" ErrorKind::TypeMismatch raise_error
                 fi
             else
                 sig Signature::type_vars actual stack_param Parameter::typ bindings bind_generic_params_standalone = bindings
@@ -1139,6 +1277,13 @@ fn inject_trait_fn_ptrs tc:TypeChecker sig:Signature ops:List[Op] op_index:int l
         fi
         1 += index
     done
+
+    # Method-signature-diff binding for bounds with type-var args.
+    # For a bound like `I: Iterator[T]` where T is still unbound but I is
+    # bound from the stack, inspect the concrete type's implementation of
+    # each trait method and diff its signature against the trait's declared
+    # signature to bind T. Single pass in declaration order.
+    bindings function_opt sig method_diff_bind_all = bindings
 
     # Check TYPE_CAST lookahead for return type binding
     if op_index ops .length > then
@@ -1163,7 +1308,10 @@ fn inject_trait_fn_ptrs tc:TypeChecker sig:Signature ops:List[Op] op_index:int l
     type_var_keys .length 1 - = type_index
     while 0 type_index >= do
         type_index type_var_keys .get = type_var
-        type_var sig Signature::trait_bounds .get .unwrap = trait_name
+        type_var sig Signature::trait_bounds .get .unwrap = trait_bound
+        # Resolve trait type args against current bindings so that
+        # `Carrier[T]` becomes `Carrier[int]` once T has been bound.
+        bindings trait_bound trait_bound_to_str substitute_type_params = trait_name
         type_var bindings .get = concrete_opt
         if concrete_opt .is_none then
             location f"Cannot determine concrete type for type variable `{type_var}`" ErrorKind::TypeMismatch raise_error
@@ -1171,7 +1319,7 @@ fn inject_trait_fn_ptrs tc:TypeChecker sig:Signature ops:List[Op] op_index:int l
             continue
         fi
         concrete_opt .unwrap = concrete
-        trait_name GLOBAL_TRAITS .get .unwrap = trait_def
+        trait_bound TraitBound::name GLOBAL_TRAITS .get .unwrap = trait_def
 
         # Check if forwarding (type var has same trait bound in calling function)
         false = is_forwarding
@@ -1179,7 +1327,7 @@ fn inject_trait_fn_ptrs tc:TypeChecker sig:Signature ops:List[Op] op_index:int l
             concrete function_opt .unwrap Function::signature Signature::trait_bounds .get = caller_bound_opt
             if caller_bound_opt .is_some then
                 caller_bound_opt .unwrap = caller_bound_val
-                if trait_name caller_bound_val == then
+                if trait_bound caller_bound_val trait_bound_eq then
                     true = is_forwarding
                 fi
             fi
@@ -1900,41 +2048,32 @@ fn check_method_call tc:TypeChecker op:Op ops:List[Op] op_index:int function_opt
         function_opt .unwrap Function::signature Signature::trait_bounds = bounds
         receiver bounds .get = trait_opt
         if trait_opt .is_some then
-            trait_opt .unwrap = trait_name
+            trait_opt .unwrap = bound
+            bound TraitBound::name = trait_name
             trait_name GLOBAL_TRAITS .get = trait_def_opt
             if trait_def_opt .is_some then
                 trait_def_opt .unwrap = trait_def
+                # Build substitution map from trait's type_params to the
+                # bound's concrete type_args, so that a trait method like
+                # `next self:self -> Option[T]` with bound `I: Iterator[int]`
+                # resolves to `next self:I -> Option[int]` at the call site.
+                Map::new (Map[str str]) = mc_subs
+                trait_def CasaTrait::type_params = mc_tparams
+                bound TraitBound::type_args = mc_targs
+                if mc_tparams .length mc_targs .length == then
+                    0 = mc_sub_index
+                    while mc_sub_index mc_tparams .length > do
+                        mc_sub_index mc_tparams .get mc_sub_index mc_targs .get mc_subs .set = mc_subs
+                        1 += mc_sub_index
+                    done
+                fi
                 0 = trait_method_index
                 while trait_method_index trait_def CasaTrait::methods .length > do
                     trait_method_index trait_def CasaTrait::methods .get = trait_method
                     if method_name trait_method TraitMethod::name == then
                         f"__trait_{receiver}_{method_name}" = hidden_var
                         tc stack_pop drop
-                        # Resolve trait sig: replace "self" with the type variable
-                        trait_method TraitMethod::signature = trait_sig
-                        List::new (List[Parameter]) = resolved_params
-                        0 = resolved_param_index
-                        while resolved_param_index trait_sig Signature::parameters .length > do
-                            resolved_param_index trait_sig Signature::parameters .get = resolved_param
-                            if "self" resolved_param Parameter::typ == then
-                                receiver resolved_param Parameter::name make_named_param resolved_params .push
-                            else
-                                resolved_param resolved_params .push
-                            fi
-                            1 += resolved_param_index
-                        done
-                        List::new (List[str]) = resolved_returns
-                        0 = resolved_return_index
-                        while resolved_return_index trait_sig Signature::return_types .length > do
-                            resolved_return_index trait_sig Signature::return_types .get = resolved_return
-                            if "self" resolved_return == then
-                                receiver resolved_returns .push
-                            else
-                                resolved_return resolved_returns .push
-                            fi
-                            1 += resolved_return_index
-                        done
-                        resolved_returns resolved_params make_signature = resolved_sig
+                        mc_subs receiver trait_method TraitMethod::signature resolve_trait_sig apply_type_subs_to_sig = resolved_sig
                         receiver tc stack_push
                         f"{receiver}::{method_name}" resolved_sig tc apply_signature
                         OpKind::OpPushVar op Op::set_kind

--- a/tests/compiler/test_traits.casa
+++ b/tests/compiler/test_traits.casa
@@ -126,6 +126,30 @@ fn test_trait_has_location {
     "has file" "" "MyTrait" GLOBAL_TRAITS .get .unwrap CasaTrait::location Location::file != assert_true
 }
 
+fn test_trait_non_generic_has_empty_type_params {
+    "trait_non_generic_has_empty_type_params" test_start
+    HASHABLE_TRAIT trait_test_parse drop
+    "empty type params" 0 "Hashable" GLOBAL_TRAITS .get .unwrap CasaTrait::type_params .length assert_eq
+}
+
+fn test_trait_generic_single_type_param {
+    "trait_generic_single_type_param" test_start
+    "trait Iterator[T] { fn next self:self -> Option[T] }" trait_test_parse drop
+    "registered" "Iterator" GLOBAL_TRAITS .get .is_some assert_true
+    "type params count" 1 "Iterator" GLOBAL_TRAITS .get .unwrap CasaTrait::type_params .length assert_eq
+    "type param name" "T" 0 "Iterator" GLOBAL_TRAITS .get .unwrap CasaTrait::type_params .get assert_str_eq
+}
+
+fn test_trait_generic_multi_type_params {
+    "trait_generic_multi_type_params" test_start
+    "trait Mapper[K V] { fn map self:self -> V }" trait_test_parse drop
+    "registered" "Mapper" GLOBAL_TRAITS .get .is_some assert_true
+    "Mapper" GLOBAL_TRAITS .get .unwrap CasaTrait::type_params = tps
+    "type params count" 2 tps .length assert_eq
+    "first" "K" 0 tps .get assert_str_eq
+    "second" "V" 1 tps .get assert_str_eq
+}
+
 # ============================================================================
 # Trait parsing errors
 # ============================================================================
@@ -175,7 +199,7 @@ fn test_trait_bound_basic {
     "trait Hashable { fn hash self:self -> int }\nfn tbtest[K: Hashable] K -> int { .hash }" trait_test_parse drop
     "tbtest" GLOBAL_FUNCTIONS .get .unwrap = func
     "K in type_vars" "K" func Function::signature Signature::type_vars .has assert_true
-    "K bound" "Hashable" "K" func Function::signature Signature::trait_bounds .get .unwrap assert_str_eq
+    "K bound" "Hashable" "K" func Function::signature Signature::trait_bounds .get .unwrap TraitBound::name assert_str_eq
 }
 
 fn test_trait_bound_with_unbounded_var {
@@ -184,7 +208,7 @@ fn test_trait_bound_with_unbounded_var {
     "tbtest" GLOBAL_FUNCTIONS .get .unwrap = func
     "K in vars" "K" func Function::signature Signature::type_vars .has assert_true
     "V in vars" "V" func Function::signature Signature::type_vars .has assert_true
-    "K bound" "Hashable" "K" func Function::signature Signature::trait_bounds .get .unwrap assert_str_eq
+    "K bound" "Hashable" "K" func Function::signature Signature::trait_bounds .get .unwrap TraitBound::name assert_str_eq
     "V no bound" "V" func Function::signature Signature::trait_bounds .get .is_none assert_true
 }
 
@@ -192,8 +216,8 @@ fn test_trait_bound_multiple_bounded {
     "trait_bound_multiple_bounded" test_start
     "trait Hashable { fn hash self:self -> int }\ntrait Printable { fn to_str self:self -> str }\nfn tbtest[K: Hashable, V: Printable] K V -> int { .to_str drop .hash }" trait_test_parse drop
     "tbtest" GLOBAL_FUNCTIONS .get .unwrap = func
-    "K bound" "Hashable" "K" func Function::signature Signature::trait_bounds .get .unwrap assert_str_eq
-    "V bound" "Printable" "V" func Function::signature Signature::trait_bounds .get .unwrap assert_str_eq
+    "K bound" "Hashable" "K" func Function::signature Signature::trait_bounds .get .unwrap TraitBound::name assert_str_eq
+    "V bound" "Printable" "V" func Function::signature Signature::trait_bounds .get .unwrap TraitBound::name assert_str_eq
 }
 
 fn test_trait_bound_undefined_raises {
@@ -350,6 +374,18 @@ fn test_partial_impl_does_not_satisfy {
     "partial_impl_does_not_satisfy" test_start
     HASHABLE_TRAIT "struct Baz { val: int }\nimpl Baz { fn hash self:Baz -> int { self Baz::val } }\n" str::concat trait_test_resolve drop
     "does not satisfy" Option::None (Option[Function]) "Hashable" "Baz" type_satisfies_trait ! assert_true
+}
+
+fn test_struct_satisfies_generic_trait_concrete_int {
+    "struct_satisfies_generic_trait_concrete_int" test_start
+    "trait Carrier[T] { fn get self:self -> T }\nstruct Counter { val: int }\nimpl Counter { fn get self:Counter -> int { self Counter::val } }\n" trait_test_resolve drop
+    "satisfies" Option::None (Option[Function]) "Carrier[int]" "Counter" type_satisfies_trait assert_true
+}
+
+fn test_struct_does_not_satisfy_generic_trait_wrong_inner {
+    "struct_does_not_satisfy_generic_trait_wrong_inner" test_start
+    "trait Carrier[T] { fn get self:self -> T }\nstruct Counter { val: int }\nimpl Counter { fn get self:Counter -> int { self Counter::val } }\n" trait_test_resolve drop
+    "does not satisfy str" Option::None (Option[Function]) "Carrier[str]" "Counter" type_satisfies_trait ! assert_true
 }
 
 fn test_undefined_trait_returns_false {
@@ -532,8 +568,8 @@ fn test_type_var_with_matching_bound_satisfies {
     "type_var_with_matching_bound_satisfies" test_start
     HASHABLE_TRAIT trait_test_parse drop
     # Build a Signature with K bounded by Hashable
-    Map::new (Map[str str]) = bounds
-    "K" "Hashable" bounds .set = bounds
+    Map::new (Map[str TraitBound]) = bounds
+    "K" "Hashable" make_simple_trait_bound bounds .set = bounds
     Set::new (Set[str]) = type_vars
     "K" type_vars .add = type_vars
     # Construct Signature: parameters, return_types, type_vars, trait_bounds
@@ -549,7 +585,7 @@ fn test_type_var_without_bound_does_not_satisfy {
     # Build a Signature with K but no trait bounds
     Set::new (Set[str]) = type_vars
     "K" type_vars .add = type_vars
-    Map::new (Map[str str]) type_vars List::new (List[str]) List::new (List[Parameter]) Signature = sig
+    Map::new (Map[str TraitBound]) type_vars List::new (List[str]) List::new (List[Parameter]) Signature = sig
     sig empty_location List::new (List[Op]) "test_fn" make_function_with_sig = func
     func Option::Some = func_opt
     "does not satisfy" func_opt "Hashable" "K" type_satisfies_trait ! assert_true
@@ -559,8 +595,8 @@ fn test_type_var_with_wrong_bound_does_not_satisfy {
     "type_var_with_wrong_bound_does_not_satisfy" test_start
     "trait Hashable { fn hash self:self -> int }\ntrait Printable { fn to_str self:self -> str }\n" trait_test_parse drop
     # Build a Signature with K bounded by Printable, check against Hashable
-    Map::new (Map[str str]) = bounds
-    "K" "Printable" bounds .set = bounds
+    Map::new (Map[str TraitBound]) = bounds
+    "K" "Printable" make_simple_trait_bound bounds .set = bounds
     Set::new (Set[str]) = type_vars
     "K" type_vars .add = type_vars
     bounds type_vars List::new (List[str]) List::new (List[Parameter]) Signature = sig
@@ -581,12 +617,12 @@ fn test_trait_bounds_default_empty {
 
 fn test_trait_bounds_preserved_in_signature {
     "trait_bounds_preserved_in_signature" test_start
-    Map::new (Map[str str]) = bounds
-    "K" "Hashable" bounds .set = bounds
+    Map::new (Map[str TraitBound]) = bounds
+    "K" "Hashable" make_simple_trait_bound bounds .set = bounds
     Set::new (Set[str]) = type_vars
     "K" type_vars .add = type_vars
     bounds type_vars List::new (List[str]) List::new (List[Parameter]) Signature = sig
-    "preserved" "Hashable" "K" sig Signature::trait_bounds .get .unwrap assert_str_eq
+    "preserved" "Hashable" "K" sig Signature::trait_bounds .get .unwrap TraitBound::name assert_str_eq
 }
 
 # ============================================================================
@@ -661,6 +697,126 @@ fn test_trait_bounded_fn_with_non_satisfying_type_raises {
     disable_test_mode
 }
 
+fn test_generic_trait_bound_compound_type_arg_preserves_space {
+    "generic_trait_bound_compound_type_arg_preserves_space" test_start
+    "trait Carrier[T] { fn get self:self -> T }\nfn uses[I: Carrier[Map[str int]]] i:I -> int { 0 }\n" trait_test_parse drop
+    "uses" GLOBAL_FUNCTIONS .get .unwrap = func
+    "I" func Function::signature Signature::trait_bounds .get .unwrap = bound
+    "preserved" "Carrier[Map[str int]]" bound trait_bound_to_str assert_str_eq
+}
+
+fn test_generic_trait_bound_wrong_arity_raises {
+    "generic_trait_bound_wrong_arity_raises" test_start
+    enable_test_mode
+    clear_errors
+    "trait Carrier[T] { fn get self:self -> T }\nfn uses[I: Carrier[int str]] i:I -> int { 0 }\n" trait_test_parse drop
+    "has errors" assert_has_errors
+    "arity" ErrorKind::Syntax assert_error_kind
+    clear_errors
+    disable_test_mode
+}
+
+fn test_generic_trait_bound_missing_args_raises {
+    "generic_trait_bound_missing_args_raises" test_start
+    enable_test_mode
+    clear_errors
+    "trait Carrier[T] { fn get self:self -> T }\nfn uses[I: Carrier] i:I -> int { 0 }\n" trait_test_parse drop
+    "has errors" assert_has_errors
+    "arity" ErrorKind::Syntax assert_error_kind
+    clear_errors
+    disable_test_mode
+}
+
+fn test_non_generic_trait_with_args_raises {
+    "non_generic_trait_with_args_raises" test_start
+    enable_test_mode
+    clear_errors
+    "trait Simple { fn m self:self -> int }\nfn uses[I: Simple[int]] i:I -> int { 0 }\n" trait_test_parse drop
+    "has errors" assert_has_errors
+    "arity" ErrorKind::Syntax assert_error_kind
+    clear_errors
+    disable_test_mode
+}
+
+fn test_generic_trait_bound_concrete_hidden_param_type {
+    "generic_trait_bound_concrete_hidden_param_type" test_start
+    "trait Carrier[T] { fn get self:self -> T }\nstruct Counter { val: int }\nimpl Counter { fn get self:Counter -> int { self Counter::val } }\nfn use_carrier[I: Carrier[int]] i:I -> int { i .get }\n" trait_test_typecheck drop
+    "use_carrier" GLOBAL_FUNCTIONS .get .unwrap = func
+    # Find the hidden __trait_I_get parameter and assert its type substituted T with int.
+    false = found
+    0 = index
+    while index func Function::signature Signature::parameters .length > do
+        index func Function::signature Signature::parameters .get = param
+        if "__trait_I_get" param Parameter::name == then
+            true = found
+            "hidden type" "fn[I -> int]" param Parameter::typ assert_str_eq
+        fi
+        1 += index
+    done
+    "hidden param present" found assert_true
+}
+
+fn test_generic_trait_bound_concrete_call_site_injects_fn_ptr {
+    "generic_trait_bound_concrete_call_site_injects_fn_ptr" test_start
+    enable_test_mode
+    clear_errors
+    "trait Carrier[T] { fn get self:self -> T }\nstruct Counter { val: int }\nimpl Counter { fn get self:Counter -> int { self Counter::val } }\nfn use_carrier[I: Carrier[int]] i:I -> int { i .get }\n42 Counter = c\nc use_carrier drop\n" trait_test_typecheck drop
+    "no errors" 0 ERRORS .length assert_eq
+    clear_errors
+    disable_test_mode
+}
+
+fn test_type_var_arg_bound_conflict_with_param_raises {
+    "type_var_arg_bound_conflict_with_param_raises" test_start
+    enable_test_mode
+    clear_errors
+    "trait Carrier[T] { fn get self:self -> T }\nstruct IntBox { v: int }\nimpl IntBox { fn get self:IntBox -> int { self IntBox::v } }\nfn zip[T, I: Carrier[T]] t:T i:I -> T { t drop i .get }\n\"x\" 1 IntBox zip drop\n" trait_test_typecheck drop
+    "has errors" assert_has_errors
+    clear_errors
+    disable_test_mode
+}
+
+fn test_type_var_arg_bound_structural_mismatch_raises {
+    "type_var_arg_bound_structural_mismatch_raises" test_start
+    enable_test_mode
+    clear_errors
+    "trait Carrier[T] { fn get self:self -> T }\nstruct Plain { v: int }\nfn use_any[T, I: Carrier[T]] i:I -> T { i .get }\n1 Plain = p\np use_any drop\n" trait_test_typecheck drop
+    "has errors" assert_has_errors
+    clear_errors
+    disable_test_mode
+}
+
+fn test_type_var_arg_generic_trait_bound_happy_path {
+    "type_var_arg_generic_trait_bound_happy_path" test_start
+    enable_test_mode
+    clear_errors
+    "trait Carrier[T] { fn get self:self -> T }\nstruct IntBox { v: int }\nimpl IntBox { fn get self:IntBox -> int { self IntBox::v } }\nfn use_any[T, I: Carrier[T]] i:I -> T { i .get }\n42 IntBox = b\nb use_any drop\n" trait_test_typecheck drop
+    "no errors" 0 ERRORS .length assert_eq
+    clear_errors
+    disable_test_mode
+}
+
+fn test_generic_trait_bound_structural_mismatch_raises {
+    "generic_trait_bound_structural_mismatch_raises" test_start
+    enable_test_mode
+    clear_errors
+    "trait Carrier[T] { fn get self:self -> T }\nstruct StrHolder { s: str }\nimpl StrHolder { fn get self:StrHolder -> str { self StrHolder::s } }\nfn uses[I: Carrier[int]] i:I -> int { i .get }\n\"x\" StrHolder = sh\nsh uses drop\n" trait_test_typecheck drop
+    "has errors" assert_has_errors
+    clear_errors
+    disable_test_mode
+}
+
+fn test_trait_bounded_fn_with_conflicting_type_var_raises {
+    "trait_bounded_fn_with_conflicting_type_var_raises" test_start
+    enable_test_mode
+    clear_errors
+    HASHABLE_TRAIT "struct A { v: int }\nstruct B { v: int }\nimpl A { fn hash self:A -> int { self A::v } fn eq self:A other:A -> bool { self A::v other A::v == } }\nimpl B { fn hash self:B -> int { self B::v } fn eq self:B other:B -> bool { self B::v other B::v == } }\nfn gnarly[K: Hashable] a:K b:K -> int { b drop a .hash }\n1 A = av\n2 B = bv\nbv av gnarly drop\n" str::concat trait_test_typecheck drop
+    "has errors" assert_has_errors
+    "type mismatch for conflicting type var" ErrorKind::TypeMismatch assert_error_kind
+    clear_errors
+    disable_test_mode
+}
+
 # ============================================================================
 # Parse map type in signature
 # ============================================================================
@@ -728,6 +884,9 @@ test_trait_eq_method_return
 test_trait_empty
 test_trait_single_method
 test_trait_has_location
+test_trait_non_generic_has_empty_type_params
+test_trait_generic_single_type_param
+test_trait_generic_multi_type_params
 
 # Trait parsing errors
 test_trait_unclosed_block_raises
@@ -753,6 +912,8 @@ test_trait_hidden_params_creates_assign_ops
 test_struct_with_impl_satisfies
 test_struct_without_impl_does_not_satisfy
 test_partial_impl_does_not_satisfy
+test_struct_satisfies_generic_trait_concrete_int
+test_struct_does_not_satisfy_generic_trait_wrong_inner
 test_undefined_trait_returns_false
 
 # Multi-param generics
@@ -790,6 +951,17 @@ test_ampersand_k_coloncolon_method_resolved_as_push_variable
 
 # Auto-injection errors
 test_trait_bounded_fn_with_non_satisfying_type_raises
+test_trait_bounded_fn_with_conflicting_type_var_raises
+test_generic_trait_bound_compound_type_arg_preserves_space
+test_generic_trait_bound_wrong_arity_raises
+test_generic_trait_bound_missing_args_raises
+test_non_generic_trait_with_args_raises
+test_generic_trait_bound_concrete_hidden_param_type
+test_generic_trait_bound_concrete_call_site_injects_fn_ptr
+test_generic_trait_bound_structural_mismatch_raises
+test_type_var_arg_generic_trait_bound_happy_path
+test_type_var_arg_bound_conflict_with_param_raises
+test_type_var_arg_bound_structural_mismatch_raises
 
 # Parse map type
 test_parse_map_type_in_signature


### PR DESCRIPTION
## Summary

Adds end-to-end support for generic trait declarations (`trait Foo[T] { ... }`) and generic trait bounds on functions and impl blocks, including bounds that carry caller type variables (`fn collect[T, I: Iterator[T]] ...`).

This is Phase A of a two-phase effort. Phase B will add a `for`/`in` loop + `.iter` wrappers on top of this.

## Data model
- `CasaTrait.type_params: List[str]`
- `TraitBound { name: str, type_args: List[str] }`
- `Signature.trait_bounds` migrated from `Map[str str]` to `Map[str TraitBound]`
- `substitute_type_params` / `apply_type_subs_to_sig` helpers in `common.casa`

## Parser
- `parse_trait` reads optional `[T U ...]` after the trait name
- `parse_type_vars` accepts `I: Trait[arg1 arg2 ...]` via a new `parse_bound_type_args` helper with bracket-depth counting that preserves inner spacing for compound args like `Map[str int]`
- Arity check against the trait's declared `type_params`
- Hidden-param construction extracted to a shared `build_hidden_trait_methods` helper used by `parse_function` and `inject_impl_trait_params`; the helper applies the bound's `{trait_param -> bound_arg}` substitution to every method signature

## Typechecker
- `type_satisfies_trait` accepts concrete generic refs like `"Carrier[int]"` and substitutes trait type params through to the method signature match
- `inject_trait_fn_ptrs` resolves `trait_name` via `substitute_type_params` so lingering caller type vars get resolved before satisfaction checks
- New method-signature-diff binding pass (`method_diff_bind_all` → `method_diff_bind_for_bound` → `diff_method_sig` → `bind_from_type_slot`) binds caller type vars like `T` in `I: Iterator[T]` by diffing the concrete impl's method signatures against the trait's declaration; single pass, declaration order, handles one level of nested generics
- `check_method_call` for dot syntax on trait-bounded type vars now uses `resolve_trait_sig + apply_type_subs_to_sig` so the return type reflects the bound's type args (fixes a pre-existing `make_named_param` arg-order bug that surfaced `self` as a literal type)
- `inject_trait_fn_ptrs` stack binding now detects conflicts between multiple type-var binding sources and raises `TypeMismatch` instead of silently keeping the first-bound value
- Trait bound forwarding compares bounds structurally via `trait_bound_eq`

## Tests
16 new tests in `tests/compiler/test_traits.casa` (143 total, up from 127) covering: non-generic vs generic `type_params`, concrete-arg bounds end-to-end, parse errors for wrong arity / missing args / non-generic trait with args, structural mismatches, type-var-arg bounds happy path + error paths, conflict detection, and compound type-arg spacing.

## Test plan
- [x] `tests/test_compiler.sh` — all 20 suites green (incl. `self_compilation` and `fixed_point`)
- [x] `tests/test_examples.sh` — all 33 examples green
- [x] Self-compile stable across stage1/stage2/stage3