### PR TITLE
refactor: introduce SymbolStore and thread compiler structs

### DIFF
--- a/casa.casa
+++ b/casa.casa
@@ -60,8 +60,8 @@ fn main {
 
     # Parse
     "Parsing ops" log_info
-    tokens parse_ops = ops
-    ops resolve_identifiers_global = ops
+    tokens DEFAULT_PARSER parse_ops = ops
+    ops DEFAULT_PARSER resolve_identifiers_global = ops
 
     # Type check
     "Type checking ops" log_info

--- a/casa.casa
+++ b/casa.casa
@@ -76,7 +76,7 @@ fn main {
 
     # Compile bytecode
     "Compiling bytecode" log_info
-    ops compile_bytecode = program
+    ops DEFAULT_PARSER.store compile_bytecode = program
 
     # Emit assembly
     "Emitting assembly" log_info

--- a/compiler/bytecode.casa
+++ b/compiler/bytecode.casa
@@ -59,9 +59,11 @@ struct BytecodeCompiler {
     locals_count:     int
     string_table:     List[str]
     constants_table:  List[str]
+    store:            SymbolStore
 }
 
-fn make_compiler ops:List[Op] -> BytecodeCompiler {
+fn make_compiler store:SymbolStore ops:List[Op] -> BytecodeCompiler {
+    store
     List::new (List[str])
     List::new (List[str])
     0
@@ -70,7 +72,8 @@ fn make_compiler ops:List[Op] -> BytecodeCompiler {
     BytecodeCompiler
 }
 
-fn make_compiler_with_tables ops:List[Op] function:int string_table:List[str] constants_table:List[str] -> BytecodeCompiler {
+fn make_compiler_with_tables store:SymbolStore ops:List[Op] function:int string_table:List[str] constants_table:List[str] -> BytecodeCompiler {
+    store
     constants_table
     string_table
     0
@@ -116,9 +119,9 @@ fn resolve_variable compiler:BytecodeCompiler variable_name:str -> ResolvedVaria
             local_index InstKind::InstLocalSet InstKind::InstLocalGet ResolvedVariable return
         fi
     fi
-    variable_name GLOBAL_VARIABLES .has = is_global
+    variable_name compiler.store.variables .has = is_global
     if is_global then
-        variable_name GLOBAL_VARIABLES .keys string_list_index = global_index
+        variable_name compiler.store.variables .keys string_list_index = global_index
         global_index InstKind::InstGlobalSet InstKind::InstGlobalGet ResolvedVariable return
     fi
     f"Variable `{variable_name}` is not defined\n" eprint
@@ -344,7 +347,7 @@ fn compile_while_block compiler:BytecodeCompiler op:Op op_index:int bytecode:Lis
 fn compile_match_arm_enum compiler:BytecodeCompiler pattern_ptr:int is_last:bool next_arm:Option[int] bytecode:List[Inst] {
     pattern_ptr (EnumVariant) = variant
     variant EnumVariant::enum_name = enum_name
-    enum_name GLOBAL_ENUMS .get .unwrap = casa_enum
+    enum_name compiler.store.enums .get .unwrap = casa_enum
 
     if is_last ! variant is_wildcard_variant ! && then
         InstKind::InstDup make_inst bytecode .push
@@ -395,7 +398,7 @@ fn compile_match_arm_literal compiler:BytecodeCompiler pattern_ptr:int is_last:b
 
 fn compile_match_arm_struct compiler:BytecodeCompiler pattern_ptr:int bytecode:List[Inst] {
     pattern_ptr (StructPattern) = pattern
-    pattern StructPattern::struct_name GLOBAL_STRUCTS .get .unwrap = casa_struct
+    pattern StructPattern::struct_name compiler.store.structs .get .unwrap = casa_struct
 
     # Build field offset map
     0 = index
@@ -463,8 +466,8 @@ fn compile_match_block compiler:BytecodeCompiler op:Op op_index:int bytecode:Lis
         elif "enum_variant" annotation == then
             pattern_ptr (EnumVariant) = variant
             variant EnumVariant::enum_name = enum_name
-            if "" enum_name != enum_name GLOBAL_ENUMS .has && then
-                enum_name GLOBAL_ENUMS .get .unwrap = casa_enum
+            if "" enum_name != enum_name compiler.store.enums .has && then
+                enum_name compiler.store.enums .get .unwrap = casa_enum
                 casa_enum has_inner_values = has_inner
                 if has_inner then
                     bytecode next_arm is_last pattern_ptr compiler compile_match_arm_enum
@@ -578,7 +581,7 @@ fn compile_enum_variant compiler:BytecodeCompiler variant:EnumVariant casa_enum:
 fn compile_is_check compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
     op Op::value (EnumVariant) = variant
     variant EnumVariant::enum_name = enum_name
-    enum_name GLOBAL_ENUMS .get .unwrap = casa_enum
+    enum_name compiler.store.enums .get .unwrap = casa_enum
 
     if casa_enum has_inner_values ! then
         # Plain enum: compare ordinal directly
@@ -637,7 +640,7 @@ fn compile_is_check compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
 
 fn compile_struct_literal compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
     op Op::value (StructLiteral) = literal
-    literal StructLiteral::struct_name GLOBAL_STRUCTS .get .unwrap = casa_struct
+    literal StructLiteral::struct_name compiler.store.structs .get .unwrap = casa_struct
     casa_struct CasaStruct::members .length = count
 
     # Store all field values into temp locals (top of stack = last in field_order)
@@ -762,7 +765,7 @@ fn compile_function compiler:BytecodeCompiler function:Function op:Op {
     function Function::name COMPILED_FUNCTIONS .add = COMPILED_FUNCTIONS
 
     List::new (List[Inst]) = function_bytecode
-    compiler BytecodeCompiler::constants_table compiler BytecodeCompiler::string_table function (int) ops make_compiler_with_tables = function_compiler
+    compiler BytecodeCompiler::constants_table compiler BytecodeCompiler::string_table function (int) ops compiler.store make_compiler_with_tables = function_compiler
     function_bytecode function_compiler compile_ops
 
     # Handle locals
@@ -800,11 +803,11 @@ fn compile_function_ops compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
     op op_str_value = name
 
     if OpKind::OpFnCall op Op::kind == then
-        name GLOBAL_FUNCTIONS .get .unwrap = function
+        name compiler.store.functions .get .unwrap = function
         op function compiler compile_function
         name InstKind::InstFnCall make_inst_str bytecode .push
     elif OpKind::OpFnPush op Op::kind == then
-        name GLOBAL_FUNCTIONS .get = function_opt
+        name compiler.store.functions .get = function_opt
         if function_opt .is_none then
             op Op::location f"Function `{name}` is not defined" ErrorKind::UndefinedName make_error ERRORS .push
             return
@@ -860,7 +863,7 @@ fn compile_op compiler:BytecodeCompiler op:Op op_index:int bytecode:List[Inst] {
             OpKind::OpGt kind == ||
             OpKind::OpGe kind == ||
             "" op Op::type_annotation != &&
-            op Op::type_annotation GLOBAL_ENUMS .has &&
+            op Op::type_annotation compiler.store.enums .has &&
         then
             bytecode op compiler compile_enum_comparison
             return
@@ -901,7 +904,7 @@ fn compile_op compiler:BytecodeCompiler op:Op op_index:int bytecode:List[Inst] {
         # Non-str cases are rewritten to OpMethodCall during type checking.
     elif OpKind::OpFnCall kind == OpKind::OpFnPush kind == || then
         if OpKind::OpFnPush kind == then
-            op op_str_value GLOBAL_FUNCTIONS .get = function_opt
+            op op_str_value compiler.store.functions .get = function_opt
             if function_opt .is_some then
                 function_opt .unwrap = function_check
                 if function_check Function::has_deferred_methods then
@@ -926,7 +929,7 @@ fn compile_op compiler:BytecodeCompiler op:Op op_index:int bytecode:List[Inst] {
         # No instruction emitted
     elif OpKind::OpPushEnumVariant kind == then
         op Op::value (EnumVariant) = variant
-        variant EnumVariant::enum_name GLOBAL_ENUMS .get .unwrap = casa_enum
+        variant EnumVariant::enum_name compiler.store.enums .get .unwrap = casa_enum
         if casa_enum has_inner_values then
             bytecode casa_enum variant compiler compile_enum_variant
         else
@@ -1024,15 +1027,15 @@ fn compile_ops compiler:BytecodeCompiler bytecode:List[Inst] {
 # Main entry: compile_bytecode
 # ============================================================================
 
-fn compile_bytecode ops:List[Op] -> Program {
+fn compile_bytecode store:SymbolStore ops:List[Op] -> Program {
     reset_labels
 
     List::new (List[Inst]) = bytecode
-    ops make_compiler = compiler
+    ops store make_compiler = compiler
 
     # Emit globals init if needed
-    if 0 GLOBAL_VARIABLES .length != then
-        GLOBAL_VARIABLES .length InstKind::InstGlobalsInit make_inst_int bytecode .push
+    if 0 compiler.store.variables .length != then
+        compiler.store.variables .length InstKind::InstGlobalsInit make_inst_int bytecode .push
     fi
 
     bytecode compiler compile_ops
@@ -1053,11 +1056,11 @@ fn compile_bytecode ops:List[Op] -> Program {
 
     # Compile all used functions
     Map::new (Map[str List[Inst]]) = functions
-    GLOBAL_FUNCTIONS .keys = function_names
+    compiler.store.functions .keys = function_names
     0 = function_index
     while function_index function_names .length > do
         function_index function_names .get = function_name
-        function_name GLOBAL_FUNCTIONS .get .unwrap = function
+        function_name compiler.store.functions .get .unwrap = function
         if 0 function Function::bytecode .length != then
             function_name function Function::bytecode functions .set = functions
         fi
@@ -1065,7 +1068,7 @@ fn compile_bytecode ops:List[Op] -> Program {
     done
 
     compiler BytecodeCompiler::constants_table .length
-    GLOBAL_VARIABLES .length
+    compiler.store.variables .length
     compiler BytecodeCompiler::string_table
     functions
     bytecode

--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -1406,3 +1406,46 @@ fn string_list_index items:List[str] value:str -> int {
     done
     -1
 }
+
+# ============================================================================
+# SymbolStore
+#
+# Shared declaration state threaded through the parser/typechecker/bytecode
+# pipeline. Replaces the legacy module-level globals (GLOBAL_FUNCTIONS etc.)
+# in compiler/parser.casa. Each phase holds a `store: SymbolStore` field on
+# its owning struct (Parser, TypeChecker, BytecodeCompiler) and reaches
+# declarations via dot syntax, e.g. `typechecker.store.functions .get`.
+#
+# Maps and sets are heap-backed in casa, so passing SymbolStore by value
+# copies the struct but not the underlying map data — all holders observe
+# the same mutations.
+# ============================================================================
+
+struct SymbolStore {
+    functions: Map[str Function]
+    variables: Map[str Variable]
+    enums:     Map[str CasaEnum]
+    structs:   Map[str CasaStruct]
+    traits:    Map[str CasaTrait]
+    builtins:  Set[str]
+}
+
+fn symbol_store_new -> SymbolStore {
+    Set::new (Set[str]) = builtins
+    "int"  builtins .add = builtins
+    "bool" builtins .add = builtins
+    "str"  builtins .add = builtins
+    "char" builtins .add = builtins
+    "cstr" builtins .add = builtins
+    "ptr"  builtins .add = builtins
+    "array" builtins .add = builtins
+    "any"  builtins .add = builtins
+
+    builtins
+    Map::new (Map[str CasaTrait])
+    Map::new (Map[str CasaStruct])
+    Map::new (Map[str CasaEnum])
+    Map::new (Map[str Variable])
+    Map::new (Map[str Function])
+    SymbolStore
+}

--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -1411,8 +1411,7 @@ fn string_list_index items:List[str] value:str -> int {
 # SymbolStore
 #
 # Shared declaration state threaded through the parser/typechecker/bytecode
-# pipeline. Replaces the legacy module-level globals (GLOBAL_FUNCTIONS etc.)
-# in compiler/parser.casa. Each phase holds a `store: SymbolStore` field on
+# pipeline. Each phase holds a `store: SymbolStore` field on
 # its owning struct (Parser, TypeChecker, BytecodeCompiler) and reaches
 # declarations via dot syntax, e.g. `typechecker.store.functions .get`.
 #

--- a/compiler/parser.casa
+++ b/compiler/parser.casa
@@ -4,24 +4,37 @@
 # common.casa, error.casa, and lexer.casa.
 
 # ============================================================================
-# Global state
+# Parser struct and shared state
+#
+# `Parser` owns the `SymbolStore` plus parser-private `included_files`. A
+# single default parser is constructed at module load so that the legacy
+# `GLOBAL_*` module-level names can be kept as heap-aliases pointing at the
+# default parser's store maps. Subsequent phases (typechecker, bytecode)
+# continue to read through those aliases until they are converted in a
+# follow-up commit.
 # ============================================================================
 
-Map::new (Map[str Function]) = GLOBAL_FUNCTIONS
-Map::new (Map[str Variable]) = GLOBAL_VARIABLES
-Map::new (Map[str CasaEnum]) = GLOBAL_ENUMS
-Map::new (Map[str CasaStruct]) = GLOBAL_STRUCTS
-Map::new (Map[str CasaTrait]) = GLOBAL_TRAITS
-Set::new (Set[str]) = INCLUDED_FILES
-Set::new (Set[str]) = BUILTIN_TYPES
-"int" BUILTIN_TYPES .add = BUILTIN_TYPES
-"bool" BUILTIN_TYPES .add = BUILTIN_TYPES
-"str" BUILTIN_TYPES .add = BUILTIN_TYPES
-"char" BUILTIN_TYPES .add = BUILTIN_TYPES
-"cstr" BUILTIN_TYPES .add = BUILTIN_TYPES
-"ptr" BUILTIN_TYPES .add = BUILTIN_TYPES
-"array" BUILTIN_TYPES .add = BUILTIN_TYPES
-"any" BUILTIN_TYPES .add = BUILTIN_TYPES
+struct Parser {
+    store:          SymbolStore
+    included_files: Set[str]
+}
+
+fn make_parser store:SymbolStore -> Parser {
+    Set::new (Set[str])
+    store
+    Parser
+}
+
+symbol_store_new = DEFAULT_STORE
+DEFAULT_STORE make_parser = DEFAULT_PARSER
+
+DEFAULT_STORE SymbolStore::functions = GLOBAL_FUNCTIONS
+DEFAULT_STORE SymbolStore::variables = GLOBAL_VARIABLES
+DEFAULT_STORE SymbolStore::enums     = GLOBAL_ENUMS
+DEFAULT_STORE SymbolStore::structs   = GLOBAL_STRUCTS
+DEFAULT_STORE SymbolStore::traits    = GLOBAL_TRAITS
+DEFAULT_STORE SymbolStore::builtins  = BUILTIN_TYPES
+DEFAULT_PARSER Parser::included_files = INCLUDED_FILES
 
 # ============================================================================
 # Simple keyword -> OpKind mapping

--- a/compiler/parser.casa
+++ b/compiler/parser.casa
@@ -7,11 +7,8 @@
 # Parser struct and shared state
 #
 # `Parser` owns the `SymbolStore` plus parser-private `included_files`. A
-# single default parser is constructed at module load so that the legacy
-# `GLOBAL_*` module-level names can be kept as heap-aliases pointing at the
-# default parser's store maps. Subsequent phases (typechecker, bytecode)
-# continue to read through those aliases until they are converted in a
-# follow-up commit.
+# single default parser is constructed at module load; the compiler entry
+# point and tests reuse it via `DEFAULT_PARSER`.
 # ============================================================================
 
 struct Parser {
@@ -27,14 +24,6 @@ fn make_parser store:SymbolStore -> Parser {
 
 symbol_store_new = DEFAULT_STORE
 DEFAULT_STORE make_parser = DEFAULT_PARSER
-
-DEFAULT_STORE SymbolStore::functions = GLOBAL_FUNCTIONS
-DEFAULT_STORE SymbolStore::variables = GLOBAL_VARIABLES
-DEFAULT_STORE SymbolStore::enums     = GLOBAL_ENUMS
-DEFAULT_STORE SymbolStore::structs   = GLOBAL_STRUCTS
-DEFAULT_STORE SymbolStore::traits    = GLOBAL_TRAITS
-DEFAULT_STORE SymbolStore::builtins  = BUILTIN_TYPES
-DEFAULT_PARSER Parser::included_files = INCLUDED_FILES
 
 # ============================================================================
 # Simple keyword -> OpKind mapping
@@ -852,7 +841,7 @@ fn parse_signature cursor:TokenCursor -> Signature {
 # Walks the given trait bounds and returns a flat list of (var_name, fn_type)
 # pairs describing each hidden `__trait_{type_var}_{method}` parameter that
 # must be injected. Used by both parse_function and inject_impl_trait_params.
-# Bounds whose trait is not registered in GLOBAL_TRAITS are silently skipped,
+# Bounds whose trait is not registered in the store are silently skipped,
 # matching the pre-extraction behavior of both call sites.
 fn build_hidden_trait_methods parser:Parser trait_bounds:Map[str TraitBound] -> List[HiddenTraitMethod] {
     List::new (List[HiddenTraitMethod]) = result
@@ -2157,7 +2146,7 @@ fn resolve_identifiers_fn parser:Parser ops:List[Op] function:Function -> List[O
         if OpKind::OpAssignVar ri_kind == then
             ri_op op_str_value = ri_var_name
             ri_var_name make_variable = ri_var
-            # Global scope: store in GLOBAL_VARIABLES
+            # Global scope: store in parser.store.variables
             if GLOBAL_SCOPE_LABEL function Function::name == then
                 ri_var_name ri_var parser.store.variables .set drop
                 continue

--- a/compiler/parser.casa
+++ b/compiler/parser.casa
@@ -431,7 +431,7 @@ fn get_op_array cursor:TokenCursor -> Op {
 # parse_block_ops - parse { ... } delimited block
 # ============================================================================
 
-fn parse_block_ops cursor:TokenCursor function_name:str -> List[Op] {
+fn parse_block_ops parser:Parser cursor:TokenCursor function_name:str -> List[Op] {
     "{" cursor expect_token_value = open_token
     List::new (List[Op]) = ops
     while true do
@@ -444,10 +444,10 @@ fn parse_block_ops cursor:TokenCursor function_name:str -> List[Op] {
             ops return
         fi
         if TokenKind::FstringStart token Token::kind == then
-            ops function_name cursor token handle_fstring
+            ops function_name cursor token parser handle_fstring
             continue
         fi
-        ops function_name cursor token token_to_op
+        ops function_name cursor token parser token_to_op
     done
     ops
 }
@@ -456,7 +456,7 @@ fn parse_block_ops cursor:TokenCursor function_name:str -> List[Op] {
 # handle_fstring - parse f-string tokens into ops
 # ============================================================================
 
-fn parse_fstring_expr cursor:TokenCursor function_name:str -> List[Op] {
+fn parse_fstring_expr parser:Parser cursor:TokenCursor function_name:str -> List[Op] {
     List::new (List[Op]) = ops
     while true do
         cursor tc_pop = token_opt
@@ -466,15 +466,15 @@ fn parse_fstring_expr cursor:TokenCursor function_name:str -> List[Op] {
             break
         fi
         if TokenKind::FstringStart token Token::kind == then
-            ops function_name cursor token handle_fstring
+            ops function_name cursor token parser handle_fstring
             continue
         fi
-        ops function_name cursor token token_to_op
+        ops function_name cursor token parser token_to_op
     done
     ops
 }
 
-fn handle_fstring start_token:Token cursor:TokenCursor function_name:str ops:List[Op] {
+fn handle_fstring parser:Parser start_token:Token cursor:TokenCursor function_name:str ops:List[Op] {
     0 = part_count
     while true do
         cursor tc_pop = token_opt
@@ -484,10 +484,10 @@ fn handle_fstring start_token:Token cursor:TokenCursor function_name:str ops:Lis
             token Token::location OpKind::OpPushStr token Token::value make_op_str ops .push
             1 += part_count
         elif TokenKind::FstringExprStart token Token::kind == then
-            function_name cursor parse_fstring_expr = expr_ops
+            function_name cursor parser parse_fstring_expr = expr_ops
             f"lambda__{function_name}_o{token Token::location Location::span Span::offset}" = lambda_name
             token Token::location expr_ops lambda_name make_function = lambda_function
-            lambda_name lambda_function GLOBAL_FUNCTIONS .set = GLOBAL_FUNCTIONS
+            lambda_name lambda_function parser.store.functions .set drop
             token Token::location OpKind::OpFnPush lambda_name make_op_str ops .push
             token Token::location OpKind::OpFnExec 0 make_op ops .push
             token Token::location OpKind::OpFstringToStr "" make_op_str ops .push
@@ -509,7 +509,7 @@ fn handle_fstring start_token:Token cursor:TokenCursor function_name:str ops:Lis
 # get_op_delimiter - convert delimiter token to op
 # ============================================================================
 
-fn get_op_delimiter token:Token cursor:TokenCursor function_name:str ops:List[Op] {
+fn get_op_delimiter parser:Parser token:Token cursor:TokenCursor function_name:str ops:List[Op] {
     token Token::value = value
 
     # Arrow -> set_field
@@ -530,10 +530,10 @@ fn get_op_delimiter token:Token cursor:TokenCursor function_name:str ops:List[Op
     # Open brace { -> lambda
     if "{" value == then
         cursor tc_retreat
-        function_name cursor parse_block_ops = lambda_ops
+        function_name cursor parser parse_block_ops = lambda_ops
         f"lambda__{function_name}_o{token Token::location Location::span Span::offset}" = lambda_name
         token Token::location lambda_ops lambda_name make_function = lambda_function
-        lambda_name lambda_function GLOBAL_FUNCTIONS .set = GLOBAL_FUNCTIONS
+        lambda_name lambda_function parser.store.functions .set drop
         token Token::location OpKind::OpFnPush lambda_name make_op_str ops .push
         return
     fi
@@ -701,7 +701,7 @@ fn parse_bound_type_args cursor:TokenCursor trait_token:Token -> List[str] {
     bound_args
 }
 
-fn parse_type_vars cursor:TokenCursor -> List[str] {
+fn parse_type_vars parser:Parser cursor:TokenCursor -> List[str] {
     "[" cursor expect_token_value drop
     List::new (List[str]) = vars
     Set::new (Set[str]) = seen
@@ -721,7 +721,7 @@ fn parse_type_vars cursor:TokenCursor -> List[str] {
         fi
         if "," token Token::value == then continue fi
         if TokenKind::Identifier token Token::kind == then
-            if token Token::value BUILTIN_TYPES .has then
+            if token Token::value parser.store.builtins .has then
                 token Token::location f"Type variable `{token Token::value}` shadows built-in type" ErrorKind::DuplicateName raise_error
             fi
             if token Token::value seen .has then
@@ -736,7 +736,7 @@ fn parse_type_vars cursor:TokenCursor -> List[str] {
                     cursor tc_pop drop  # consume :
                     TokenKind::Identifier cursor expect_token_kind = trait_token
                     trait_token Token::value = bound_trait_name
-                    bound_trait_name GLOBAL_TRAITS .get = bound_trait_def_opt
+                    bound_trait_name parser.store.traits .get = bound_trait_def_opt
                     if bound_trait_def_opt .is_none then
                         trait_token Token::location f"Trait `{bound_trait_name}` is not defined" ErrorKind::UndefinedName raise_error
                     fi
@@ -854,14 +854,14 @@ fn parse_signature cursor:TokenCursor -> Signature {
 # must be injected. Used by both parse_function and inject_impl_trait_params.
 # Bounds whose trait is not registered in GLOBAL_TRAITS are silently skipped,
 # matching the pre-extraction behavior of both call sites.
-fn build_hidden_trait_methods trait_bounds:Map[str TraitBound] -> List[HiddenTraitMethod] {
+fn build_hidden_trait_methods parser:Parser trait_bounds:Map[str TraitBound] -> List[HiddenTraitMethod] {
     List::new (List[HiddenTraitMethod]) = result
     trait_bounds .keys = bound_keys
     0 = bound_index
     while bound_index bound_keys .length > do
         bound_index bound_keys .get = bound_type_var
         bound_type_var trait_bounds .get .unwrap = bound
-        bound TraitBound::name GLOBAL_TRAITS .get = bound_trait_opt
+        bound TraitBound::name parser.store.traits .get = bound_trait_opt
         if bound_trait_opt .is_some then
             bound_trait_opt .unwrap = bound_trait
             # Build substitution map from trait's declared type_params to the
@@ -895,7 +895,7 @@ fn build_hidden_trait_methods trait_bounds:Map[str TraitBound] -> List[HiddenTra
 # parse_function - parse function definition
 # ============================================================================
 
-fn parse_function cursor:TokenCursor -> Function {
+fn parse_function parser:Parser cursor:TokenCursor -> Function {
     "fn" cursor expect_token_value drop
     TokenKind::Identifier cursor expect_token_kind = name_token
 
@@ -904,7 +904,7 @@ fn parse_function cursor:TokenCursor -> Function {
     cursor tc_peek = tvars_opt
     if tvars_opt .is_some then
         if "[" tvars_opt .unwrap Token::value == then
-            cursor parse_type_vars = type_vars
+            cursor parser parse_type_vars = type_vars
         fi
     fi
 
@@ -927,7 +927,7 @@ fn parse_function cursor:TokenCursor -> Function {
     # Inject hidden __trait_* parameters for trait-bounded type vars
     if 0 sig Signature::trait_bounds .keys .length != then
         List::new (List[Parameter]) = hidden_params
-        sig Signature::trait_bounds build_hidden_trait_methods = hidden_methods
+        sig Signature::trait_bounds parser build_hidden_trait_methods = hidden_methods
         0 = hidden_index
         while hidden_index hidden_methods .length > do
             hidden_index hidden_methods .get = hidden
@@ -960,7 +960,7 @@ fn parse_function cursor:TokenCursor -> Function {
         1 += param_iter
     done
 
-    name_token Token::value cursor parse_block_ops = body_ops
+    name_token Token::value cursor parser parse_block_ops = body_ops
     0 = body_index
     while body_index body_ops .length > do
         body_index body_ops .get ops .push
@@ -976,7 +976,7 @@ fn parse_function cursor:TokenCursor -> Function {
 # parse_enum - parse enum definition
 # ============================================================================
 
-fn parse_enum cursor:TokenCursor -> CasaEnum {
+fn parse_enum parser:Parser cursor:TokenCursor -> CasaEnum {
     "enum" cursor expect_token_value drop
     TokenKind::Identifier cursor expect_token_kind = name_token
 
@@ -985,7 +985,7 @@ fn parse_enum cursor:TokenCursor -> CasaEnum {
     cursor tc_peek = tvars_opt
     if tvars_opt .is_some then
         if "[" tvars_opt .unwrap Token::value == then
-            cursor parse_type_vars = type_vars
+            cursor parser parse_type_vars = type_vars
         fi
     fi
 
@@ -1042,7 +1042,7 @@ fn parse_enum cursor:TokenCursor -> CasaEnum {
 # _create_member_accessor - create getter/setter for struct members
 # ============================================================================
 
-fn create_member_accessor struct_name:str member_name:str member_type:str member_index:int location:Location type_vars:List[str] {
+fn create_member_accessor parser:Parser struct_name:str member_name:str member_type:str member_index:int location:Location type_vars:List[str] {
     member_index 8 * = offset
 
     # Parameterize the struct name when the struct has type vars
@@ -1074,10 +1074,10 @@ fn create_member_accessor struct_name:str member_name:str member_type:str member
     sig_type_vars getter_sig Signature::set_type_vars
     getter_sig location getter_ops getter_name make_function_with_sig = getter
 
-    if getter_name GLOBAL_FUNCTIONS .get .is_some then
+    if getter_name parser.store.functions .get .is_some then
         location f"Function `{getter_name}` is already defined" ErrorKind::DuplicateName raise_error
     fi
-    getter_name getter GLOBAL_FUNCTIONS .set = GLOBAL_FUNCTIONS
+    getter_name getter parser.store.functions .set drop
 
     # Setter
     f"{struct_name}::set_{member_name}" = setter_name
@@ -1095,17 +1095,17 @@ fn create_member_accessor struct_name:str member_name:str member_type:str member
     sig_type_vars setter_sig Signature::set_type_vars
     setter_sig location setter_ops setter_name make_function_with_sig = setter
 
-    if setter_name GLOBAL_FUNCTIONS .get .is_some then
+    if setter_name parser.store.functions .get .is_some then
         location f"Function `{setter_name}` is already defined" ErrorKind::DuplicateName raise_error
     fi
-    setter_name setter GLOBAL_FUNCTIONS .set = GLOBAL_FUNCTIONS
+    setter_name setter parser.store.functions .set drop
 }
 
 # ============================================================================
 # parse_struct - parse struct definition
 # ============================================================================
 
-fn parse_struct cursor:TokenCursor -> CasaStruct {
+fn parse_struct parser:Parser cursor:TokenCursor -> CasaStruct {
     "struct" cursor expect_token_value drop
     TokenKind::Identifier cursor expect_token_kind = name_token
 
@@ -1114,7 +1114,7 @@ fn parse_struct cursor:TokenCursor -> CasaStruct {
     cursor tc_peek = tvars_opt
     if tvars_opt .is_some then
         if "[" tvars_opt .unwrap Token::value == then
-            cursor parse_type_vars = type_vars
+            cursor parser parse_type_vars = type_vars
             # Trait bounds are not allowed on struct definitions
             if 0 LAST_TRAIT_BOUNDS .keys .length != then
                 name_token Token::location "Trait bounds are not allowed on struct definitions. Use `impl[K: Bound] StructName[K]` instead" ErrorKind::UnexpectedToken raise_error
@@ -1134,7 +1134,7 @@ fn parse_struct cursor:TokenCursor -> CasaStruct {
         ":" cursor expect_token_value drop
         cursor parse_type = member_type
 
-        type_vars member_token Token::location members .length member_type member_token Token::value name_token Token::value create_member_accessor
+        type_vars member_token Token::location members .length member_type member_token Token::value name_token Token::value parser create_member_accessor
         member_type member_token Token::value Member members .push
     done
 
@@ -1261,7 +1261,7 @@ fn parse_trait cursor:TokenCursor -> CasaTrait {
 # parse_impl_block - parse impl Type { fn methods... }
 # ============================================================================
 
-fn inject_impl_trait_params function:Function type_vars:List[str] trait_bounds:Map[str TraitBound] {
+fn inject_impl_trait_params parser:Parser function:Function type_vars:List[str] trait_bounds:Map[str TraitBound] {
     function Function::signature = sig
 
     # Merge type vars into function signature
@@ -1288,7 +1288,7 @@ fn inject_impl_trait_params function:Function type_vars:List[str] trait_bounds:M
     # Inject hidden __trait_* parameters
     List::new (List[Parameter]) = hidden_params
     0 = insert_pos
-    sig Signature::trait_bounds build_hidden_trait_methods = hidden_methods
+    sig Signature::trait_bounds parser build_hidden_trait_methods = hidden_methods
     0 = hidden_index
     while hidden_index hidden_methods .length > do
         hidden_index hidden_methods .get = hidden
@@ -1313,7 +1313,7 @@ fn inject_impl_trait_params function:Function type_vars:List[str] trait_bounds:M
     fi
 }
 
-fn parse_impl_block cursor:TokenCursor {
+fn parse_impl_block parser:Parser cursor:TokenCursor {
     "impl" cursor expect_token_value drop
 
     # Parse optional type parameters with trait bounds
@@ -1322,7 +1322,7 @@ fn parse_impl_block cursor:TokenCursor {
     cursor tc_peek = tvars_opt
     if tvars_opt .is_some then
         if "[" tvars_opt .unwrap Token::value == then
-            cursor parse_type_vars = type_vars
+            cursor parser parse_type_vars = type_vars
             LAST_TRAIT_BOUNDS = trait_bounds
         fi
     fi
@@ -1342,17 +1342,17 @@ fn parse_impl_block cursor:TokenCursor {
         cursor tc_peek = fn_opt
         if fn_opt .is_none then break fi
         if "fn" fn_opt .unwrap Token::value != then break fi
-        cursor parse_function = function
+        cursor parser parse_function = function
         f"{base_type}::{function Function::name}" = fn_name
         fn_name function Function::set_name
         # Merge inherited type vars and trait bounds from impl block
         if 0 type_vars .length != then
-            trait_bounds type_vars function inject_impl_trait_params
+            trait_bounds type_vars function parser inject_impl_trait_params
         fi
-        if fn_name GLOBAL_FUNCTIONS .get .is_some then
+        if fn_name parser.store.functions .get .is_some then
             function Function::location f"Identifier `{fn_name}` is already defined" ErrorKind::DuplicateName raise_error
         fi
-        fn_name function GLOBAL_FUNCTIONS .set = GLOBAL_FUNCTIONS
+        fn_name function parser.store.functions .set drop
     done
     "}" cursor expect_token_value drop
 }
@@ -1367,7 +1367,7 @@ fn token_line token:Token -> int {
     token Token::location Location::span Span::offset source_opt .unwrap offset_to_line_col
 }
 
-fn is_match_arm_boundary cursor:TokenCursor -> bool {
+fn is_match_arm_boundary parser:Parser cursor:TokenCursor -> bool {
     cursor TokenCursor::pos = pos
     cursor TokenCursor::tokens = token_list
     if pos 1 + token_list .length < then false return fi
@@ -1386,7 +1386,7 @@ fn is_match_arm_boundary cursor:TokenCursor -> bool {
     # Identifier =>
     if "=>" next_token Token::value == then true return fi
     # StructName { ... } =>
-    if "{" next_token Token::value == token Token::value GLOBAL_STRUCTS .get .is_some && then
+    if "{" next_token Token::value == token Token::value parser.store.structs .get .is_some && then
         true return
     fi
     # EnumName::Variant(bindings) => pattern
@@ -1410,9 +1410,9 @@ fn is_match_arm_boundary cursor:TokenCursor -> bool {
     false
 }
 
-fn parse_struct_match_pattern name_token:Token cursor:TokenCursor -> StructPattern {
+fn parse_struct_match_pattern parser:Parser name_token:Token cursor:TokenCursor -> StructPattern {
     "{" cursor expect_token_value drop
-    name_token Token::value GLOBAL_STRUCTS .get = struct_opt
+    name_token Token::value parser.store.structs .get = struct_opt
     if struct_opt .is_none then
         name_token Token::location f"Struct `{name_token Token::value}` is not defined" ErrorKind::UndefinedName raise_error
     fi
@@ -1462,7 +1462,7 @@ fn parse_literal_match_pattern token:Token -> LiteralPattern {
     "" "int" 0 LiteralPattern
 }
 
-fn handle_keyword_match token:Token cursor:TokenCursor function_name:str -> List[Op] {
+fn handle_keyword_match parser:Parser token:Token cursor:TokenCursor function_name:str -> List[Op] {
     List::new (List[Op]) = ops
     token Token::location OpKind::OpMatchStart 0 make_op ops .push
 
@@ -1489,7 +1489,7 @@ fn handle_keyword_match token:Token cursor:TokenCursor function_name:str -> List
             arm_token Token::location "Expected match pattern or `_`" ErrorKind::UnexpectedToken raise_error
         elif cursor tc_peek .is_some "{" cursor tc_peek .unwrap Token::value == && then
             # Struct pattern
-            cursor arm_token parse_struct_match_pattern = struct_pattern
+            cursor arm_token parser parse_struct_match_pattern = struct_pattern
             "struct_pattern" arm_token Token::location OpKind::OpMatchArm struct_pattern (int) make_op_annotated ops .push
         elif arm_token Token::value "::" str::find 0 > then
             # Bare identifier
@@ -1530,7 +1530,7 @@ fn handle_keyword_match token:Token cursor:TokenCursor function_name:str -> List
         # Parse arm body
         cursor tc_peek = body_peek
         if body_peek .is_some "{" body_peek .unwrap Token::value == && then
-            function_name cursor parse_block_ops = block_ops
+            function_name cursor parser parse_block_ops = block_ops
             0 = block_index
             while block_index block_ops .length > do
                 block_index block_ops .get ops .push
@@ -1539,7 +1539,7 @@ fn handle_keyword_match token:Token cursor:TokenCursor function_name:str -> List
         else
             # Single-line arm body
             while cursor tc_is_finished ! do
-                if cursor is_match_arm_boundary then break fi
+                if cursor parser is_match_arm_boundary then break fi
                 cursor tc_peek = end_peek
                 if end_peek .is_some "end" end_peek .unwrap Token::value == && then
                     break
@@ -1548,10 +1548,10 @@ fn handle_keyword_match token:Token cursor:TokenCursor function_name:str -> List
                 if body_token_opt .is_none then break fi
                 body_token_opt .unwrap = body_token
                 if TokenKind::FstringStart body_token Token::kind == then
-                    ops function_name cursor body_token handle_fstring
+                    ops function_name cursor body_token parser handle_fstring
                     continue
                 fi
-                ops function_name cursor body_token token_to_op
+                ops function_name cursor body_token parser token_to_op
             done
         fi
     done
@@ -1674,7 +1674,7 @@ fn handle_keyword_include token:Token cursor:TokenCursor -> Op {
 # not collide. Nested `while`/`for` inside the body or the iterable
 # expression are detected via depth counting on `while`/`for` openers and
 # `done` closers so the enclosing `do`/`done` pair is identified correctly.
-fn handle_keyword_for token:Token cursor:TokenCursor function_name:str ops:List[Op] {
+fn handle_keyword_for parser:Parser token:Token cursor:TokenCursor function_name:str ops:List[Op] {
     TokenKind::Identifier cursor expect_token_kind = loop_var_token
     loop_var_token Token::value = loop_var_name
     "in" cursor expect_token_value drop
@@ -1707,10 +1707,10 @@ fn handle_keyword_for token:Token cursor:TokenCursor function_name:str ops:List[
         fi
         cursor tc_pop drop
         if TokenKind::FstringStart peeked_token Token::kind == then
-            ops function_name cursor peeked_token handle_fstring
+            ops function_name cursor peeked_token parser handle_fstring
             continue
         fi
-        ops function_name cursor peeked_token token_to_op
+        ops function_name cursor peeked_token parser token_to_op
     done
 
     # Loop preamble: store iterator into hidden local, then open the while
@@ -1749,10 +1749,10 @@ fn handle_keyword_for token:Token cursor:TokenCursor function_name:str ops:List[
         fi
         cursor tc_pop drop
         if TokenKind::FstringStart body_token Token::kind == then
-            ops function_name cursor body_token handle_fstring
+            ops function_name cursor body_token parser handle_fstring
             continue
         fi
-        ops function_name cursor body_token token_to_op
+        ops function_name cursor body_token parser token_to_op
     done
 }
 
@@ -1760,7 +1760,7 @@ fn handle_keyword_for token:Token cursor:TokenCursor function_name:str ops:List[
 # get_op_keyword - handle all keywords
 # ============================================================================
 
-fn get_op_keyword token:Token cursor:TokenCursor function_name:str ops:List[Op] {
+fn get_op_keyword parser:Parser token:Token cursor:TokenCursor function_name:str ops:List[Op] {
     token Token::value keyword_from_str = keyword_opt
     if keyword_opt .is_none then
         token Token::location f"Token `{token Token::value}` is not a keyword" ErrorKind::Syntax raise_error
@@ -1783,11 +1783,11 @@ fn get_op_keyword token:Token cursor:TokenCursor function_name:str ops:List[Op] 
     if KeywordKind::EnumKw keyword == then
         token Token::location "Enums" function_name require_global_scope
         cursor tc_retreat
-        cursor parse_enum = casa_enum
-        if casa_enum CasaEnum::name GLOBAL_ENUMS .get .is_some then
+        cursor parser parse_enum = casa_enum
+        if casa_enum CasaEnum::name parser.store.enums .get .is_some then
             casa_enum CasaEnum::location f"Enum `{casa_enum CasaEnum::name}` is already defined" ErrorKind::DuplicateName raise_error
         fi
-        casa_enum CasaEnum::name casa_enum GLOBAL_ENUMS .set = GLOBAL_ENUMS
+        casa_enum CasaEnum::name casa_enum parser.store.enums .set drop
         return
     fi
 
@@ -1795,11 +1795,11 @@ fn get_op_keyword token:Token cursor:TokenCursor function_name:str ops:List[Op] 
     if KeywordKind::Fn keyword == then
         token Token::location "Functions" function_name require_global_scope
         cursor tc_retreat
-        cursor parse_function = function
-        if function Function::name GLOBAL_FUNCTIONS .get .is_some then
+        cursor parser parse_function = function
+        if function Function::name parser.store.functions .get .is_some then
             function Function::location f"Identifier `{function Function::name}` is already defined" ErrorKind::DuplicateName raise_error
         fi
-        function Function::name function GLOBAL_FUNCTIONS .set = GLOBAL_FUNCTIONS
+        function Function::name function parser.store.functions .set drop
         return
     fi
 
@@ -1807,7 +1807,7 @@ fn get_op_keyword token:Token cursor:TokenCursor function_name:str ops:List[Op] 
     if KeywordKind::Impl keyword == then
         token Token::location "Implementation blocks" function_name require_global_scope
         cursor tc_retreat
-        cursor parse_impl_block
+        cursor parser parse_impl_block
         return
     fi
 
@@ -1824,7 +1824,7 @@ fn get_op_keyword token:Token cursor:TokenCursor function_name:str ops:List[Op] 
 
     # match
     if KeywordKind::Match keyword == then
-        function_name cursor token handle_keyword_match = match_ops
+        function_name cursor token parser handle_keyword_match = match_ops
         0 = match_index
         while match_index match_ops .length > do
             match_index match_ops .get ops .push
@@ -1837,14 +1837,14 @@ fn get_op_keyword token:Token cursor:TokenCursor function_name:str ops:List[Op] 
     if KeywordKind::StructKw keyword == then
         token Token::location "Structs" function_name require_global_scope
         cursor tc_retreat
-        cursor parse_struct = casa_struct
-        casa_struct CasaStruct::name casa_struct GLOBAL_STRUCTS .set = GLOBAL_STRUCTS
+        cursor parser parse_struct = casa_struct
+        casa_struct CasaStruct::name casa_struct parser.store.structs .set drop
         return
     fi
 
     # for
     if KeywordKind::For keyword == then
-        ops function_name cursor token handle_keyword_for
+        ops function_name cursor token parser handle_keyword_for
         return
     fi
 
@@ -1858,10 +1858,10 @@ fn get_op_keyword token:Token cursor:TokenCursor function_name:str ops:List[Op] 
         token Token::location "Traits" function_name require_global_scope
         cursor tc_retreat
         cursor parse_trait = casa_trait
-        if casa_trait CasaTrait::name GLOBAL_TRAITS .get .is_some then
+        if casa_trait CasaTrait::name parser.store.traits .get .is_some then
             casa_trait CasaTrait::location f"Trait `{casa_trait CasaTrait::name}` is already defined" ErrorKind::DuplicateName raise_error
         fi
-        casa_trait CasaTrait::name casa_trait GLOBAL_TRAITS .set = GLOBAL_TRAITS
+        casa_trait CasaTrait::name casa_trait parser.store.traits .set drop
         return
     fi
 }
@@ -1880,7 +1880,7 @@ fn is_struct_field_boundary cursor:TokenCursor member_names:List[str] -> bool {
     ":" pos 1 + token_list .get Token::value ==
 }
 
-fn parse_struct_field_value cursor:TokenCursor struct_name:str member_names:List[str] function_name:str all_ops:List[Op] {
+fn parse_struct_field_value parser:Parser cursor:TokenCursor struct_name:str member_names:List[str] function_name:str all_ops:List[Op] {
     while cursor tc_is_finished ! do
         cursor tc_peek = peek_opt
         if peek_opt .is_none then break fi
@@ -1890,16 +1890,16 @@ fn parse_struct_field_value cursor:TokenCursor struct_name:str member_names:List
         if value_opt .is_none then break fi
         value_opt .unwrap = value_token
         if TokenKind::FstringStart value_token Token::kind == then
-            all_ops function_name cursor value_token handle_fstring
+            all_ops function_name cursor value_token parser handle_fstring
             continue
         fi
-        all_ops function_name cursor value_token token_to_op
+        all_ops function_name cursor value_token parser token_to_op
     done
 }
 
-fn parse_struct_literal name_token:Token cursor:TokenCursor function_name:str -> List[Op] {
+fn parse_struct_literal parser:Parser name_token:Token cursor:TokenCursor function_name:str -> List[Op] {
     "{" cursor expect_token_value drop
-    name_token Token::value GLOBAL_STRUCTS .get .unwrap = casa_struct
+    name_token Token::value parser.store.structs .get .unwrap = casa_struct
     List::new (List[str]) = member_names
     0 = member_index
     while member_index casa_struct CasaStruct::members .length > do
@@ -1934,7 +1934,7 @@ fn parse_struct_literal name_token:Token cursor:TokenCursor function_name:str ->
         ":" cursor expect_token_value drop
 
         all_ops .length = ops_before
-        all_ops function_name member_names name_token Token::value cursor parse_struct_field_value
+        all_ops function_name member_names name_token Token::value cursor parser parse_struct_field_value
         if ops_before all_ops .length == then
             field_token Token::location f"Missing value for field `{field_token Token::value}`" ErrorKind::Syntax raise_error
         fi
@@ -1949,13 +1949,13 @@ fn parse_struct_literal name_token:Token cursor:TokenCursor function_name:str ->
 # token_to_op - main dispatch: token kind -> handler
 # ============================================================================
 
-fn token_to_op token:Token cursor:TokenCursor function_name:str ops:List[Op] {
+fn token_to_op parser:Parser token:Token cursor:TokenCursor function_name:str ops:List[Op] {
     token Token::kind = kind
 
     if TokenKind::Eof kind == then return fi
 
     if TokenKind::Delimiter kind == then
-        ops function_name cursor token get_op_delimiter
+        ops function_name cursor token parser get_op_delimiter
         return
     fi
 
@@ -1970,7 +1970,7 @@ fn token_to_op token:Token cursor:TokenCursor function_name:str ops:List[Op] {
     fi
 
     if TokenKind::Keyword kind == then
-        ops function_name cursor token get_op_keyword
+        ops function_name cursor token parser get_op_keyword
         return
     fi
 
@@ -1984,8 +1984,8 @@ fn token_to_op token:Token cursor:TokenCursor function_name:str ops:List[Op] {
         cursor tc_peek = next_opt
         if next_opt .is_some then
             if "{" next_opt .unwrap Token::value == then
-                if token Token::value GLOBAL_STRUCTS .get .is_some then
-                    function_name cursor token parse_struct_literal = struct_literal_ops
+                if token Token::value parser.store.structs .get .is_some then
+                    function_name cursor token parser parse_struct_literal = struct_literal_ops
                     0 = struct_index
                     while struct_index struct_literal_ops .length > do
                         struct_index struct_literal_ops .get ops .push
@@ -2026,7 +2026,7 @@ fn token_to_op token:Token cursor:TokenCursor function_name:str ops:List[Op] {
 # parse_ops - main parse loop
 # ============================================================================
 
-fn parse_ops tokens:List[Token] -> List[Op] {
+fn parse_ops parser:Parser tokens:List[Token] -> List[Op] {
     tokens tc_new = cursor
     List::new (List[Op]) = ops
     while cursor tc_is_finished ! do
@@ -2034,10 +2034,10 @@ fn parse_ops tokens:List[Token] -> List[Op] {
         if token_opt .is_none then break fi
         token_opt .unwrap = token
         if TokenKind::FstringStart token Token::kind == then
-            ops GLOBAL_SCOPE_LABEL cursor token handle_fstring
+            ops GLOBAL_SCOPE_LABEL cursor token parser handle_fstring
             continue
         fi
-        ops GLOBAL_SCOPE_LABEL cursor token token_to_op
+        ops GLOBAL_SCOPE_LABEL cursor token parser token_to_op
     done
     ops
 }
@@ -2046,7 +2046,7 @@ fn parse_ops tokens:List[Token] -> List[Op] {
 # resolve_identifiers - post-parse pass
 # ============================================================================
 
-fn gather_captures lambda_function:Function function:Function {
+fn gather_captures parser:Parser lambda_function:Function function:Function {
     0 = index
     while index lambda_function Function::ops .length > do
         index lambda_function Function::ops .get = op
@@ -2070,7 +2070,7 @@ fn gather_captures lambda_function:Function function:Function {
 
         if captured ! then
             # Check global variables
-            name GLOBAL_VARIABLES .get = global_var_opt
+            name parser.store.variables .get = global_var_opt
             if global_var_opt .is_some then
                 global_var_opt .unwrap lambda_function Function::captures .push
             fi
@@ -2079,19 +2079,19 @@ fn gather_captures lambda_function:Function function:Function {
     done
 }
 
-fn resolve_array_identifiers items:List[Op] function:Function errors:List[CasaError] {
+fn resolve_array_identifiers parser:Parser items:List[Op] function:Function errors:List[CasaError] {
     0 = rai_i
     while rai_i items .length > do
         rai_i items .get = rai_item
         if OpKind::OpPushArray rai_item Op::kind == then
-            errors function rai_item Op::value (List[Op]) resolve_array_identifiers
+            errors function rai_item Op::value (List[Op]) parser resolve_array_identifiers
         elif OpKind::OpIdentifier rai_item Op::kind == then
             rai_item op_str_value = rai_name
             if rai_name function Function::variables variable_list_contains then
                 OpKind::OpPushVar rai_item Op::set_kind
             elif rai_name function Function::captures variable_list_contains then
                 OpKind::OpPushCapture rai_item Op::set_kind
-            elif rai_name GLOBAL_VARIABLES .get .is_some then
+            elif rai_name parser.store.variables .get .is_some then
                 OpKind::OpPushVar rai_item Op::set_kind
             else
                 rai_item Op::location f"Identifier `{rai_name}` is not defined" ErrorKind::UndefinedName make_error errors .push
@@ -2101,10 +2101,10 @@ fn resolve_array_identifiers items:List[Op] function:Function errors:List[CasaEr
     done
 }
 
-fn resolve_enum_variant variant:EnumVariant op:Op function:Function errors:List[CasaError] {
+fn resolve_enum_variant parser:Parser variant:EnumVariant op:Op function:Function errors:List[CasaError] {
     # Resolve enum variant ordinal if still unresolved
     if variant EnumVariant::enum_name .length 0 != variant EnumVariant::ordinal .is_none && then
-        variant EnumVariant::enum_name GLOBAL_ENUMS .get = rev_enum_opt
+        variant EnumVariant::enum_name parser.store.enums .get = rev_enum_opt
         if rev_enum_opt .is_none then
             op Op::location f"Enum `{variant EnumVariant::enum_name}` is not defined" ErrorKind::UndefinedName make_error errors .push
         else
@@ -2124,7 +2124,7 @@ fn resolve_enum_variant variant:EnumVariant op:Op function:Function errors:List[
             rev_bi variant EnumVariant::bindings .get = rev_var_name
             rev_var_name make_variable = rev_var
             if GLOBAL_SCOPE_LABEL function Function::name == then
-                rev_var_name rev_var GLOBAL_VARIABLES .set = GLOBAL_VARIABLES
+                rev_var_name rev_var parser.store.variables .set drop
             else
                 if rev_var_name function Function::variables variable_list_contains ! then
                     rev_var function Function::variables .push
@@ -2135,17 +2135,17 @@ fn resolve_enum_variant variant:EnumVariant op:Op function:Function errors:List[
     fi
 }
 
-fn resolve_identifiers_global ops:List[Op] -> List[Op] {
+fn resolve_identifiers_global parser:Parser ops:List[Op] -> List[Op] {
     # Create a dummy function for global scope resolution
     empty_location List::new (List[Op]) GLOBAL_SCOPE_LABEL make_function = ri_dummy
-    ri_dummy ops resolve_identifiers_fn
+    ri_dummy ops parser resolve_identifiers_fn
 }
 
 fn resolve_identifiers ops:List[Op] function:Function -> List[Op] {
-    function ops resolve_identifiers_fn
+    function ops DEFAULT_PARSER resolve_identifiers_fn
 }
 
-fn resolve_identifiers_fn ops:List[Op] function:Function -> List[Op] {
+fn resolve_identifiers_fn parser:Parser ops:List[Op] function:Function -> List[Op] {
     0 = ri_index
     List::new (List[CasaError]) = ri_errors
     while ri_index ops .length > do
@@ -2159,12 +2159,12 @@ fn resolve_identifiers_fn ops:List[Op] function:Function -> List[Op] {
             ri_var_name make_variable = ri_var
             # Global scope: store in GLOBAL_VARIABLES
             if GLOBAL_SCOPE_LABEL function Function::name == then
-                ri_var_name ri_var GLOBAL_VARIABLES .set = GLOBAL_VARIABLES
+                ri_var_name ri_var parser.store.variables .set drop
                 continue
             fi
             # Function scope: add to function variables if new
             if ri_var_name function Function::variables variable_list_contains ! then
-                if ri_var_name GLOBAL_VARIABLES .get .is_none then
+                if ri_var_name parser.store.variables .get .is_none then
                     ri_var function Function::variables .push
                 fi
             fi
@@ -2174,11 +2174,11 @@ fn resolve_identifiers_fn ops:List[Op] function:Function -> List[Op] {
         # FN_PUSH: resolve lambda captures and identifiers
         if OpKind::OpFnPush ri_kind == then
             ri_op op_str_value = ri_fn_name
-            ri_fn_name GLOBAL_FUNCTIONS .get = ri_lambda_opt
+            ri_fn_name parser.store.functions .get = ri_lambda_opt
             if ri_lambda_opt .is_some then
                 ri_lambda_opt .unwrap = ri_lambda
                 true ri_lambda Function::set_is_used
-                function ri_lambda gather_captures
+                function ri_lambda parser gather_captures
                 ri_lambda ri_lambda Function::ops resolve_identifiers = ri_lambda_resolved
                 ri_lambda_resolved ri_lambda Function::set_ops
             fi
@@ -2187,7 +2187,7 @@ fn resolve_identifiers_fn ops:List[Op] function:Function -> List[Op] {
 
         # PUSH_ARRAY: resolve identifiers inside array literals
         if OpKind::OpPushArray ri_kind == then
-            ri_errors function ri_op Op::value (List[Op]) resolve_array_identifiers
+            ri_errors function ri_op Op::value (List[Op]) parser resolve_array_identifiers
             continue
         fi
 
@@ -2216,7 +2216,7 @@ fn resolve_identifiers_fn ops:List[Op] function:Function -> List[Op] {
                     fi
                 fi
                 if ri_ref_is_trait ! then
-                    ri_ref_name GLOBAL_FUNCTIONS .get = ri_ref_fn_opt
+                    ri_ref_name parser.store.functions .get = ri_ref_fn_opt
                     if ri_ref_fn_opt .is_some then
                         OpKind::OpFnPush ri_op Op::set_kind
                         ri_ref_name (int) ri_op Op::set_value
@@ -2232,7 +2232,7 @@ fn resolve_identifiers_fn ops:List[Op] function:Function -> List[Op] {
             if ri_ident "::" str::find 0 <= then
                 ri_ident "::" str::find = ri_sep
                 ri_ident 0 ri_sep str::substring = ri_enum_name
-                ri_enum_name GLOBAL_ENUMS .get = ri_enum_opt
+                ri_enum_name parser.store.enums .get = ri_enum_opt
                 if ri_enum_opt .is_some then
                     ri_ident ri_sep 2 + ri_ident .length ri_sep - 2 - str::substring = ri_vname
                     ri_vname ri_enum_opt .unwrap CasaEnum::variants string_list_index = ri_ordinal
@@ -2271,7 +2271,7 @@ fn resolve_identifiers_fn ops:List[Op] function:Function -> List[Op] {
             fi
 
             # Global function
-            ri_ident GLOBAL_FUNCTIONS .get = ri_gfn_opt
+            ri_ident parser.store.functions .get = ri_gfn_opt
             if ri_gfn_opt .is_some then
                 OpKind::OpFnCall ri_op Op::set_kind
                 true ri_gfn_opt .unwrap Function::set_is_used
@@ -2285,13 +2285,13 @@ fn resolve_identifiers_fn ops:List[Op] function:Function -> List[Op] {
             fi
 
             # Global variable
-            if ri_ident GLOBAL_VARIABLES .get .is_some then
+            if ri_ident parser.store.variables .get .is_some then
                 OpKind::OpPushVar ri_op Op::set_kind
                 continue
             fi
 
             # Struct constructor
-            ri_ident GLOBAL_STRUCTS .get = ri_struct_opt
+            ri_ident parser.store.structs .get = ri_struct_opt
             if ri_struct_opt .is_some then
                 OpKind::OpStructNew ri_op Op::set_kind
                 ri_struct_opt .unwrap (int) ri_op Op::set_value
@@ -2299,7 +2299,7 @@ fn resolve_identifiers_fn ops:List[Op] function:Function -> List[Op] {
             fi
 
             # Enum name -> variant count
-            ri_ident GLOBAL_ENUMS .get = ri_enum2_opt
+            ri_ident parser.store.enums .get = ri_enum2_opt
             if ri_enum2_opt .is_some then
                 OpKind::OpPushInt ri_op Op::set_kind
                 ri_enum2_opt .unwrap CasaEnum::variants .length ri_op Op::set_value
@@ -2322,7 +2322,7 @@ fn resolve_identifiers_fn ops:List[Op] function:Function -> List[Op] {
                     ri_ma_si ri_ma_sp_keys .get ri_ma_sp StructPattern::bindings .get .unwrap = ri_ma_sv_name
                     ri_ma_sv_name make_variable = ri_ma_sv
                     if GLOBAL_SCOPE_LABEL function Function::name == then
-                        ri_ma_sv_name ri_ma_sv GLOBAL_VARIABLES .set = GLOBAL_VARIABLES
+                        ri_ma_sv_name ri_ma_sv parser.store.variables .set drop
                     else
                         if ri_ma_sv_name function Function::variables variable_list_contains ! then
                             ri_ma_sv function Function::variables .push
@@ -2333,7 +2333,7 @@ fn resolve_identifiers_fn ops:List[Op] function:Function -> List[Op] {
             elif "enum_variant" ri_ma_tag == then
                 # EnumVariant: resolve ordinal and register bindings
                 ri_op Op::value (EnumVariant) = ri_ma_ev
-                ri_errors function ri_op ri_ma_ev resolve_enum_variant
+                ri_errors function ri_op ri_ma_ev parser resolve_enum_variant
             fi
             # literal_pattern: no resolution needed
             continue
@@ -2342,17 +2342,17 @@ fn resolve_identifiers_fn ops:List[Op] function:Function -> List[Op] {
         # IS_CHECK: resolve enum variant
         if OpKind::OpIsCheck ri_kind == then
             ri_op Op::value (EnumVariant) = ri_is_ev
-            ri_errors function ri_op ri_is_ev resolve_enum_variant
+            ri_errors function ri_op ri_is_ev parser resolve_enum_variant
             continue
         fi
 
         # INCLUDE_FILE: process included file
         if OpKind::OpIncludeFile ri_kind == then
             ri_op op_str_value = ri_inc_path
-            if ri_inc_path INCLUDED_FILES .has ! then
-                ri_inc_path INCLUDED_FILES .add = INCLUDED_FILES
+            if ri_inc_path parser.included_files .has ! then
+                ri_inc_path parser.included_files .add drop
                 ri_inc_path lex_file = ri_inc_tokens
-                ri_inc_tokens parse_ops = ri_inc_ops
+                ri_inc_tokens parser parse_ops = ri_inc_ops
                 # Splice included ops at current position (before remaining ops)
                 # Build: ops[:ri_index] + inc_ops + ops[ri_index:]
                 List::new (List[Op]) = ri_new_ops

--- a/compiler/typechecker.casa
+++ b/compiler/typechecker.casa
@@ -70,9 +70,11 @@ struct TypeChecker {
     current_op_context:  str
     current_expect_ctx:  str
     in_branch_condition: bool
+    store:               SymbolStore
 }
 
-fn make_typechecker -> TypeChecker {
+fn make_typechecker store:SymbolStore -> TypeChecker {
+    store                            # store
     false                            # in_branch_condition
     ""                               # current_expect_ctx
     ""                               # current_op_context
@@ -196,7 +198,7 @@ fn is_type_variable typ:str -> bool {
     # Check if it's a known type variable in enums
     typ extract_generic_base = itv_base
     if itv_base .is_some then
-        itv_base .unwrap GLOBAL_ENUMS .get .is_some return
+        itv_base .unwrap DEFAULT_PARSER.store.enums .get .is_some return
     fi
     false
 }
@@ -214,7 +216,7 @@ fn types_match_params expected:str actual:str -> bool {
     expected extract_generic_base = base_opt
     Set::new (Set[str]) = type_vars
     if base_opt .is_some then
-        base_opt .unwrap GLOBAL_ENUMS .get = enum_opt
+        base_opt .unwrap DEFAULT_PARSER.store.enums .get = enum_opt
         if enum_opt .is_some then
             0 = type_index
             while type_index enum_opt .unwrap CasaEnum::type_vars .length > do
@@ -222,7 +224,7 @@ fn types_match_params expected:str actual:str -> bool {
                 1 += type_index
             done
         fi
-        base_opt .unwrap GLOBAL_STRUCTS .get = struct_opt
+        base_opt .unwrap DEFAULT_PARSER.store.structs .get = struct_opt
         if struct_opt .is_some then
             0 = type_index
             while type_index struct_opt .unwrap CasaStruct::type_vars .length > do
@@ -401,7 +403,7 @@ fn bind_type_var tc:TypeChecker bindings:Map[str str] type_var:str actual:str ->
 fn is_enum_type_var typ:str -> bool {
     typ extract_generic_base = base
     if base .is_some then
-        base .unwrap GLOBAL_ENUMS .get .is_some
+        base .unwrap DEFAULT_PARSER.store.enums .get .is_some
     else
         false
     fi
@@ -619,15 +621,15 @@ fn check_comparison tc:TypeChecker op:Op {
     tc stack_pop = type2
     type1 resolve_match_type = base1
     type2 resolve_match_type = base2
-    base1 GLOBAL_ENUMS .get .is_some = is_enum1
-    base2 GLOBAL_ENUMS .get .is_some = is_enum2
+    base1 tc.store.enums .get .is_some = is_enum1
+    base2 tc.store.enums .get .is_some = is_enum2
     if is_enum1 is_enum2 || then
         if type1 type2 != then
             tc TypeChecker::current_location f"Cannot compare `{type2}` with `{type1}`" ErrorKind::TypeMismatch raise_error
         fi
         # Annotate for bytecode: data-carrying enums need heap tag comparison
         if is_enum1 then
-            base1 GLOBAL_ENUMS .get .unwrap = casa_enum
+            base1 tc.store.enums .get .unwrap = casa_enum
             if casa_enum has_inner_values then
                 base1 op Op::set_type_annotation
             fi
@@ -789,7 +791,7 @@ fn check_assignment tc:TypeChecker op:Op function_opt:Option[Function] {
     fi
 
     # Try global variables
-    var_name GLOBAL_VARIABLES .get = global_opt
+    var_name tc.store.variables .get = global_opt
     if global_opt .is_some then
         global_opt .unwrap = global_var
         if
@@ -827,7 +829,7 @@ fn simulate_trait_exec tc:TypeChecker function:Function var_name:str {
     trait_suffix trait_sep 1 + trait_suffix .length trait_sep - 1 - str::substring = trait_method_name
     trait_type_var function Function::signature Signature::trait_bounds .get = trait_bound_opt
     if trait_bound_opt .is_none then return fi
-    trait_bound_opt .unwrap TraitBound::name GLOBAL_TRAITS .get = trait_def_opt
+    trait_bound_opt .unwrap TraitBound::name tc.store.traits .get = trait_def_opt
     if trait_def_opt .is_none then return fi
     trait_def_opt .unwrap = trait_def
     0 = trait_lookup_index
@@ -884,7 +886,7 @@ fn check_push_var tc:TypeChecker op:Op function_opt:Option[Function] {
     fi
 
     # Check global variables
-    var_name GLOBAL_VARIABLES .get = global_opt
+    var_name tc.store.variables .get = global_opt
     if global_opt .is_some then
         global_opt .unwrap Variable::typ = global_type
         if "" global_type != then
@@ -1035,7 +1037,7 @@ fn type_satisfies_trait type_name:str trait_name:str function_opt:Option[Functio
     # Accept both bare ("Iterator") and concrete generic ("Iterator[int]") trait names.
     trait_name extract_generic_base = trait_base_opt
     if trait_base_opt .is_some then trait_base_opt .unwrap else trait_name fi = trait_lookup_name
-    trait_lookup_name GLOBAL_TRAITS .get = trait_opt
+    trait_lookup_name DEFAULT_PARSER.store.traits .get = trait_opt
     if trait_opt .is_none then false return fi
     trait_opt .unwrap = trait_def
     # Build substitution map from trait's type_params to concrete args from trait_name.
@@ -1066,14 +1068,14 @@ fn type_satisfies_trait type_name:str trait_name:str function_opt:Option[Functio
     while index trait_def CasaTrait::methods .length > do
         index trait_def CasaTrait::methods .get = method
         f"{type_name}::{method TraitMethod::name}" = fn_name
-        fn_name GLOBAL_FUNCTIONS .get = fn_opt
+        fn_name DEFAULT_PARSER.store.functions .get = fn_opt
         false = via_generic_base
         # Fall back to the generic base type (e.g. `Option::to_str` for `Option[int]`)
         if fn_opt .is_none then
             type_name extract_generic_base = base_opt
             if base_opt .is_some then
                 f"{base_opt .unwrap}::{method TraitMethod::name}" = fn_name
-                fn_name GLOBAL_FUNCTIONS .get = fn_opt
+                fn_name DEFAULT_PARSER.store.functions .get = fn_opt
                 true = via_generic_base
             fi
         fi
@@ -1206,7 +1208,7 @@ fn diff_method_sig bindings:Map[str str] sig:Signature tparams:List[str] bargs:L
 }
 
 fn method_diff_bind_for_bound bindings:Map[str str] sig:Signature bound:TraitBound concrete:str -> Map[str str] {
-    bound TraitBound::name GLOBAL_TRAITS .get = mdbb_trait_opt
+    bound TraitBound::name DEFAULT_PARSER.store.traits .get = mdbb_trait_opt
     if mdbb_trait_opt .is_none then bindings return fi
     mdbb_trait_opt .unwrap = mdbb_trait
     mdbb_trait CasaTrait::type_params = mdbb_tparams
@@ -1215,7 +1217,7 @@ fn method_diff_bind_for_bound bindings:Map[str str] sig:Signature bound:TraitBou
     0 = mdbb_method_idx
     while mdbb_method_idx mdbb_trait CasaTrait::methods .length > do
         mdbb_method_idx mdbb_trait CasaTrait::methods .get = mdbb_method
-        f"{concrete}::{mdbb_method TraitMethod::name}" GLOBAL_FUNCTIONS .get = mdbb_fn_opt
+        f"{concrete}::{mdbb_method TraitMethod::name}" DEFAULT_PARSER.store.functions .get = mdbb_fn_opt
         if mdbb_fn_opt .is_some then
             concrete mdbb_method TraitMethod::signature resolve_trait_sig = mdbb_trait_resolved
             mdbb_fn_opt .unwrap Function::signature mdbb_trait_resolved mdbb_bargs mdbb_tparams sig bindings diff_method_sig = bindings
@@ -1319,7 +1321,7 @@ fn inject_trait_fn_ptrs tc:TypeChecker sig:Signature ops:List[Op] op_index:int l
             continue
         fi
         concrete_opt .unwrap = concrete
-        trait_bound TraitBound::name GLOBAL_TRAITS .get .unwrap = trait_def
+        trait_bound TraitBound::name tc.store.traits .get .unwrap = trait_def
 
         # Check if forwarding (type var has same trait bound in calling function)
         false = is_forwarding
@@ -1357,7 +1359,7 @@ fn inject_trait_fn_ptrs tc:TypeChecker sig:Signature ops:List[Op] op_index:int l
             while 0 method_index >= do
                 method_index trait_def CasaTrait::methods .get = method
                 f"{concrete}::{method TraitMethod::name}" = fn_name
-                fn_name GLOBAL_FUNCTIONS .get = global_fn_opt
+                fn_name tc.store.functions .get = global_fn_opt
                 if global_fn_opt .is_none then
                     location f"Function `{fn_name}` required by trait `{trait_name}` not found" ErrorKind::TypeMismatch raise_error
                     method_index 1 - = method_index
@@ -1390,7 +1392,7 @@ fn check_function_ops tc:TypeChecker op:Op ops:List[Op] op_index:int function_op
     op Op::kind = kind
     if OpKind::OpFnCall kind == then
         op op_str_value = fn_name
-        fn_name GLOBAL_FUNCTIONS .get = fn_opt
+        fn_name tc.store.functions .get = fn_opt
         if fn_opt .is_some then
             fn_opt .unwrap = function
             function ensure_typechecked
@@ -1413,7 +1415,7 @@ fn check_function_ops tc:TypeChecker op:Op ops:List[Op] op_index:int function_op
         fi
     elif OpKind::OpFnPush kind == then
         op op_str_value = push_name
-        push_name GLOBAL_FUNCTIONS .get = push_fn_opt
+        push_name tc.store.functions .get = push_fn_opt
         if push_fn_opt .is_some then
             push_fn_opt .unwrap = push_fn
             push_fn ensure_typechecked
@@ -1517,7 +1519,7 @@ fn check_syscalls tc:TypeChecker op:Op {
 fn check_enum_variant tc:TypeChecker op:Op {
     op Op::value (EnumVariant) = variant
     variant EnumVariant::enum_name = enum_name
-    enum_name GLOBAL_ENUMS .get = enum_opt
+    enum_name tc.store.enums .get = enum_opt
     if enum_opt .is_none then
         enum_name tc stack_push
         return
@@ -1585,12 +1587,12 @@ fn check_enum_variant tc:TypeChecker op:Op {
 fn check_is tc:TypeChecker op:Op {
     tc stack_pop = typ
     typ resolve_match_type = base
-    if base GLOBAL_ENUMS .get .is_none then
+    if base tc.store.enums .get .is_none then
         tc TypeChecker::current_location f"`is` requires an enum type, got `{typ}`" ErrorKind::TypeMismatch raise_error
         "bool" tc stack_push
         return
     fi
-    base GLOBAL_ENUMS .get .unwrap = casa_enum
+    base tc.store.enums .get .unwrap = casa_enum
     op Op::value (EnumVariant) = variant
     # Validate the variant belongs to the correct enum
     if "" variant EnumVariant::enum_name != then
@@ -1616,11 +1618,11 @@ fn check_is tc:TypeChecker op:Op {
 # ============================================================================
 
 fn resolve_match_type typ:str -> str {
-    if typ GLOBAL_ENUMS .get .is_some then typ return fi
-    if typ GLOBAL_STRUCTS .get .is_some then typ return fi
+    if typ DEFAULT_PARSER.store.enums .get .is_some then typ return fi
+    if typ DEFAULT_PARSER.store.structs .get .is_some then typ return fi
     typ extract_generic_base = base
     if base .is_some then
-        if base .unwrap GLOBAL_ENUMS .get .is_some then
+        if base .unwrap DEFAULT_PARSER.store.enums .get .is_some then
             base .unwrap return
         fi
     fi
@@ -1640,7 +1642,7 @@ fn set_binding_type var_name:str field_type:str function_opt:Option[Function] {
             1 += index
         done
     fi
-    var_name GLOBAL_VARIABLES .get = global_opt
+    var_name DEFAULT_PARSER.store.variables .get = global_opt
     if global_opt .is_some then
         field_type global_opt .unwrap Variable::set_typ
     fi
@@ -1686,7 +1688,7 @@ fn check_match tc:TypeChecker op:Op function_opt:Option[Function] {
                 "" variant EnumVariant::enum_name ==
                 is_wildcard ! &&
             then
-                arm_base GLOBAL_ENUMS .get = bare_enum_opt
+                arm_base tc.store.enums .get = bare_enum_opt
                 if bare_enum_opt .is_some then
                     bare_enum_opt .unwrap = bare_enum
                     variant EnumVariant::variant_name = bare_name
@@ -1752,7 +1754,7 @@ fn check_match tc:TypeChecker op:Op function_opt:Option[Function] {
         if "struct_pattern" pattern_tag == then
             # StructPattern bindings
             pattern_ptr (StructPattern) = struct_pat2
-            struct_pat2 StructPattern::struct_name GLOBAL_STRUCTS .get .unwrap = matched_struct
+            struct_pat2 StructPattern::struct_name tc.store.structs .get .unwrap = matched_struct
             struct_pat2 StructPattern::bindings .keys = binding_keys
             0 = binding_index
             while binding_index binding_keys .length > do
@@ -1773,7 +1775,7 @@ fn check_match tc:TypeChecker op:Op function_opt:Option[Function] {
             if 0 variant EnumVariant::bindings .length != then
             # EnumVariant bindings
             match_subject_type resolve_match_type = base_enum_name
-            base_enum_name GLOBAL_ENUMS .get = enum_opt
+            base_enum_name tc.store.enums .get = enum_opt
             if enum_opt .is_some then
                 enum_opt .unwrap = casa_enum
                 variant EnumVariant::variant_name casa_enum CasaEnum::variant_types .get = inner_opt
@@ -1861,8 +1863,8 @@ fn check_match tc:TypeChecker op:Op function_opt:Option[Function] {
         MATCH_WILDCARD covered_set .has = has_wildcard
 
         # Check exhaustiveness
-        if end_base GLOBAL_ENUMS .get .is_some has_wildcard ! && then
-            end_base GLOBAL_ENUMS .get .unwrap = end_enum
+        if end_base tc.store.enums .get .is_some has_wildcard ! && then
+            end_base tc.store.enums .get .unwrap = end_enum
             List::new (List[str]) = missing
             0 = variant_index
             while variant_index end_enum CasaEnum::variants .length > do
@@ -1883,7 +1885,7 @@ fn check_match tc:TypeChecker op:Op function_opt:Option[Function] {
                 op Op::location f"Non-exhaustive match, missing arms: {missing_builder .build}" ErrorKind::TypeMismatch raise_error
             fi
         fi
-        if end_base GLOBAL_STRUCTS .get .is_some has_wildcard ! && then
+        if end_base tc.store.structs .get .is_some has_wildcard ! && then
             if end_base covered_set .has ! then
                 op Op::location f"Non-exhaustive match on struct `{end_match_type}`" ErrorKind::TypeMismatch raise_error
             fi
@@ -1972,7 +1974,7 @@ fn check_struct_new tc:TypeChecker op:Op {
 fn check_struct_literal tc:TypeChecker op:Op {
     op Op::value (StructLiteral) = literal
     literal StructLiteral::struct_name = name
-    name GLOBAL_STRUCTS .get = struct_opt
+    name tc.store.structs .get = struct_opt
     if struct_opt .is_none then
         name tc stack_push
         return
@@ -2003,7 +2005,7 @@ fn check_struct_literal tc:TypeChecker op:Op {
 
 fn find_method_by_name method_name:str -> Option[str] {
     f"::{method_name}" = suffix
-    GLOBAL_FUNCTIONS .keys = keys
+    DEFAULT_PARSER.store.functions .keys = keys
     "" = found
     "" = found_with_traits
     0 = index
@@ -2011,7 +2013,7 @@ fn find_method_by_name method_name:str -> Option[str] {
         index keys .get = key
         if key suffix str::ends_with then
             if key "lambda__" str::starts_with ! then
-                key GLOBAL_FUNCTIONS .get .unwrap = function
+                key DEFAULT_PARSER.store.functions .get .unwrap = function
                 if 0 function Function::signature Signature::trait_bounds .keys .length == then
                     if "" found == then
                         key = found
@@ -2050,7 +2052,7 @@ fn check_method_call tc:TypeChecker op:Op ops:List[Op] op_index:int function_opt
         if trait_opt .is_some then
             trait_opt .unwrap = bound
             bound TraitBound::name = trait_name
-            trait_name GLOBAL_TRAITS .get = trait_def_opt
+            trait_name tc.store.traits .get = trait_def_opt
             if trait_def_opt .is_some then
                 trait_def_opt .unwrap = trait_def
                 # Build substitution map from trait's type_params to the
@@ -2091,14 +2093,14 @@ fn check_method_call tc:TypeChecker op:Op ops:List[Op] op_index:int function_opt
 
     # Look up Type::method
     f"{receiver}::{method_name}" = fn_name
-    fn_name GLOBAL_FUNCTIONS .get = fn_opt
+    fn_name tc.store.functions .get = fn_opt
 
     # Try generic base type
     if fn_opt .is_none then
         receiver extract_generic_base = base_opt
         if base_opt .is_some then
             f"{base_opt .unwrap}::{method_name}" = fn_name
-            fn_name GLOBAL_FUNCTIONS .get = fn_opt
+            fn_name tc.store.functions .get = fn_opt
         fi
     fi
 
@@ -2108,7 +2110,7 @@ fn check_method_call tc:TypeChecker op:Op ops:List[Op] op_index:int function_opt
             method_name find_method_by_name = any_match_opt
             if any_match_opt .is_some then
                 any_match_opt .unwrap = fn_name
-                fn_name GLOBAL_FUNCTIONS .get = fn_opt
+                fn_name tc.store.functions .get = fn_opt
             fi
         fi
     fi
@@ -2173,7 +2175,7 @@ fn ensure_typechecked function:Function {
 # ============================================================================
 
 fn type_check_ops ops:List[Op] function_opt:Option[Function] -> Signature {
-    make_typechecker = checker
+    DEFAULT_PARSER.store make_typechecker = checker
     ERRORS .length = errors_before_ops
     0 = op_index
     while op_index ops .length > do
@@ -2466,11 +2468,11 @@ fn type_check_ops ops:List[Op] function_opt:Option[Function] -> Signature {
 # ============================================================================
 
 fn type_check_functions {
-    GLOBAL_FUNCTIONS .keys = function_keys
+    DEFAULT_PARSER.store.functions .keys = function_keys
     0 = func_index
     while func_index function_keys .length > do
         func_index function_keys .get = func_name
-        func_name GLOBAL_FUNCTIONS .get .unwrap = current_fn
+        func_name DEFAULT_PARSER.store.functions .get .unwrap = current_fn
         if current_fn Function::is_typechecked then
             1 += func_index
             continue

--- a/lib/test_helpers.casa
+++ b/lib/test_helpers.casa
@@ -76,24 +76,12 @@ fn assert_warning_contains needle:str msg:str {
 }
 
 fn clear_global_state {
-    Map::new (Map[str Function]) = cgs_functions
-    cgs_functions = GLOBAL_FUNCTIONS
-    cgs_functions DEFAULT_PARSER Parser::store SymbolStore::set_functions
-    Map::new (Map[str Variable]) = cgs_variables
-    cgs_variables = GLOBAL_VARIABLES
-    cgs_variables DEFAULT_PARSER Parser::store SymbolStore::set_variables
-    Map::new (Map[str CasaEnum]) = cgs_enums
-    cgs_enums = GLOBAL_ENUMS
-    cgs_enums DEFAULT_PARSER Parser::store SymbolStore::set_enums
-    Map::new (Map[str CasaStruct]) = cgs_structs
-    cgs_structs = GLOBAL_STRUCTS
-    cgs_structs DEFAULT_PARSER Parser::store SymbolStore::set_structs
-    Map::new (Map[str CasaTrait]) = cgs_traits
-    cgs_traits = GLOBAL_TRAITS
-    cgs_traits DEFAULT_PARSER Parser::store SymbolStore::set_traits
-    Set::new (Set[str]) = cgs_included
-    cgs_included = INCLUDED_FILES
-    cgs_included DEFAULT_PARSER Parser::set_included_files
+    Map::new (Map[str Function]) DEFAULT_PARSER Parser::store SymbolStore::set_functions
+    Map::new (Map[str Variable]) DEFAULT_PARSER Parser::store SymbolStore::set_variables
+    Map::new (Map[str CasaEnum]) DEFAULT_PARSER Parser::store SymbolStore::set_enums
+    Map::new (Map[str CasaStruct]) DEFAULT_PARSER Parser::store SymbolStore::set_structs
+    Map::new (Map[str CasaTrait]) DEFAULT_PARSER Parser::store SymbolStore::set_traits
+    Set::new (Set[str]) DEFAULT_PARSER Parser::set_included_files
     Map::new (Map[str str]) = SOURCE_CACHE
     List::new (List[CasaError]) = ERRORS
     List::new (List[CasaWarning]) = WARNINGS

--- a/lib/test_helpers.casa
+++ b/lib/test_helpers.casa
@@ -76,12 +76,24 @@ fn assert_warning_contains needle:str msg:str {
 }
 
 fn clear_global_state {
-    Map::new (Map[str Function]) = GLOBAL_FUNCTIONS
-    Map::new (Map[str Variable]) = GLOBAL_VARIABLES
-    Map::new (Map[str CasaEnum]) = GLOBAL_ENUMS
-    Map::new (Map[str CasaStruct]) = GLOBAL_STRUCTS
-    Map::new (Map[str CasaTrait]) = GLOBAL_TRAITS
-    Set::new (Set[str]) = INCLUDED_FILES
+    Map::new (Map[str Function]) = cgs_functions
+    cgs_functions = GLOBAL_FUNCTIONS
+    cgs_functions DEFAULT_PARSER Parser::store SymbolStore::set_functions
+    Map::new (Map[str Variable]) = cgs_variables
+    cgs_variables = GLOBAL_VARIABLES
+    cgs_variables DEFAULT_PARSER Parser::store SymbolStore::set_variables
+    Map::new (Map[str CasaEnum]) = cgs_enums
+    cgs_enums = GLOBAL_ENUMS
+    cgs_enums DEFAULT_PARSER Parser::store SymbolStore::set_enums
+    Map::new (Map[str CasaStruct]) = cgs_structs
+    cgs_structs = GLOBAL_STRUCTS
+    cgs_structs DEFAULT_PARSER Parser::store SymbolStore::set_structs
+    Map::new (Map[str CasaTrait]) = cgs_traits
+    cgs_traits = GLOBAL_TRAITS
+    cgs_traits DEFAULT_PARSER Parser::store SymbolStore::set_traits
+    Set::new (Set[str]) = cgs_included
+    cgs_included = INCLUDED_FILES
+    cgs_included DEFAULT_PARSER Parser::set_included_files
     Map::new (Map[str str]) = SOURCE_CACHE
     List::new (List[CasaError]) = ERRORS
     List::new (List[CasaWarning]) = WARNINGS

--- a/lsp.casa
+++ b/lsp.casa
@@ -290,24 +290,12 @@ fn clear_compilation_state {
     Map::new (Map[str str]) = SOURCE_CACHE
     List::new (List[CasaError]) = ERRORS
     List::new (List[CasaWarning]) = WARNINGS
-    Map::new (Map[str Function]) = ccs_functions
-    ccs_functions = GLOBAL_FUNCTIONS
-    ccs_functions DEFAULT_PARSER Parser::store SymbolStore::set_functions
-    Map::new (Map[str Variable]) = ccs_variables
-    ccs_variables = GLOBAL_VARIABLES
-    ccs_variables DEFAULT_PARSER Parser::store SymbolStore::set_variables
-    Map::new (Map[str CasaEnum]) = ccs_enums
-    ccs_enums = GLOBAL_ENUMS
-    ccs_enums DEFAULT_PARSER Parser::store SymbolStore::set_enums
-    Map::new (Map[str CasaStruct]) = ccs_structs
-    ccs_structs = GLOBAL_STRUCTS
-    ccs_structs DEFAULT_PARSER Parser::store SymbolStore::set_structs
-    Map::new (Map[str CasaTrait]) = ccs_traits
-    ccs_traits = GLOBAL_TRAITS
-    ccs_traits DEFAULT_PARSER Parser::store SymbolStore::set_traits
-    Set::new (Set[str]) = ccs_included
-    ccs_included = INCLUDED_FILES
-    ccs_included DEFAULT_PARSER Parser::set_included_files
+    Map::new (Map[str Function]) DEFAULT_PARSER Parser::store SymbolStore::set_functions
+    Map::new (Map[str Variable]) DEFAULT_PARSER Parser::store SymbolStore::set_variables
+    Map::new (Map[str CasaEnum]) DEFAULT_PARSER Parser::store SymbolStore::set_enums
+    Map::new (Map[str CasaStruct]) DEFAULT_PARSER Parser::store SymbolStore::set_structs
+    Map::new (Map[str CasaTrait]) DEFAULT_PARSER Parser::store SymbolStore::set_traits
+    Set::new (Set[str]) DEFAULT_PARSER Parser::set_included_files
 }
 
 fn run_pipeline file_path:str source:str -> DocumentState {
@@ -352,44 +340,44 @@ fn run_pipeline file_path:str source:str -> DocumentState {
     file_path
     final_source
     Map::new (Map[str Variable]) = vars_copy
-    GLOBAL_VARIABLES .keys = var_keys
+    DEFAULT_PARSER.store.variables .keys = var_keys
     0 = var_index
     while var_index var_keys .length > do
         var_index var_keys .get = var_name
-        var_name GLOBAL_VARIABLES .get .unwrap = var_value
+        var_name DEFAULT_PARSER.store.variables .get .unwrap = var_value
         var_name var_value vars_copy .set = vars_copy
         1 += var_index
     done
     vars_copy
 
     Map::new (Map[str CasaEnum]) = enums_copy
-    GLOBAL_ENUMS .keys = enum_keys
+    DEFAULT_PARSER.store.enums .keys = enum_keys
     0 = enum_index
     while enum_index enum_keys .length > do
         enum_index enum_keys .get = enum_name
-        enum_name GLOBAL_ENUMS .get .unwrap = enum_value
+        enum_name DEFAULT_PARSER.store.enums .get .unwrap = enum_value
         enum_name enum_value enums_copy .set = enums_copy
         1 += enum_index
     done
     enums_copy
 
     Map::new (Map[str CasaStruct]) = structs_copy
-    GLOBAL_STRUCTS .keys = struct_keys
+    DEFAULT_PARSER.store.structs .keys = struct_keys
     0 = struct_index
     while struct_index struct_keys .length > do
         struct_index struct_keys .get = struct_name
-        struct_name GLOBAL_STRUCTS .get .unwrap = struct_value
+        struct_name DEFAULT_PARSER.store.structs .get .unwrap = struct_value
         struct_name struct_value structs_copy .set = structs_copy
         1 += struct_index
     done
     structs_copy
 
     Map::new (Map[str Function]) = fns_copy
-    GLOBAL_FUNCTIONS .keys = fn_keys
+    DEFAULT_PARSER.store.functions .keys = fn_keys
     0 = fn_index
     while fn_index fn_keys .length > do
         fn_index fn_keys .get = fn_name
-        fn_name GLOBAL_FUNCTIONS .get .unwrap = fn_value
+        fn_name DEFAULT_PARSER.store.functions .get .unwrap = fn_value
         fn_name fn_value fns_copy .set = fns_copy
         1 += fn_index
     done

--- a/lsp.casa
+++ b/lsp.casa
@@ -290,12 +290,24 @@ fn clear_compilation_state {
     Map::new (Map[str str]) = SOURCE_CACHE
     List::new (List[CasaError]) = ERRORS
     List::new (List[CasaWarning]) = WARNINGS
-    Map::new (Map[str Function]) = GLOBAL_FUNCTIONS
-    Map::new (Map[str Variable]) = GLOBAL_VARIABLES
-    Map::new (Map[str CasaEnum]) = GLOBAL_ENUMS
-    Map::new (Map[str CasaStruct]) = GLOBAL_STRUCTS
-    Map::new (Map[str CasaTrait]) = GLOBAL_TRAITS
-    Set::new (Set[str]) = INCLUDED_FILES
+    Map::new (Map[str Function]) = ccs_functions
+    ccs_functions = GLOBAL_FUNCTIONS
+    ccs_functions DEFAULT_PARSER Parser::store SymbolStore::set_functions
+    Map::new (Map[str Variable]) = ccs_variables
+    ccs_variables = GLOBAL_VARIABLES
+    ccs_variables DEFAULT_PARSER Parser::store SymbolStore::set_variables
+    Map::new (Map[str CasaEnum]) = ccs_enums
+    ccs_enums = GLOBAL_ENUMS
+    ccs_enums DEFAULT_PARSER Parser::store SymbolStore::set_enums
+    Map::new (Map[str CasaStruct]) = ccs_structs
+    ccs_structs = GLOBAL_STRUCTS
+    ccs_structs DEFAULT_PARSER Parser::store SymbolStore::set_structs
+    Map::new (Map[str CasaTrait]) = ccs_traits
+    ccs_traits = GLOBAL_TRAITS
+    ccs_traits DEFAULT_PARSER Parser::store SymbolStore::set_traits
+    Set::new (Set[str]) = ccs_included
+    ccs_included = INCLUDED_FILES
+    ccs_included DEFAULT_PARSER Parser::set_included_files
 }
 
 fn run_pipeline file_path:str source:str -> DocumentState {
@@ -319,8 +331,8 @@ fn run_pipeline file_path:str source:str -> DocumentState {
     file_path source lex_source = tokens
 
     # Parse
-    tokens parse_ops = ops
-    ops resolve_identifiers_global = ops
+    tokens DEFAULT_PARSER parse_ops = ops
+    ops DEFAULT_PARSER resolve_identifiers_global = ops
 
     # Type check
     if 0 ops .length != then

--- a/tests/compiler/test_argv.casa
+++ b/tests/compiler/test_argv.casa
@@ -13,15 +13,15 @@ include "../../lib/test.casa"
 
 fn tc_string_argv code:str -> Signature {
     "test" code lex_source = tokens
-    tokens parse_ops = ops
-    ops resolve_identifiers_global = ops
+    tokens DEFAULT_PARSER parse_ops = ops
+    ops DEFAULT_PARSER resolve_identifiers_global = ops
     Option::None (Option[Function]) ops type_check_ops
 }
 
 fn compile_string_argv code:str -> Program {
     "test" code lex_source = tokens
-    tokens parse_ops = ops
-    ops resolve_identifiers_global = ops
+    tokens DEFAULT_PARSER parse_ops = ops
+    ops DEFAULT_PARSER resolve_identifiers_global = ops
     Option::None (Option[Function]) ops type_check_ops drop
     ops compile_bytecode
 }
@@ -64,14 +64,14 @@ fn test_lex_argv {
 fn test_parse_argc {
     "parse_argc" test_start
     "test" "argc" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "argc kind" OpKind::OpArgc 0 ops .get Op::kind == assert_true
 }
 
 fn test_parse_argv {
     "parse_argv" test_start
     "test" "argv" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "argv kind" OpKind::OpArgv 0 ops .get Op::kind == assert_true
 }
 

--- a/tests/compiler/test_argv.casa
+++ b/tests/compiler/test_argv.casa
@@ -23,7 +23,7 @@ fn compile_string_argv code:str -> Program {
     tokens DEFAULT_PARSER parse_ops = ops
     ops DEFAULT_PARSER resolve_identifiers_global = ops
     Option::None (Option[Function]) ops type_check_ops drop
-    ops compile_bytecode
+    ops DEFAULT_PARSER.store compile_bytecode
 }
 
 fn emit_string_argv code:str -> str {

--- a/tests/compiler/test_array_methods.casa
+++ b/tests/compiler/test_array_methods.casa
@@ -20,16 +20,16 @@ include "../../lib/test_helpers.casa"
 fn tc_am code:str -> Signature {
     clear_global_state
     "test" code lex_source = tokens
-    tokens parse_ops = ops
-    ops resolve_identifiers_global = ops
+    tokens DEFAULT_PARSER parse_ops = ops
+    ops DEFAULT_PARSER resolve_identifiers_global = ops
     Option::None (Option[Function]) ops type_check_ops
 }
 
 fn compile_am code:str -> Program {
     clear_global_state
     "test" code lex_source = tokens
-    tokens parse_ops = ops
-    ops resolve_identifiers_global = ops
+    tokens DEFAULT_PARSER parse_ops = ops
+    ops DEFAULT_PARSER resolve_identifiers_global = ops
     Option::None (Option[Function]) ops type_check_ops drop
     ops compile_bytecode
 }

--- a/tests/compiler/test_array_methods.casa
+++ b/tests/compiler/test_array_methods.casa
@@ -31,7 +31,7 @@ fn compile_am code:str -> Program {
     tokens DEFAULT_PARSER parse_ops = ops
     ops DEFAULT_PARSER resolve_identifiers_global = ops
     Option::None (Option[Function]) ops type_check_ops drop
-    ops compile_bytecode
+    ops DEFAULT_PARSER.store compile_bytecode
 }
 
 fn emit_am code:str -> str {

--- a/tests/compiler/test_bytecode.casa
+++ b/tests/compiler/test_bytecode.casa
@@ -2,9 +2,6 @@ include "../../compiler/common.casa"
 include "../../compiler/error.casa"
 include "../../lib/test.casa"
 
-# ============================================================================
-# Shared test store replaces the legacy GLOBAL_* stubs
-# ============================================================================
 symbol_store_new = TEST_STORE
 
 include "../../compiler/bytecode.casa"

--- a/tests/compiler/test_bytecode.casa
+++ b/tests/compiler/test_bytecode.casa
@@ -3,14 +3,18 @@ include "../../compiler/error.casa"
 include "../../lib/test.casa"
 
 # ============================================================================
-# Stub globals normally provided by parser.casa
+# Shared test store replaces the legacy GLOBAL_* stubs
 # ============================================================================
-Map::new (Map[str Function]) = GLOBAL_FUNCTIONS
-Map::new (Map[str Variable]) = GLOBAL_VARIABLES
-Map::new (Map[str CasaEnum]) = GLOBAL_ENUMS
-Map::new (Map[str CasaStruct]) = GLOBAL_STRUCTS
+symbol_store_new = TEST_STORE
 
 include "../../compiler/bytecode.casa"
+
+fn reset_test_store {
+    Map::new (Map[str Function]) TEST_STORE SymbolStore::set_functions
+    Map::new (Map[str Variable]) TEST_STORE SymbolStore::set_variables
+    Map::new (Map[str CasaEnum]) TEST_STORE SymbolStore::set_enums
+    Map::new (Map[str CasaStruct]) TEST_STORE SymbolStore::set_structs
+}
 
 # ============================================================================
 # Test helpers
@@ -61,7 +65,7 @@ fn test_new_label {
 fn test_intern_string {
     "intern_string" test_start
     List::new (List[Op]) = ops
-    ops make_compiler = compiler
+    ops TEST_STORE make_compiler = compiler
     # intern_string compiler:BytecodeCompiler value:str
     # param1=compiler, param2=value -> value compiler intern_string
     "first string index" 0 "hello" compiler intern_string assert_eq
@@ -73,7 +77,7 @@ fn test_intern_string {
 fn test_intern_constant {
     "intern_constant" test_start
     List::new (List[Op]) = ops
-    ops make_compiler = compiler
+    ops TEST_STORE make_compiler = compiler
     "first constant index" 0 "MY_CONST" compiler intern_constant assert_eq
     "same constant same index" 0 "MY_CONST" compiler intern_constant assert_eq
     "second constant index" 1 "OTHER" compiler intern_constant assert_eq
@@ -85,7 +89,7 @@ fn test_compile_push_int {
     List::new (List[Op]) = ops
     OpKind::OpPushInt 42 test_make_op ops .push
 
-    ops make_compiler = compiler
+    ops TEST_STORE make_compiler = compiler
     List::new (List[Inst]) = bytecode
     # compile_ops compiler:BytecodeCompiler bytecode:List[Inst]
     # param1=compiler, param2=bytecode -> bytecode compiler compile_ops
@@ -104,7 +108,7 @@ fn test_compile_push_bool {
     List::new (List[Op]) = ops
     OpKind::OpPushBool 1 test_make_op ops .push
 
-    ops make_compiler = compiler
+    ops TEST_STORE make_compiler = compiler
     List::new (List[Inst]) = bytecode
     bytecode compiler compile_ops
 
@@ -118,7 +122,7 @@ fn test_compile_push_str {
     List::new (List[Op]) = ops
     OpKind::OpPushStr "hello" test_make_op_str ops .push
 
-    ops make_compiler = compiler
+    ops TEST_STORE make_compiler = compiler
     List::new (List[Inst]) = bytecode
     bytecode compiler compile_ops
 
@@ -133,7 +137,7 @@ fn test_compile_push_char {
     List::new (List[Op]) = ops
     OpKind::OpPushChar 'A' (int) test_make_op ops .push
 
-    ops make_compiler = compiler
+    ops TEST_STORE make_compiler = compiler
     List::new (List[Inst]) = bytecode
     bytecode compiler compile_ops
 
@@ -150,7 +154,7 @@ fn test_compile_direct_ops {
     OpKind::OpDup 0 test_make_op ops .push
     OpKind::OpDrop 0 test_make_op ops .push
 
-    ops make_compiler = compiler
+    ops TEST_STORE make_compiler = compiler
     List::new (List[Inst]) = bytecode
     bytecode compiler compile_ops
 
@@ -168,13 +172,13 @@ fn test_compile_variable_assign_and_push {
     # Set up a global variable
     # Map.set self:Map[K V] value:V key:K -> param1=self, param2=value, param3=key
     # key value self .set
-    "x" "" make_variable GLOBAL_VARIABLES .set = GLOBAL_VARIABLES
+    "x" "" make_variable TEST_STORE.variables .set drop
 
     List::new (List[Op]) = ops
     OpKind::OpAssignVar "x" test_make_op_str ops .push
     OpKind::OpPushVar "x" test_make_op_str ops .push
 
-    ops make_compiler = compiler
+    ops TEST_STORE make_compiler = compiler
     List::new (List[Inst]) = bytecode
     bytecode compiler compile_ops
 
@@ -183,7 +187,7 @@ fn test_compile_variable_assign_and_push {
     "push var kind" InstKind::InstGlobalGet 2 bytecode .get Inst::kind == assert_true
 
     # Clean up
-    Map::new (Map[str Variable]) = GLOBAL_VARIABLES
+    Map::new (Map[str Variable]) TEST_STORE SymbolStore::set_variables
 }
 
 fn test_compile_local_variable {
@@ -206,7 +210,7 @@ fn test_compile_local_variable {
     # make_compiler_with_tables ops:List[Op] function:int string_table:List[str] constants_table:List[str]
     # param1=ops, param2=function, param3=string_table, param4=constants_table
     # push order: constants_table, string_table, function, ops
-    List::new (List[str]) List::new (List[str]) func (int) fn_ops make_compiler_with_tables = compiler
+    List::new (List[str]) List::new (List[str]) func (int) fn_ops TEST_STORE make_compiler_with_tables = compiler
     bytecode compiler compile_ops
 
     # Index 0 is label, 1 is LOCAL_SET, 2 is LOCAL_GET
@@ -222,7 +226,7 @@ fn test_compile_fstring_concat {
     List::new (List[Op]) = ops
     OpKind::OpFstringConcat 3 test_make_op ops .push
 
-    ops make_compiler = compiler
+    ops TEST_STORE make_compiler = compiler
     List::new (List[Inst]) = bytecode
     bytecode compiler compile_ops
 
@@ -236,7 +240,7 @@ fn test_compile_type_cast_no_output {
     List::new (List[Op]) = ops
     OpKind::OpTypeCast 0 test_make_op ops .push
 
-    ops make_compiler = compiler
+    ops TEST_STORE make_compiler = compiler
     List::new (List[Inst]) = bytecode
     bytecode compiler compile_ops
 
@@ -250,7 +254,7 @@ fn test_compile_include_no_output {
     List::new (List[Op]) = ops
     OpKind::OpIncludeFile 0 test_make_op ops .push
 
-    ops make_compiler = compiler
+    ops TEST_STORE make_compiler = compiler
     List::new (List[Inst]) = bytecode
     bytecode compiler compile_ops
 
@@ -279,7 +283,7 @@ fn test_compile_if_block {
     "op 0 is if_start" OpKind::OpIfStart 0 ops .get Op::kind == assert_true
     "op 2 is if_end" OpKind::OpIfEnd 2 ops .get Op::kind == assert_true
 
-    ops make_compiler = compiler
+    ops TEST_STORE make_compiler = compiler
     List::new (List[Inst]) = bytecode
     bytecode compiler compile_ops
 
@@ -298,7 +302,7 @@ fn test_compile_while_block {
     OpKind::OpWhileCondition 0 test_make_op ops .push
     OpKind::OpWhileEnd 0 test_make_op ops .push
 
-    ops make_compiler = compiler
+    ops TEST_STORE make_compiler = compiler
     List::new (List[Inst]) = bytecode
     bytecode compiler compile_ops
 
@@ -318,7 +322,7 @@ fn test_compile_string_eq {
     # make_op_annotated value:int kind:int location:Location annotation:str
     "str" OpKind::OpEq 0 test_make_op_annotated ops .push
 
-    ops make_compiler = compiler
+    ops TEST_STORE make_compiler = compiler
     List::new (List[Inst]) = bytecode
     bytecode compiler compile_ops
 
@@ -331,7 +335,7 @@ fn test_compile_string_ne {
     List::new (List[Op]) = ops
     "str" OpKind::OpNe 0 test_make_op_annotated ops .push
 
-    ops make_compiler = compiler
+    ops TEST_STORE make_compiler = compiler
     List::new (List[Inst]) = bytecode
     bytecode compiler compile_ops
 
@@ -343,12 +347,12 @@ fn test_compile_string_ne {
 fn test_compile_assign_increment {
     "compile_assign_increment" test_start
     reset_labels
-    "counter" "" make_variable GLOBAL_VARIABLES .set = GLOBAL_VARIABLES
+    "counter" "" make_variable TEST_STORE.variables .set drop
 
     List::new (List[Op]) = ops
     OpKind::OpAssignInc "counter" test_make_op_str ops .push
 
-    ops make_compiler = compiler
+    ops TEST_STORE make_compiler = compiler
     List::new (List[Inst]) = bytecode
     bytecode compiler compile_ops
 
@@ -358,18 +362,18 @@ fn test_compile_assign_increment {
     "inc add" InstKind::InstAdd 2 bytecode .get Inst::kind == assert_true
     "inc set" InstKind::InstGlobalSet 3 bytecode .get Inst::kind == assert_true
 
-    Map::new (Map[str Variable]) = GLOBAL_VARIABLES
+    Map::new (Map[str Variable]) TEST_STORE SymbolStore::set_variables
 }
 
 fn test_compile_assign_decrement {
     "compile_assign_decrement" test_start
     reset_labels
-    "counter" "" make_variable GLOBAL_VARIABLES .set = GLOBAL_VARIABLES
+    "counter" "" make_variable TEST_STORE.variables .set drop
 
     List::new (List[Op]) = ops
     OpKind::OpAssignDec "counter" test_make_op_str ops .push
 
-    ops make_compiler = compiler
+    ops TEST_STORE make_compiler = compiler
     List::new (List[Inst]) = bytecode
     bytecode compiler compile_ops
 
@@ -380,7 +384,7 @@ fn test_compile_assign_decrement {
     "dec sub" InstKind::InstSub 3 bytecode .get Inst::kind == assert_true
     "dec set" InstKind::InstGlobalSet 4 bytecode .get Inst::kind == assert_true
 
-    Map::new (Map[str Variable]) = GLOBAL_VARIABLES
+    Map::new (Map[str Variable]) TEST_STORE SymbolStore::set_variables
 }
 
 fn test_compile_push_bool_false {
@@ -389,7 +393,7 @@ fn test_compile_push_bool_false {
     List::new (List[Op]) = ops
     OpKind::OpPushBool 0 test_make_op ops .push
 
-    ops make_compiler = compiler
+    ops TEST_STORE make_compiler = compiler
     List::new (List[Inst]) = bytecode
     bytecode compiler compile_ops
 
@@ -419,7 +423,7 @@ fn test_compile_more_direct_ops {
     OpKind::OpOver 0 test_make_op ops .push
     OpKind::OpRot 0 test_make_op ops .push
 
-    ops make_compiler = compiler
+    ops TEST_STORE make_compiler = compiler
     List::new (List[Inst]) = bytecode
     bytecode compiler compile_ops
 
@@ -452,7 +456,7 @@ fn test_compile_direct_ops_bitwise {
     OpKind::OpBitXor 0 test_make_op ops .push
     OpKind::OpBitNot 0 test_make_op ops .push
 
-    ops make_compiler = compiler
+    ops TEST_STORE make_compiler = compiler
     List::new (List[Inst]) = bytecode
     bytecode compiler compile_ops
 
@@ -476,7 +480,7 @@ fn test_compile_direct_ops_memory {
     OpKind::OpStore32 0 test_make_op ops .push
     OpKind::OpStore64 0 test_make_op ops .push
 
-    ops make_compiler = compiler
+    ops TEST_STORE make_compiler = compiler
     List::new (List[Inst]) = bytecode
     bytecode compiler compile_ops
 
@@ -503,7 +507,7 @@ fn test_compile_direct_ops_syscall {
     OpKind::OpSyscall5 0 test_make_op ops .push
     OpKind::OpSyscall6 0 test_make_op ops .push
 
-    ops make_compiler = compiler
+    ops TEST_STORE make_compiler = compiler
     List::new (List[Inst]) = bytecode
     bytecode compiler compile_ops
 
@@ -526,7 +530,7 @@ fn test_compile_direct_ops_print {
     OpKind::OpPrintCstr 0 test_make_op ops .push
     OpKind::OpPrintBool 0 test_make_op ops .push
 
-    ops make_compiler = compiler
+    ops TEST_STORE make_compiler = compiler
     List::new (List[Inst]) = bytecode
     bytecode compiler compile_ops
 
@@ -544,7 +548,7 @@ fn test_compile_direct_ops_fn {
     OpKind::OpFnExec 0 test_make_op ops .push
     OpKind::OpFnReturn 0 test_make_op ops .push
 
-    ops make_compiler = compiler
+    ops TEST_STORE make_compiler = compiler
     List::new (List[Inst]) = bytecode
     bytecode compiler compile_ops
 
@@ -566,7 +570,7 @@ fn test_compile_push_array {
     List::new (List[Op]) = ops
     make_test_location OpKind::OpPushArray items (int) make_op ops .push
 
-    ops make_compiler = compiler
+    ops TEST_STORE make_compiler = compiler
     List::new (List[Inst]) = bytecode
     bytecode compiler compile_ops
 
@@ -612,7 +616,7 @@ fn test_compile_if_elif_else {
     OpKind::OpIfElse 0 test_make_op ops .push
     OpKind::OpIfEnd 0 test_make_op ops .push
 
-    ops make_compiler = compiler
+    ops TEST_STORE make_compiler = compiler
     List::new (List[Inst]) = bytecode
     bytecode compiler compile_ops
 
@@ -640,15 +644,15 @@ fn test_compile_fn_call {
     "compile_fn_call" test_start
     reset_labels
 
-    # Register a function in GLOBAL_FUNCTIONS
+    # Register a function in TEST_STORE.functions
     List::new (List[Op]) = fn_ops
     make_test_location fn_ops "greet" make_function = func
-    "greet" func GLOBAL_FUNCTIONS .set = GLOBAL_FUNCTIONS
+    "greet" func TEST_STORE.functions .set drop
 
     List::new (List[Op]) = ops
     OpKind::OpFnCall "greet" test_make_op_str ops .push
 
-    ops make_compiler = compiler
+    ops TEST_STORE make_compiler = compiler
     List::new (List[Inst]) = bytecode
     bytecode compiler compile_ops
 
@@ -657,23 +661,23 @@ fn test_compile_fn_call {
     "fn_call inst kind" InstKind::InstFnCall 1 bytecode .get Inst::kind == assert_true
 
     # Clean up
-    Map::new (Map[str Function]) = GLOBAL_FUNCTIONS
+    Map::new (Map[str Function]) TEST_STORE SymbolStore::set_functions
 }
 
 fn test_compile_fn_push {
     "compile_fn_push" test_start
     reset_labels
 
-    # Register a function in GLOBAL_FUNCTIONS with has_deferred_methods = 0
+    # Register a function in TEST_STORE.functions with has_deferred_methods = 0
     List::new (List[Op]) = fn_ops
     OpKind::OpPushInt 1 test_make_op fn_ops .push
     make_test_location fn_ops "adder" make_function = func
-    "adder" func GLOBAL_FUNCTIONS .set = GLOBAL_FUNCTIONS
+    "adder" func TEST_STORE.functions .set drop
 
     List::new (List[Op]) = ops
     OpKind::OpFnPush "adder" test_make_op_str ops .push
 
-    ops make_compiler = compiler
+    ops TEST_STORE make_compiler = compiler
     List::new (List[Inst]) = bytecode
     bytecode compiler compile_ops
 
@@ -682,7 +686,7 @@ fn test_compile_fn_push {
     "fn_push has instrs" 0 bytecode .length != assert_true
 
     # Clean up
-    Map::new (Map[str Function]) = GLOBAL_FUNCTIONS
+    Map::new (Map[str Function]) TEST_STORE SymbolStore::set_functions
 }
 
 # ============================================================================

--- a/tests/compiler/test_bytecode.casa
+++ b/tests/compiler/test_bytecode.casa
@@ -9,13 +9,6 @@ symbol_store_new = TEST_STORE
 
 include "../../compiler/bytecode.casa"
 
-fn reset_test_store {
-    Map::new (Map[str Function]) TEST_STORE SymbolStore::set_functions
-    Map::new (Map[str Variable]) TEST_STORE SymbolStore::set_variables
-    Map::new (Map[str CasaEnum]) TEST_STORE SymbolStore::set_enums
-    Map::new (Map[str CasaStruct]) TEST_STORE SymbolStore::set_structs
-}
-
 # ============================================================================
 # Test helpers
 # ============================================================================

--- a/tests/compiler/test_display.casa
+++ b/tests/compiler/test_display.casa
@@ -19,21 +19,21 @@ include "../../lib/test_helpers.casa"
 fn display_test_parse code:str -> List[Op] {
     clear_global_state
     "test" code lex_source = tokens
-    tokens parse_ops
+    tokens DEFAULT_PARSER parse_ops
 }
 
 fn display_test_resolve code:str -> List[Op] {
     clear_global_state
     "test" code lex_source = tokens
-    tokens parse_ops = ops
-    ops resolve_identifiers_global
+    tokens DEFAULT_PARSER parse_ops = ops
+    ops DEFAULT_PARSER resolve_identifiers_global
 }
 
 fn display_test_typecheck code:str -> Signature {
     clear_global_state
     "test" code lex_source = tokens
-    tokens parse_ops = ops
-    ops resolve_identifiers_global = ops
+    tokens DEFAULT_PARSER parse_ops = ops
+    ops DEFAULT_PARSER resolve_identifiers_global = ops
     Option::None (Option[Function]) ops type_check_ops
 }
 
@@ -42,8 +42,8 @@ fn display_test_typecheck_error code:str -> Signature {
     clear_errors
     clear_global_state
     "test" code lex_source = tokens
-    tokens parse_ops = ops
-    ops resolve_identifiers_global = ops
+    tokens DEFAULT_PARSER parse_ops = ops
+    ops DEFAULT_PARSER resolve_identifiers_global = ops
     Option::None (Option[Function]) ops type_check_ops
 }
 

--- a/tests/compiler/test_display.casa
+++ b/tests/compiler/test_display.casa
@@ -183,7 +183,7 @@ fn test_type_satisfies_trait_no_fallback_method {
 fn test_trait_exec_pushes_return_type {
     "trait_exec_pushes_return_type" test_start
     DISPLAY_TRAIT "struct Tag { val: int }\nimpl Tag { fn to_str self:Tag -> str { \"tag\" } }\nfn show[T: Display] x:T -> str { x T::to_str }\n1 Tag = t\nt show drop\n" str::concat display_test_typecheck drop
-    "show" GLOBAL_FUNCTIONS .get .unwrap = func
+    "show" DEFAULT_PARSER.store.functions .get .unwrap = func
     "signature has str return type" "str" 0 func Function::signature Signature::return_types .get assert_str_eq
     "no errors" assert_no_errors
 }

--- a/tests/compiler/test_enum.casa
+++ b/tests/compiler/test_enum.casa
@@ -25,29 +25,29 @@ include "../../lib/test_helpers.casa"
 fn test_parse_code code:str -> List[Op] {
     clear_global_state
     "test" code lex_source = tokens
-    tokens parse_ops
+    tokens DEFAULT_PARSER parse_ops
 }
 
 fn resolve_enum code:str -> List[Op] {
     clear_global_state
     "test" code lex_source = tokens
-    tokens parse_ops = ops
-    ops resolve_identifiers_global
+    tokens DEFAULT_PARSER parse_ops = ops
+    ops DEFAULT_PARSER resolve_identifiers_global
 }
 
 fn tc_enum code:str -> Signature {
     clear_global_state
     "test" code lex_source = tokens
-    tokens parse_ops = ops
-    ops resolve_identifiers_global = ops
+    tokens DEFAULT_PARSER parse_ops = ops
+    ops DEFAULT_PARSER resolve_identifiers_global = ops
     Option::None (Option[Function]) ops type_check_ops
 }
 
 fn compile_enum code:str -> Program {
     clear_global_state
     "test" code lex_source = tokens
-    tokens parse_ops = ops
-    ops resolve_identifiers_global = ops
+    tokens DEFAULT_PARSER parse_ops = ops
+    ops DEFAULT_PARSER resolve_identifiers_global = ops
     Option::None (Option[Function]) ops type_check_ops drop
     ops compile_bytecode
 }

--- a/tests/compiler/test_enum.casa
+++ b/tests/compiler/test_enum.casa
@@ -49,7 +49,7 @@ fn compile_enum code:str -> Program {
     tokens DEFAULT_PARSER parse_ops = ops
     ops DEFAULT_PARSER resolve_identifiers_global = ops
     Option::None (Option[Function]) ops type_check_ops drop
-    ops compile_bytecode
+    ops DEFAULT_PARSER.store compile_bytecode
 }
 
 fn count_ops ops:List[Op] kind:OpKind -> int {
@@ -103,25 +103,25 @@ fn has_push_value bytecode:List[Inst] value:int -> bool {
 fn test_test_parse_code_registers_globally {
     "test_parse_code_registers_globally" test_start
     "enum Color { Red Green Blue }" test_parse_code drop
-    "registered" "Color" GLOBAL_ENUMS .get .is_some assert_true
+    "registered" "Color" DEFAULT_PARSER.store.enums .get .is_some assert_true
 }
 
 fn test_test_parse_code_name {
     "test_parse_code_name" test_start
     "enum Color { Red Green Blue }" test_parse_code drop
-    "name" "Color" "Color" GLOBAL_ENUMS .get .unwrap CasaEnum::name assert_str_eq
+    "name" "Color" "Color" DEFAULT_PARSER.store.enums .get .unwrap CasaEnum::name assert_str_eq
 }
 
 fn test_test_parse_code_variant_count {
     "test_parse_code_variant_count" test_start
     "enum Color { Red Green Blue }" test_parse_code drop
-    "count" 3 "Color" GLOBAL_ENUMS .get .unwrap CasaEnum::variants .length assert_eq
+    "count" 3 "Color" DEFAULT_PARSER.store.enums .get .unwrap CasaEnum::variants .length assert_eq
 }
 
 fn test_test_parse_code_variant_names {
     "test_parse_code_variant_names" test_start
     "enum Color { Red Green Blue }" test_parse_code drop
-    "Color" GLOBAL_ENUMS .get .unwrap = color
+    "Color" DEFAULT_PARSER.store.enums .get .unwrap = color
     "Red" "Red" 0 color CasaEnum::variants .get assert_str_eq
     "Green" "Green" 1 color CasaEnum::variants .get assert_str_eq
     "Blue" "Blue" 2 color CasaEnum::variants .get assert_str_eq
@@ -130,26 +130,26 @@ fn test_test_parse_code_variant_names {
 fn test_test_parse_code_has_location {
     "test_parse_code_has_location" test_start
     "enum Color { Red Green Blue }" test_parse_code drop
-    "has file" "" "Color" GLOBAL_ENUMS .get .unwrap CasaEnum::location Location::file != assert_true
+    "has file" "" "Color" DEFAULT_PARSER.store.enums .get .unwrap CasaEnum::location Location::file != assert_true
 }
 
 fn test_test_parse_code_single_variant {
     "test_parse_code_single_variant" test_start
     "enum Unit { Only }" test_parse_code drop
-    "count" 1 "Unit" GLOBAL_ENUMS .get .unwrap CasaEnum::variants .length assert_eq
-    "name" "Only" 0 "Unit" GLOBAL_ENUMS .get .unwrap CasaEnum::variants .get assert_str_eq
+    "count" 1 "Unit" DEFAULT_PARSER.store.enums .get .unwrap CasaEnum::variants .length assert_eq
+    "name" "Only" 0 "Unit" DEFAULT_PARSER.store.enums .get .unwrap CasaEnum::variants .get assert_str_eq
 }
 
 fn test_test_parse_code_many_variants {
     "test_parse_code_many_variants" test_start
     "enum Direction { North South East West }" test_parse_code drop
-    "count" 4 "Direction" GLOBAL_ENUMS .get .unwrap CasaEnum::variants .length assert_eq
+    "count" 4 "Direction" DEFAULT_PARSER.store.enums .get .unwrap CasaEnum::variants .length assert_eq
 }
 
 fn test_test_parse_code_with_inner_types {
     "test_parse_code_with_inner_types" test_start
     SHAPE_ENUM test_parse_code drop
-    "Shape" GLOBAL_ENUMS .get .unwrap = shape
+    "Shape" DEFAULT_PARSER.store.enums .get .unwrap = shape
     "Circle types" 1 "Circle" shape CasaEnum::variant_types .get .unwrap .length assert_eq
     "Circle type" "int" 0 "Circle" shape CasaEnum::variant_types .get .unwrap .get assert_str_eq
     "Rectangle types" 2 "Rectangle" shape CasaEnum::variant_types .get .unwrap .length assert_eq
@@ -159,19 +159,19 @@ fn test_test_parse_code_with_inner_types {
 fn test_test_parse_code_has_inner_values {
     "test_parse_code_has_inner_values" test_start
     SHAPE_ENUM test_parse_code drop
-    "has inner" "Shape" GLOBAL_ENUMS .get .unwrap has_inner_values assert_true
+    "has inner" "Shape" DEFAULT_PARSER.store.enums .get .unwrap has_inner_values assert_true
 }
 
 fn test_parse_plain_enum_no_inner_values {
     "parse_plain_enum_no_inner_values" test_start
     COLOR_ENUM test_parse_code drop
-    "no inner" "Color" GLOBAL_ENUMS .get .unwrap has_inner_values ! assert_true
+    "no inner" "Color" DEFAULT_PARSER.store.enums .get .unwrap has_inner_values ! assert_true
 }
 
 fn test_parse_generic_enum_type_vars {
     "parse_generic_enum_type_vars" test_start
     OPTION_ENUM test_parse_code drop
-    "Option" GLOBAL_ENUMS .get .unwrap = option
+    "Option" DEFAULT_PARSER.store.enums .get .unwrap = option
     "type var count" 1 option CasaEnum::type_vars .length assert_eq
     "type var T" "T" 0 option CasaEnum::type_vars .get assert_str_eq
 }
@@ -179,7 +179,7 @@ fn test_parse_generic_enum_type_vars {
 fn test_parse_generic_enum_two_type_vars {
     "parse_generic_enum_two_type_vars" test_start
     RESULT_ENUM test_parse_code drop
-    "Result" GLOBAL_ENUMS .get .unwrap = result
+    "Result" DEFAULT_PARSER.store.enums .get .unwrap = result
     "type var count" 2 result CasaEnum::type_vars .length assert_eq
     "type var T" "T" 0 result CasaEnum::type_vars .get assert_str_eq
     "type var E" "E" 1 result CasaEnum::type_vars .get assert_str_eq
@@ -689,7 +689,7 @@ fn test_is_plain_enum {
 fn test_parse_generic_enum_type_var_order_preserved {
     "parse_generic_enum_type_var_order_preserved" test_start
     "enum Pair[A B] { Left(A) Right(B) }\n" test_parse_code drop
-    "Pair" GLOBAL_ENUMS .get .unwrap = pair
+    "Pair" DEFAULT_PARSER.store.enums .get .unwrap = pair
     "type var A" "A" 0 pair CasaEnum::type_vars .get assert_str_eq
     "type var B" "B" 1 pair CasaEnum::type_vars .get assert_str_eq
 }

--- a/tests/compiler/test_enum_variant_hint.casa
+++ b/tests/compiler/test_enum_variant_hint.casa
@@ -16,8 +16,8 @@ include "../../lib/test_helpers.casa"
 fn tc_evh code:str -> Signature {
     clear_global_state
     "test" code lex_source = tokens
-    tokens parse_ops = ops
-    ops resolve_identifiers_global = ops
+    tokens DEFAULT_PARSER parse_ops = ops
+    ops DEFAULT_PARSER resolve_identifiers_global = ops
     Option::None (Option[Function]) ops type_check_ops
 }
 

--- a/tests/compiler/test_generic_structs.casa
+++ b/tests/compiler/test_generic_structs.casa
@@ -15,29 +15,29 @@ include "../../lib/test_helpers.casa"
 fn parse_gs code:str -> List[Op] {
     clear_global_state
     "test" code lex_source = tokens
-    tokens parse_ops
+    tokens DEFAULT_PARSER parse_ops
 }
 
 fn resolve_gs code:str -> List[Op] {
     clear_global_state
     "test" code lex_source = tokens
-    tokens parse_ops = ops
-    ops resolve_identifiers_global
+    tokens DEFAULT_PARSER parse_ops = ops
+    ops DEFAULT_PARSER resolve_identifiers_global
 }
 
 fn tc_gs code:str -> Signature {
     clear_global_state
     "test" code lex_source = tokens
-    tokens parse_ops = ops
-    ops resolve_identifiers_global = ops
+    tokens DEFAULT_PARSER parse_ops = ops
+    ops DEFAULT_PARSER resolve_identifiers_global = ops
     Option::None (Option[Function]) ops type_check_ops
 }
 
 fn compile_gs code:str -> Program {
     clear_global_state
     "test" code lex_source = tokens
-    tokens parse_ops = ops
-    ops resolve_identifiers_global = ops
+    tokens DEFAULT_PARSER parse_ops = ops
+    ops DEFAULT_PARSER resolve_identifiers_global = ops
     Option::None (Option[Function]) ops type_check_ops drop
     ops compile_bytecode
 }

--- a/tests/compiler/test_generic_structs.casa
+++ b/tests/compiler/test_generic_structs.casa
@@ -39,7 +39,7 @@ fn compile_gs code:str -> Program {
     tokens DEFAULT_PARSER parse_ops = ops
     ops DEFAULT_PARSER resolve_identifiers_global = ops
     Option::None (Option[Function]) ops type_check_ops drop
-    ops compile_bytecode
+    ops DEFAULT_PARSER.store compile_bytecode
 }
 
 fn emit_gs code:str -> str {
@@ -62,8 +62,8 @@ fn assert_contains needle:str haystack:str msg:str {
 fn test_parse_generic_struct {
     "parse_generic_struct" test_start
     "struct Box[T] { value: T }" parse_gs drop
-    "registered" "Box" GLOBAL_STRUCTS .get .is_some assert_true
-    "Box" GLOBAL_STRUCTS .get .unwrap = box_struct
+    "registered" "Box" DEFAULT_PARSER.store.structs .get .is_some assert_true
+    "Box" DEFAULT_PARSER.store.structs .get .unwrap = box_struct
     "type vars count" 1 box_struct CasaStruct::type_vars .length assert_eq
     "type var T" "T" 0 box_struct CasaStruct::type_vars .get assert_str_eq
     "member name" "value" 0 box_struct CasaStruct::members .get Member::name assert_str_eq
@@ -73,7 +73,7 @@ fn test_parse_generic_struct {
 fn test_parse_generic_struct_multiple_type_vars {
     "parse_generic_struct_multiple_type_vars" test_start
     "struct Pair[A B] { first: A second: B }" parse_gs drop
-    "Pair" GLOBAL_STRUCTS .get .unwrap = pair_struct
+    "Pair" DEFAULT_PARSER.store.structs .get .unwrap = pair_struct
     "type vars count" 2 pair_struct CasaStruct::type_vars .length assert_eq
     "type var A" "A" 0 pair_struct CasaStruct::type_vars .get assert_str_eq
     "type var B" "B" 1 pair_struct CasaStruct::type_vars .get assert_str_eq
@@ -93,8 +93,8 @@ fn test_parse_struct_rejects_trait_bounds {
 fn test_parse_generic_struct_generates_getter {
     "parse_generic_struct_generates_getter" test_start
     "struct Box[T] { value: T }" parse_gs drop
-    "getter exists" "Box::value" GLOBAL_FUNCTIONS .get .is_some assert_true
-    "Box::value" GLOBAL_FUNCTIONS .get .unwrap = getter
+    "getter exists" "Box::value" DEFAULT_PARSER.store.functions .get .is_some assert_true
+    "Box::value" DEFAULT_PARSER.store.functions .get .unwrap = getter
     "getter param type" "Box[T]" 0 getter Function::signature Signature::parameters .get Parameter::typ assert_str_eq
     "getter return type" "T" 0 getter Function::signature Signature::return_types .get assert_str_eq
 }
@@ -102,8 +102,8 @@ fn test_parse_generic_struct_generates_getter {
 fn test_parse_generic_struct_generates_setter {
     "parse_generic_struct_generates_setter" test_start
     "struct Box[T] { value: T }" parse_gs drop
-    "setter exists" "Box::set_value" GLOBAL_FUNCTIONS .get .is_some assert_true
-    "Box::set_value" GLOBAL_FUNCTIONS .get .unwrap = setter
+    "setter exists" "Box::set_value" DEFAULT_PARSER.store.functions .get .is_some assert_true
+    "Box::set_value" DEFAULT_PARSER.store.functions .get .unwrap = setter
     "setter param 0 type" "Box[T]" 0 setter Function::signature Signature::parameters .get Parameter::typ assert_str_eq
     "setter param 1 type" "T" 1 setter Function::signature Signature::parameters .get Parameter::typ assert_str_eq
 }
@@ -111,14 +111,14 @@ fn test_parse_generic_struct_generates_setter {
 fn test_parse_nongeneric_struct_has_empty_type_vars {
     "parse_nongeneric_struct_has_empty_type_vars" test_start
     "struct Point { x: int y: int }" parse_gs drop
-    "Point" GLOBAL_STRUCTS .get .unwrap = point_struct
+    "Point" DEFAULT_PARSER.store.structs .get .unwrap = point_struct
     "no type vars" 0 point_struct CasaStruct::type_vars .length assert_eq
 }
 
 fn test_parse_impl_with_type_params {
     "parse_impl_with_type_params" test_start
     "trait Hashable { fn hash int -> int }\nstruct Box[K] { data: K }\nimpl[K: Hashable] Box[K] {\n    fn get self:Box[K] -> K { self Box::data }\n}\n" parse_gs drop
-    "method exists" "Box::get" GLOBAL_FUNCTIONS .get .is_some assert_true
+    "method exists" "Box::get" DEFAULT_PARSER.store.functions .get .is_some assert_true
 }
 
 # ============================================================================

--- a/tests/compiler/test_lsp.casa
+++ b/tests/compiler/test_lsp.casa
@@ -90,9 +90,9 @@ fn test_clear_compilation_state_clears_all_global_state {
     "clear_compilation_state_clears_all_global_state" test_start
     # Populate state by running the pipeline
     "fn greet { 42 print }" lsp_test_state drop
-    "has functions before" 0 GLOBAL_FUNCTIONS .keys .length > assert_true
+    "has functions before" 0 DEFAULT_PARSER.store.functions .keys .length > assert_true
     clear_compilation_state
-    "no functions" 0 GLOBAL_FUNCTIONS .keys .length assert_eq
+    "no functions" 0 DEFAULT_PARSER.store.functions .keys .length assert_eq
     "no errors"    0 ERRORS .length assert_eq
     "no warnings"  0 WARNINGS .length assert_eq
 }

--- a/tests/compiler/test_parser.casa
+++ b/tests/compiler/test_parser.casa
@@ -284,9 +284,9 @@ fn test_parse_function_def {
     "parse_function_def" test_start
     "test" "fn add a:int b:int -> int { a b + }" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    # parse_ops should register the function in GLOBAL_FUNCTIONS
-    "fn registered" "add" GLOBAL_FUNCTIONS .get .is_some assert_true
-    "add" GLOBAL_FUNCTIONS .get .unwrap = add_fn
+    # parse_ops should register the function in DEFAULT_PARSER.store.functions
+    "fn registered" "add" DEFAULT_PARSER.store.functions .get .is_some assert_true
+    "add" DEFAULT_PARSER.store.functions .get .unwrap = add_fn
     "fn name" "add" add_fn Function::name assert_str_eq
     "param count" 2 add_fn Function::signature Signature::parameters .length assert_eq
     "return count" 1 add_fn Function::signature Signature::return_types .length assert_eq
@@ -301,8 +301,8 @@ fn test_parse_enum_def {
     "parse_enum_def" test_start
     "test" "enum Color { Red Green Blue }" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "enum registered" "Color" GLOBAL_ENUMS .get .is_some assert_true
-    "Color" GLOBAL_ENUMS .get .unwrap = color_enum
+    "enum registered" "Color" DEFAULT_PARSER.store.enums .get .is_some assert_true
+    "Color" DEFAULT_PARSER.store.enums .get .unwrap = color_enum
     "variant count" 3 color_enum CasaEnum::variants .length assert_eq
     "variant 0" "Red" 0 color_enum CasaEnum::variants .get assert_str_eq
     "variant 1" "Green" 1 color_enum CasaEnum::variants .get assert_str_eq
@@ -317,13 +317,13 @@ fn test_parse_struct_def {
     "parse_struct_def" test_start
     "test" "struct Point { x: int y: int }" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "struct registered" "Point" GLOBAL_STRUCTS .get .is_some assert_true
-    "Point" GLOBAL_STRUCTS .get .unwrap = point_struct
+    "struct registered" "Point" DEFAULT_PARSER.store.structs .get .is_some assert_true
+    "Point" DEFAULT_PARSER.store.structs .get .unwrap = point_struct
     "member count" 2 point_struct CasaStruct::members .length assert_eq
     "member 0 name" "x" 0 point_struct CasaStruct::members .get Member::name assert_str_eq
     "member 0 type" "int" 0 point_struct CasaStruct::members .get Member::typ assert_str_eq
-    "getter registered" "Point::x" GLOBAL_FUNCTIONS .get .is_some assert_true
-    "setter registered" "Point::set_x" GLOBAL_FUNCTIONS .get .is_some assert_true
+    "getter registered" "Point::x" DEFAULT_PARSER.store.functions .get .is_some assert_true
+    "setter registered" "Point::set_x" DEFAULT_PARSER.store.functions .get .is_some assert_true
 }
 
 # ============================================================================

--- a/tests/compiler/test_parser.casa
+++ b/tests/compiler/test_parser.casa
@@ -11,7 +11,7 @@ include "../../lib/test.casa"
 fn test_parse_integer {
     "parse_integer" test_start
     "test" "42" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "count" 1 ops .length assert_eq
     "kind" OpKind::OpPushInt 0 ops .get Op::kind == assert_true
     "value" 42 0 ops .get Op::value assert_eq
@@ -20,7 +20,7 @@ fn test_parse_integer {
 fn test_parse_negative_integer {
     "parse_negative_integer" test_start
     "test" "-7" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "count" 1 ops .length assert_eq
     "kind" OpKind::OpPushInt 0 ops .get Op::kind == assert_true
     "value" 0 7 - 0 ops .get Op::value assert_eq
@@ -29,7 +29,7 @@ fn test_parse_negative_integer {
 fn test_parse_bool_true {
     "parse_bool_true" test_start
     "test" "true" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "count" 1 ops .length assert_eq
     "kind" OpKind::OpPushBool 0 ops .get Op::kind == assert_true
     "value" 1 0 ops .get Op::value assert_eq
@@ -38,7 +38,7 @@ fn test_parse_bool_true {
 fn test_parse_bool_false {
     "parse_bool_false" test_start
     "test" "false" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "count" 1 ops .length assert_eq
     "kind" OpKind::OpPushBool 0 ops .get Op::kind == assert_true
     "value" 0 0 ops .get Op::value assert_eq
@@ -47,7 +47,7 @@ fn test_parse_bool_false {
 fn test_parse_string {
     "parse_string" test_start
     "test" "\"hello\"" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "count" 1 ops .length assert_eq
     "kind" OpKind::OpPushStr 0 ops .get Op::kind == assert_true
     "value" "hello" 0 ops .get op_str_value assert_str_eq
@@ -56,7 +56,7 @@ fn test_parse_string {
 fn test_parse_char {
     "parse_char" test_start
     "test" "'A'" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "count" 1 ops .length assert_eq
     "kind" OpKind::OpPushChar 0 ops .get Op::kind == assert_true
     "value" 65 0 ops .get Op::value assert_eq
@@ -69,56 +69,56 @@ fn test_parse_char {
 fn test_parse_keyword_if {
     "parse_keyword_if" test_start
     "test" "if" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "kind" OpKind::OpIfStart 0 ops .get Op::kind == assert_true
 }
 
 fn test_parse_keyword_then {
     "parse_keyword_then" test_start
     "test" "then" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "kind" OpKind::OpIfCondition 0 ops .get Op::kind == assert_true
 }
 
 fn test_parse_keyword_else {
     "parse_keyword_else" test_start
     "test" "else" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "kind" OpKind::OpIfElse 0 ops .get Op::kind == assert_true
 }
 
 fn test_parse_keyword_fi {
     "parse_keyword_fi" test_start
     "test" "fi" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "kind" OpKind::OpIfEnd 0 ops .get Op::kind == assert_true
 }
 
 fn test_parse_keyword_while {
     "parse_keyword_while" test_start
     "test" "while" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "kind" OpKind::OpWhileStart 0 ops .get Op::kind == assert_true
 }
 
 fn test_parse_keyword_do {
     "parse_keyword_do" test_start
     "test" "do" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "kind" OpKind::OpWhileCondition 0 ops .get Op::kind == assert_true
 }
 
 fn test_parse_keyword_done {
     "parse_keyword_done" test_start
     "test" "done" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "kind" OpKind::OpWhileEnd 0 ops .get Op::kind == assert_true
 }
 
 fn test_parse_keyword_return {
     "parse_keyword_return" test_start
     "test" "return" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "kind" OpKind::OpFnReturn 0 ops .get Op::kind == assert_true
 }
 
@@ -129,42 +129,42 @@ fn test_parse_keyword_return {
 fn test_parse_operator_add {
     "parse_operator_add" test_start
     "test" "+" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "kind" OpKind::OpAdd 0 ops .get Op::kind == assert_true
 }
 
 fn test_parse_operator_sub {
     "parse_operator_sub" test_start
     "test" "1 -" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "kind" OpKind::OpSub 1 ops .get Op::kind == assert_true
 }
 
 fn test_parse_operator_eq {
     "parse_operator_eq" test_start
     "test" "==" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "kind" OpKind::OpEq 0 ops .get Op::kind == assert_true
 }
 
 fn test_parse_operator_not {
     "parse_operator_not" test_start
     "test" "!" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "kind" OpKind::OpNot 0 ops .get Op::kind == assert_true
 }
 
 fn test_parse_operator_and {
     "parse_operator_and" test_start
     "test" "&&" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "kind" OpKind::OpAnd 0 ops .get Op::kind == assert_true
 }
 
 fn test_parse_operator_or {
     "parse_operator_or" test_start
     "test" "||" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "kind" OpKind::OpOr 0 ops .get Op::kind == assert_true
 }
 
@@ -175,28 +175,28 @@ fn test_parse_operator_or {
 fn test_parse_intrinsic_drop {
     "parse_intrinsic_drop" test_start
     "test" "drop" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "kind" OpKind::OpDrop 0 ops .get Op::kind == assert_true
 }
 
 fn test_parse_intrinsic_dup {
     "parse_intrinsic_dup" test_start
     "test" "dup" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "kind" OpKind::OpDup 0 ops .get Op::kind == assert_true
 }
 
 fn test_parse_intrinsic_swap {
     "parse_intrinsic_swap" test_start
     "test" "swap" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "kind" OpKind::OpSwap 0 ops .get Op::kind == assert_true
 }
 
 fn test_parse_intrinsic_print {
     "parse_intrinsic_print" test_start
     "test" "print" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "kind" OpKind::OpPrint 0 ops .get Op::kind == assert_true
 }
 
@@ -207,7 +207,7 @@ fn test_parse_intrinsic_print {
 fn test_parse_type_cast {
     "parse_type_cast" test_start
     "test" "(int)" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "count" 1 ops .length assert_eq
     "kind" OpKind::OpTypeCast 0 ops .get Op::kind == assert_true
     "value" "int" 0 ops .get op_str_value assert_str_eq
@@ -216,7 +216,7 @@ fn test_parse_type_cast {
 fn test_parse_type_cast_str {
     "parse_type_cast_str" test_start
     "test" "(str)" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "kind" OpKind::OpTypeCast 0 ops .get Op::kind == assert_true
     "value" "str" 0 ops .get op_str_value assert_str_eq
 }
@@ -228,7 +228,7 @@ fn test_parse_type_cast_str {
 fn test_parse_variable_assign {
     "parse_variable_assign" test_start
     "test" "42 = foo" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "count" 2 ops .length assert_eq
     "push kind" OpKind::OpPushInt 0 ops .get Op::kind == assert_true
     "assign kind" OpKind::OpAssignVar 1 ops .get Op::kind == assert_true
@@ -238,7 +238,7 @@ fn test_parse_variable_assign {
 fn test_parse_variable_inc {
     "parse_variable_inc" test_start
     "test" "1 += counter" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "push kind" OpKind::OpPushInt 0 ops .get Op::kind == assert_true
     "inc kind" OpKind::OpAssignInc 1 ops .get Op::kind == assert_true
     "inc name" "counter" 1 ops .get op_str_value assert_str_eq
@@ -251,7 +251,7 @@ fn test_parse_variable_inc {
 fn test_parse_method_call {
     "parse_method_call" test_start
     "test" ".length" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "kind" OpKind::OpMethodCall 0 ops .get Op::kind == assert_true
     "value" "length" 0 ops .get op_str_value assert_str_eq
 }
@@ -259,7 +259,7 @@ fn test_parse_method_call {
 fn test_parse_setter_call {
     "parse_setter_call" test_start
     "test" "->name" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "kind" OpKind::OpMethodCall 0 ops .get Op::kind == assert_true
     "value" "set_name" 0 ops .get op_str_value assert_str_eq
 }
@@ -271,7 +271,7 @@ fn test_parse_setter_call {
 fn test_parse_identifier {
     "parse_identifier" test_start
     "test" "foo" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "kind" OpKind::OpIdentifier 0 ops .get Op::kind == assert_true
     "value" "foo" 0 ops .get op_str_value assert_str_eq
 }
@@ -283,7 +283,7 @@ fn test_parse_identifier {
 fn test_parse_function_def {
     "parse_function_def" test_start
     "test" "fn add a:int b:int -> int { a b + }" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     # parse_ops should register the function in GLOBAL_FUNCTIONS
     "fn registered" "add" GLOBAL_FUNCTIONS .get .is_some assert_true
     "add" GLOBAL_FUNCTIONS .get .unwrap = add_fn
@@ -300,7 +300,7 @@ fn test_parse_function_def {
 fn test_parse_enum_def {
     "parse_enum_def" test_start
     "test" "enum Color { Red Green Blue }" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "enum registered" "Color" GLOBAL_ENUMS .get .is_some assert_true
     "Color" GLOBAL_ENUMS .get .unwrap = color_enum
     "variant count" 3 color_enum CasaEnum::variants .length assert_eq
@@ -316,7 +316,7 @@ fn test_parse_enum_def {
 fn test_parse_struct_def {
     "parse_struct_def" test_start
     "test" "struct Point { x: int y: int }" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "struct registered" "Point" GLOBAL_STRUCTS .get .is_some assert_true
     "Point" GLOBAL_STRUCTS .get .unwrap = point_struct
     "member count" 2 point_struct CasaStruct::members .length assert_eq
@@ -333,7 +333,7 @@ fn test_parse_struct_def {
 fn test_parse_if_construct {
     "parse_if_construct" test_start
     "test" "if true then 42 else 0 fi" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "if" OpKind::OpIfStart 0 ops .get Op::kind == assert_true
     "true" OpKind::OpPushBool 1 ops .get Op::kind == assert_true
     "then" OpKind::OpIfCondition 2 ops .get Op::kind == assert_true
@@ -346,7 +346,7 @@ fn test_parse_if_construct {
 fn test_parse_while_construct {
     "parse_while_construct" test_start
     "test" "while true do break done" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "while" OpKind::OpWhileStart 0 ops .get Op::kind == assert_true
     "true" OpKind::OpPushBool 1 ops .get Op::kind == assert_true
     "do" OpKind::OpWhileCondition 2 ops .get Op::kind == assert_true
@@ -361,7 +361,7 @@ fn test_parse_while_construct {
 fn test_parse_match_construct {
     "parse_match_construct" test_start
     "test" "enum Dir { Up Down }\nmatch Up => 1 Down => 2 end" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "match start" OpKind::OpMatchStart 0 ops .get Op::kind == assert_true
 }
 
@@ -372,7 +372,7 @@ fn test_parse_match_construct {
 fn test_parse_multiple_ops {
     "parse_multiple_ops" test_start
     "test" "1 2 + = result" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "count" 4 ops .length assert_eq
     "push 1" OpKind::OpPushInt 0 ops .get Op::kind == assert_true
     "push 2" OpKind::OpPushInt 1 ops .get Op::kind == assert_true
@@ -387,63 +387,63 @@ fn test_parse_multiple_ops {
 fn test_parse_operator_mul {
     "parse_operator_mul" test_start
     "test" "1 2 *" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "kind" OpKind::OpMul 2 ops .get Op::kind == assert_true
 }
 
 fn test_parse_operator_div {
     "parse_operator_div" test_start
     "test" "1 2 /" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "kind" OpKind::OpDiv 2 ops .get Op::kind == assert_true
 }
 
 fn test_parse_operator_mod {
     "parse_operator_mod" test_start
     "test" "1 2 %" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "kind" OpKind::OpMod 2 ops .get Op::kind == assert_true
 }
 
 fn test_parse_operator_lt {
     "parse_operator_lt" test_start
     "test" "1 2 <" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "kind" OpKind::OpLt 2 ops .get Op::kind == assert_true
 }
 
 fn test_parse_operator_gt {
     "parse_operator_gt" test_start
     "test" "1 2 >" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "kind" OpKind::OpGt 2 ops .get Op::kind == assert_true
 }
 
 fn test_parse_operator_le {
     "parse_operator_le" test_start
     "test" "1 2 <=" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "kind" OpKind::OpLe 2 ops .get Op::kind == assert_true
 }
 
 fn test_parse_operator_ge {
     "parse_operator_ge" test_start
     "test" "1 2 >=" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "kind" OpKind::OpGe 2 ops .get Op::kind == assert_true
 }
 
 fn test_parse_operator_ne {
     "parse_operator_ne" test_start
     "test" "1 2 !=" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "kind" OpKind::OpNe 2 ops .get Op::kind == assert_true
 }
 
 fn test_parse_operator_bit_not {
     "parse_operator_bit_not" test_start
     "test" "1 ~" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "kind" OpKind::OpBitNot 1 ops .get Op::kind == assert_true
 }
 
@@ -454,28 +454,28 @@ fn test_parse_operator_bit_not {
 fn test_parse_intrinsic_over {
     "parse_intrinsic_over" test_start
     "test" "over" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "kind" OpKind::OpOver 0 ops .get Op::kind == assert_true
 }
 
 fn test_parse_intrinsic_rot {
     "parse_intrinsic_rot" test_start
     "test" "rot" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "kind" OpKind::OpRot 0 ops .get Op::kind == assert_true
 }
 
 fn test_parse_intrinsic_typeof {
     "parse_intrinsic_typeof" test_start
     "test" "typeof" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "kind" OpKind::OpTypeof 0 ops .get Op::kind == assert_true
 }
 
 fn test_parse_intrinsic_alloc {
     "parse_intrinsic_alloc" test_start
     "test" "alloc" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "kind" OpKind::OpHeapAlloc 0 ops .get Op::kind == assert_true
 }
 
@@ -486,7 +486,7 @@ fn test_parse_intrinsic_alloc {
 fn test_parse_variable_dec {
     "parse_variable_dec" test_start
     "test" "1 -= counter" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "push kind" OpKind::OpPushInt 0 ops .get Op::kind == assert_true
     "dec kind" OpKind::OpAssignDec 1 ops .get Op::kind == assert_true
     "dec name" "counter" 1 ops .get op_str_value assert_str_eq
@@ -499,7 +499,7 @@ fn test_parse_variable_dec {
 fn test_parse_keyword_elif {
     "parse_keyword_elif" test_start
     "test" "elif" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "kind" OpKind::OpIfElif 0 ops .get Op::kind == assert_true
 }
 
@@ -510,14 +510,14 @@ fn test_parse_keyword_elif {
 fn test_parse_keyword_break {
     "parse_keyword_break" test_start
     "test" "break" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "kind" OpKind::OpWhileBreak 0 ops .get Op::kind == assert_true
 }
 
 fn test_parse_keyword_continue {
     "parse_keyword_continue" test_start
     "test" "continue" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "kind" OpKind::OpWhileContinue 0 ops .get Op::kind == assert_true
 }
 
@@ -528,7 +528,7 @@ fn test_parse_keyword_continue {
 fn test_parse_string_with_escapes {
     "parse_string_with_escapes" test_start
     "test" "\"hello\\nworld\"" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "count" 1 ops .length assert_eq
     "kind" OpKind::OpPushStr 0 ops .get Op::kind == assert_true
     "value" "hello\nworld" 0 ops .get op_str_value assert_str_eq

--- a/tests/compiler/test_struct_literal.casa
+++ b/tests/compiler/test_struct_literal.casa
@@ -39,7 +39,7 @@ fn sl_compile code:str -> Program {
     tokens DEFAULT_PARSER parse_ops = ops
     ops DEFAULT_PARSER resolve_identifiers_global = ops
     Option::None (Option[Function]) ops type_check_ops drop
-    ops compile_bytecode
+    ops DEFAULT_PARSER.store compile_bytecode
 }
 
 fn sl_count_ops ops:List[Op] kind:OpKind -> int {

--- a/tests/compiler/test_struct_literal.casa
+++ b/tests/compiler/test_struct_literal.casa
@@ -22,22 +22,22 @@ include "../../lib/test_helpers.casa"
 fn sl_parse code:str -> List[Op] {
     clear_global_state
     "test" code lex_source = tokens
-    tokens parse_ops
+    tokens DEFAULT_PARSER parse_ops
 }
 
 fn sl_typecheck code:str -> Signature {
     clear_global_state
     "test" code lex_source = tokens
-    tokens parse_ops = ops
-    ops resolve_identifiers_global = ops
+    tokens DEFAULT_PARSER parse_ops = ops
+    ops DEFAULT_PARSER resolve_identifiers_global = ops
     Option::None (Option[Function]) ops type_check_ops
 }
 
 fn sl_compile code:str -> Program {
     clear_global_state
     "test" code lex_source = tokens
-    tokens parse_ops = ops
-    ops resolve_identifiers_global = ops
+    tokens DEFAULT_PARSER parse_ops = ops
+    ops DEFAULT_PARSER resolve_identifiers_global = ops
     Option::None (Option[Function]) ops type_check_ops drop
     ops compile_bytecode
 }

--- a/tests/compiler/test_traits.casa
+++ b/tests/compiler/test_traits.casa
@@ -19,21 +19,21 @@ include "../../lib/test_helpers.casa"
 fn trait_test_parse code:str -> List[Op] {
     clear_global_state
     "test" code lex_source = tokens
-    tokens parse_ops
+    tokens DEFAULT_PARSER parse_ops
 }
 
 fn trait_test_resolve code:str -> List[Op] {
     clear_global_state
     "test" code lex_source = tokens
-    tokens parse_ops = ops
-    ops resolve_identifiers_global
+    tokens DEFAULT_PARSER parse_ops = ops
+    ops DEFAULT_PARSER resolve_identifiers_global
 }
 
 fn trait_test_typecheck code:str -> Signature {
     clear_global_state
     "test" code lex_source = tokens
-    tokens parse_ops = ops
-    ops resolve_identifiers_global = ops
+    tokens DEFAULT_PARSER parse_ops = ops
+    ops DEFAULT_PARSER resolve_identifiers_global = ops
     Option::None (Option[Function]) ops type_check_ops
 }
 

--- a/tests/compiler/test_traits.casa
+++ b/tests/compiler/test_traits.casa
@@ -44,25 +44,25 @@ fn trait_test_typecheck code:str -> Signature {
 fn test_trait_registers_globally {
     "trait_registers_globally" test_start
     HASHABLE_TRAIT trait_test_parse drop
-    "registered" "Hashable" GLOBAL_TRAITS .get .is_some assert_true
+    "registered" "Hashable" DEFAULT_PARSER.store.traits .get .is_some assert_true
 }
 
 fn test_trait_name {
     "trait_name" test_start
     "trait Hashable { fn hash self:self -> int }" trait_test_parse drop
-    "name" "Hashable" "Hashable" GLOBAL_TRAITS .get .unwrap CasaTrait::name assert_str_eq
+    "name" "Hashable" "Hashable" DEFAULT_PARSER.store.traits .get .unwrap CasaTrait::name assert_str_eq
 }
 
 fn test_trait_method_count {
     "trait_method_count" test_start
     HASHABLE_TRAIT trait_test_parse drop
-    "count" 2 "Hashable" GLOBAL_TRAITS .get .unwrap CasaTrait::methods .length assert_eq
+    "count" 2 "Hashable" DEFAULT_PARSER.store.traits .get .unwrap CasaTrait::methods .length assert_eq
 }
 
 fn test_trait_method_names {
     "trait_method_names" test_start
     HASHABLE_TRAIT trait_test_parse drop
-    "Hashable" GLOBAL_TRAITS .get .unwrap = hashable
+    "Hashable" DEFAULT_PARSER.store.traits .get .unwrap = hashable
     "hash" "hash" 0 hashable CasaTrait::methods .get TraitMethod::name assert_str_eq
     "eq" "eq" 1 hashable CasaTrait::methods .get TraitMethod::name assert_str_eq
 }
@@ -70,7 +70,7 @@ fn test_trait_method_names {
 fn test_trait_method_sig_params {
     "trait_method_sig_params" test_start
     HASHABLE_TRAIT trait_test_parse drop
-    "Hashable" GLOBAL_TRAITS .get .unwrap CasaTrait::methods = methods
+    "Hashable" DEFAULT_PARSER.store.traits .get .unwrap CasaTrait::methods = methods
     0 methods .get TraitMethod::signature = hash_sig
     "param count" 1 hash_sig Signature::parameters .length assert_eq
     "param type" "self" 0 hash_sig Signature::parameters .get Parameter::typ assert_str_eq
@@ -80,7 +80,7 @@ fn test_trait_method_sig_params {
 fn test_trait_method_sig_return {
     "trait_method_sig_return" test_start
     HASHABLE_TRAIT trait_test_parse drop
-    "Hashable" GLOBAL_TRAITS .get .unwrap CasaTrait::methods = methods
+    "Hashable" DEFAULT_PARSER.store.traits .get .unwrap CasaTrait::methods = methods
     0 methods .get TraitMethod::signature = hash_sig
     "return count" 1 hash_sig Signature::return_types .length assert_eq
     "return type" "int" 0 hash_sig Signature::return_types .get assert_str_eq
@@ -89,7 +89,7 @@ fn test_trait_method_sig_return {
 fn test_trait_eq_method_params {
     "trait_eq_method_params" test_start
     HASHABLE_TRAIT trait_test_parse drop
-    "Hashable" GLOBAL_TRAITS .get .unwrap CasaTrait::methods = methods
+    "Hashable" DEFAULT_PARSER.store.traits .get .unwrap CasaTrait::methods = methods
     1 methods .get TraitMethod::signature = eq_sig
     "param count" 2 eq_sig Signature::parameters .length assert_eq
     "param0 type" "self" 0 eq_sig Signature::parameters .get Parameter::typ assert_str_eq
@@ -99,7 +99,7 @@ fn test_trait_eq_method_params {
 fn test_trait_eq_method_return {
     "trait_eq_method_return" test_start
     HASHABLE_TRAIT trait_test_parse drop
-    "Hashable" GLOBAL_TRAITS .get .unwrap CasaTrait::methods = methods
+    "Hashable" DEFAULT_PARSER.store.traits .get .unwrap CasaTrait::methods = methods
     1 methods .get TraitMethod::signature = eq_sig
     "return count" 1 eq_sig Signature::return_types .length assert_eq
     "return type" "bool" 0 eq_sig Signature::return_types .get assert_str_eq
@@ -108,14 +108,14 @@ fn test_trait_eq_method_return {
 fn test_trait_empty {
     "trait_empty" test_start
     "trait Empty { }" trait_test_parse drop
-    "registered" "Empty" GLOBAL_TRAITS .get .is_some assert_true
-    "no methods" 0 "Empty" GLOBAL_TRAITS .get .unwrap CasaTrait::methods .length assert_eq
+    "registered" "Empty" DEFAULT_PARSER.store.traits .get .is_some assert_true
+    "no methods" 0 "Empty" DEFAULT_PARSER.store.traits .get .unwrap CasaTrait::methods .length assert_eq
 }
 
 fn test_trait_single_method {
     "trait_single_method" test_start
     "trait Printable { fn to_str self:self -> str }" trait_test_parse drop
-    "Printable" GLOBAL_TRAITS .get .unwrap = printable
+    "Printable" DEFAULT_PARSER.store.traits .get .unwrap = printable
     "method count" 1 printable CasaTrait::methods .length assert_eq
     "method name" "to_str" 0 printable CasaTrait::methods .get TraitMethod::name assert_str_eq
 }
@@ -123,28 +123,28 @@ fn test_trait_single_method {
 fn test_trait_has_location {
     "trait_has_location" test_start
     "trait MyTrait { fn do_thing self:self -> int }" trait_test_parse drop
-    "has file" "" "MyTrait" GLOBAL_TRAITS .get .unwrap CasaTrait::location Location::file != assert_true
+    "has file" "" "MyTrait" DEFAULT_PARSER.store.traits .get .unwrap CasaTrait::location Location::file != assert_true
 }
 
 fn test_trait_non_generic_has_empty_type_params {
     "trait_non_generic_has_empty_type_params" test_start
     HASHABLE_TRAIT trait_test_parse drop
-    "empty type params" 0 "Hashable" GLOBAL_TRAITS .get .unwrap CasaTrait::type_params .length assert_eq
+    "empty type params" 0 "Hashable" DEFAULT_PARSER.store.traits .get .unwrap CasaTrait::type_params .length assert_eq
 }
 
 fn test_trait_generic_single_type_param {
     "trait_generic_single_type_param" test_start
     "trait Iterator[T] { fn next self:self -> Option[T] }" trait_test_parse drop
-    "registered" "Iterator" GLOBAL_TRAITS .get .is_some assert_true
-    "type params count" 1 "Iterator" GLOBAL_TRAITS .get .unwrap CasaTrait::type_params .length assert_eq
-    "type param name" "T" 0 "Iterator" GLOBAL_TRAITS .get .unwrap CasaTrait::type_params .get assert_str_eq
+    "registered" "Iterator" DEFAULT_PARSER.store.traits .get .is_some assert_true
+    "type params count" 1 "Iterator" DEFAULT_PARSER.store.traits .get .unwrap CasaTrait::type_params .length assert_eq
+    "type param name" "T" 0 "Iterator" DEFAULT_PARSER.store.traits .get .unwrap CasaTrait::type_params .get assert_str_eq
 }
 
 fn test_trait_generic_multi_type_params {
     "trait_generic_multi_type_params" test_start
     "trait Mapper[K V] { fn map self:self -> V }" trait_test_parse drop
-    "registered" "Mapper" GLOBAL_TRAITS .get .is_some assert_true
-    "Mapper" GLOBAL_TRAITS .get .unwrap CasaTrait::type_params = tps
+    "registered" "Mapper" DEFAULT_PARSER.store.traits .get .is_some assert_true
+    "Mapper" DEFAULT_PARSER.store.traits .get .unwrap CasaTrait::type_params = tps
     "type params count" 2 tps .length assert_eq
     "first" "K" 0 tps .get assert_str_eq
     "second" "V" 1 tps .get assert_str_eq
@@ -197,7 +197,7 @@ fn test_trait_duplicate_raises {
 fn test_trait_bound_basic {
     "trait_bound_basic" test_start
     "trait Hashable { fn hash self:self -> int }\nfn tbtest[K: Hashable] K -> int { .hash }" trait_test_parse drop
-    "tbtest" GLOBAL_FUNCTIONS .get .unwrap = func
+    "tbtest" DEFAULT_PARSER.store.functions .get .unwrap = func
     "K in type_vars" "K" func Function::signature Signature::type_vars .has assert_true
     "K bound" "Hashable" "K" func Function::signature Signature::trait_bounds .get .unwrap TraitBound::name assert_str_eq
 }
@@ -205,7 +205,7 @@ fn test_trait_bound_basic {
 fn test_trait_bound_with_unbounded_var {
     "trait_bound_with_unbounded_var" test_start
     "trait Hashable { fn hash self:self -> int }\nfn tbtest[K: Hashable, V] K V -> int { drop .hash }" trait_test_parse drop
-    "tbtest" GLOBAL_FUNCTIONS .get .unwrap = func
+    "tbtest" DEFAULT_PARSER.store.functions .get .unwrap = func
     "K in vars" "K" func Function::signature Signature::type_vars .has assert_true
     "V in vars" "V" func Function::signature Signature::type_vars .has assert_true
     "K bound" "Hashable" "K" func Function::signature Signature::trait_bounds .get .unwrap TraitBound::name assert_str_eq
@@ -215,7 +215,7 @@ fn test_trait_bound_with_unbounded_var {
 fn test_trait_bound_multiple_bounded {
     "trait_bound_multiple_bounded" test_start
     "trait Hashable { fn hash self:self -> int }\ntrait Printable { fn to_str self:self -> str }\nfn tbtest[K: Hashable, V: Printable] K V -> int { .to_str drop .hash }" trait_test_parse drop
-    "tbtest" GLOBAL_FUNCTIONS .get .unwrap = func
+    "tbtest" DEFAULT_PARSER.store.functions .get .unwrap = func
     "K bound" "Hashable" "K" func Function::signature Signature::trait_bounds .get .unwrap TraitBound::name assert_str_eq
     "V bound" "Printable" "V" func Function::signature Signature::trait_bounds .get .unwrap TraitBound::name assert_str_eq
 }
@@ -239,7 +239,7 @@ fn test_trait_bound_undefined_raises {
 fn test_trait_hidden_params_prepended {
     "trait_hidden_params_prepended" test_start
     "trait Hashable { fn hash self:self -> int }\nfn tbtest[K: Hashable] K -> int { .hash }" trait_test_parse drop
-    "tbtest" GLOBAL_FUNCTIONS .get .unwrap = func
+    "tbtest" DEFAULT_PARSER.store.functions .get .unwrap = func
     0 = hidden_count
     0 = index
     while index func Function::signature Signature::parameters .length > do
@@ -255,7 +255,7 @@ fn test_trait_hidden_params_prepended {
 fn test_trait_hidden_param_name {
     "trait_hidden_param_name" test_start
     "trait Hashable { fn hash self:self -> int }\nfn tbtest[K: Hashable] K -> int { .hash }" trait_test_parse drop
-    "tbtest" GLOBAL_FUNCTIONS .get .unwrap = func
+    "tbtest" DEFAULT_PARSER.store.functions .get .unwrap = func
     false = found
     0 = index
     while index func Function::signature Signature::parameters .length > do
@@ -270,7 +270,7 @@ fn test_trait_hidden_param_name {
 fn test_trait_hidden_param_type {
     "trait_hidden_param_type" test_start
     "trait Hashable { fn hash self:self -> int }\nfn tbtest[K: Hashable] K -> int { .hash }" trait_test_parse drop
-    "tbtest" GLOBAL_FUNCTIONS .get .unwrap = func
+    "tbtest" DEFAULT_PARSER.store.functions .get .unwrap = func
     0 = index
     while index func Function::signature Signature::parameters .length > do
         index func Function::signature Signature::parameters .get = param
@@ -284,7 +284,7 @@ fn test_trait_hidden_param_type {
 fn test_trait_two_methods_hidden_params {
     "trait_two_methods_hidden_params" test_start
     HASHABLE_TRAIT "fn tbtest[K: Hashable] K -> int { .hash }" str::concat trait_test_parse drop
-    "tbtest" GLOBAL_FUNCTIONS .get .unwrap = func
+    "tbtest" DEFAULT_PARSER.store.functions .get .unwrap = func
     0 = hidden_count
     false = has_hash
     false = has_eq
@@ -306,7 +306,7 @@ fn test_trait_two_methods_hidden_params {
 fn test_trait_hidden_params_correct_types {
     "trait_hidden_params_correct_types" test_start
     HASHABLE_TRAIT "fn tbtest[K: Hashable] K -> int { .hash }" str::concat trait_test_parse drop
-    "tbtest" GLOBAL_FUNCTIONS .get .unwrap = func
+    "tbtest" DEFAULT_PARSER.store.functions .get .unwrap = func
     0 = index
     while index func Function::signature Signature::parameters .length > do
         index func Function::signature Signature::parameters .get = param
@@ -323,7 +323,7 @@ fn test_trait_hidden_params_correct_types {
 fn test_trait_hidden_params_creates_variables {
     "trait_hidden_params_creates_variables" test_start
     "trait Hashable { fn hash self:self -> int }\nfn tbtest[K: Hashable] K -> int { .hash }" trait_test_parse drop
-    "tbtest" GLOBAL_FUNCTIONS .get .unwrap = func
+    "tbtest" DEFAULT_PARSER.store.functions .get .unwrap = func
     false = found
     0 = index
     while index func Function::variables .length > do
@@ -338,7 +338,7 @@ fn test_trait_hidden_params_creates_variables {
 fn test_trait_hidden_params_creates_assign_ops {
     "trait_hidden_params_creates_assign_ops" test_start
     "trait Hashable { fn hash self:self -> int }\nfn tbtest[K: Hashable] K -> int { .hash }" trait_test_parse drop
-    "tbtest" GLOBAL_FUNCTIONS .get .unwrap = func
+    "tbtest" DEFAULT_PARSER.store.functions .get .unwrap = func
     false = found
     0 = index
     while index func Function::ops .length > do
@@ -634,7 +634,7 @@ fn test_k_coloncolon_method_resolved_as_push_variable_exec {
     enable_test_mode
     clear_errors
     HASHABLE_TRAIT "struct MyType { val: int }\nimpl MyType {\n    fn hash self:MyType -> int { self MyType::val }\n    fn eq self:MyType other:MyType -> bool { self MyType::val other MyType::val == }\n}\nfn get_hash[K: Hashable] k:K -> int { k K::hash }\n42 MyType = m\nm get_hash drop\n" str::concat trait_test_typecheck drop
-    "get_hash" GLOBAL_FUNCTIONS .get .unwrap = func
+    "get_hash" DEFAULT_PARSER.store.functions .get .unwrap = func
     # K::hash resolves to OpPushVar with trait_exec annotation
     false = found_push_var
     false = found_trait_exec
@@ -663,7 +663,7 @@ fn test_ampersand_k_coloncolon_method_resolved_as_push_variable {
     enable_test_mode
     clear_errors
     HASHABLE_TRAIT "struct MyType { val: int }\nimpl MyType {\n    fn hash self:MyType -> int { self MyType::val }\n    fn eq self:MyType other:MyType -> bool { self MyType::val other MyType::val == }\n}\nfn get_hash_fn[K: Hashable] -> fn[K -> int] { &K::hash }\n42 MyType = m\nm get_hash_fn drop\n" str::concat trait_test_typecheck drop
-    "get_hash_fn" GLOBAL_FUNCTIONS .get .unwrap = func
+    "get_hash_fn" DEFAULT_PARSER.store.functions .get .unwrap = func
     # &K::hash resolves to OpPushVar without trait_exec annotation (fn ref)
     false = found_push_var
     0 = index
@@ -700,7 +700,7 @@ fn test_trait_bounded_fn_with_non_satisfying_type_raises {
 fn test_generic_trait_bound_compound_type_arg_preserves_space {
     "generic_trait_bound_compound_type_arg_preserves_space" test_start
     "trait Carrier[T] { fn get self:self -> T }\nfn uses[I: Carrier[Map[str int]]] i:I -> int { 0 }\n" trait_test_parse drop
-    "uses" GLOBAL_FUNCTIONS .get .unwrap = func
+    "uses" DEFAULT_PARSER.store.functions .get .unwrap = func
     "I" func Function::signature Signature::trait_bounds .get .unwrap = bound
     "preserved" "Carrier[Map[str int]]" bound trait_bound_to_str assert_str_eq
 }
@@ -741,7 +741,7 @@ fn test_non_generic_trait_with_args_raises {
 fn test_generic_trait_bound_concrete_hidden_param_type {
     "generic_trait_bound_concrete_hidden_param_type" test_start
     "trait Carrier[T] { fn get self:self -> T }\nstruct Counter { val: int }\nimpl Counter { fn get self:Counter -> int { self Counter::val } }\nfn use_carrier[I: Carrier[int]] i:I -> int { i .get }\n" trait_test_typecheck drop
-    "use_carrier" GLOBAL_FUNCTIONS .get .unwrap = func
+    "use_carrier" DEFAULT_PARSER.store.functions .get .unwrap = func
     # Find the hidden __trait_I_get parameter and assert its type substituted T with int.
     false = found
     0 = index
@@ -834,14 +834,14 @@ fn test_parse_map_type_in_signature {
 fn test_dot_hash_on_bounded_type_var {
     "dot_hash_on_bounded_type_var" test_start
     HASHABLE_TRAIT "fn get_hash[K: Hashable] k:K -> int { k .hash }\n" str::concat trait_test_typecheck drop
-    "get_hash" GLOBAL_FUNCTIONS .get .unwrap = func
+    "get_hash" DEFAULT_PARSER.store.functions .get .unwrap = func
     "has sig" func Function::signature Signature::parameters .length 0 != assert_true
 }
 
 fn test_dot_eq_on_bounded_type_var {
     "dot_eq_on_bounded_type_var" test_start
     HASHABLE_TRAIT "fn are_eq[K: Hashable] a:K b:K -> bool { b a .eq }\n" str::concat trait_test_typecheck drop
-    "are_eq" GLOBAL_FUNCTIONS .get .unwrap = func
+    "are_eq" DEFAULT_PARSER.store.functions .get .unwrap = func
     "has sig" func Function::signature Signature::parameters .length 0 != assert_true
 }
 

--- a/tests/compiler/test_type_annotations.casa
+++ b/tests/compiler/test_type_annotations.casa
@@ -19,14 +19,14 @@ include "../../lib/test_helpers.casa"
 fn test_parse code:str -> List[Op] {
     clear_global_state
     "test" code lex_source = tokens
-    tokens parse_ops
+    tokens DEFAULT_PARSER parse_ops
 }
 
 fn tc_code code:str -> Signature {
     clear_global_state
     "test" code lex_source = tokens
-    tokens parse_ops = ops
-    ops resolve_identifiers_global = ops
+    tokens DEFAULT_PARSER parse_ops = ops
+    ops DEFAULT_PARSER resolve_identifiers_global = ops
     Option::None (Option[Function]) ops type_check_ops
 }
 

--- a/tests/compiler/test_type_annotations.casa
+++ b/tests/compiler/test_type_annotations.casa
@@ -123,7 +123,7 @@ fn test_no_annotation {
 fn test_annotation_in_function {
     "annotation_in_function" test_start
     "fn foo { 42 = x:int x drop }" test_parse drop
-    "foo" GLOBAL_FUNCTIONS .get .unwrap = function
+    "foo" DEFAULT_PARSER.store.functions .get .unwrap = function
     function Function::ops find_assign_ops = assigns
     false = found
     0 = index

--- a/tests/compiler/test_typechecker.casa
+++ b/tests/compiler/test_typechecker.casa
@@ -11,7 +11,7 @@ include "../../lib/test_helpers.casa"
 # ============================================================================
 
 fn tc_check ops:List[Op] -> TypeChecker {
-    make_typechecker = helper_tc
+    DEFAULT_PARSER.store make_typechecker = helper_tc
     0 = helper_i
     while helper_i ops .length > do
         helper_i ops .get = helper_op

--- a/tests/compiler/test_typechecker.casa
+++ b/tests/compiler/test_typechecker.casa
@@ -507,7 +507,7 @@ fn test_stacks_compatible {
 fn test_typecheck_simple_expression {
     "typecheck_simple_expression" test_start
     "test" "10 20 +" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     Option::None (Option[Function]) ops type_check_ops = sig
     "params" 0 sig Signature::parameters .length assert_eq
     "returns" 1 sig Signature::return_types .length assert_eq
@@ -520,8 +520,8 @@ fn test_typecheck_simple_expression {
 
 fn tc_string code:str -> Signature {
     "test" code lex_source = tokens
-    tokens parse_ops = ops
-    ops resolve_identifiers_global = ops
+    tokens DEFAULT_PARSER parse_ops = ops
+    ops DEFAULT_PARSER resolve_identifiers_global = ops
     Option::None (Option[Function]) ops type_check_ops
 }
 
@@ -1030,8 +1030,8 @@ fn tc_string_error code:str -> Signature {
     enable_test_mode
     clear_errors
     "test" code lex_source = tokens
-    tokens parse_ops = ops
-    ops resolve_identifiers_global = ops
+    tokens DEFAULT_PARSER parse_ops = ops
+    ops DEFAULT_PARSER resolve_identifiers_global = ops
     Option::None (Option[Function]) ops type_check_ops
 }
 

--- a/tests/compiler/test_typeof.casa
+++ b/tests/compiler/test_typeof.casa
@@ -13,15 +13,15 @@ include "../../lib/test.casa"
 
 fn tc_typeof code:str -> Signature {
     "test" code lex_source = tokens
-    tokens parse_ops = ops
-    ops resolve_identifiers_global = ops
+    tokens DEFAULT_PARSER parse_ops = ops
+    ops DEFAULT_PARSER resolve_identifiers_global = ops
     Option::None (Option[Function]) ops type_check_ops
 }
 
 fn compile_typeof code:str -> Program {
     "test" code lex_source = tokens
-    tokens parse_ops = ops
-    ops resolve_identifiers_global = ops
+    tokens DEFAULT_PARSER parse_ops = ops
+    ops DEFAULT_PARSER resolve_identifiers_global = ops
     Option::None (Option[Function]) ops type_check_ops drop
     ops compile_bytecode
 }
@@ -81,7 +81,7 @@ fn test_lex_typeof {
 fn test_parse_typeof {
     "parse_typeof" test_start
     "test" "42 typeof" lex_source = tokens
-    tokens parse_ops = ops
+    tokens DEFAULT_PARSER parse_ops = ops
     "typeof kind" OpKind::OpTypeof 1 ops .get Op::kind == assert_true
 }
 

--- a/tests/compiler/test_typeof.casa
+++ b/tests/compiler/test_typeof.casa
@@ -23,7 +23,7 @@ fn compile_typeof code:str -> Program {
     tokens DEFAULT_PARSER parse_ops = ops
     ops DEFAULT_PARSER resolve_identifiers_global = ops
     Option::None (Option[Function]) ops type_check_ops drop
-    ops compile_bytecode
+    ops DEFAULT_PARSER.store compile_bytecode
 }
 
 fn emit_typeof code:str -> str {


### PR DESCRIPTION
## Summary
- Introduces `SymbolStore` to hold functions/variables/enums/structs/traits maps
- Threads `Parser`, `TypeChecker`, and `BytecodeCompiler` structs through the pipeline, each holding a `store` field

Closes #79.

## Test plan
- [x] tests/test_compiler.sh
- [x] tests/test_examples.sh