### PR TITLE
refactor(typechecker): BranchFrame sum type for branch machinery (#81)

### DIFF
--- a/compiler/typechecker.casa
+++ b/compiler/typechecker.casa
@@ -19,55 +19,106 @@ fn ts_new -> TypedStack {
     TypedStack
 }
 
+# Deep-copy a TypedStack into a new, independent value.
+fn ts_snapshot source:TypedStack -> TypedStack {
+    List::new (List[str]) = new_types
+    List::new (List[Location]) = new_origins
+    0 = snap_index
+    while snap_index source TypedStack::types .length > do
+        snap_index source TypedStack::types .get new_types .push
+        snap_index source TypedStack::origins .get new_origins .push
+        1 += snap_index
+    done
+    new_origins new_types TypedStack
+}
+
+# Mutate `target` in place so it deep-equals `source`. `source` is unchanged.
+fn ts_restore target:TypedStack source:TypedStack {
+    List::new (List[str]) = new_types
+    List::new (List[Location]) = new_origins
+    0 = restore_index
+    while restore_index source TypedStack::types .length > do
+        restore_index source TypedStack::types .get new_types .push
+        restore_index source TypedStack::origins .get new_origins .push
+        1 += restore_index
+    done
+    new_types target TypedStack::set_types
+    new_origins target TypedStack::set_origins
+}
+
+# Pure stack comparison on the types slice (origins are not compared).
+fn ts_equals left:TypedStack right:TypedStack -> bool {
+    left TypedStack::types right TypedStack::types stacks_equal
+}
+
+# Produce the unified types list between two TypedStacks, or empty on incompatibility.
+fn ts_unify_types target:TypedStack candidate:TypedStack -> List[str] {
+    target TypedStack::types candidate TypedStack::types stacks_compatible
+}
+
 # ============================================================================
-# BranchedStack — tracks stack state across conditional and loop branches
+# Branch contexts — one specialized struct per branch kind (if / while / match).
 # ============================================================================
 
-struct BranchedStack {
-    before:                 List[str]
-    after:                  List[str]
-    before_origins:         List[Location]
-    after_origins:          List[Location]
-    condition_present:      bool
-    default_present:        bool
-    branch_records:         List[str]
-    current_branch_label:   str
+struct IfContext {
+    before:                  TypedStack
+    after:                   TypedStack
+    condition_present:       bool
+    default_present:         bool
+    current_branch_label:    str
     current_branch_location: Location
-    match_type:             str
 }
 
-fn copy_str_list source:List[str] -> List[str] {
-    List::new (List[str]) = result
-    0 = index
-    while index source .length > do
-        index source .get result .push
-        1 += index
-    done
-    result
+struct WhileContext {
+    before:                  TypedStack
+    condition_present:       bool
+    current_branch_location: Location
 }
 
-fn copy_location_list source:List[Location] -> List[Location] {
-    List::new (List[Location]) = result
-    0 = index
-    while index source .length > do
-        index source .get result .push
-        1 += index
-    done
-    result
+struct MatchContext {
+    before:                  TypedStack
+    after:                   TypedStack
+    condition_present:       bool
+    default_present:         bool
+    branch_records:          List[str]
+    match_type:              str
+    current_branch_label:    str
+    current_branch_location: Location
 }
 
-fn make_branched_stack stack:List[str] origins:List[Location] -> BranchedStack {
-    ""
+enum BranchFrame {
+    BranchIf(IfContext)
+    BranchWhile(WhileContext)
+    BranchMatch(MatchContext)
+}
+
+fn make_if_context -> IfContext {
     empty_location
     ""
+    false
+    false
+    ts_new
+    ts_new
+    IfContext
+}
+
+fn make_while_context -> WhileContext {
+    empty_location
+    false
+    ts_new
+    WhileContext
+}
+
+fn make_match_context match_type:str -> MatchContext {
+    empty_location
+    ""
+    match_type
     List::new (List[str])
+    true      # default_present — starts true; cleared when a non-wildcard arm is seen
     false
-    false
-    origins copy_location_list
-    origins copy_location_list
-    stack copy_str_list
-    stack copy_str_list
-    BranchedStack
+    ts_new
+    ts_new
+    MatchContext
 }
 
 # ============================================================================
@@ -77,9 +128,9 @@ fn make_branched_stack stack:List[str] origins:List[Location] -> BranchedStack {
 struct TypeChecker {
     live:                TypedStack
     parameters:          List[Parameter]
-    return_types:        List[str]
+    return_types:        TypedStack
     has_return_types:    bool
-    branched_stacks:     List[BranchedStack]
+    branched_stacks:     List[BranchFrame]
     current_location:    Location
     current_op_context:  str
     current_expect_ctx:  str
@@ -93,9 +144,9 @@ fn make_typechecker store:SymbolStore -> TypeChecker {
     ""                               # current_expect_ctx
     ""                               # current_op_context
     empty_location                   # current_location
-    List::new (List[BranchedStack])  # branched_stacks
+    List::new (List[BranchFrame])    # branched_stacks
     false                            # has_return_types
-    List::new (List[str])            # return_types
+    ts_new                           # return_types
     List::new (List[Parameter])      # parameters
     ts_new                           # live
     TypeChecker
@@ -920,78 +971,80 @@ fn check_push_var tc:TypeChecker op:Op function_opt:Option[Function] {
 fn check_if_block tc:TypeChecker op:Op {
     op Op::kind = kind
     if OpKind::OpIfStart kind == then
-        tc TypeChecker::live TypedStack::origins tc TypeChecker::live TypedStack::types make_branched_stack = branched
-        op Op::location branched BranchedStack::set_current_branch_location
-        branched tc TypeChecker::branched_stacks .push
+        make_if_context = if_ctx
+        op Op::location if_ctx IfContext::set_current_branch_location
+        if_ctx BranchFrame::BranchIf = if_frame
+        if_frame tc TypeChecker::branched_stacks .push
         true tc TypeChecker::set_in_branch_condition
     elif OpKind::OpIfCondition kind == then
         false tc TypeChecker::set_in_branch_condition
         "bool" tc expect_type drop
         if 0 tc TypeChecker::branched_stacks .length == then return fi
-        tc TypeChecker::branched_stacks .length 1 - tc TypeChecker::branched_stacks .get = branched_stack
-        if branched_stack BranchedStack::condition_present ! then
-            true branched_stack BranchedStack::set_condition_present
-            tc TypeChecker::live TypedStack::types copy_str_list branched_stack BranchedStack::set_before
-            tc TypeChecker::live TypedStack::origins copy_location_list branched_stack BranchedStack::set_before_origins
-            tc TypeChecker::live TypedStack::types copy_str_list branched_stack BranchedStack::set_after
-            tc TypeChecker::live TypedStack::origins copy_location_list branched_stack BranchedStack::set_after_origins
-            "if" branched_stack BranchedStack::set_current_branch_label
+        tc TypeChecker::branched_stacks .length 1 - tc TypeChecker::branched_stacks .get = top_frame
+        if top_frame BranchFrame::BranchIf(if_ctx) is then
+            if if_ctx IfContext::condition_present ! then
+                true if_ctx IfContext::set_condition_present
+                tc TypeChecker::live if_ctx IfContext::before ts_restore
+                tc TypeChecker::live if_ctx IfContext::after ts_restore
+                "if" if_ctx IfContext::set_current_branch_label
+            fi
         fi
     elif
         OpKind::OpIfElif kind ==
         OpKind::OpIfElse kind == ||
     then
         if 0 tc TypeChecker::branched_stacks .length == then return fi
-        tc TypeChecker::branched_stacks .length 1 - tc TypeChecker::branched_stacks .get = branched_stack
-        if OpKind::OpIfElse kind == then
-            true branched_stack BranchedStack::set_default_present
-            false tc TypeChecker::set_in_branch_condition
-        else
-            true tc TypeChecker::set_in_branch_condition
+        tc TypeChecker::branched_stacks .length 1 - tc TypeChecker::branched_stacks .get = top_frame
+        if top_frame BranchFrame::BranchIf(if_ctx) is then
+            if OpKind::OpIfElse kind == then
+                true if_ctx IfContext::set_default_present
+                false tc TypeChecker::set_in_branch_condition
+            else
+                true tc TypeChecker::set_in_branch_condition
+            fi
+            if_ctx IfContext::before = if_before
+            if_ctx IfContext::after = if_after
+            if if_before tc TypeChecker::live ts_equals if_after if_before ts_equals && then
+                op Op::location if_ctx IfContext::set_current_branch_location
+                return
+            fi
+            if_after tc TypeChecker::live ts_unify_types = unified
+            if 0 unified .length != if_after if_before ts_equals ! && then
+                unified if_after TypedStack::set_types
+                if_before tc TypeChecker::live ts_restore
+                op Op::location if_ctx IfContext::set_current_branch_location
+                return
+            fi
+            if if_after if_before ts_equals then
+                tc TypeChecker::live if_after ts_restore
+                if_before tc TypeChecker::live ts_restore
+                op Op::location if_ctx IfContext::set_current_branch_location
+                return
+            fi
+            op Op::location "Branches have incompatible stack effects" ErrorKind::StackMismatch add_error
         fi
-        branched_stack BranchedStack::before = before
-        branched_stack BranchedStack::after = after
-        if tc TypeChecker::live TypedStack::types before stacks_equal before after stacks_equal && then
-            op Op::location branched_stack BranchedStack::set_current_branch_location
-            return
-        fi
-        tc TypeChecker::live TypedStack::types after stacks_compatible = unified
-        if 0 unified .length != before after stacks_equal ! && then
-            unified branched_stack BranchedStack::set_after
-            before copy_str_list tc TypeChecker::live TypedStack::set_types
-            branched_stack BranchedStack::before_origins copy_location_list tc TypeChecker::live TypedStack::set_origins
-            op Op::location branched_stack BranchedStack::set_current_branch_location
-            return
-        fi
-        if before after stacks_equal then
-            tc TypeChecker::live TypedStack::types copy_str_list branched_stack BranchedStack::set_after
-            tc TypeChecker::live TypedStack::origins copy_location_list branched_stack BranchedStack::set_after_origins
-            before copy_str_list tc TypeChecker::live TypedStack::set_types
-            branched_stack BranchedStack::before_origins copy_location_list tc TypeChecker::live TypedStack::set_origins
-            op Op::location branched_stack BranchedStack::set_current_branch_location
-            return
-        fi
-        op Op::location "Branches have incompatible stack effects" ErrorKind::StackMismatch add_error
     elif OpKind::OpIfEnd kind == then
-        tc TypeChecker::branched_stacks .pop = branched_stack
-        branched_stack BranchedStack::before = before
-        branched_stack BranchedStack::after = after
-        if tc TypeChecker::live TypedStack::types before stacks_equal before after stacks_equal && then
-            return
+        tc TypeChecker::branched_stacks .pop = top_frame
+        if top_frame BranchFrame::BranchIf(if_ctx) is then
+            if_ctx IfContext::before = if_before
+            if_ctx IfContext::after = if_after
+            if if_before tc TypeChecker::live ts_equals if_after if_before ts_equals && then
+                return
+            fi
+            if_after tc TypeChecker::live ts_unify_types = unified
+            if 0 unified .length != if_ctx IfContext::default_present && then
+                if_after tc TypeChecker::live ts_restore
+                unified tc TypeChecker::live TypedStack::set_types
+                return
+            fi
+            if_before tc TypeChecker::live ts_unify_types = unified_before
+            if 0 unified_before .length != if_ctx IfContext::default_present ! && then
+                if_before tc TypeChecker::live ts_restore
+                unified_before tc TypeChecker::live TypedStack::set_types
+                return
+            fi
+            op Op::location "Branches have incompatible stack effects" ErrorKind::StackMismatch add_error
         fi
-        tc TypeChecker::live TypedStack::types after stacks_compatible = unified
-        if 0 unified .length != branched_stack BranchedStack::default_present && then
-            unified tc TypeChecker::live TypedStack::set_types
-            branched_stack BranchedStack::after_origins copy_location_list tc TypeChecker::live TypedStack::set_origins
-            return
-        fi
-        tc TypeChecker::live TypedStack::types before stacks_compatible = unified_before
-        if 0 unified_before .length != branched_stack BranchedStack::default_present ! && then
-            unified_before tc TypeChecker::live TypedStack::set_types
-            branched_stack BranchedStack::before_origins copy_location_list tc TypeChecker::live TypedStack::set_origins
-            return
-        fi
-        op Op::location "Branches have incompatible stack effects" ErrorKind::StackMismatch add_error
     fi
 }
 
@@ -1002,13 +1055,18 @@ fn check_if_block tc:TypeChecker op:Op {
 fn check_while_block tc:TypeChecker op:Op {
     op Op::kind = kind
     if OpKind::OpWhileStart kind == then
-        tc TypeChecker::live TypedStack::origins tc TypeChecker::live TypedStack::types make_branched_stack = branched
-        branched tc TypeChecker::branched_stacks .push
+        make_while_context = while_ctx
+        tc TypeChecker::live while_ctx WhileContext::before ts_restore
+        op Op::location while_ctx WhileContext::set_current_branch_location
+        while_ctx BranchFrame::BranchWhile = while_frame
+        while_frame tc TypeChecker::branched_stacks .push
     elif OpKind::OpWhileCondition kind == then
         "bool" tc expect_type drop
         if 0 tc TypeChecker::branched_stacks .length == then return fi
-        tc TypeChecker::branched_stacks .length 1 - tc TypeChecker::branched_stacks .get = branched_stack
-        true branched_stack BranchedStack::set_condition_present
+        tc TypeChecker::branched_stacks .length 1 - tc TypeChecker::branched_stacks .get = top_frame
+        if top_frame BranchFrame::BranchWhile(while_ctx) is then
+            true while_ctx WhileContext::set_condition_present
+        fi
     elif
         OpKind::OpWhileBreak kind ==
         OpKind::OpWhileContinue kind == ||
@@ -1439,12 +1497,17 @@ fn check_function_ops tc:TypeChecker op:Op ops:List[Op] op_index:int function_op
     elif OpKind::OpFnReturn kind == then
         if tc TypeChecker::has_return_types ! then
             true tc TypeChecker::set_has_return_types
-            tc TypeChecker::live TypedStack::types copy_str_list tc TypeChecker::set_return_types
+            tc TypeChecker::live tc TypeChecker::return_types ts_restore
         fi
         if 0 tc TypeChecker::branched_stacks .length != then
-            tc TypeChecker::branched_stacks .length 1 - tc TypeChecker::branched_stacks .get = branched_stack
-            branched_stack BranchedStack::before copy_str_list tc TypeChecker::live TypedStack::set_types
-            branched_stack BranchedStack::before_origins copy_location_list tc TypeChecker::live TypedStack::set_origins
+            tc TypeChecker::branched_stacks .length 1 - tc TypeChecker::branched_stacks .get = top_frame
+            if top_frame BranchFrame::BranchIf(if_ctx) is then
+                if_ctx IfContext::before tc TypeChecker::live ts_restore
+            elif top_frame BranchFrame::BranchWhile(while_ctx) is then
+                while_ctx WhileContext::before tc TypeChecker::live ts_restore
+            elif top_frame BranchFrame::BranchMatch(match_ctx) is then
+                match_ctx MatchContext::before tc TypeChecker::live ts_restore
+            fi
         fi
     fi
     op_index
@@ -1665,286 +1728,287 @@ fn check_match tc:TypeChecker op:Op function_opt:Option[Function] {
     op Op::kind = kind
     if OpKind::OpMatchStart kind == then
         tc stack_pop = match_type
-        tc TypeChecker::live TypedStack::origins tc TypeChecker::live TypedStack::types make_branched_stack = branched
-        match_type branched BranchedStack::set_match_type
-        true branched BranchedStack::set_default_present
-        branched tc TypeChecker::branched_stacks .push
+        match_type make_match_context = match_ctx
+        op Op::location match_ctx MatchContext::set_current_branch_location
+        match_ctx BranchFrame::BranchMatch = match_frame
+        match_frame tc TypeChecker::branched_stacks .push
     elif OpKind::OpMatchArm kind == then
         if 0 tc TypeChecker::branched_stacks .length == then return fi
-        tc TypeChecker::branched_stacks .length 1 - tc TypeChecker::branched_stacks .get = branched_stack
-        branched_stack BranchedStack::match_type = match_subject_type
+        tc TypeChecker::branched_stacks .length 1 - tc TypeChecker::branched_stacks .get = top_frame
+        if top_frame BranchFrame::BranchMatch(match_ctx) is then
+            match_ctx MatchContext::match_type = match_subject_type
 
-        # Determine pattern type from annotation tag set by parser
-        op Op::value = pattern_ptr
-        op Op::type_annotation = pattern_tag
-        "" = covered_key
-        match_subject_type resolve_match_type = arm_base
-        false = is_wildcard
-        false = is_enum_pattern
+            # Determine pattern type from annotation tag set by parser
+            op Op::value = pattern_ptr
+            op Op::type_annotation = pattern_tag
+            "" = covered_key
+            match_subject_type resolve_match_type = arm_base
+            false = is_wildcard
+            false = is_enum_pattern
 
-        if "struct_pattern" pattern_tag == then
-            pattern_ptr (StructPattern) = struct_pat
-            f"__covered:{struct_pat StructPattern::struct_name}" = covered_key
-        elif "literal_pattern" pattern_tag == then
-            pattern_ptr (LiteralPattern) = literal_pat
-            f"__covered:{literal_pat LiteralPattern::raw}" = covered_key
-        else
-            # Enum variant (includes wildcard)
-            pattern_ptr (EnumVariant) = variant
-            true = is_enum_pattern
-            if MATCH_WILDCARD variant EnumVariant::variant_name == then
-                true = is_wildcard
-            fi
-            f"__covered:{variant EnumVariant::variant_name}" = covered_key
-            # Check for bare variant (no enum qualifier)
-            if
-                "" variant EnumVariant::enum_name ==
-                is_wildcard ! &&
-            then
-                arm_base tc.store.enums .get = bare_enum_opt
-                if bare_enum_opt .is_some then
-                    bare_enum_opt .unwrap = bare_enum
-                    variant EnumVariant::variant_name = bare_name
-                    # Check if the bare name is a variant of the matched enum
-                    bare_name bare_enum CasaEnum::variants string_list_index = bare_index
-                    if 0 bare_index >= then
-                        op Op::location f"Unqualified enum variant `{bare_name}`. Did you mean `{arm_base}::{bare_name}`?" ErrorKind::TypeMismatch raise_error
-                    else
-                        op Op::location f"Expected qualified enum variant (e.g. `{arm_base}::{0 bare_enum CasaEnum::variants .get}`) or `_`, got `{bare_name}`" ErrorKind::TypeMismatch raise_error
+            if "struct_pattern" pattern_tag == then
+                pattern_ptr (StructPattern) = struct_pat
+                f"__covered:{struct_pat StructPattern::struct_name}" = covered_key
+            elif "literal_pattern" pattern_tag == then
+                pattern_ptr (LiteralPattern) = literal_pat
+                f"__covered:{literal_pat LiteralPattern::raw}" = covered_key
+            else
+                # Enum variant (includes wildcard)
+                pattern_ptr (EnumVariant) = variant
+                true = is_enum_pattern
+                if MATCH_WILDCARD variant EnumVariant::variant_name == then
+                    true = is_wildcard
+                fi
+                f"__covered:{variant EnumVariant::variant_name}" = covered_key
+                # Check for bare variant (no enum qualifier)
+                if
+                    "" variant EnumVariant::enum_name ==
+                    is_wildcard ! &&
+                then
+                    arm_base tc.store.enums .get = bare_enum_opt
+                    if bare_enum_opt .is_some then
+                        bare_enum_opt .unwrap = bare_enum
+                        variant EnumVariant::variant_name = bare_name
+                        # Check if the bare name is a variant of the matched enum
+                        bare_name bare_enum CasaEnum::variants string_list_index = bare_index
+                        if 0 bare_index >= then
+                            op Op::location f"Unqualified enum variant `{bare_name}`. Did you mean `{arm_base}::{bare_name}`?" ErrorKind::TypeMismatch raise_error
+                        else
+                            op Op::location f"Expected qualified enum variant (e.g. `{arm_base}::{0 bare_enum CasaEnum::variants .get}`) or `_`, got `{bare_name}`" ErrorKind::TypeMismatch raise_error
+                        fi
                     fi
                 fi
             fi
-        fi
 
-        # Check for duplicate arms
-        if "" covered_key != then
-            0 = dup_index
-            while dup_index branched_stack BranchedStack::branch_records .length > do
-                dup_index branched_stack BranchedStack::branch_records .get = record
-                if covered_key record == then
+            # Check for duplicate arms
+            if "" covered_key != then
+                0 = dup_index
+                while dup_index match_ctx MatchContext::branch_records .length > do
+                    dup_index match_ctx MatchContext::branch_records .get = record
+                    if covered_key record == then
+                        op Op::location f"Duplicate match arm for `{covered_key}`" ErrorKind::DuplicateName raise_error
+                    fi
+                    1 += dup_index
+                done
+                if covered_key match_ctx MatchContext::current_branch_label == then
                     op Op::location f"Duplicate match arm for `{covered_key}`" ErrorKind::DuplicateName raise_error
                 fi
-                1 += dup_index
-            done
-            if covered_key branched_stack BranchedStack::current_branch_label == then
-                op Op::location f"Duplicate match arm for `{covered_key}`" ErrorKind::DuplicateName raise_error
             fi
-        fi
 
-        # Handle branch state
-        if branched_stack BranchedStack::condition_present then
-            # Record previous arm
-            if "" branched_stack BranchedStack::current_branch_label != then
-                branched_stack BranchedStack::current_branch_label branched_stack BranchedStack::branch_records .push
-            fi
-            if
-                tc TypeChecker::live TypedStack::types branched_stack BranchedStack::before stacks_equal
-                branched_stack BranchedStack::before branched_stack BranchedStack::after stacks_equal &&
-            then
-                0 drop
-            else
-                tc TypeChecker::live TypedStack::types branched_stack BranchedStack::after stacks_compatible = unified
-                if 0 unified .length != branched_stack BranchedStack::before branched_stack BranchedStack::after stacks_equal ! && then
-                    unified branched_stack BranchedStack::set_after
-                elif branched_stack BranchedStack::before branched_stack BranchedStack::after stacks_equal then
-                    tc TypeChecker::live TypedStack::types copy_str_list branched_stack BranchedStack::set_after
-                    tc TypeChecker::live TypedStack::origins copy_location_list branched_stack BranchedStack::set_after_origins
+            # Handle branch state
+            if match_ctx MatchContext::condition_present then
+                # Record previous arm
+                if "" match_ctx MatchContext::current_branch_label != then
+                    match_ctx MatchContext::current_branch_label match_ctx MatchContext::branch_records .push
+                fi
+                match_ctx MatchContext::before = match_before
+                match_ctx MatchContext::after = match_after
+                if
+                    match_before tc TypeChecker::live ts_equals
+                    match_after match_before ts_equals &&
+                then
+                    0 drop
                 else
-                    op Op::location "Match arms have incompatible stack effects" ErrorKind::StackMismatch add_error
+                    match_after tc TypeChecker::live ts_unify_types = unified
+                    if 0 unified .length != match_after match_before ts_equals ! && then
+                        unified match_after TypedStack::set_types
+                    elif match_after match_before ts_equals then
+                        tc TypeChecker::live match_after ts_restore
+                    else
+                        op Op::location "Match arms have incompatible stack effects" ErrorKind::StackMismatch add_error
+                    fi
                 fi
+                match_before tc TypeChecker::live ts_restore
+            else
+                true match_ctx MatchContext::set_condition_present
+                tc TypeChecker::live match_ctx MatchContext::before ts_restore
+                tc TypeChecker::live match_ctx MatchContext::after ts_restore
             fi
-            branched_stack BranchedStack::before copy_str_list tc TypeChecker::live TypedStack::set_types
-            branched_stack BranchedStack::before_origins copy_location_list tc TypeChecker::live TypedStack::set_origins
-        else
-            true branched_stack BranchedStack::set_condition_present
-            tc TypeChecker::live TypedStack::types copy_str_list branched_stack BranchedStack::set_before
-            tc TypeChecker::live TypedStack::origins copy_location_list branched_stack BranchedStack::set_before_origins
-            tc TypeChecker::live TypedStack::types copy_str_list branched_stack BranchedStack::set_after
-            tc TypeChecker::live TypedStack::origins copy_location_list branched_stack BranchedStack::set_after_origins
-        fi
 
-        # Set types on pattern bindings
-        if "struct_pattern" pattern_tag == then
-            # StructPattern bindings
-            pattern_ptr (StructPattern) = struct_pat2
-            struct_pat2 StructPattern::struct_name tc.store.structs .get .unwrap = matched_struct
-            struct_pat2 StructPattern::bindings .keys = binding_keys
-            0 = binding_index
-            while binding_index binding_keys .length > do
-                binding_index binding_keys .get = field_name
-                field_name struct_pat2 StructPattern::bindings .get .unwrap = bound_var
-                0 = member_index
-                while member_index matched_struct CasaStruct::members .length > do
-                    member_index matched_struct CasaStruct::members .get = member
-                    if field_name member Member::name == then
-                        function_opt member Member::typ bound_var set_binding_type
-                    fi
-                    1 += member_index
-                done
-                1 += binding_index
-            done
-        elif is_enum_pattern is_wildcard ! && then
-            pattern_ptr (EnumVariant) = variant
-            if 0 variant EnumVariant::bindings .length != then
-            # EnumVariant bindings
-            match_subject_type resolve_match_type = base_enum_name
-            base_enum_name tc.store.enums .get = enum_opt
-            if enum_opt .is_some then
-                enum_opt .unwrap = casa_enum
-                variant EnumVariant::variant_name casa_enum CasaEnum::variant_types .get = inner_opt
-                if inner_opt .is_some then
-                    inner_opt .unwrap = inner_types
-                    # Resolve generic type vars from match subject
-                    Map::new (Map[str str]) = type_bindings
-                    if 0 casa_enum CasaEnum::type_vars .length != then
-                        match_subject_type extract_generic_params = params_opt
-                        if params_opt .is_some then
-                            params_opt .unwrap = type_params
-                            0 = type_var_index
-                            while
-                                type_var_index casa_enum CasaEnum::type_vars .length >
-                                type_var_index type_params .length > &&
-                            do
-                                type_var_index casa_enum CasaEnum::type_vars .get type_var_index type_params .get type_bindings .set = type_bindings
-                                1 += type_var_index
-                            done
+            # Set types on pattern bindings
+            if "struct_pattern" pattern_tag == then
+                # StructPattern bindings
+                pattern_ptr (StructPattern) = struct_pat2
+                struct_pat2 StructPattern::struct_name tc.store.structs .get .unwrap = matched_struct
+                struct_pat2 StructPattern::bindings .keys = binding_keys
+                0 = binding_index
+                while binding_index binding_keys .length > do
+                    binding_index binding_keys .get = field_name
+                    field_name struct_pat2 StructPattern::bindings .get .unwrap = bound_var
+                    0 = member_index
+                    while member_index matched_struct CasaStruct::members .length > do
+                        member_index matched_struct CasaStruct::members .get = member
+                        if field_name member Member::name == then
+                            function_opt member Member::typ bound_var set_binding_type
                         fi
-                    fi
-                    0 = bind_index
-                    while
-                        bind_index variant EnumVariant::bindings .length >
-                        bind_index inner_types .length > &&
-                    do
-                        bind_index variant EnumVariant::bindings .get = binding_var
-                        bind_index inner_types .get = binding_type
-                        binding_type type_bindings .get = resolved_opt
-                        if resolved_opt .is_some then
-                            resolved_opt .unwrap = binding_type
-                        fi
-                        function_opt binding_type binding_var set_binding_type
-                        1 += bind_index
+                        1 += member_index
                     done
+                    1 += binding_index
+                done
+            elif is_enum_pattern is_wildcard ! && then
+                pattern_ptr (EnumVariant) = variant
+                if 0 variant EnumVariant::bindings .length != then
+                # EnumVariant bindings
+                match_subject_type resolve_match_type = base_enum_name
+                base_enum_name tc.store.enums .get = enum_opt
+                if enum_opt .is_some then
+                    enum_opt .unwrap = casa_enum
+                    variant EnumVariant::variant_name casa_enum CasaEnum::variant_types .get = inner_opt
+                    if inner_opt .is_some then
+                        inner_opt .unwrap = inner_types
+                        # Resolve generic type vars from match subject
+                        Map::new (Map[str str]) = type_bindings
+                        if 0 casa_enum CasaEnum::type_vars .length != then
+                            match_subject_type extract_generic_params = params_opt
+                            if params_opt .is_some then
+                                params_opt .unwrap = type_params
+                                0 = type_var_index
+                                while
+                                    type_var_index casa_enum CasaEnum::type_vars .length >
+                                    type_var_index type_params .length > &&
+                                do
+                                    type_var_index casa_enum CasaEnum::type_vars .get type_var_index type_params .get type_bindings .set = type_bindings
+                                    1 += type_var_index
+                                done
+                            fi
+                        fi
+                        0 = bind_index
+                        while
+                            bind_index variant EnumVariant::bindings .length >
+                            bind_index inner_types .length > &&
+                        do
+                            bind_index variant EnumVariant::bindings .get = binding_var
+                            bind_index inner_types .get = binding_type
+                            binding_type type_bindings .get = resolved_opt
+                            if resolved_opt .is_some then
+                                resolved_opt .unwrap = binding_type
+                            fi
+                            function_opt binding_type binding_var set_binding_type
+                            1 += bind_index
+                        done
+                    fi
+                fi
                 fi
             fi
-            fi
-        fi
 
-        covered_key branched_stack BranchedStack::set_current_branch_label
-        op Op::location branched_stack BranchedStack::set_current_branch_location
+            covered_key match_ctx MatchContext::set_current_branch_label
+            op Op::location match_ctx MatchContext::set_current_branch_location
+        fi
 
     elif OpKind::OpMatchEnd kind == then
-        tc TypeChecker::branched_stacks .pop = branched_stack
-        # Record last arm label
-        if "" branched_stack BranchedStack::current_branch_label != then
-            branched_stack BranchedStack::current_branch_label branched_stack BranchedStack::branch_records .push
-        fi
-        # Record last arm stack effect (same logic as next-arm recording)
-        if branched_stack BranchedStack::condition_present then
-            if
-                tc TypeChecker::live TypedStack::types branched_stack BranchedStack::before stacks_equal
-                branched_stack BranchedStack::before branched_stack BranchedStack::after stacks_equal &&
-            then
-                0 drop
-            else
-                tc TypeChecker::live TypedStack::types branched_stack BranchedStack::after stacks_compatible = last_unified
-                if 0 last_unified .length != branched_stack BranchedStack::before branched_stack BranchedStack::after stacks_equal ! && then
-                    last_unified branched_stack BranchedStack::set_after
-                elif branched_stack BranchedStack::before branched_stack BranchedStack::after stacks_equal then
-                    tc TypeChecker::live TypedStack::types copy_str_list branched_stack BranchedStack::set_after
-                    tc TypeChecker::live TypedStack::origins copy_location_list branched_stack BranchedStack::set_after_origins
+        tc TypeChecker::branched_stacks .pop = top_frame
+        if top_frame BranchFrame::BranchMatch(match_ctx) is then
+            # Record last arm label
+            if "" match_ctx MatchContext::current_branch_label != then
+                match_ctx MatchContext::current_branch_label match_ctx MatchContext::branch_records .push
+            fi
+            # Record last arm stack effect (same logic as next-arm recording)
+            if match_ctx MatchContext::condition_present then
+                match_ctx MatchContext::before = match_before
+                match_ctx MatchContext::after = match_after
+                if
+                    match_before tc TypeChecker::live ts_equals
+                    match_after match_before ts_equals &&
+                then
+                    0 drop
                 else
-                    op Op::location "Match arms have incompatible stack effects" ErrorKind::StackMismatch add_error
-                fi
-            fi
-            branched_stack BranchedStack::before copy_str_list tc TypeChecker::live TypedStack::set_types
-            branched_stack BranchedStack::before_origins copy_location_list tc TypeChecker::live TypedStack::set_origins
-        fi
-
-        branched_stack BranchedStack::match_type = end_match_type
-        end_match_type resolve_match_type = end_base
-
-        # Build covered set
-        Set::new (Set[str]) = covered_set
-        0 = covered_index
-        while covered_index branched_stack BranchedStack::branch_records .length > do
-            covered_index branched_stack BranchedStack::branch_records .get = record
-            if record "__covered:" str::starts_with then
-                record 10 record .length 10 - str::substring covered_set .add = covered_set
-            fi
-            1 += covered_index
-        done
-        MATCH_WILDCARD covered_set .has = has_wildcard
-
-        # Check exhaustiveness
-        if end_base tc.store.enums .get .is_some has_wildcard ! && then
-            end_base tc.store.enums .get .unwrap = end_enum
-            List::new (List[str]) = missing
-            0 = variant_index
-            while variant_index end_enum CasaEnum::variants .length > do
-                variant_index end_enum CasaEnum::variants .get = variant_name
-                if variant_name covered_set .has ! then
-                    variant_name missing .push
-                fi
-                1 += variant_index
-            done
-            if 0 missing .length != then
-                StringBuilder::new = missing_builder
-                0 = missing_index
-                while missing_index missing .length > do
-                    if 0 missing_index != then ", " missing_builder .append fi
-                    f"`{end_base}::{missing_index missing .get}`" missing_builder .append
-                    1 += missing_index
-                done
-                op Op::location f"Non-exhaustive match, missing arms: {missing_builder .build}" ErrorKind::TypeMismatch raise_error
-            fi
-        fi
-        if end_base tc.store.structs .get .is_some has_wildcard ! && then
-            if end_base covered_set .has ! then
-                op Op::location f"Non-exhaustive match on struct `{end_match_type}`" ErrorKind::TypeMismatch raise_error
-            fi
-        fi
-        # Literal exhaustiveness
-        if
-            "bool" end_base ==
-            "int" end_base == ||
-            "char" end_base == ||
-            "str" end_base == ||
-        then
-            if has_wildcard ! then
-                if "bool" end_base == then
-                    List::new (List[str]) = bool_missing
-                    if "true" covered_set .has ! then "true" bool_missing .push fi
-                    if "false" covered_set .has ! then "false" bool_missing .push fi
-                    if 0 bool_missing .length != then
-                        op Op::location "Non-exhaustive match on `bool`" ErrorKind::TypeMismatch raise_error
+                    match_after tc TypeChecker::live ts_unify_types = last_unified
+                    if 0 last_unified .length != match_after match_before ts_equals ! && then
+                        last_unified match_after TypedStack::set_types
+                    elif match_after match_before ts_equals then
+                        tc TypeChecker::live match_after ts_restore
+                    else
+                        op Op::location "Match arms have incompatible stack effects" ErrorKind::StackMismatch add_error
                     fi
-                else
-                    op Op::location f"Non-exhaustive match on type `{end_base}`. A wildcard `_` arm is required" ErrorKind::TypeMismatch raise_error
+                fi
+                match_before tc TypeChecker::live ts_restore
+            fi
+
+            match_ctx MatchContext::match_type = end_match_type
+            end_match_type resolve_match_type = end_base
+
+            # Build covered set
+            Set::new (Set[str]) = covered_set
+            0 = covered_index
+            while covered_index match_ctx MatchContext::branch_records .length > do
+                covered_index match_ctx MatchContext::branch_records .get = record
+                if record "__covered:" str::starts_with then
+                    record 10 record .length 10 - str::substring covered_set .add = covered_set
+                fi
+                1 += covered_index
+            done
+            MATCH_WILDCARD covered_set .has = has_wildcard
+
+            # Check exhaustiveness
+            if end_base tc.store.enums .get .is_some has_wildcard ! && then
+                end_base tc.store.enums .get .unwrap = end_enum
+                List::new (List[str]) = missing
+                0 = variant_index
+                while variant_index end_enum CasaEnum::variants .length > do
+                    variant_index end_enum CasaEnum::variants .get = variant_name
+                    if variant_name covered_set .has ! then
+                        variant_name missing .push
+                    fi
+                    1 += variant_index
+                done
+                if 0 missing .length != then
+                    StringBuilder::new = missing_builder
+                    0 = missing_index
+                    while missing_index missing .length > do
+                        if 0 missing_index != then ", " missing_builder .append fi
+                        f"`{end_base}::{missing_index missing .get}`" missing_builder .append
+                        1 += missing_index
+                    done
+                    op Op::location f"Non-exhaustive match, missing arms: {missing_builder .build}" ErrorKind::TypeMismatch raise_error
                 fi
             fi
-        fi
+            if end_base tc.store.structs .get .is_some has_wildcard ! && then
+                if end_base covered_set .has ! then
+                    op Op::location f"Non-exhaustive match on struct `{end_match_type}`" ErrorKind::TypeMismatch raise_error
+                fi
+            fi
+            # Literal exhaustiveness
+            if
+                "bool" end_base ==
+                "int" end_base == ||
+                "char" end_base == ||
+                "str" end_base == ||
+            then
+                if has_wildcard ! then
+                    if "bool" end_base == then
+                        List::new (List[str]) = bool_missing
+                        if "true" covered_set .has ! then "true" bool_missing .push fi
+                        if "false" covered_set .has ! then "false" bool_missing .push fi
+                        if 0 bool_missing .length != then
+                            op Op::location "Non-exhaustive match on `bool`" ErrorKind::TypeMismatch raise_error
+                        fi
+                    else
+                        op Op::location f"Non-exhaustive match on type `{end_base}`. A wildcard `_` arm is required" ErrorKind::TypeMismatch raise_error
+                    fi
+                fi
+            fi
 
-        # Apply final stack state
-        branched_stack BranchedStack::before = before
-        branched_stack BranchedStack::after = after
-        # When stack == before and before == after, nothing changed
-        if tc TypeChecker::live TypedStack::types before stacks_equal before after stacks_equal && then
-            return
+            # Apply final stack state
+            match_ctx MatchContext::before = final_before
+            match_ctx MatchContext::after = final_after
+            # When stack == before and before == after, nothing changed
+            if final_before tc TypeChecker::live ts_equals final_after final_before ts_equals && then
+                return
+            fi
+            # When stack == before but after differs (e.g. wildcard-only match),
+            # accept the after state directly
+            if final_before tc TypeChecker::live ts_equals final_after final_before ts_equals ! && then
+                final_after tc TypeChecker::live ts_restore
+                return
+            fi
+            final_after tc TypeChecker::live ts_unify_types = unified
+            if 0 unified .length != then
+                final_after tc TypeChecker::live ts_restore
+                unified tc TypeChecker::live TypedStack::set_types
+                return
+            fi
+            op Op::location "Match arms have incompatible stack effects" ErrorKind::StackMismatch add_error
         fi
-        # When stack == before but after differs (e.g. wildcard-only match),
-        # accept the after state directly
-        if tc TypeChecker::live TypedStack::types before stacks_equal before after stacks_equal ! && then
-            after tc TypeChecker::live TypedStack::set_types
-            branched_stack BranchedStack::after_origins copy_location_list tc TypeChecker::live TypedStack::set_origins
-            return
-        fi
-        tc TypeChecker::live TypedStack::types after stacks_compatible = unified
-        if 0 unified .length != then
-            unified tc TypeChecker::live TypedStack::set_types
-            branched_stack BranchedStack::after_origins copy_location_list tc TypeChecker::live TypedStack::set_origins
-            return
-        fi
-        op Op::location "Match arms have incompatible stack effects" ErrorKind::StackMismatch add_error
     fi
 }
 

--- a/compiler/typechecker.casa
+++ b/compiler/typechecker.casa
@@ -79,7 +79,6 @@ struct MatchContext {
     before:                  TypedStack
     after:                   TypedStack
     condition_present:       bool
-    default_present:         bool
     branch_records:          List[str]
     match_type:              str
     current_branch_label:    str
@@ -114,7 +113,6 @@ fn make_match_context match_type:str -> MatchContext {
     ""
     match_type
     List::new (List[str])
-    true      # default_present — starts true; cleared when a non-wildcard arm is seen
     false
     ts_new
     ts_new
@@ -1729,6 +1727,11 @@ fn check_match tc:TypeChecker op:Op function_opt:Option[Function] {
     if OpKind::OpMatchStart kind == then
         tc stack_pop = match_type
         match_type make_match_context = match_ctx
+        # Snapshot the entry stack state eagerly so that an OpFnReturn visiting
+        # this frame before any OpMatchArm still finds a correct `before` to
+        # restore from. Matches the pre-refactor make_branched_stack behavior.
+        tc TypeChecker::live match_ctx MatchContext::before ts_restore
+        tc TypeChecker::live match_ctx MatchContext::after ts_restore
         op Op::location match_ctx MatchContext::set_current_branch_location
         match_ctx BranchFrame::BranchMatch = match_frame
         match_frame tc TypeChecker::branched_stacks .push

--- a/compiler/typechecker.casa
+++ b/compiler/typechecker.casa
@@ -5,6 +5,21 @@
 # lexer.casa, and parser.casa.
 
 # ============================================================================
+# TypedStack — pair of (types, origins) lists tracked by the type checker
+# ============================================================================
+
+struct TypedStack {
+    types:   List[str]
+    origins: List[Location]
+}
+
+fn ts_new -> TypedStack {
+    List::new (List[Location])
+    List::new (List[str])
+    TypedStack
+}
+
+# ============================================================================
 # BranchedStack — tracks stack state across conditional and loop branches
 # ============================================================================
 
@@ -60,8 +75,7 @@ fn make_branched_stack stack:List[str] origins:List[Location] -> BranchedStack {
 # ============================================================================
 
 struct TypeChecker {
-    stack:               List[str]
-    stack_origins:       List[Location]
+    live:                TypedStack
     parameters:          List[Parameter]
     return_types:        List[str]
     has_return_types:    bool
@@ -83,8 +97,7 @@ fn make_typechecker store:SymbolStore -> TypeChecker {
     false                            # has_return_types
     List::new (List[str])            # return_types
     List::new (List[Parameter])      # parameters
-    List::new (List[Location])       # stack_origins
-    List::new (List[str])            # stack
+    ts_new                           # live
     TypeChecker
 }
 
@@ -93,38 +106,38 @@ fn make_typechecker store:SymbolStore -> TypeChecker {
 # ============================================================================
 
 fn stack_push tc:TypeChecker typ:str {
-    typ tc TypeChecker::stack .push
-    tc TypeChecker::current_location tc TypeChecker::stack_origins .push
+    typ tc TypeChecker::live TypedStack::types .push
+    tc TypeChecker::current_location tc TypeChecker::live TypedStack::origins .push
 }
 
 fn stack_push_origin tc:TypeChecker typ:str origin:Location {
-    typ tc TypeChecker::stack .push
-    origin tc TypeChecker::stack_origins .push
+    typ tc TypeChecker::live TypedStack::types .push
+    origin tc TypeChecker::live TypedStack::origins .push
 }
 
 fn stack_peek tc:TypeChecker -> str {
-    if 0 tc TypeChecker::stack .length == then
+    if 0 tc TypeChecker::live TypedStack::types .length == then
         ANY_TYPE return
     fi
-    tc TypeChecker::stack .length 1 - tc TypeChecker::stack .get
+    tc TypeChecker::live TypedStack::types .length 1 - tc TypeChecker::live TypedStack::types .get
 }
 
 fn stack_pop tc:TypeChecker -> str {
-    if 0 tc TypeChecker::stack .length == then
+    if 0 tc TypeChecker::live TypedStack::types .length == then
         ANY_TYPE make_param tc TypeChecker::parameters .push
         ANY_TYPE return
     fi
-    tc TypeChecker::stack_origins .pop drop
-    tc TypeChecker::stack .pop
+    tc TypeChecker::live TypedStack::origins .pop drop
+    tc TypeChecker::live TypedStack::types .pop
 }
 
 fn expect_type tc:TypeChecker expected:str -> str {
-    if 0 tc TypeChecker::stack .length == then
+    if 0 tc TypeChecker::live TypedStack::types .length == then
         expected make_param tc TypeChecker::parameters .push
         expected return
     fi
-    tc TypeChecker::stack_origins .pop = et_origin
-    tc TypeChecker::stack .pop = et_actual
+    tc TypeChecker::live TypedStack::origins .pop = et_origin
+    tc TypeChecker::live TypedStack::types .pop = et_actual
     # Check if types are compatible
     if expected et_actual types_match then
         et_actual return
@@ -907,7 +920,7 @@ fn check_push_var tc:TypeChecker op:Op function_opt:Option[Function] {
 fn check_if_block tc:TypeChecker op:Op {
     op Op::kind = kind
     if OpKind::OpIfStart kind == then
-        tc TypeChecker::stack_origins tc TypeChecker::stack make_branched_stack = branched
+        tc TypeChecker::live TypedStack::origins tc TypeChecker::live TypedStack::types make_branched_stack = branched
         op Op::location branched BranchedStack::set_current_branch_location
         branched tc TypeChecker::branched_stacks .push
         true tc TypeChecker::set_in_branch_condition
@@ -918,10 +931,10 @@ fn check_if_block tc:TypeChecker op:Op {
         tc TypeChecker::branched_stacks .length 1 - tc TypeChecker::branched_stacks .get = branched_stack
         if branched_stack BranchedStack::condition_present ! then
             true branched_stack BranchedStack::set_condition_present
-            tc TypeChecker::stack copy_str_list branched_stack BranchedStack::set_before
-            tc TypeChecker::stack_origins copy_location_list branched_stack BranchedStack::set_before_origins
-            tc TypeChecker::stack copy_str_list branched_stack BranchedStack::set_after
-            tc TypeChecker::stack_origins copy_location_list branched_stack BranchedStack::set_after_origins
+            tc TypeChecker::live TypedStack::types copy_str_list branched_stack BranchedStack::set_before
+            tc TypeChecker::live TypedStack::origins copy_location_list branched_stack BranchedStack::set_before_origins
+            tc TypeChecker::live TypedStack::types copy_str_list branched_stack BranchedStack::set_after
+            tc TypeChecker::live TypedStack::origins copy_location_list branched_stack BranchedStack::set_after_origins
             "if" branched_stack BranchedStack::set_current_branch_label
         fi
     elif
@@ -938,23 +951,23 @@ fn check_if_block tc:TypeChecker op:Op {
         fi
         branched_stack BranchedStack::before = before
         branched_stack BranchedStack::after = after
-        if tc TypeChecker::stack before stacks_equal before after stacks_equal && then
+        if tc TypeChecker::live TypedStack::types before stacks_equal before after stacks_equal && then
             op Op::location branched_stack BranchedStack::set_current_branch_location
             return
         fi
-        tc TypeChecker::stack after stacks_compatible = unified
+        tc TypeChecker::live TypedStack::types after stacks_compatible = unified
         if 0 unified .length != before after stacks_equal ! && then
             unified branched_stack BranchedStack::set_after
-            before copy_str_list tc TypeChecker::set_stack
-            branched_stack BranchedStack::before_origins copy_location_list tc TypeChecker::set_stack_origins
+            before copy_str_list tc TypeChecker::live TypedStack::set_types
+            branched_stack BranchedStack::before_origins copy_location_list tc TypeChecker::live TypedStack::set_origins
             op Op::location branched_stack BranchedStack::set_current_branch_location
             return
         fi
         if before after stacks_equal then
-            tc TypeChecker::stack copy_str_list branched_stack BranchedStack::set_after
-            tc TypeChecker::stack_origins copy_location_list branched_stack BranchedStack::set_after_origins
-            before copy_str_list tc TypeChecker::set_stack
-            branched_stack BranchedStack::before_origins copy_location_list tc TypeChecker::set_stack_origins
+            tc TypeChecker::live TypedStack::types copy_str_list branched_stack BranchedStack::set_after
+            tc TypeChecker::live TypedStack::origins copy_location_list branched_stack BranchedStack::set_after_origins
+            before copy_str_list tc TypeChecker::live TypedStack::set_types
+            branched_stack BranchedStack::before_origins copy_location_list tc TypeChecker::live TypedStack::set_origins
             op Op::location branched_stack BranchedStack::set_current_branch_location
             return
         fi
@@ -963,19 +976,19 @@ fn check_if_block tc:TypeChecker op:Op {
         tc TypeChecker::branched_stacks .pop = branched_stack
         branched_stack BranchedStack::before = before
         branched_stack BranchedStack::after = after
-        if tc TypeChecker::stack before stacks_equal before after stacks_equal && then
+        if tc TypeChecker::live TypedStack::types before stacks_equal before after stacks_equal && then
             return
         fi
-        tc TypeChecker::stack after stacks_compatible = unified
+        tc TypeChecker::live TypedStack::types after stacks_compatible = unified
         if 0 unified .length != branched_stack BranchedStack::default_present && then
-            unified tc TypeChecker::set_stack
-            branched_stack BranchedStack::after_origins copy_location_list tc TypeChecker::set_stack_origins
+            unified tc TypeChecker::live TypedStack::set_types
+            branched_stack BranchedStack::after_origins copy_location_list tc TypeChecker::live TypedStack::set_origins
             return
         fi
-        tc TypeChecker::stack before stacks_compatible = unified_before
+        tc TypeChecker::live TypedStack::types before stacks_compatible = unified_before
         if 0 unified_before .length != branched_stack BranchedStack::default_present ! && then
-            unified_before tc TypeChecker::set_stack
-            branched_stack BranchedStack::before_origins copy_location_list tc TypeChecker::set_stack_origins
+            unified_before tc TypeChecker::live TypedStack::set_types
+            branched_stack BranchedStack::before_origins copy_location_list tc TypeChecker::live TypedStack::set_origins
             return
         fi
         op Op::location "Branches have incompatible stack effects" ErrorKind::StackMismatch add_error
@@ -989,7 +1002,7 @@ fn check_if_block tc:TypeChecker op:Op {
 fn check_while_block tc:TypeChecker op:Op {
     op Op::kind = kind
     if OpKind::OpWhileStart kind == then
-        tc TypeChecker::stack_origins tc TypeChecker::stack make_branched_stack = branched
+        tc TypeChecker::live TypedStack::origins tc TypeChecker::live TypedStack::types make_branched_stack = branched
         branched tc TypeChecker::branched_stacks .push
     elif OpKind::OpWhileCondition kind == then
         "bool" tc expect_type drop
@@ -1258,13 +1271,13 @@ fn inject_trait_fn_ptrs tc:TypeChecker sig:Signature ops:List[Op] op_index:int l
     done
 
     # Peek at stack to bind type variables
-    tc TypeChecker::stack .length = depth
+    tc TypeChecker::live TypedStack::types .length = depth
     0 = index
     while index non_hidden .length > do
         depth 1 - index - = stack_index
         if 0 stack_index >= then
             index non_hidden .get = stack_param
-            stack_index tc TypeChecker::stack .get = actual
+            stack_index tc TypeChecker::live TypedStack::types .get = actual
             if stack_param Parameter::typ sig Signature::type_vars .has then
                 stack_param Parameter::typ = binding_type_var
                 binding_type_var bindings .get = existing_binding_opt
@@ -1426,12 +1439,12 @@ fn check_function_ops tc:TypeChecker op:Op ops:List[Op] op_index:int function_op
     elif OpKind::OpFnReturn kind == then
         if tc TypeChecker::has_return_types ! then
             true tc TypeChecker::set_has_return_types
-            tc TypeChecker::stack copy_str_list tc TypeChecker::set_return_types
+            tc TypeChecker::live TypedStack::types copy_str_list tc TypeChecker::set_return_types
         fi
         if 0 tc TypeChecker::branched_stacks .length != then
             tc TypeChecker::branched_stacks .length 1 - tc TypeChecker::branched_stacks .get = branched_stack
-            branched_stack BranchedStack::before copy_str_list tc TypeChecker::set_stack
-            branched_stack BranchedStack::before_origins copy_location_list tc TypeChecker::set_stack_origins
+            branched_stack BranchedStack::before copy_str_list tc TypeChecker::live TypedStack::set_types
+            branched_stack BranchedStack::before_origins copy_location_list tc TypeChecker::live TypedStack::set_origins
         fi
     fi
     op_index
@@ -1652,7 +1665,7 @@ fn check_match tc:TypeChecker op:Op function_opt:Option[Function] {
     op Op::kind = kind
     if OpKind::OpMatchStart kind == then
         tc stack_pop = match_type
-        tc TypeChecker::stack_origins tc TypeChecker::stack make_branched_stack = branched
+        tc TypeChecker::live TypedStack::origins tc TypeChecker::live TypedStack::types make_branched_stack = branched
         match_type branched BranchedStack::set_match_type
         true branched BranchedStack::set_default_present
         branched tc TypeChecker::branched_stacks .push
@@ -1725,29 +1738,29 @@ fn check_match tc:TypeChecker op:Op function_opt:Option[Function] {
                 branched_stack BranchedStack::current_branch_label branched_stack BranchedStack::branch_records .push
             fi
             if
-                tc TypeChecker::stack branched_stack BranchedStack::before stacks_equal
+                tc TypeChecker::live TypedStack::types branched_stack BranchedStack::before stacks_equal
                 branched_stack BranchedStack::before branched_stack BranchedStack::after stacks_equal &&
             then
                 0 drop
             else
-                tc TypeChecker::stack branched_stack BranchedStack::after stacks_compatible = unified
+                tc TypeChecker::live TypedStack::types branched_stack BranchedStack::after stacks_compatible = unified
                 if 0 unified .length != branched_stack BranchedStack::before branched_stack BranchedStack::after stacks_equal ! && then
                     unified branched_stack BranchedStack::set_after
                 elif branched_stack BranchedStack::before branched_stack BranchedStack::after stacks_equal then
-                    tc TypeChecker::stack copy_str_list branched_stack BranchedStack::set_after
-                    tc TypeChecker::stack_origins copy_location_list branched_stack BranchedStack::set_after_origins
+                    tc TypeChecker::live TypedStack::types copy_str_list branched_stack BranchedStack::set_after
+                    tc TypeChecker::live TypedStack::origins copy_location_list branched_stack BranchedStack::set_after_origins
                 else
                     op Op::location "Match arms have incompatible stack effects" ErrorKind::StackMismatch add_error
                 fi
             fi
-            branched_stack BranchedStack::before copy_str_list tc TypeChecker::set_stack
-            branched_stack BranchedStack::before_origins copy_location_list tc TypeChecker::set_stack_origins
+            branched_stack BranchedStack::before copy_str_list tc TypeChecker::live TypedStack::set_types
+            branched_stack BranchedStack::before_origins copy_location_list tc TypeChecker::live TypedStack::set_origins
         else
             true branched_stack BranchedStack::set_condition_present
-            tc TypeChecker::stack copy_str_list branched_stack BranchedStack::set_before
-            tc TypeChecker::stack_origins copy_location_list branched_stack BranchedStack::set_before_origins
-            tc TypeChecker::stack copy_str_list branched_stack BranchedStack::set_after
-            tc TypeChecker::stack_origins copy_location_list branched_stack BranchedStack::set_after_origins
+            tc TypeChecker::live TypedStack::types copy_str_list branched_stack BranchedStack::set_before
+            tc TypeChecker::live TypedStack::origins copy_location_list branched_stack BranchedStack::set_before_origins
+            tc TypeChecker::live TypedStack::types copy_str_list branched_stack BranchedStack::set_after
+            tc TypeChecker::live TypedStack::origins copy_location_list branched_stack BranchedStack::set_after_origins
         fi
 
         # Set types on pattern bindings
@@ -1828,23 +1841,23 @@ fn check_match tc:TypeChecker op:Op function_opt:Option[Function] {
         # Record last arm stack effect (same logic as next-arm recording)
         if branched_stack BranchedStack::condition_present then
             if
-                tc TypeChecker::stack branched_stack BranchedStack::before stacks_equal
+                tc TypeChecker::live TypedStack::types branched_stack BranchedStack::before stacks_equal
                 branched_stack BranchedStack::before branched_stack BranchedStack::after stacks_equal &&
             then
                 0 drop
             else
-                tc TypeChecker::stack branched_stack BranchedStack::after stacks_compatible = last_unified
+                tc TypeChecker::live TypedStack::types branched_stack BranchedStack::after stacks_compatible = last_unified
                 if 0 last_unified .length != branched_stack BranchedStack::before branched_stack BranchedStack::after stacks_equal ! && then
                     last_unified branched_stack BranchedStack::set_after
                 elif branched_stack BranchedStack::before branched_stack BranchedStack::after stacks_equal then
-                    tc TypeChecker::stack copy_str_list branched_stack BranchedStack::set_after
-                    tc TypeChecker::stack_origins copy_location_list branched_stack BranchedStack::set_after_origins
+                    tc TypeChecker::live TypedStack::types copy_str_list branched_stack BranchedStack::set_after
+                    tc TypeChecker::live TypedStack::origins copy_location_list branched_stack BranchedStack::set_after_origins
                 else
                     op Op::location "Match arms have incompatible stack effects" ErrorKind::StackMismatch add_error
                 fi
             fi
-            branched_stack BranchedStack::before copy_str_list tc TypeChecker::set_stack
-            branched_stack BranchedStack::before_origins copy_location_list tc TypeChecker::set_stack_origins
+            branched_stack BranchedStack::before copy_str_list tc TypeChecker::live TypedStack::set_types
+            branched_stack BranchedStack::before_origins copy_location_list tc TypeChecker::live TypedStack::set_origins
         fi
 
         branched_stack BranchedStack::match_type = end_match_type
@@ -1915,20 +1928,20 @@ fn check_match tc:TypeChecker op:Op function_opt:Option[Function] {
         branched_stack BranchedStack::before = before
         branched_stack BranchedStack::after = after
         # When stack == before and before == after, nothing changed
-        if tc TypeChecker::stack before stacks_equal before after stacks_equal && then
+        if tc TypeChecker::live TypedStack::types before stacks_equal before after stacks_equal && then
             return
         fi
         # When stack == before but after differs (e.g. wildcard-only match),
         # accept the after state directly
-        if tc TypeChecker::stack before stacks_equal before after stacks_equal ! && then
-            after tc TypeChecker::set_stack
-            branched_stack BranchedStack::after_origins copy_location_list tc TypeChecker::set_stack_origins
+        if tc TypeChecker::live TypedStack::types before stacks_equal before after stacks_equal ! && then
+            after tc TypeChecker::live TypedStack::set_types
+            branched_stack BranchedStack::after_origins copy_location_list tc TypeChecker::live TypedStack::set_origins
             return
         fi
-        tc TypeChecker::stack after stacks_compatible = unified
+        tc TypeChecker::live TypedStack::types after stacks_compatible = unified
         if 0 unified .length != then
-            unified tc TypeChecker::set_stack
-            branched_stack BranchedStack::after_origins copy_location_list tc TypeChecker::set_stack_origins
+            unified tc TypeChecker::live TypedStack::set_types
+            branched_stack BranchedStack::after_origins copy_location_list tc TypeChecker::live TypedStack::set_origins
             return
         fi
         op Op::location "Match arms have incompatible stack effects" ErrorKind::StackMismatch add_error
@@ -2439,7 +2452,7 @@ fn type_check_ops ops:List[Op] function_opt:Option[Function] -> Signature {
     done
 
     # Build inferred signature
-    checker TypeChecker::stack checker TypeChecker::parameters make_signature = inferred
+    checker TypeChecker::live TypedStack::types checker TypeChecker::parameters make_signature = inferred
 
     # Verify against declared signature if function has one
     ERRORS .length errors_before_ops < = had_type_errors

--- a/tests/compiler/test_typechecker.casa
+++ b/tests/compiler/test_typechecker.casa
@@ -110,6 +110,24 @@ fn tc_check ops:List[Op] -> TypeChecker {
             "int" helper_tc stack_push
         elif OpKind::OpArgv helper_kind == then
             "ptr" helper_tc stack_push
+        # Branch ops — routed to real handlers so tests can exercise the
+        # BranchFrame sum type and the if/while/match branch algebra.
+        elif
+            OpKind::OpIfStart helper_kind ==
+            OpKind::OpIfCondition helper_kind == ||
+            OpKind::OpIfElif helper_kind == ||
+            OpKind::OpIfElse helper_kind == ||
+            OpKind::OpIfEnd helper_kind == ||
+        then
+            helper_op helper_tc check_if_block
+        elif
+            OpKind::OpWhileStart helper_kind ==
+            OpKind::OpWhileCondition helper_kind == ||
+            OpKind::OpWhileBreak helper_kind == ||
+            OpKind::OpWhileContinue helper_kind == ||
+            OpKind::OpWhileEnd helper_kind == ||
+        then
+            helper_op helper_tc check_while_block
         fi
 
         1 += helper_i
@@ -1580,6 +1598,157 @@ fn test_error_str_lt_comparison {
 }
 
 # ============================================================================
+# Tests: Branch frame machinery (RFC #81)
+# ============================================================================
+
+# An `if true then fi` block with an empty body leaves the live stack unchanged
+# and pops the BranchIf frame cleanly.
+fn test_branch_if_empty_body {
+    "branch_if_empty_body" test_start
+    List::new (List[Op]) = ops
+    empty_location OpKind::OpIfStart 0 make_op ops .push
+    empty_location OpKind::OpPushBool 1 make_op ops .push
+    empty_location OpKind::OpIfCondition 0 make_op ops .push
+    empty_location OpKind::OpIfEnd 0 make_op ops .push
+    ops tc_check = result_tc
+    "live empty after empty if" 0 result_tc TypeChecker::live TypedStack::types .length assert_eq
+    "frame stack empty" 0 result_tc TypeChecker::branched_stacks .length assert_eq
+}
+
+# `if cond then push_int else push_int fi` unifies to a single `int` on the live stack.
+fn test_branch_if_else_agree_int {
+    "branch_if_else_agree_int" test_start
+    List::new (List[Op]) = ops
+    empty_location OpKind::OpIfStart 0 make_op ops .push
+    empty_location OpKind::OpPushBool 1 make_op ops .push
+    empty_location OpKind::OpIfCondition 0 make_op ops .push
+    empty_location OpKind::OpPushInt 10 make_op ops .push
+    empty_location OpKind::OpIfElse 0 make_op ops .push
+    empty_location OpKind::OpPushInt 20 make_op ops .push
+    empty_location OpKind::OpIfEnd 0 make_op ops .push
+    ops tc_check = result_tc
+    "live has one item" 1 result_tc TypeChecker::live TypedStack::types .length assert_eq
+    "unified type is int" "int" 0 result_tc TypeChecker::live TypedStack::types .get assert_str_eq
+    "frame stack empty" 0 result_tc TypeChecker::branched_stacks .length assert_eq
+}
+
+# OpIfEnd must pop the BranchFrame from branched_stacks.
+fn test_branch_if_end_pops_frame {
+    "branch_if_end_pops_frame" test_start
+    List::new (List[Op]) = ops
+    empty_location OpKind::OpIfStart 0 make_op ops .push
+    empty_location OpKind::OpPushBool 1 make_op ops .push
+    empty_location OpKind::OpIfCondition 0 make_op ops .push
+    ops tc_check = result_tc
+    "frame pushed on OpIfStart" 1 result_tc TypeChecker::branched_stacks .length assert_eq
+    # Close the block
+    List::new (List[Op]) = close_ops
+    empty_location OpKind::OpIfEnd 0 make_op close_ops .push
+    0 = ci
+    while ci close_ops .length > do
+        ci close_ops .get result_tc check_if_block
+        1 += ci
+    done
+    "frame popped on OpIfEnd" 0 result_tc TypeChecker::branched_stacks .length assert_eq
+}
+
+# A `while cond do done` with an empty body pushes and pops a BranchWhile frame.
+fn test_branch_while_empty_body {
+    "branch_while_empty_body" test_start
+    List::new (List[Op]) = ops
+    empty_location OpKind::OpWhileStart 0 make_op ops .push
+    empty_location OpKind::OpPushBool 0 make_op ops .push
+    empty_location OpKind::OpWhileCondition 0 make_op ops .push
+    empty_location OpKind::OpWhileEnd 0 make_op ops .push
+    ops tc_check = result_tc
+    "live empty" 0 result_tc TypeChecker::live TypedStack::types .length assert_eq
+    "frame stack empty" 0 result_tc TypeChecker::branched_stacks .length assert_eq
+}
+
+# Direct exercise of the BranchFrame sum type: confirm that the top frame
+# destructures to the right variant and that mutation through the binding
+# persists on the frame stored in branched_stacks.
+fn test_branch_frame_kind_dispatch {
+    "branch_frame_kind_dispatch" test_start
+    make_typechecker = tc
+    List::new (List[Op]) = ops
+    empty_location OpKind::OpIfStart 0 make_op ops .push
+    0 = bd_i
+    while bd_i ops .length > do
+        bd_i ops .get tc check_if_block
+        1 += bd_i
+    done
+    "pushed BranchIf frame" 1 tc TypeChecker::branched_stacks .length assert_eq
+    tc TypeChecker::branched_stacks .length 1 - tc TypeChecker::branched_stacks .get = top_frame
+    false = is_if
+    false = is_while
+    false = is_match
+    if top_frame BranchFrame::BranchIf(bd_if_ctx) is then
+        true = is_if
+        # Mutate through the destructure binding — mutation must persist.
+        true bd_if_ctx IfContext::set_default_present
+    fi
+    if top_frame BranchFrame::BranchWhile(bd_while_ctx) is then
+        true = is_while
+    fi
+    if top_frame BranchFrame::BranchMatch(bd_match_ctx) is then
+        true = is_match
+    fi
+    "top frame is BranchIf" is_if assert_true
+    "top frame is not BranchWhile" is_while assert_false
+    "top frame is not BranchMatch" is_match assert_false
+    # Re-destructure to verify mutation persisted.
+    tc TypeChecker::branched_stacks .length 1 - tc TypeChecker::branched_stacks .get = top_frame2
+    false = default_present_after
+    if top_frame2 BranchFrame::BranchIf(bd_if_ctx2) is then
+        bd_if_ctx2 IfContext::default_present = default_present_after
+    fi
+    "mutation persists through binding" default_present_after assert_true
+}
+
+# OpFnReturn inside a branch restores live from the frame's `before` snapshot.
+fn test_branch_return_inside_if_restores_live {
+    "branch_return_inside_if_restores_live" test_start
+    make_typechecker = tc
+    # Seed the live stack with a single `int`.
+    "int" tc stack_push
+    # Begin an `if true then` block.
+    List::new (List[Op]) = begin_ops
+    empty_location OpKind::OpIfStart 0 make_op begin_ops .push
+    empty_location OpKind::OpPushBool 1 make_op begin_ops .push
+    empty_location OpKind::OpIfCondition 0 make_op begin_ops .push
+    0 = br_i
+    while br_i begin_ops .length > do
+        br_i begin_ops .get = br_op
+        br_op Op::kind = br_kind
+        if
+            OpKind::OpIfStart br_kind ==
+            OpKind::OpIfCondition br_kind == ||
+        then
+            br_op tc check_if_block
+        elif OpKind::OpPushBool br_kind == then
+            "bool" tc stack_push
+        fi
+        1 += br_i
+    done
+    # Body modifies the stack by pushing an extra `str`.
+    "str" tc stack_push
+    "stack grew inside branch" 2 tc TypeChecker::live TypedStack::types .length assert_eq
+    # Simulate OpFnReturn: first visit snapshots live into return_types, then
+    # restores live from the top frame's before snapshot.
+    "has_return_types starts false" tc TypeChecker::has_return_types assert_false
+    tc TypeChecker::live tc TypeChecker::return_types ts_restore
+    true tc TypeChecker::set_has_return_types
+    tc TypeChecker::branched_stacks .length 1 - tc TypeChecker::branched_stacks .get = ret_frame
+    if ret_frame BranchFrame::BranchIf(ret_if_ctx) is then
+        ret_if_ctx IfContext::before tc TypeChecker::live ts_restore
+    fi
+    "live restored to pre-branch state" 1 tc TypeChecker::live TypedStack::types .length assert_eq
+    "restored type is int" "int" 0 tc TypeChecker::live TypedStack::types .get assert_str_eq
+    "return_types snapshot captured full state" 2 tc TypeChecker::return_types TypedStack::types .length assert_eq
+}
+
+# ============================================================================
 # Run all tests
 # ============================================================================
 
@@ -1689,4 +1858,10 @@ test_type_cast_bool_to_int
 test_tc_pipeline_str_equality
 test_error_comparison_str_lt_int
 test_error_str_lt_comparison
+test_branch_if_empty_body
+test_branch_if_else_agree_int
+test_branch_if_end_pops_frame
+test_branch_while_empty_body
+test_branch_frame_kind_dispatch
+test_branch_return_inside_if_restores_live
 test_summary

--- a/tests/compiler/test_typechecker.casa
+++ b/tests/compiler/test_typechecker.casa
@@ -126,8 +126,8 @@ fn test_push_int_stack {
     List::new (List[Op]) = ops
     empty_location OpKind::OpPushInt 42 make_op ops .push
     ops tc_check = result_tc
-    "stack has one item" 1 result_tc TypeChecker::stack .length assert_eq
-    "type is int" "int" 0 result_tc TypeChecker::stack .get assert_str_eq
+    "stack has one item" 1 result_tc TypeChecker::live TypedStack::types .length assert_eq
+    "type is int" "int" 0 result_tc TypeChecker::live TypedStack::types .get assert_str_eq
 }
 
 # ============================================================================
@@ -141,8 +141,8 @@ fn test_add_stack_effect {
     empty_location OpKind::OpPushInt 20 make_op ops .push
     empty_location OpKind::OpAdd 0 make_op ops .push
     ops tc_check = result_tc
-    "stack has one item after add" 1 result_tc TypeChecker::stack .length assert_eq
-    "result type is int" "int" 0 result_tc TypeChecker::stack .get assert_str_eq
+    "stack has one item after add" 1 result_tc TypeChecker::live TypedStack::types .length assert_eq
+    "result type is int" "int" 0 result_tc TypeChecker::live TypedStack::types .get assert_str_eq
 }
 
 # ============================================================================
@@ -158,8 +158,8 @@ fn test_arithmetic_ops {
     empty_location OpKind::OpPushInt 3 make_op ops_sub .push
     empty_location OpKind::OpSub 0 make_op ops_sub .push
     ops_sub tc_check = tc_sub
-    "sub result" 1 tc_sub TypeChecker::stack .length assert_eq
-    "sub type" "int" 0 tc_sub TypeChecker::stack .get assert_str_eq
+    "sub result" 1 tc_sub TypeChecker::live TypedStack::types .length assert_eq
+    "sub type" "int" 0 tc_sub TypeChecker::live TypedStack::types .get assert_str_eq
 
     # Mul
     List::new (List[Op]) = ops_mul
@@ -167,7 +167,7 @@ fn test_arithmetic_ops {
     empty_location OpKind::OpPushInt 3 make_op ops_mul .push
     empty_location OpKind::OpMul 0 make_op ops_mul .push
     ops_mul tc_check = tc_mul
-    "mul type" "int" 0 tc_mul TypeChecker::stack .get assert_str_eq
+    "mul type" "int" 0 tc_mul TypeChecker::live TypedStack::types .get assert_str_eq
 
     # Div
     List::new (List[Op]) = ops_div
@@ -175,7 +175,7 @@ fn test_arithmetic_ops {
     empty_location OpKind::OpPushInt 2 make_op ops_div .push
     empty_location OpKind::OpDiv 0 make_op ops_div .push
     ops_div tc_check = tc_div
-    "div type" "int" 0 tc_div TypeChecker::stack .get assert_str_eq
+    "div type" "int" 0 tc_div TypeChecker::live TypedStack::types .get assert_str_eq
 
     # Mod
     List::new (List[Op]) = ops_mod
@@ -183,7 +183,7 @@ fn test_arithmetic_ops {
     empty_location OpKind::OpPushInt 3 make_op ops_mod .push
     empty_location OpKind::OpMod 0 make_op ops_mod .push
     ops_mod tc_check = tc_mod
-    "mod type" "int" 0 tc_mod TypeChecker::stack .get assert_str_eq
+    "mod type" "int" 0 tc_mod TypeChecker::live TypedStack::types .get assert_str_eq
 }
 
 # ============================================================================
@@ -197,8 +197,8 @@ fn test_comparison_produces_bool {
     empty_location OpKind::OpPushInt 2 make_op ops .push
     empty_location OpKind::OpLt 0 make_op ops .push
     ops tc_check = result_tc
-    "stack after lt" 1 result_tc TypeChecker::stack .length assert_eq
-    "lt result is bool" "bool" 0 result_tc TypeChecker::stack .get assert_str_eq
+    "stack after lt" 1 result_tc TypeChecker::live TypedStack::types .length assert_eq
+    "lt result is bool" "bool" 0 result_tc TypeChecker::live TypedStack::types .get assert_str_eq
 }
 
 # ============================================================================
@@ -213,7 +213,7 @@ fn test_boolean_ops {
     empty_location OpKind::OpPushBool 0 make_op ops_and .push
     empty_location OpKind::OpAnd 0 make_op ops_and .push
     ops_and tc_check = tc_and
-    "and result" "bool" 0 tc_and TypeChecker::stack .get assert_str_eq
+    "and result" "bool" 0 tc_and TypeChecker::live TypedStack::types .get assert_str_eq
 
     # OR
     List::new (List[Op]) = ops_or
@@ -221,14 +221,14 @@ fn test_boolean_ops {
     empty_location OpKind::OpPushBool 0 make_op ops_or .push
     empty_location OpKind::OpOr 0 make_op ops_or .push
     ops_or tc_check = tc_or
-    "or result" "bool" 0 tc_or TypeChecker::stack .get assert_str_eq
+    "or result" "bool" 0 tc_or TypeChecker::live TypedStack::types .get assert_str_eq
 
     # NOT
     List::new (List[Op]) = ops_not
     empty_location OpKind::OpPushBool 1 make_op ops_not .push
     empty_location OpKind::OpNot 0 make_op ops_not .push
     ops_not tc_check = tc_not
-    "not result" "bool" 0 tc_not TypeChecker::stack .get assert_str_eq
+    "not result" "bool" 0 tc_not TypeChecker::live TypedStack::types .get assert_str_eq
 }
 
 # ============================================================================
@@ -241,9 +241,9 @@ fn test_dup_stack_effect {
     empty_location OpKind::OpPushInt 42 make_op ops .push
     empty_location OpKind::OpDup 0 make_op ops .push
     ops tc_check = result_tc
-    "stack after dup" 2 result_tc TypeChecker::stack .length assert_eq
-    "first is int" "int" 0 result_tc TypeChecker::stack .get assert_str_eq
-    "second is int" "int" 1 result_tc TypeChecker::stack .get assert_str_eq
+    "stack after dup" 2 result_tc TypeChecker::live TypedStack::types .length assert_eq
+    "first is int" "int" 0 result_tc TypeChecker::live TypedStack::types .get assert_str_eq
+    "second is int" "int" 1 result_tc TypeChecker::live TypedStack::types .get assert_str_eq
 }
 
 # ============================================================================
@@ -257,9 +257,9 @@ fn test_swap_stack_effect {
     empty_location OpKind::OpPushStr "hello" (int) make_op ops .push
     empty_location OpKind::OpSwap 0 make_op ops .push
     ops tc_check = result_tc
-    "stack after swap" 2 result_tc TypeChecker::stack .length assert_eq
-    "bottom is str" "str" 0 result_tc TypeChecker::stack .get assert_str_eq
-    "top is int" "int" 1 result_tc TypeChecker::stack .get assert_str_eq
+    "stack after swap" 2 result_tc TypeChecker::live TypedStack::types .length assert_eq
+    "bottom is str" "str" 0 result_tc TypeChecker::live TypedStack::types .get assert_str_eq
+    "top is int" "int" 1 result_tc TypeChecker::live TypedStack::types .get assert_str_eq
 }
 
 # ============================================================================
@@ -273,10 +273,10 @@ fn test_over_stack_effect {
     empty_location OpKind::OpPushStr "hello" (int) make_op ops .push
     empty_location OpKind::OpOver 0 make_op ops .push
     ops tc_check = result_tc
-    "stack after over" 3 result_tc TypeChecker::stack .length assert_eq
-    "bottom is int" "int" 0 result_tc TypeChecker::stack .get assert_str_eq
-    "middle is str" "str" 1 result_tc TypeChecker::stack .get assert_str_eq
-    "top is int" "int" 2 result_tc TypeChecker::stack .get assert_str_eq
+    "stack after over" 3 result_tc TypeChecker::live TypedStack::types .length assert_eq
+    "bottom is int" "int" 0 result_tc TypeChecker::live TypedStack::types .get assert_str_eq
+    "middle is str" "str" 1 result_tc TypeChecker::live TypedStack::types .get assert_str_eq
+    "top is int" "int" 2 result_tc TypeChecker::live TypedStack::types .get assert_str_eq
 }
 
 # ============================================================================
@@ -290,8 +290,8 @@ fn test_drop_stack_effect {
     empty_location OpKind::OpPushStr "hello" (int) make_op ops .push
     empty_location OpKind::OpDrop 0 make_op ops .push
     ops tc_check = result_tc
-    "stack after drop" 1 result_tc TypeChecker::stack .length assert_eq
-    "remaining is int" "int" 0 result_tc TypeChecker::stack .get assert_str_eq
+    "stack after drop" 1 result_tc TypeChecker::live TypedStack::types .length assert_eq
+    "remaining is int" "int" 0 result_tc TypeChecker::live TypedStack::types .get assert_str_eq
 }
 
 # ============================================================================
@@ -306,11 +306,11 @@ fn test_rot_stack_effect {
     empty_location OpKind::OpPushBool 1 make_op ops .push
     empty_location OpKind::OpRot 0 make_op ops .push
     ops tc_check = result_tc
-    "stack after rot" 3 result_tc TypeChecker::stack .length assert_eq
+    "stack after rot" 3 result_tc TypeChecker::live TypedStack::types .length assert_eq
     # ROT: pop t1(bool), t2(str), t3(int) -> push t2(str), t1(bool), t3(int)
-    "bottom is str" "str" 0 result_tc TypeChecker::stack .get assert_str_eq
-    "middle is bool" "bool" 1 result_tc TypeChecker::stack .get assert_str_eq
-    "top is int" "int" 2 result_tc TypeChecker::stack .get assert_str_eq
+    "bottom is str" "str" 0 result_tc TypeChecker::live TypedStack::types .get assert_str_eq
+    "middle is bool" "bool" 1 result_tc TypeChecker::live TypedStack::types .get assert_str_eq
+    "top is int" "int" 2 result_tc TypeChecker::live TypedStack::types .get assert_str_eq
 }
 
 # ============================================================================
@@ -323,8 +323,8 @@ fn test_type_cast {
     empty_location OpKind::OpPushInt 42 make_op ops .push
     empty_location OpKind::OpTypeCast "str" (int) make_op ops .push
     ops tc_check = result_tc
-    "stack after cast" 1 result_tc TypeChecker::stack .length assert_eq
-    "cast to str" "str" 0 result_tc TypeChecker::stack .get assert_str_eq
+    "stack after cast" 1 result_tc TypeChecker::live TypedStack::types .length assert_eq
+    "cast to str" "str" 0 result_tc TypeChecker::live TypedStack::types .get assert_str_eq
 }
 
 # ============================================================================
@@ -339,11 +339,11 @@ fn test_push_literals {
     empty_location OpKind::OpPushBool 1 make_op ops .push
     empty_location OpKind::OpPushChar 65 make_op ops .push
     ops tc_check = result_tc
-    "four items on stack" 4 result_tc TypeChecker::stack .length assert_eq
-    "int" "int" 0 result_tc TypeChecker::stack .get assert_str_eq
-    "str" "str" 1 result_tc TypeChecker::stack .get assert_str_eq
-    "bool" "bool" 2 result_tc TypeChecker::stack .get assert_str_eq
-    "char" "char" 3 result_tc TypeChecker::stack .get assert_str_eq
+    "four items on stack" 4 result_tc TypeChecker::live TypedStack::types .length assert_eq
+    "int" "int" 0 result_tc TypeChecker::live TypedStack::types .get assert_str_eq
+    "str" "str" 1 result_tc TypeChecker::live TypedStack::types .get assert_str_eq
+    "bool" "bool" 2 result_tc TypeChecker::live TypedStack::types .get assert_str_eq
+    "char" "char" 3 result_tc TypeChecker::live TypedStack::types .get assert_str_eq
 }
 
 # ============================================================================
@@ -385,8 +385,8 @@ fn test_typeof_effect {
     empty_location OpKind::OpPushInt 42 make_op ops .push
     empty_location OpKind::OpTypeof 0 make_op ops .push
     ops tc_check = result_tc
-    "stack after typeof" 1 result_tc TypeChecker::stack .length assert_eq
-    "typeof result is str" "str" 0 result_tc TypeChecker::stack .get assert_str_eq
+    "stack after typeof" 1 result_tc TypeChecker::live TypedStack::types .length assert_eq
+    "typeof result is str" "str" 0 result_tc TypeChecker::live TypedStack::types .get assert_str_eq
 }
 
 # ============================================================================
@@ -401,7 +401,7 @@ fn test_bitwise_ops {
     empty_location OpKind::OpPushInt 42 make_op ops_bnot .push
     empty_location OpKind::OpBitNot 0 make_op ops_bnot .push
     ops_bnot tc_check = tc_bnot
-    "bitnot result" "int" 0 tc_bnot TypeChecker::stack .get assert_str_eq
+    "bitnot result" "int" 0 tc_bnot TypeChecker::live TypedStack::types .get assert_str_eq
 
     # SHL
     List::new (List[Op]) = ops_shl
@@ -409,7 +409,7 @@ fn test_bitwise_ops {
     empty_location OpKind::OpPushInt 3 make_op ops_shl .push
     empty_location OpKind::OpShl 0 make_op ops_shl .push
     ops_shl tc_check = tc_shl
-    "shl result" "int" 0 tc_shl TypeChecker::stack .get assert_str_eq
+    "shl result" "int" 0 tc_shl TypeChecker::live TypedStack::types .get assert_str_eq
 
     # BIT_AND
     List::new (List[Op]) = ops_band
@@ -417,7 +417,7 @@ fn test_bitwise_ops {
     empty_location OpKind::OpPushInt 1 make_op ops_band .push
     empty_location OpKind::OpBitAnd 0 make_op ops_band .push
     ops_band tc_check = tc_band
-    "bitand result" "int" 0 tc_band TypeChecker::stack .get assert_str_eq
+    "bitand result" "int" 0 tc_band TypeChecker::live TypedStack::types .get assert_str_eq
 }
 
 # ============================================================================
@@ -432,7 +432,7 @@ fn test_memory_ops {
     empty_location OpKind::OpPushInt 100 make_op ops_alloc .push
     empty_location OpKind::OpHeapAlloc 0 make_op ops_alloc .push
     ops_alloc tc_check = tc_alloc
-    "alloc result is ptr" "ptr" 0 tc_alloc TypeChecker::stack .get assert_str_eq
+    "alloc result is ptr" "ptr" 0 tc_alloc TypeChecker::live TypedStack::types .get assert_str_eq
 }
 
 # ============================================================================
@@ -445,9 +445,9 @@ fn test_argc_argv {
     empty_location OpKind::OpArgc 0 make_op ops .push
     empty_location OpKind::OpArgv 0 make_op ops .push
     ops tc_check = result_tc
-    "stack count" 2 result_tc TypeChecker::stack .length assert_eq
-    "argc is int" "int" 0 result_tc TypeChecker::stack .get assert_str_eq
-    "argv is ptr" "ptr" 1 result_tc TypeChecker::stack .get assert_str_eq
+    "stack count" 2 result_tc TypeChecker::live TypedStack::types .length assert_eq
+    "argc is int" "int" 0 result_tc TypeChecker::live TypedStack::types .get assert_str_eq
+    "argv is ptr" "ptr" 1 result_tc TypeChecker::live TypedStack::types .get assert_str_eq
 }
 
 # ============================================================================
@@ -629,7 +629,7 @@ fn test_print_pops_stack {
     empty_location OpKind::OpPushInt 42 make_op ops .push
     empty_location OpKind::OpPrint 0 make_op ops .push
     ops tc_check = result_tc
-    "stack empty after print" 0 result_tc TypeChecker::stack .length assert_eq
+    "stack empty after print" 0 result_tc TypeChecker::live TypedStack::types .length assert_eq
 }
 
 # ============================================================================
@@ -642,7 +642,7 @@ fn test_typeof_str {
     empty_location OpKind::OpPushStr "hi" (int) make_op ops .push
     empty_location OpKind::OpTypeof 0 make_op ops .push
     ops tc_check = result_tc
-    "typeof str result" "str" 0 result_tc TypeChecker::stack .get assert_str_eq
+    "typeof str result" "str" 0 result_tc TypeChecker::live TypedStack::types .get assert_str_eq
 }
 
 fn test_typeof_bool {
@@ -651,7 +651,7 @@ fn test_typeof_bool {
     empty_location OpKind::OpPushBool 1 make_op ops .push
     empty_location OpKind::OpTypeof 0 make_op ops .push
     ops tc_check = result_tc
-    "typeof bool result" "str" 0 result_tc TypeChecker::stack .get assert_str_eq
+    "typeof bool result" "str" 0 result_tc TypeChecker::live TypedStack::types .get assert_str_eq
 }
 
 # ============================================================================
@@ -667,7 +667,7 @@ fn test_all_comparison_ops {
     empty_location OpKind::OpPushInt 1 make_op ops_eq .push
     empty_location OpKind::OpEq 0 make_op ops_eq .push
     ops_eq tc_check = tc_eq
-    "eq is bool" "bool" 0 tc_eq TypeChecker::stack .get assert_str_eq
+    "eq is bool" "bool" 0 tc_eq TypeChecker::live TypedStack::types .get assert_str_eq
 
     # Ne
     List::new (List[Op]) = ops_ne
@@ -675,7 +675,7 @@ fn test_all_comparison_ops {
     empty_location OpKind::OpPushInt 2 make_op ops_ne .push
     empty_location OpKind::OpNe 0 make_op ops_ne .push
     ops_ne tc_check = tc_ne
-    "ne is bool" "bool" 0 tc_ne TypeChecker::stack .get assert_str_eq
+    "ne is bool" "bool" 0 tc_ne TypeChecker::live TypedStack::types .get assert_str_eq
 
     # Le
     List::new (List[Op]) = ops_le
@@ -683,7 +683,7 @@ fn test_all_comparison_ops {
     empty_location OpKind::OpPushInt 2 make_op ops_le .push
     empty_location OpKind::OpLe 0 make_op ops_le .push
     ops_le tc_check = tc_le
-    "le is bool" "bool" 0 tc_le TypeChecker::stack .get assert_str_eq
+    "le is bool" "bool" 0 tc_le TypeChecker::live TypedStack::types .get assert_str_eq
 
     # Ge
     List::new (List[Op]) = ops_ge
@@ -691,7 +691,7 @@ fn test_all_comparison_ops {
     empty_location OpKind::OpPushInt 2 make_op ops_ge .push
     empty_location OpKind::OpGe 0 make_op ops_ge .push
     ops_ge tc_check = tc_ge
-    "ge is bool" "bool" 0 tc_ge TypeChecker::stack .get assert_str_eq
+    "ge is bool" "bool" 0 tc_ge TypeChecker::live TypedStack::types .get assert_str_eq
 
     # Gt
     List::new (List[Op]) = ops_gt
@@ -699,7 +699,7 @@ fn test_all_comparison_ops {
     empty_location OpKind::OpPushInt 2 make_op ops_gt .push
     empty_location OpKind::OpGt 0 make_op ops_gt .push
     ops_gt tc_check = tc_gt
-    "gt is bool" "bool" 0 tc_gt TypeChecker::stack .get assert_str_eq
+    "gt is bool" "bool" 0 tc_gt TypeChecker::live TypedStack::types .get assert_str_eq
 }
 
 # ============================================================================
@@ -713,7 +713,7 @@ fn test_string_comparison_annotation {
     empty_location OpKind::OpPushStr "b" (int) make_op ops .push
     empty_location OpKind::OpEq 0 make_op ops .push
     ops tc_check = result_tc
-    "str cmp is bool" "bool" 0 result_tc TypeChecker::stack .get assert_str_eq
+    "str cmp is bool" "bool" 0 result_tc TypeChecker::live TypedStack::types .get assert_str_eq
     "annotation is str" "str" 2 ops .get Op::type_annotation assert_str_eq
 }
 
@@ -728,7 +728,7 @@ fn test_bitwise_shr {
     empty_location OpKind::OpPushInt 2 make_op ops .push
     empty_location OpKind::OpShr 0 make_op ops .push
     ops tc_check = result_tc
-    "shr result" "int" 0 result_tc TypeChecker::stack .get assert_str_eq
+    "shr result" "int" 0 result_tc TypeChecker::live TypedStack::types .get assert_str_eq
 }
 
 fn test_bitwise_or {
@@ -738,7 +738,7 @@ fn test_bitwise_or {
     empty_location OpKind::OpPushInt 3 make_op ops .push
     empty_location OpKind::OpBitOr 0 make_op ops .push
     ops tc_check = result_tc
-    "bitor result" "int" 0 result_tc TypeChecker::stack .get assert_str_eq
+    "bitor result" "int" 0 result_tc TypeChecker::live TypedStack::types .get assert_str_eq
 }
 
 fn test_bitwise_xor {
@@ -748,7 +748,7 @@ fn test_bitwise_xor {
     empty_location OpKind::OpPushInt 3 make_op ops .push
     empty_location OpKind::OpBitXor 0 make_op ops .push
     ops tc_check = result_tc
-    "bitxor result" "int" 0 result_tc TypeChecker::stack .get assert_str_eq
+    "bitxor result" "int" 0 result_tc TypeChecker::live TypedStack::types .get assert_str_eq
 }
 
 # ============================================================================
@@ -764,7 +764,7 @@ fn test_memory_load_sizes {
     empty_location OpKind::OpHeapAlloc 0 make_op ops8 .push
     empty_location OpKind::OpLoad8 0 make_op ops8 .push
     ops8 tc_check = tc8
-    "load8 result" "int" 0 tc8 TypeChecker::stack .get assert_str_eq
+    "load8 result" "int" 0 tc8 TypeChecker::live TypedStack::types .get assert_str_eq
 
     # load16
     List::new (List[Op]) = ops16
@@ -772,7 +772,7 @@ fn test_memory_load_sizes {
     empty_location OpKind::OpHeapAlloc 0 make_op ops16 .push
     empty_location OpKind::OpLoad16 0 make_op ops16 .push
     ops16 tc_check = tc16
-    "load16 result" "int" 0 tc16 TypeChecker::stack .get assert_str_eq
+    "load16 result" "int" 0 tc16 TypeChecker::live TypedStack::types .get assert_str_eq
 
     # load32
     List::new (List[Op]) = ops32
@@ -780,7 +780,7 @@ fn test_memory_load_sizes {
     empty_location OpKind::OpHeapAlloc 0 make_op ops32 .push
     empty_location OpKind::OpLoad32 0 make_op ops32 .push
     ops32 tc_check = tc32
-    "load32 result" "int" 0 tc32 TypeChecker::stack .get assert_str_eq
+    "load32 result" "int" 0 tc32 TypeChecker::live TypedStack::types .get assert_str_eq
 }
 
 fn test_memory_store_sizes {
@@ -793,7 +793,7 @@ fn test_memory_store_sizes {
     empty_location OpKind::OpHeapAlloc 0 make_op ops8 .push
     empty_location OpKind::OpStore8 0 make_op ops8 .push
     ops8 tc_check = tc8
-    "store8 empty" 0 tc8 TypeChecker::stack .length assert_eq
+    "store8 empty" 0 tc8 TypeChecker::live TypedStack::types .length assert_eq
 
     # store16
     List::new (List[Op]) = ops16
@@ -802,7 +802,7 @@ fn test_memory_store_sizes {
     empty_location OpKind::OpHeapAlloc 0 make_op ops16 .push
     empty_location OpKind::OpStore16 0 make_op ops16 .push
     ops16 tc_check = tc16
-    "store16 empty" 0 tc16 TypeChecker::stack .length assert_eq
+    "store16 empty" 0 tc16 TypeChecker::live TypedStack::types .length assert_eq
 
     # store32
     List::new (List[Op]) = ops32
@@ -811,7 +811,7 @@ fn test_memory_store_sizes {
     empty_location OpKind::OpHeapAlloc 0 make_op ops32 .push
     empty_location OpKind::OpStore32 0 make_op ops32 .push
     ops32 tc_check = tc32
-    "store32 empty" 0 tc32 TypeChecker::stack .length assert_eq
+    "store32 empty" 0 tc32 TypeChecker::live TypedStack::types .length assert_eq
 }
 
 # ============================================================================
@@ -1145,7 +1145,7 @@ fn test_memory_store64 {
     empty_location OpKind::OpHeapAlloc 0 make_op ops .push
     empty_location OpKind::OpStore64 0 make_op ops .push
     ops tc_check = result_tc
-    "store64 empty" 0 result_tc TypeChecker::stack .length assert_eq
+    "store64 empty" 0 result_tc TypeChecker::live TypedStack::types .length assert_eq
 }
 
 # ============================================================================
@@ -1201,8 +1201,8 @@ fn test_syscall_op_level {
     empty_location OpKind::OpPushInt 60 make_op ops0 .push
     empty_location OpKind::OpSyscall0 0 make_op ops0 .push
     ops0 tc_check = tc0
-    "syscall0 result" 1 tc0 TypeChecker::stack .length assert_eq
-    "syscall0 type" "int" 0 tc0 TypeChecker::stack .get assert_str_eq
+    "syscall0 result" 1 tc0 TypeChecker::live TypedStack::types .length assert_eq
+    "syscall0 type" "int" 0 tc0 TypeChecker::live TypedStack::types .get assert_str_eq
 
     # syscall1: pops 2 (1 arg + syscall number), pushes int
     List::new (List[Op]) = ops1
@@ -1210,8 +1210,8 @@ fn test_syscall_op_level {
     empty_location OpKind::OpPushInt 60 make_op ops1 .push
     empty_location OpKind::OpSyscall1 0 make_op ops1 .push
     ops1 tc_check = tc1
-    "syscall1 result" 1 tc1 TypeChecker::stack .length assert_eq
-    "syscall1 type" "int" 0 tc1 TypeChecker::stack .get assert_str_eq
+    "syscall1 result" 1 tc1 TypeChecker::live TypedStack::types .length assert_eq
+    "syscall1 type" "int" 0 tc1 TypeChecker::live TypedStack::types .get assert_str_eq
 
     # syscall3: pops 4 (3 args + syscall number), pushes int
     List::new (List[Op]) = ops3
@@ -1221,8 +1221,8 @@ fn test_syscall_op_level {
     empty_location OpKind::OpPushInt 1 make_op ops3 .push
     empty_location OpKind::OpSyscall3 0 make_op ops3 .push
     ops3 tc_check = tc3
-    "syscall3 result" 1 tc3 TypeChecker::stack .length assert_eq
-    "syscall3 type" "int" 0 tc3 TypeChecker::stack .get assert_str_eq
+    "syscall3 result" 1 tc3 TypeChecker::live TypedStack::types .length assert_eq
+    "syscall3 type" "int" 0 tc3 TypeChecker::live TypedStack::types .get assert_str_eq
 }
 
 # ============================================================================
@@ -1235,7 +1235,7 @@ fn test_typeof_char {
     empty_location OpKind::OpPushChar 65 make_op ops .push
     empty_location OpKind::OpTypeof 0 make_op ops .push
     ops tc_check = result_tc
-    "typeof char result" "str" 0 result_tc TypeChecker::stack .get assert_str_eq
+    "typeof char result" "str" 0 result_tc TypeChecker::live TypedStack::types .get assert_str_eq
 }
 
 fn test_typeof_ptr {
@@ -1245,7 +1245,7 @@ fn test_typeof_ptr {
     empty_location OpKind::OpHeapAlloc 0 make_op ops .push
     empty_location OpKind::OpTypeof 0 make_op ops .push
     ops tc_check = result_tc
-    "typeof ptr result" "str" 0 result_tc TypeChecker::stack .get assert_str_eq
+    "typeof ptr result" "str" 0 result_tc TypeChecker::live TypedStack::types .get assert_str_eq
 }
 
 # ============================================================================
@@ -1258,9 +1258,9 @@ fn test_dup_preserves_str {
     empty_location OpKind::OpPushStr "hello" (int) make_op ops .push
     empty_location OpKind::OpDup 0 make_op ops .push
     ops tc_check = result_tc
-    "dup str count" 2 result_tc TypeChecker::stack .length assert_eq
-    "dup str first" "str" 0 result_tc TypeChecker::stack .get assert_str_eq
-    "dup str second" "str" 1 result_tc TypeChecker::stack .get assert_str_eq
+    "dup str count" 2 result_tc TypeChecker::live TypedStack::types .length assert_eq
+    "dup str first" "str" 0 result_tc TypeChecker::live TypedStack::types .get assert_str_eq
+    "dup str second" "str" 1 result_tc TypeChecker::live TypedStack::types .get assert_str_eq
 }
 
 fn test_dup_preserves_bool {
@@ -1269,9 +1269,9 @@ fn test_dup_preserves_bool {
     empty_location OpKind::OpPushBool 1 make_op ops .push
     empty_location OpKind::OpDup 0 make_op ops .push
     ops tc_check = result_tc
-    "dup bool count" 2 result_tc TypeChecker::stack .length assert_eq
-    "dup bool first" "bool" 0 result_tc TypeChecker::stack .get assert_str_eq
-    "dup bool second" "bool" 1 result_tc TypeChecker::stack .get assert_str_eq
+    "dup bool count" 2 result_tc TypeChecker::live TypedStack::types .length assert_eq
+    "dup bool first" "bool" 0 result_tc TypeChecker::live TypedStack::types .get assert_str_eq
+    "dup bool second" "bool" 1 result_tc TypeChecker::live TypedStack::types .get assert_str_eq
 }
 
 # ============================================================================
@@ -1531,8 +1531,8 @@ fn test_type_cast_str_to_int {
     empty_location OpKind::OpPushStr "hello" (int) make_op ops .push
     empty_location OpKind::OpTypeCast "int" (int) make_op ops .push
     ops tc_check = result_tc
-    "cast str to int" 1 result_tc TypeChecker::stack .length assert_eq
-    "cast result" "int" 0 result_tc TypeChecker::stack .get assert_str_eq
+    "cast str to int" 1 result_tc TypeChecker::live TypedStack::types .length assert_eq
+    "cast result" "int" 0 result_tc TypeChecker::live TypedStack::types .get assert_str_eq
 }
 
 fn test_type_cast_bool_to_int {
@@ -1541,7 +1541,7 @@ fn test_type_cast_bool_to_int {
     empty_location OpKind::OpPushBool 1 make_op ops .push
     empty_location OpKind::OpTypeCast "int" (int) make_op ops .push
     ops tc_check = result_tc
-    "cast bool to int" "int" 0 result_tc TypeChecker::stack .get assert_str_eq
+    "cast bool to int" "int" 0 result_tc TypeChecker::live TypedStack::types .get assert_str_eq
 }
 
 # ============================================================================


### PR DESCRIPTION
## Summary
Implements [#81](https://github.com/frendsick/casa/issues/81): replaces the TypeChecker's flat `BranchedStack` struct (10 fields mixing if/while/match concerns + 28 aliasing-defensive `copy_str_list`/`copy_location_list` calls at handler level) with a casa sum type.

- `enum BranchFrame { BranchIf(IfContext) BranchWhile(WhileContext) BranchMatch(MatchContext) }` — three specialized context structs, each carrying only the fields relevant to its branch kind.
- `TypedStack { types, origins }` wraps the parallel type+origin lists; `ts_snapshot`/`ts_restore` are the only functions that deep-copy them.
- Handlers destructure the top frame via `if frame BranchFrame::BranchX(ctx) is then ... fi` and mutate the payload in place.

**Premise correction recorded in the plan:** RFC #81's original design was constrained by the claim "without sum-type support". Verified in-tree that casa already supports user-defined payload enums, multi-slot tuple variants, destructuring, and exhaustive match (`examples/enum.casa`, `casa.casa:37`, `parser.casa:550`, `typechecker.casa:1883`). The unified-with-dead-fields workaround was unnecessary.

## Phases (reviewable independently)

| Commit | What |
|---|---|
| Phase 1 | `TypedStack` wrapping of `(types, origins)` — pure field rename, no behavior change |
| Phase 2 | `BranchFrame` sum type + `IfContext`/`WhileContext`/`MatchContext`; rewrote `check_if_block`, `check_while_block`, `check_match`, and the `OpFnReturn` handler; deleted `BranchedStack`, `copy_str_list`, `copy_location_list`, `make_branched_stack` |
| Phase 3 | `tc_check` routes branch ops to real handlers; 6 new unit tests exercising the BranchFrame machinery (231 → 250 assertions) |
| fixup | Review findings: removed dead `MatchContext::default_present` field; `OpMatchStart` now eagerly snapshots `tc.live` (matches pre-refactor semantics and the `check_while_block` pattern) |

## Verification sweep (all pass)
- `grep 'copy_str_list\|copy_location_list' compiler/typechecker.casa` → 0
- `grep 'BranchedStack' compiler/typechecker.casa` → 0
- `grep 'TypeChecker::stack\b\|stack_origins' compiler/typechecker.casa` → 0
- `bash tests/test_compiler.sh` → 20/20 groups pass, including `self_compilation` and `fixed_point`

## Test plan
- [x] `bash tests/test_compiler.sh` (20/20 groups, 250 typechecker assertions)
- [x] Self-compilation: stage0 → stage1 → stage2 works
- [x] Fixed-point test passes
- [x] Example programs build (covered by `test_examples` group)
- [x] New branch-coverage tests exercise BranchFrame destructuring, mutation persistence through bindings, OpFnReturn-inside-if restore

## Out of scope
- Cursor-based `StackState` (can be added later behind the `TypedStack` API)
- Error collector / label generator deepening (separate RFCs)

resolves: #81
