### PR TITLE
Fix parse_trait crash on EOF after method signature

### DIFF
--- a/compiler/parser.casa
+++ b/compiler/parser.casa
@@ -1290,18 +1290,20 @@ fn parse_trait parser:Parser cursor:TokenCursor -> CasaTrait {
 
             # Parse optional method-level type parameters (e.g., fn map[U])
             List::new (List[str]) = method_type_vars
-            cursor.peek = mtv_bracket_opt
-            if mtv_bracket_opt.is_some "[" mtv_bracket_opt.unwrap Token::value == && then
-                cursor parse_method_type_vars = method_type_vars
+            if cursor.peek Option::Some (mtv_bracket) is then
+                if "[" mtv_bracket Token::value == then
+                    cursor parse_method_type_vars = method_type_vars
+                fi
             fi
 
             cursor parse_trait_method_signature = method_sig
 
             # Parse optional default method body
             List::new (List[Op]) = default_ops
-            cursor.peek = body_peek_opt
-            if body_peek_opt.is_some "{" body_peek_opt.unwrap Token::value == && then
-                f"{name_token Token::value}::{method_name Token::value}" cursor parser parse_block_ops = default_ops
+            if cursor.peek Option::Some (body_peek) is then
+                if "{" body_peek Token::value == then
+                    f"{name_token Token::value}::{method_name Token::value}" cursor parser parse_block_ops = default_ops
+                fi
             fi
 
             method_type_vars default_ops method_sig method_name Token::value TraitMethod methods.push

--- a/tests/compiler/test_traits.casa
+++ b/tests/compiler/test_traits.casa
@@ -888,8 +888,8 @@ test_trait_generic_single_type_param
 test_trait_generic_multi_type_params
 
 # Trait parsing errors
-# TODO: test_trait_unclosed_block_raises and test_trait_unexpected_token_raises
-# crash due to expect_token unwrap in resilient mode — fix in a separate PR
+test_trait_unclosed_block_raises
+test_trait_unexpected_token_raises
 test_trait_duplicate_raises
 
 # Trait bounds


### PR DESCRIPTION
## Summary

- Fix eager-unwrap crash in `parse_trait` that broke the two error-handling
  tests PR #97 had to skip. The `is_some ... unwrap && then` idiom evaluates
  both sides eagerly in Casa, so `body_peek_opt.unwrap` ran on None when the
  last method signature ended at EOF.
- Switch the two affected peeks (`mtv_bracket_opt`, `body_peek_opt`) to
  `Option::Some (x) is` destructuring per STYLE.md.
- Re-enable `test_trait_unclosed_block_raises` and
  `test_trait_unexpected_token_raises` in `tests/compiler/test_traits.casa`.

## Test plan

- [x] `tests/test_compiler.sh` — 20/20 passed (incl. self_compilation and
  fixed_point)
- [x] `tests/test_examples.sh` — 37/37 passed
- [x] `test_traits` assertion count goes 140 → 143 (unclosed test adds 1,
  unexpected-token test adds 2)