### PR TITLE
Consolidate pattern matching into pattern.casa

### DIFF
--- a/compiler/bytecode.casa
+++ b/compiler/bytecode.casa
@@ -394,94 +394,106 @@ fn compile_while_block compiler:BytecodeCompiler op:Op op_index:int bytecode:Lis
 # ============================================================================
 # Compile match block
 # ============================================================================
+# compile_match_op — per-arm bytecode entry point dispatching on PatternKind.
+# Replaces the three former compile_match_arm_* helpers and consolidates
+# literal / enum / struct emission behind a single pattern-driven function.
 
-fn compile_match_arm_enum
+fn compile_match_op
     compiler:BytecodeCompiler
-    pattern_ptr:int
+    op:Op
     is_last:bool
     next_arm:Option[int]
     bytecode:List[Inst]
 {
-    pattern_ptr (EnumVariant) = variant
-    variant EnumVariant::enum_name = enum_name
-    enum_name compiler.store.enums.get.unwrap = casa_enum
+    op pattern_kind = kind
 
-    if is_last ! variant is_wildcard_variant ! && then
-        InstKind::InstDup make_inst bytecode.push
-        InstKind::InstLoad64 make_inst bytecode.push
-        variant EnumVariant::ordinal.unwrap InstKind::InstPush make_inst_int bytecode.push
-        InstKind::InstEq make_inst bytecode.push
-        next_arm.unwrap InstKind::InstJumpNe make_inst_int bytecode.push
+    if PatternKind::PatStruct kind == then
+        op Op::value (StructPattern) = struct_pattern
+        struct_pattern StructPattern::struct_name compiler.store.structs.get.unwrap = casa_struct
+        0 = index
+        while index casa_struct CasaStruct::members.length > do
+            index casa_struct CasaStruct::members.get Member::name = field_name
+            index 8 * = offset
+            if field_name struct_pattern StructPattern::bindings.get Option::Some (var_name) is then
+                InstKind::InstDup make_inst bytecode.push
+                if 0 offset > then
+                    offset InstKind::InstPush make_inst_int bytecode.push
+                    InstKind::InstAdd make_inst bytecode.push
+                fi
+                InstKind::InstLoad64 make_inst bytecode.push
+                var_name compiler resolve_variable = resolved
+                resolved ResolvedVariable::index resolved ResolvedVariable::set_kind make_inst_int bytecode.push
+            fi
+            1 += index
+        done
+        InstKind::InstDrop make_inst bytecode.push
+        return
     fi
 
-    # Extract bindings
-    0 = index
-    while index variant EnumVariant::bindings.length > do
-        index 1 + 8 * = offset
+    if PatternKind::PatLiteral kind == then
+        op Op::value (LiteralPattern) = literal_pattern
+        if is_last then
+            InstKind::InstDrop make_inst bytecode.push
+            return
+        fi
         InstKind::InstDup make_inst bytecode.push
-        offset InstKind::InstPush make_inst_int bytecode.push
-        InstKind::InstAdd make_inst bytecode.push
-        InstKind::InstLoad64 make_inst bytecode.push
-        index variant EnumVariant::bindings.get = var_name
-        var_name compiler resolve_variable = resolved
-        resolved ResolvedVariable::index resolved ResolvedVariable::set_kind make_inst_int bytecode.push
-        1 += index
-    done
-    InstKind::InstDrop make_inst bytecode.push
-}
+        if "str" literal_pattern LiteralPattern::typ == then
+            literal_pattern LiteralPattern::value (str) = str_value
+            str_value compiler intern_string = str_index
+            str_index InstKind::InstPushStr make_inst_int bytecode.push
+            InstKind::InstStrEq make_inst bytecode.push
+        elif "char" literal_pattern LiteralPattern::typ == then
+            literal_pattern LiteralPattern::value InstKind::InstPush make_inst_int bytecode.push
+            InstKind::InstEq make_inst bytecode.push
+        else
+            literal_pattern LiteralPattern::value InstKind::InstPush make_inst_int bytecode.push
+            InstKind::InstEq make_inst bytecode.push
+        fi
+        next_arm.unwrap InstKind::InstJumpNe make_inst_int bytecode.push
+        InstKind::InstDrop make_inst bytecode.push
+        return
+    fi
 
-fn compile_match_arm_literal
-    compiler:BytecodeCompiler
-    pattern_ptr:int
-    is_last:bool
-    next_arm:Option[int]
-    bytecode:List[Inst]
-{
-    pattern_ptr (LiteralPattern) = pattern
+    # Enum variant (wildcard or named).
+    op Op::value (EnumVariant) = variant
+    variant EnumVariant::enum_name = enum_name
+    op pattern_is_wildcard = is_wildcard
+    if "" enum_name != enum_name compiler.store.enums.has && then
+        enum_name compiler.store.enums.get.unwrap = casa_enum
+        casa_enum has_inner_values = has_inner
+        if has_inner then
+            if is_last ! is_wildcard ! && then
+                InstKind::InstDup make_inst bytecode.push
+                InstKind::InstLoad64 make_inst bytecode.push
+                variant EnumVariant::ordinal.unwrap InstKind::InstPush make_inst_int bytecode.push
+                InstKind::InstEq make_inst bytecode.push
+                next_arm.unwrap InstKind::InstJumpNe make_inst_int bytecode.push
+            fi
+            0 = index
+            while index variant EnumVariant::bindings.length > do
+                index 1 + 8 * = offset
+                InstKind::InstDup make_inst bytecode.push
+                offset InstKind::InstPush make_inst_int bytecode.push
+                InstKind::InstAdd make_inst bytecode.push
+                InstKind::InstLoad64 make_inst bytecode.push
+                index variant EnumVariant::bindings.get = var_name
+                var_name compiler resolve_variable = resolved
+                resolved ResolvedVariable::index resolved ResolvedVariable::set_kind make_inst_int bytecode.push
+                1 += index
+            done
+            InstKind::InstDrop make_inst bytecode.push
+            return
+        fi
+    fi
+
     if is_last then
         InstKind::InstDrop make_inst bytecode.push
         return
     fi
     InstKind::InstDup make_inst bytecode.push
-    if "str" pattern LiteralPattern::typ == then
-        pattern LiteralPattern::value (str) = str_value
-        str_value compiler intern_string = str_index
-        str_index InstKind::InstPushStr make_inst_int bytecode.push
-        InstKind::InstStrEq make_inst bytecode.push
-    elif "char" pattern LiteralPattern::typ == then
-        pattern LiteralPattern::value InstKind::InstPush make_inst_int bytecode.push
-        InstKind::InstEq make_inst bytecode.push
-    else
-        pattern LiteralPattern::value InstKind::InstPush make_inst_int bytecode.push
-        InstKind::InstEq make_inst bytecode.push
-    fi
+    variant EnumVariant::ordinal.unwrap InstKind::InstPush make_inst_int bytecode.push
+    InstKind::InstEq make_inst bytecode.push
     next_arm.unwrap InstKind::InstJumpNe make_inst_int bytecode.push
-    InstKind::InstDrop make_inst bytecode.push
-}
-
-fn compile_match_arm_struct compiler:BytecodeCompiler pattern_ptr:int bytecode:List[Inst] {
-    pattern_ptr (StructPattern) = pattern
-    pattern StructPattern::struct_name compiler.store.structs.get.unwrap = casa_struct
-
-    # Build field offset map
-    0 = index
-    while index casa_struct CasaStruct::members.length > do
-        index casa_struct CasaStruct::members.get Member::name = field_name
-        index 8 * = offset
-
-        # Check if this field is bound
-        if field_name pattern StructPattern::bindings.get Option::Some (var_name) is then
-            InstKind::InstDup make_inst bytecode.push
-            if 0 offset > then
-                offset InstKind::InstPush make_inst_int bytecode.push
-                InstKind::InstAdd make_inst bytecode.push
-            fi
-            InstKind::InstLoad64 make_inst bytecode.push
-            var_name compiler resolve_variable = resolved
-            resolved ResolvedVariable::index resolved ResolvedVariable::set_kind make_inst_int bytecode.push
-        fi
-        1 += index
-    done
     InstKind::InstDrop make_inst bytecode.push
 }
 
@@ -498,7 +510,6 @@ fn compile_match_block compiler:BytecodeCompiler op:Op op_index:int bytecode:Lis
 
         "`match` arm without matching `end`" loc end_targets OpKind::OpMatchEnd op_index ops require_matching_forward = end_label
 
-        # Check if this is the first arm (label not yet assigned)
         op_index ops.get (int) OP_LABEL_MAP.get = existing
         existing.is_some ! = is_first
 
@@ -507,50 +518,12 @@ fn compile_match_block compiler:BytecodeCompiler op:Op op_index:int bytecode:Lis
             existing.unwrap InstKind::InstLabel make_inst_int bytecode.push
         fi
 
-        # Find next arm
         List::new (List[OpKind]) = arm_targets
         OpKind::OpMatchArm arm_targets.push
         arm_targets OpKind::OpMatchEnd op_index ops find_matching_label_forward = next_arm
         next_arm.is_none = is_last
 
-        op Op::value = pattern_ptr
-
-        # Determine pattern type by checking enum_name field
-        # The pattern_ptr points to either EnumVariant, StructPattern, or LiteralPattern
-        # We use the type_annotation on the op to distinguish
-        op Op::type_annotation = annotation
-
-        if "struct_pattern" annotation == then
-            bytecode pattern_ptr compiler compile_match_arm_struct
-        elif "literal_pattern" annotation == then
-            bytecode next_arm is_last pattern_ptr compiler compile_match_arm_literal
-        elif "enum_variant" annotation == then
-            pattern_ptr (EnumVariant) = variant
-            variant EnumVariant::enum_name = enum_name
-            if "" enum_name != enum_name compiler.store.enums.has && then
-                enum_name compiler.store.enums.get.unwrap = casa_enum
-                casa_enum has_inner_values = has_inner
-                if has_inner then
-                    bytecode next_arm is_last pattern_ptr compiler compile_match_arm_enum
-                elif is_last then
-                    InstKind::InstDrop make_inst bytecode.push
-                else
-                    InstKind::InstDup make_inst bytecode.push
-                    variant EnumVariant::ordinal.unwrap InstKind::InstPush make_inst_int bytecode.push
-                    InstKind::InstEq make_inst bytecode.push
-                    next_arm.unwrap InstKind::InstJumpNe make_inst_int bytecode.push
-                    InstKind::InstDrop make_inst bytecode.push
-                fi
-            elif is_last then
-                InstKind::InstDrop make_inst bytecode.push
-            else
-                InstKind::InstDup make_inst bytecode.push
-                variant EnumVariant::ordinal.unwrap InstKind::InstPush make_inst_int bytecode.push
-                InstKind::InstEq make_inst bytecode.push
-                next_arm.unwrap InstKind::InstJumpNe make_inst_int bytecode.push
-                InstKind::InstDrop make_inst bytecode.push
-            fi
-        fi
+        bytecode next_arm is_last op compiler compile_match_op
     elif OpKind::OpMatchEnd op Op::kind == then
         op_index compiler BytecodeCompiler::ops op_ptr_to_label = end_match_label
         end_match_label InstKind::InstLabel make_inst_int bytecode.push

--- a/compiler/bytecode.casa
+++ b/compiler/bytecode.casa
@@ -398,70 +398,64 @@ fn compile_while_block compiler:BytecodeCompiler op:Op op_index:int bytecode:Lis
 # Replaces the three former compile_match_arm_* helpers and consolidates
 # literal / enum / struct emission behind a single pattern-driven function.
 
-fn compile_match_op
+fn emit_struct_arm compiler:BytecodeCompiler struct_pattern:StructPattern bytecode:List[Inst] {
+    struct_pattern StructPattern::struct_name compiler.store.structs.get.unwrap = casa_struct
+    0 = index
+    while index casa_struct CasaStruct::members.length > do
+        index casa_struct CasaStruct::members.get Member::name = field_name
+        index 8 * = offset
+        if field_name struct_pattern StructPattern::bindings.get Option::Some (var_name) is then
+            InstKind::InstDup make_inst bytecode.push
+            if 0 offset > then
+                offset InstKind::InstPush make_inst_int bytecode.push
+                InstKind::InstAdd make_inst bytecode.push
+            fi
+            InstKind::InstLoad64 make_inst bytecode.push
+            var_name compiler resolve_variable = resolved
+            resolved ResolvedVariable::index resolved ResolvedVariable::set_kind make_inst_int bytecode.push
+        fi
+        1 += index
+    done
+    InstKind::InstDrop make_inst bytecode.push
+}
+
+fn emit_literal_arm
     compiler:BytecodeCompiler
-    op:Op
+    literal_pattern:LiteralPattern
     is_last:bool
     next_arm:Option[int]
     bytecode:List[Inst]
 {
-    op pattern_kind = kind
-
-    if PatternKind::PatStruct kind == then
-        op Op::value (StructPattern) = struct_pattern
-        struct_pattern StructPattern::struct_name compiler.store.structs.get.unwrap = casa_struct
-        0 = index
-        while index casa_struct CasaStruct::members.length > do
-            index casa_struct CasaStruct::members.get Member::name = field_name
-            index 8 * = offset
-            if field_name struct_pattern StructPattern::bindings.get Option::Some (var_name) is then
-                InstKind::InstDup make_inst bytecode.push
-                if 0 offset > then
-                    offset InstKind::InstPush make_inst_int bytecode.push
-                    InstKind::InstAdd make_inst bytecode.push
-                fi
-                InstKind::InstLoad64 make_inst bytecode.push
-                var_name compiler resolve_variable = resolved
-                resolved ResolvedVariable::index resolved ResolvedVariable::set_kind make_inst_int bytecode.push
-            fi
-            1 += index
-        done
+    if is_last then
         InstKind::InstDrop make_inst bytecode.push
         return
     fi
-
-    if PatternKind::PatLiteral kind == then
-        op Op::value (LiteralPattern) = literal_pattern
-        if is_last then
-            InstKind::InstDrop make_inst bytecode.push
-            return
-        fi
-        InstKind::InstDup make_inst bytecode.push
-        if "str" literal_pattern LiteralPattern::typ == then
-            literal_pattern LiteralPattern::value (str) = str_value
-            str_value compiler intern_string = str_index
-            str_index InstKind::InstPushStr make_inst_int bytecode.push
-            InstKind::InstStrEq make_inst bytecode.push
-        elif "char" literal_pattern LiteralPattern::typ == then
-            literal_pattern LiteralPattern::value InstKind::InstPush make_inst_int bytecode.push
-            InstKind::InstEq make_inst bytecode.push
-        else
-            literal_pattern LiteralPattern::value InstKind::InstPush make_inst_int bytecode.push
-            InstKind::InstEq make_inst bytecode.push
-        fi
-        next_arm.unwrap InstKind::InstJumpNe make_inst_int bytecode.push
-        InstKind::InstDrop make_inst bytecode.push
-        return
+    InstKind::InstDup make_inst bytecode.push
+    if "str" literal_pattern LiteralPattern::typ == then
+        literal_pattern LiteralPattern::value (str) = str_value
+        str_value compiler intern_string = str_index
+        str_index InstKind::InstPushStr make_inst_int bytecode.push
+        InstKind::InstStrEq make_inst bytecode.push
+    else
+        literal_pattern LiteralPattern::value InstKind::InstPush make_inst_int bytecode.push
+        InstKind::InstEq make_inst bytecode.push
     fi
+    next_arm.unwrap InstKind::InstJumpNe make_inst_int bytecode.push
+    InstKind::InstDrop make_inst bytecode.push
+}
 
-    # Enum variant (wildcard or named).
-    op Op::value (EnumVariant) = variant
+fn emit_enum_arm
+    compiler:BytecodeCompiler
+    variant:EnumVariant
+    is_wildcard:bool
+    is_last:bool
+    next_arm:Option[int]
+    bytecode:List[Inst]
+{
     variant EnumVariant::enum_name = enum_name
-    op pattern_is_wildcard = is_wildcard
     if "" enum_name != enum_name compiler.store.enums.has && then
         enum_name compiler.store.enums.get.unwrap = casa_enum
-        casa_enum has_inner_values = has_inner
-        if has_inner then
+        if casa_enum has_inner_values then
             if is_last ! is_wildcard ! && then
                 InstKind::InstDup make_inst bytecode.push
                 InstKind::InstLoad64 make_inst bytecode.push
@@ -469,19 +463,7 @@ fn compile_match_op
                 InstKind::InstEq make_inst bytecode.push
                 next_arm.unwrap InstKind::InstJumpNe make_inst_int bytecode.push
             fi
-            0 = index
-            while index variant EnumVariant::bindings.length > do
-                index 1 + 8 * = offset
-                InstKind::InstDup make_inst bytecode.push
-                offset InstKind::InstPush make_inst_int bytecode.push
-                InstKind::InstAdd make_inst bytecode.push
-                InstKind::InstLoad64 make_inst bytecode.push
-                index variant EnumVariant::bindings.get = var_name
-                var_name compiler resolve_variable = resolved
-                resolved ResolvedVariable::index resolved ResolvedVariable::set_kind make_inst_int bytecode.push
-                1 += index
-            done
-            InstKind::InstDrop make_inst bytecode.push
+            variant bytecode compiler emit_enum_arm_bindings
             return
         fi
     fi
@@ -495,6 +477,51 @@ fn compile_match_op
     InstKind::InstEq make_inst bytecode.push
     next_arm.unwrap InstKind::InstJumpNe make_inst_int bytecode.push
     InstKind::InstDrop make_inst bytecode.push
+}
+
+fn emit_enum_arm_bindings compiler:BytecodeCompiler bytecode:List[Inst] variant:EnumVariant {
+    0 = index
+    while index variant EnumVariant::bindings.length > do
+        index 1 + 8 * = offset
+        InstKind::InstDup make_inst bytecode.push
+        offset InstKind::InstPush make_inst_int bytecode.push
+        InstKind::InstAdd make_inst bytecode.push
+        InstKind::InstLoad64 make_inst bytecode.push
+        index variant EnumVariant::bindings.get = var_name
+        var_name compiler resolve_variable = resolved
+        resolved ResolvedVariable::index resolved ResolvedVariable::set_kind make_inst_int bytecode.push
+        1 += index
+    done
+    InstKind::InstDrop make_inst bytecode.push
+}
+
+fn compile_match_op
+    compiler:BytecodeCompiler
+    op:Op
+    is_last:bool
+    next_arm:Option[int]
+    bytecode:List[Inst]
+{
+    op pattern_kind match
+        PatternKind::PatStruct => {
+            op Op::value (StructPattern) = struct_pattern
+            bytecode struct_pattern compiler emit_struct_arm
+        }
+        PatternKind::PatLiteral => {
+            op Op::value (LiteralPattern) = literal_pattern
+            bytecode next_arm is_last literal_pattern compiler emit_literal_arm
+        }
+        PatternKind::PatEnumVariant => {
+            op Op::value (EnumVariant) = variant
+            op pattern_is_wildcard = is_wildcard
+            bytecode next_arm is_last is_wildcard variant compiler emit_enum_arm
+        }
+        PatternKind::PatWildcard => {
+            if is_last then
+                InstKind::InstDrop make_inst bytecode.push
+            fi
+        }
+    end
 }
 
 fn compile_match_block compiler:BytecodeCompiler op:Op op_index:int bytecode:List[Inst] {

--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -464,18 +464,23 @@ struct Op {
     location:             Location
     type_annotation:      str
     deferred_return_type: str
+    pattern_kind:         PatternKind
 }
 
 fn make_op value:int kind:OpKind location:Location -> Op {
-    "" "" location kind value Op
+    PatternKind::PatWildcard "" "" location kind value Op
 }
 
 fn make_op_str value:str kind:OpKind location:Location -> Op {
-    "" "" location kind value (int) Op
+    PatternKind::PatWildcard "" "" location kind value (int) Op
 }
 
 fn make_op_annotated value:int kind:OpKind location:Location annotation:str -> Op {
-    "" annotation location kind value Op
+    PatternKind::PatWildcard "" annotation location kind value Op
+}
+
+fn make_op_pattern value:int kind:OpKind location:Location pattern_kind:PatternKind -> Op {
+    pattern_kind "" "" location kind value Op
 }
 
 fn clone_ops ops:List[Op] -> List[Op] {
@@ -483,7 +488,7 @@ fn clone_ops ops:List[Op] -> List[Op] {
     0 = clone_index
     while clone_index ops.length > do
         clone_index ops.get = source_op
-        source_op Op::deferred_return_type source_op Op::type_annotation source_op Op::location source_op Op::kind source_op Op::value Op result.push
+        source_op Op::pattern_kind source_op Op::deferred_return_type source_op Op::type_annotation source_op Op::location source_op Op::kind source_op Op::value Op result.push
         1 += clone_index
     done
     result
@@ -649,10 +654,9 @@ fn is_wildcard_literal_pattern pattern:LiteralPattern -> bool {
 # ============================================================================
 # PatternKind — discriminator for OpMatchArm pattern shape.
 #
-# Replaces the legacy `Op.type_annotation` string tag
-# ("struct_pattern" / "enum_variant" / "literal_pattern"). Callers read the
-# kind through the `pattern_kind` helper below; the underlying storage is
-# still the tag string until the migration completes.
+# Every match-arm Op carries its PatternKind directly in Op.pattern_kind.
+# Ops of other kinds keep a default of PatternKind::PatWildcard; the field
+# is only meaningful when Op.kind == OpKind::OpMatchArm.
 # ============================================================================
 
 enum PatternKind {
@@ -668,11 +672,7 @@ impl PatternKind {
 }
 
 fn pattern_kind op:Op -> PatternKind {
-    op Op::type_annotation = tag
-    if "struct_pattern" tag == then PatternKind::PatStruct return fi
-    if "enum_variant" tag == then PatternKind::PatEnumVariant return fi
-    if "literal_pattern" tag == then PatternKind::PatLiteral return fi
-    PatternKind::PatWildcard
+    op Op::pattern_kind
 }
 
 # ============================================================================

--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -647,6 +647,35 @@ fn is_wildcard_literal_pattern pattern:LiteralPattern -> bool {
 }
 
 # ============================================================================
+# PatternKind — discriminator for OpMatchArm pattern shape.
+#
+# Replaces the legacy `Op.type_annotation` string tag
+# ("struct_pattern" / "enum_variant" / "literal_pattern"). Callers read the
+# kind through the `pattern_kind` helper below; the underlying storage is
+# still the tag string until the migration completes.
+# ============================================================================
+
+enum PatternKind {
+    PatStruct
+    PatEnumVariant
+    PatLiteral
+    PatWildcard
+}
+
+impl PatternKind {
+    fn hash self:PatternKind -> int { self (int) int_hash }
+    fn eq self:PatternKind other:PatternKind -> bool { self other == }
+}
+
+fn pattern_kind op:Op -> PatternKind {
+    op Op::type_annotation = tag
+    if "struct_pattern" tag == then PatternKind::PatStruct return fi
+    if "enum_variant" tag == then PatternKind::PatEnumVariant return fi
+    if "literal_pattern" tag == then PatternKind::PatLiteral return fi
+    PatternKind::PatWildcard
+}
+
+# ============================================================================
 # Enum definition
 # ============================================================================
 

--- a/compiler/parser.casa
+++ b/compiler/parser.casa
@@ -1540,23 +1540,23 @@ fn parse_match_block parser:Parser token:Token cursor:TokenCursor function_name:
         if MATCH_WILDCARD arm_token Token::value == then
             "=>" cursor expect_token_value drop
             Option::None MATCH_WILDCARD "" make_enum_variant = wildcard
-            "enum_variant" arm_token Token::location OpKind::OpMatchArm wildcard (int) make_op_annotated ops.push
+            PatternKind::PatEnumVariant arm_token Token::location OpKind::OpMatchArm wildcard (int) make_op_pattern ops.push
         elif TokenKind::Literal arm_token Token::kind == then
             "=>" cursor expect_token_value drop
             arm_token parse_literal_match_pattern = literal_pattern
-            "literal_pattern" arm_token Token::location OpKind::OpMatchArm literal_pattern (int) make_op_annotated = literal_op
+            PatternKind::PatLiteral arm_token Token::location OpKind::OpMatchArm literal_pattern (int) make_op_pattern = literal_op
             literal_op ops.push
         elif TokenKind::Identifier arm_token Token::kind != then
             arm_token Token::location "Expected match pattern or `_`" ErrorKind::UnexpectedToken raise_error
         elif cursor.peek.is_some "{" cursor.peek.unwrap Token::value == && then
             # Struct pattern
             cursor arm_token parser parse_struct_match_pattern = struct_pattern
-            "struct_pattern" arm_token Token::location OpKind::OpMatchArm struct_pattern (int) make_op_annotated ops.push
+            PatternKind::PatStruct arm_token Token::location OpKind::OpMatchArm struct_pattern (int) make_op_pattern ops.push
         elif arm_token Token::value "::" str::find 0 > then
             # Bare identifier
             "=>" cursor expect_token_value drop
             Option::None arm_token Token::value "" make_enum_variant = bare_variant
-            "enum_variant" arm_token Token::location OpKind::OpMatchArm bare_variant (int) make_op_annotated ops.push
+            PatternKind::PatEnumVariant arm_token Token::location OpKind::OpMatchArm bare_variant (int) make_op_pattern ops.push
         else
             # Enum::Variant pattern
             arm_token Token::value "::" str::find = separator
@@ -1585,7 +1585,7 @@ fn parse_match_block parser:Parser token:Token cursor:TokenCursor function_name:
             "=>" cursor expect_token_value drop
             Option::None variant_name enum_name make_enum_variant = variant
             bindings variant EnumVariant::set_bindings
-            "enum_variant" arm_token Token::location OpKind::OpMatchArm variant (int) make_op_annotated ops.push
+            PatternKind::PatEnumVariant arm_token Token::location OpKind::OpMatchArm variant (int) make_op_pattern ops.push
         fi
 
         # Parse arm body

--- a/compiler/parser.casa
+++ b/compiler/parser.casa
@@ -1419,7 +1419,7 @@ fn parse_impl_block parser:Parser cursor:TokenCursor {
 }
 
 # ============================================================================
-# _handle_keyword_match - parse match block with arms
+# parse_match_block - parse a full match construct (match ... end)
 # ============================================================================
 
 fn token_line token:Token -> int {
@@ -1523,7 +1523,7 @@ fn parse_literal_match_pattern token:Token -> LiteralPattern {
     "" "int" 0 LiteralPattern
 }
 
-fn handle_keyword_match parser:Parser token:Token cursor:TokenCursor function_name:str -> List[Op] {
+fn parse_match_block parser:Parser token:Token cursor:TokenCursor function_name:str -> List[Op] {
     List::new (List[Op]) = ops
     token Token::location OpKind::OpMatchStart 0 make_op ops.push
 
@@ -1886,7 +1886,7 @@ fn get_op_keyword parser:Parser token:Token cursor:TokenCursor function_name:str
 
     # match
     if KeywordKind::Match keyword == then
-        function_name cursor token parser handle_keyword_match = match_ops
+        function_name cursor token parser parse_match_block = match_ops
         0 = match_index
         while match_index match_ops.length > do
             match_index match_ops.get ops.push

--- a/compiler/parser.casa
+++ b/compiler/parser.casa
@@ -2228,6 +2228,36 @@ fn resolve_identifiers_global parser:Parser ops:List[Op] -> List[Op] {
 fn resolve_identifiers ops:List[Op] function:Function -> List[Op] {
     function ops DEFAULT_PARSER resolve_identifiers_fn
 }
+# resolve_match_op — per-arm identifier resolution entry point.
+# Registers struct-pattern field bindings as locals/globals and resolves
+# enum-variant ordinals (delegating to resolve_enum_variant). Literal and
+# wildcard arms need no resolution.
+
+fn resolve_match_op parser:Parser function:Function op:Op errors:List[CasaError] {
+    op pattern_kind = kind
+    if PatternKind::PatStruct kind == then
+        op Op::value (StructPattern) = struct_pattern
+        struct_pattern StructPattern::bindings.keys = pattern_keys
+        0 = field_index
+        while field_index pattern_keys.length > do
+            field_index pattern_keys.get struct_pattern StructPattern::bindings.get.unwrap = match_variant_name
+            match_variant_name make_variable = match_struct_variant
+            if GLOBAL_SCOPE_LABEL function Function::name == then
+                match_variant_name match_struct_variant parser.store.variables.set drop
+            else
+                if match_variant_name function Function::variables variable_list_contains ! then
+                    match_struct_variant function Function::variables.push
+                fi
+            fi
+            1 += field_index
+        done
+        return
+    fi
+    if PatternKind::PatEnumVariant kind == then
+        op Op::value (EnumVariant) = variant
+        errors function op variant parser resolve_enum_variant
+    fi
+}
 
 fn resolve_identifiers_fn parser:Parser ops:List[Op] function:Function -> List[Op] {
     0 = op_index
@@ -2394,32 +2424,9 @@ fn resolve_identifiers_fn parser:Parser ops:List[Op] function:Function -> List[O
             continue
         fi
 
-        # MATCH_ARM: resolve enum variants and struct patterns
+        # MATCH_ARM: delegate to the pattern module.
         if OpKind::OpMatchArm op_kind == then
-            current_op Op::type_annotation = match_tag
-            if "struct_pattern" match_tag == then
-                # StructPattern: register field bindings as variables
-                current_op Op::value (StructPattern) = struct_pattern
-                struct_pattern StructPattern::bindings.keys = pattern_keys
-                0 = struct_field_index
-                while struct_field_index pattern_keys.length > do
-                    struct_field_index pattern_keys.get struct_pattern StructPattern::bindings.get.unwrap = match_variant_name
-                    match_variant_name make_variable = match_struct_variant
-                    if GLOBAL_SCOPE_LABEL function Function::name == then
-                        match_variant_name match_struct_variant parser.store.variables.set drop
-                    else
-                        if match_variant_name function Function::variables variable_list_contains ! then
-                            match_struct_variant function Function::variables.push
-                        fi
-                    fi
-                    1 += struct_field_index
-                done
-            elif "enum_variant" match_tag == then
-                # EnumVariant: resolve ordinal and register bindings
-                current_op Op::value (EnumVariant) = match_variant
-                resolve_errors function current_op match_variant parser resolve_enum_variant
-            fi
-            # literal_pattern: no resolution needed
+            resolve_errors current_op function parser resolve_match_op
             continue
         fi
 

--- a/compiler/parser.casa
+++ b/compiler/parser.casa
@@ -2233,30 +2233,36 @@ fn resolve_identifiers ops:List[Op] function:Function -> List[Op] {
 # enum-variant ordinals (delegating to resolve_enum_variant). Literal and
 # wildcard arms need no resolution.
 
+fn register_struct_pattern_binding parser:Parser function:Function binding_name:str {
+    binding_name make_variable = match_struct_variant
+    if GLOBAL_SCOPE_LABEL function Function::name == then
+        binding_name match_struct_variant parser.store.variables.set drop
+    else
+        if binding_name function Function::variables variable_list_contains ! then
+            match_struct_variant function Function::variables.push
+        fi
+    fi
+}
+
 fn resolve_match_op parser:Parser function:Function op:Op errors:List[CasaError] {
-    op pattern_kind = kind
-    if PatternKind::PatStruct kind == then
-        op Op::value (StructPattern) = struct_pattern
-        struct_pattern StructPattern::bindings.keys = pattern_keys
-        0 = field_index
-        while field_index pattern_keys.length > do
-            field_index pattern_keys.get struct_pattern StructPattern::bindings.get.unwrap = match_variant_name
-            match_variant_name make_variable = match_struct_variant
-            if GLOBAL_SCOPE_LABEL function Function::name == then
-                match_variant_name match_struct_variant parser.store.variables.set drop
-            else
-                if match_variant_name function Function::variables variable_list_contains ! then
-                    match_struct_variant function Function::variables.push
-                fi
-            fi
-            1 += field_index
-        done
-        return
-    fi
-    if PatternKind::PatEnumVariant kind == then
-        op Op::value (EnumVariant) = variant
-        errors function op variant parser resolve_enum_variant
-    fi
+    op pattern_kind match
+        PatternKind::PatStruct => {
+            op Op::value (StructPattern) = struct_pattern
+            struct_pattern StructPattern::bindings.keys = pattern_keys
+            0 = field_index
+            while field_index pattern_keys.length > do
+                field_index pattern_keys.get struct_pattern StructPattern::bindings.get.unwrap = binding_name
+                binding_name function parser register_struct_pattern_binding
+                1 += field_index
+            done
+        }
+        PatternKind::PatEnumVariant => {
+            op Op::value (EnumVariant) = variant
+            errors function op variant parser resolve_enum_variant
+        }
+        PatternKind::PatLiteral => 0 drop
+        PatternKind::PatWildcard => 0 drop
+    end
 }
 
 fn resolve_identifiers_fn parser:Parser ops:List[Op] function:Function -> List[Op] {

--- a/compiler/pattern.casa
+++ b/compiler/pattern.casa
@@ -1,12 +1,12 @@
-include "common.casa"
-
-# ============================================================================
 # pattern.casa — consolidated match-pattern module.
 #
-# Introspection primitives that every phase (parser-resolve, typechecker,
-# bytecode) can call without re-reading the legacy type_annotation tag
-# string. The tag is still the underlying storage; pattern.casa hides that
-# until the final migration commit removes it.
+# Introspection primitives and per-phase entry points every compiler phase
+# (parser-resolve, typechecker, bytecode) uses to handle match patterns
+# without re-reading the legacy Op.type_annotation tag string. The tag is
+# still the underlying storage until the final migration commit removes it.
+#
+# Included after common/error/lexer/parser and before typechecker/bytecode.
+
 # ============================================================================
 # pattern_is_wildcard: true only for a bare `_` wildcard arm.
 # Currently stored as an EnumVariant whose variant_name is "_".
@@ -69,4 +69,161 @@ fn pattern_bindings op:Op -> List[str] {
         out return
     fi
     out
+}
+
+# ============================================================================
+# typecheck_match_op — per-arm typecheck entry point.
+#
+# Handles pattern-shape validation, duplicate-arm detection, match-arm
+# stack unification, and binding-type registration for a single OpMatchArm.
+# Callers (currently check_match) delegate the entire arm body to this
+# function; start/end of the match block remain in check_match.
+# ============================================================================
+
+fn typecheck_match_op tc:TypeChecker function_opt:Option[Function] op:Op {
+    if 0 tc TypeChecker::branched_stacks.length == then return fi
+    tc TypeChecker::branched_stacks.length 1 - tc TypeChecker::branched_stacks.get = top_frame
+    if top_frame BranchFrame::BranchMatch (match_ctx) is then
+        match_ctx MatchContext::match_type = match_subject_type
+        op Op::value = pattern_ptr
+        op pattern_kind = kind
+        op pattern_covered_key = covered_key
+        match_subject_type resolve_match_type = arm_base
+        op pattern_is_wildcard = is_wildcard
+        PatternKind::PatEnumVariant kind == = is_enum_pattern
+
+        # Diagnose bare enum variants written without the `Enum::` qualifier.
+        if
+        is_enum_pattern
+        is_wildcard ! &&
+        then
+            pattern_ptr (EnumVariant) = variant
+            if "" variant EnumVariant::enum_name == then
+                arm_base tc.store.enums.get = bare_enum_opt
+                if bare_enum_opt.is_some then
+                    bare_enum_opt.unwrap = bare_enum
+                    variant EnumVariant::variant_name = bare_name
+                    bare_name bare_enum CasaEnum::variants string_list_index = bare_index
+                    if 0 bare_index >= then
+                        op Op::location f"Unqualified enum variant `{bare_name}`. Did you mean `{arm_base}::{bare_name}`?" ErrorKind::TypeMismatch raise_error
+                    else
+                        op Op::location f"Expected qualified enum variant (e.g. `{arm_base}::{0 bare_enum CasaEnum::variants.get}`) or `_`, got `{bare_name}`" ErrorKind::TypeMismatch raise_error
+                    fi
+                fi
+            fi
+        fi
+
+        # Duplicate-arm detection uses the pattern's covered key.
+        if "" covered_key != then
+            0 = dup_index
+            while dup_index match_ctx MatchContext::branch_records.length > do
+                dup_index match_ctx MatchContext::branch_records.get = record
+                if covered_key record == then
+                    op Op::location f"Duplicate match arm for `{covered_key}`" ErrorKind::DuplicateName raise_error
+                fi
+                1 += dup_index
+            done
+            if covered_key match_ctx MatchContext::current_branch_label == then
+                op Op::location f"Duplicate match arm for `{covered_key}`" ErrorKind::DuplicateName raise_error
+            fi
+        fi
+
+        # Match-arm stack unification.
+        if match_ctx MatchContext::condition_present then
+            if "" match_ctx MatchContext::current_branch_label != then
+                match_ctx MatchContext::current_branch_label match_ctx MatchContext::branch_records.push
+            fi
+            match_ctx MatchContext::before = match_before
+            match_ctx MatchContext::after = match_after
+            if
+            match_before tc TypeChecker::live.equals
+            match_after match_before.equals &&
+            then
+                0 drop
+            else
+                match_after tc TypeChecker::live.unify_types = unified
+                if 0 unified.length != match_after match_before.equals ! && then
+                    unified match_after TypedStack::set_types
+                elif match_after match_before.equals then
+                    tc TypeChecker::live match_after.restore
+                else
+                    op Op::location "Match arms have incompatible stack effects" ErrorKind::StackMismatch add_error
+                fi
+            fi
+            match_before tc TypeChecker::live.restore
+        else
+            true match_ctx MatchContext::set_condition_present
+            tc TypeChecker::live match_ctx MatchContext::before.restore
+            tc TypeChecker::live match_ctx MatchContext::after.restore
+        fi
+
+        # Set types on pattern bindings.
+        if PatternKind::PatStruct kind == then
+            pattern_ptr (StructPattern) = struct_pat2
+            struct_pat2 StructPattern::struct_name tc.store.structs.get.unwrap = matched_struct
+            struct_pat2 StructPattern::bindings.keys = binding_keys
+            0 = binding_index
+            while binding_index binding_keys.length > do
+                binding_index binding_keys.get = field_name
+                field_name struct_pat2 StructPattern::bindings.get.unwrap = bound_var
+                0 = member_index
+                while member_index matched_struct CasaStruct::members.length > do
+                    member_index matched_struct CasaStruct::members.get = member
+                    if field_name member Member::name == then
+                        function_opt member Member::typ bound_var set_binding_type
+                    fi
+                    1 += member_index
+                done
+                1 += binding_index
+            done
+        elif
+        is_enum_pattern
+        is_wildcard ! &&
+        then
+            pattern_ptr (EnumVariant) = variant
+            if 0 variant EnumVariant::bindings.length != then
+                match_subject_type resolve_match_type = base_enum_name
+                base_enum_name tc.store.enums.get = enum_opt
+                if enum_opt.is_some then
+                    enum_opt.unwrap = casa_enum
+                    variant EnumVariant::variant_name casa_enum CasaEnum::variant_types.get = inner_opt
+                    if inner_opt.is_some then
+                        inner_opt.unwrap = inner_types
+                        Map::new (Map[str str]) = type_bindings
+                        if 0 casa_enum CasaEnum::type_vars.length != then
+                            match_subject_type extract_generic_params = params_opt
+                            if params_opt.is_some then
+                                params_opt.unwrap = type_params
+                                0 = type_var_index
+                                while
+                                type_var_index casa_enum CasaEnum::type_vars.length >
+                                type_var_index type_params.length > &&
+                                do
+                                    type_var_index casa_enum CasaEnum::type_vars.get type_var_index type_params.get type_bindings.set = type_bindings
+                                    1 += type_var_index
+                                done
+                            fi
+                        fi
+                        0 = bind_index
+                        while
+                        bind_index variant EnumVariant::bindings.length >
+                        bind_index inner_types.length > &&
+                        do
+                            bind_index variant EnumVariant::bindings.get = binding_var
+                            bind_index inner_types.get = binding_type
+                            binding_type type_bindings.get = resolved_opt
+                            if resolved_opt.is_some then
+                                resolved_opt.unwrap = binding_type
+                            fi
+                            function_opt binding_type binding_var set_binding_type
+                            1 += bind_index
+                        done
+                    fi
+                fi
+            fi
+        fi
+
+        covered_key match_ctx MatchContext::set_current_branch_label
+        op Op::location match_ctx MatchContext::set_current_branch_location
+    fi
 }

--- a/compiler/pattern.casa
+++ b/compiler/pattern.casa
@@ -2,8 +2,7 @@
 #
 # Introspection primitives and per-phase entry points every compiler phase
 # (parser-resolve, typechecker, bytecode) uses to handle match patterns
-# without re-reading the legacy Op.type_annotation tag string. The tag is
-# still the underlying storage until the final migration commit removes it.
+# without re-reading the legacy Op.type_annotation tag string.
 #
 # Included after common/error/lexer/parser and before typechecker/bytecode.
 
@@ -12,63 +11,255 @@
 # Currently stored as an EnumVariant whose variant_name is "_".
 
 fn pattern_is_wildcard op:Op -> bool {
-    op pattern_kind = kind
-    if PatternKind::PatEnumVariant kind == then
-        op Op::value (EnumVariant) = variant
-        MATCH_WILDCARD variant EnumVariant::variant_name ==
-        return
-    fi
-    false
+    op pattern_kind match
+        PatternKind::PatEnumVariant => {
+            op Op::value (EnumVariant) = variant
+            MATCH_WILDCARD variant EnumVariant::variant_name ==
+        }
+        PatternKind::PatStruct => false
+        PatternKind::PatLiteral => false
+        PatternKind::PatWildcard => true
+    end
 }
+
+# ============================================================================
 # pattern_covered_key: stable key used for duplicate-arm detection and for
 # exhaustiveness bookkeeping. Mirrors the `__covered:{...}` keys the
 # typechecker already produces.
 
 fn pattern_covered_key op:Op -> str {
-    op pattern_kind = kind
-    if PatternKind::PatStruct kind == then
-        op Op::value (StructPattern) = struct_pat
-        f"__covered:{struct_pat StructPattern::struct_name}" return
-    fi
-    if PatternKind::PatLiteral kind == then
-        op Op::value (LiteralPattern) = literal_pat
-        f"__covered:{literal_pat LiteralPattern::raw}" return
-    fi
-    if PatternKind::PatEnumVariant kind == then
-        op Op::value (EnumVariant) = variant
-        f"__covered:{variant EnumVariant::variant_name}" return
-    fi
-    ""
+    op pattern_kind match
+        PatternKind::PatStruct => {
+            op Op::value (StructPattern) = struct_pat
+            f"__covered:{struct_pat StructPattern::struct_name}"
+        }
+        PatternKind::PatLiteral => {
+            op Op::value (LiteralPattern) = literal_pat
+            f"__covered:{literal_pat LiteralPattern::raw}"
+        }
+        PatternKind::PatEnumVariant => {
+            op Op::value (EnumVariant) = variant
+            f"__covered:{variant EnumVariant::variant_name}"
+        }
+        PatternKind::PatWildcard => ""
+    end
 }
+
+# ============================================================================
 # pattern_bindings: names this pattern introduces into the enclosing scope.
 # Struct patterns bind field aliases; enum variants bind payload names;
 # literals and wildcards bind nothing.
 
 fn pattern_bindings op:Op -> List[str] {
     List::new (List[str]) = out
-    op pattern_kind = kind
-    if PatternKind::PatStruct kind == then
-        op Op::value (StructPattern) = struct_pat
-        struct_pat StructPattern::bindings.keys = field_names
-        0 = binding_index
-        while binding_index field_names.length > do
-            binding_index field_names.get struct_pat StructPattern::bindings.get.unwrap = bound_name
-            bound_name out.push
-            1 += binding_index
-        done
-        out return
-    fi
-    if PatternKind::PatEnumVariant kind == then
-        op Op::value (EnumVariant) = variant
-        variant EnumVariant::bindings = names
-        0 = enum_binding_index
-        while enum_binding_index names.length > do
-            enum_binding_index names.get out.push
-            1 += enum_binding_index
-        done
-        out return
-    fi
+    op pattern_kind match
+        PatternKind::PatStruct => {
+            op Op::value (StructPattern) = struct_pat
+            struct_pat StructPattern::bindings.keys = field_names
+            0 = binding_index
+            while binding_index field_names.length > do
+                binding_index field_names.get struct_pat StructPattern::bindings.get.unwrap = bound_name
+                bound_name out.push
+                1 += binding_index
+            done
+        }
+        PatternKind::PatEnumVariant => {
+            op Op::value (EnumVariant) = variant
+            variant EnumVariant::bindings = names
+            0 = enum_binding_index
+            while enum_binding_index names.length > do
+                enum_binding_index names.get out.push
+                1 += enum_binding_index
+            done
+        }
+        PatternKind::PatLiteral => 0 drop
+        PatternKind::PatWildcard => 0 drop
+    end
     out
+}
+
+# ============================================================================
+# diagnose_bare_enum_pattern — emit a targeted error if a match arm uses an
+# unqualified enum variant (e.g. `North =>` instead of `Direction::North =>`).
+
+fn diagnose_bare_enum_pattern tc:TypeChecker op:Op variant:EnumVariant arm_base:str {
+    if "" variant EnumVariant::enum_name != then return fi
+    if arm_base tc.store.enums.get Option::Some (bare_enum) is then
+        variant EnumVariant::variant_name = bare_name
+        bare_name bare_enum CasaEnum::variants string_list_index = bare_index
+        if 0 bare_index >= then
+            op Op::location f"Unqualified enum variant `{bare_name}`. Did you mean `{arm_base}::{bare_name}`?" ErrorKind::TypeMismatch raise_error
+        else
+            op Op::location f"Expected qualified enum variant (e.g. `{arm_base}::{0 bare_enum CasaEnum::variants.get}`) or `_`, got `{bare_name}`" ErrorKind::TypeMismatch raise_error
+        fi
+    fi
+}
+
+# ============================================================================
+# detect_duplicate_arm — raise an error if the current pattern's covered key
+# has already been recorded on this match context.
+
+fn detect_duplicate_arm match_ctx:MatchContext op:Op covered_key:str {
+    if "" covered_key == then return fi
+    0 = dup_index
+    while dup_index match_ctx MatchContext::branch_records.length > do
+        dup_index match_ctx MatchContext::branch_records.get = record
+        if covered_key record == then
+            op Op::location f"Duplicate match arm for `{covered_key}`" ErrorKind::DuplicateName raise_error
+        fi
+        1 += dup_index
+    done
+    if covered_key match_ctx MatchContext::current_branch_label == then
+        op Op::location f"Duplicate match arm for `{covered_key}`" ErrorKind::DuplicateName raise_error
+    fi
+}
+
+# ============================================================================
+# unify_arm_stacks — reconcile the stack effect of the arm just finished
+# against the arm template recorded on the MatchContext. Runs only when a
+# prior arm has already executed (condition_present).
+
+fn unify_arm_stacks tc:TypeChecker match_ctx:MatchContext op:Op {
+    if "" match_ctx MatchContext::current_branch_label != then
+        match_ctx MatchContext::current_branch_label match_ctx MatchContext::branch_records.push
+    fi
+    match_ctx MatchContext::before = match_before
+    match_ctx MatchContext::after = match_after
+    if
+    match_before tc TypeChecker::live.equals
+    match_after match_before.equals &&
+    then
+        0 drop
+    else
+        match_after tc TypeChecker::live.unify_types = unified
+        if 0 unified.length != match_after match_before.equals ! && then
+            unified match_after TypedStack::set_types
+        elif match_after match_before.equals then
+            tc TypeChecker::live match_after.restore
+        else
+            op Op::location "Match arms have incompatible stack effects" ErrorKind::StackMismatch add_error
+        fi
+    fi
+    match_before tc TypeChecker::live.restore
+}
+
+# ============================================================================
+# register_struct_pattern_bindings — attach field types to each local bound
+# by a struct destructure arm.
+
+fn assign_struct_binding_type
+    matched_struct:CasaStruct
+    field_name:str
+    bound_var:str
+    function_opt:Option[Function]
+{
+    0 = member_index
+    while member_index matched_struct CasaStruct::members.length > do
+        member_index matched_struct CasaStruct::members.get = member
+        if field_name member Member::name == then
+            function_opt member Member::typ bound_var set_binding_type
+        fi
+        1 += member_index
+    done
+}
+
+fn register_struct_pattern_bindings
+    tc:TypeChecker
+    function_opt:Option[Function]
+    struct_pattern:StructPattern
+{
+    struct_pattern StructPattern::struct_name tc.store.structs.get.unwrap = matched_struct
+    struct_pattern StructPattern::bindings.keys = binding_keys
+    0 = binding_index
+    while binding_index binding_keys.length > do
+        binding_index binding_keys.get = field_name
+        field_name struct_pattern StructPattern::bindings.get.unwrap = bound_var
+        function_opt bound_var field_name matched_struct assign_struct_binding_type
+        1 += binding_index
+    done
+}
+
+# ============================================================================
+# register_enum_pattern_bindings — attach payload types to each local bound
+# by an enum-variant destructure arm.
+
+fn register_enum_pattern_bindings
+    tc:TypeChecker
+    function_opt:Option[Function]
+    variant:EnumVariant
+    match_subject_type:str
+{
+    if 0 variant EnumVariant::bindings.length == then return fi
+    match_subject_type resolve_match_type = base_enum_name
+    if base_enum_name tc.store.enums.get Option::Some (casa_enum) is then
+        if variant EnumVariant::variant_name casa_enum CasaEnum::variant_types.get Option::Some (inner_types) is then
+            match_subject_type casa_enum build_enum_type_bindings = type_bindings
+            variant type_bindings inner_types function_opt tc apply_enum_bindings
+        fi
+    fi
+}
+
+fn build_enum_type_bindings casa_enum:CasaEnum match_subject_type:str -> Map[str str] {
+    Map::new (Map[str str]) = type_bindings
+    if 0 casa_enum CasaEnum::type_vars.length == then type_bindings return fi
+    if match_subject_type extract_generic_params Option::Some (raw_params) is then
+        raw_params (List[str]) = type_params
+        0 = type_var_index
+        while
+        type_var_index casa_enum CasaEnum::type_vars.length >
+        type_var_index type_params.length > &&
+        do
+            type_var_index casa_enum CasaEnum::type_vars.get type_var_index type_params.get type_bindings.set = type_bindings
+            1 += type_var_index
+        done
+    fi
+    type_bindings
+}
+
+fn apply_enum_bindings
+    tc:TypeChecker
+    function_opt:Option[Function]
+    inner_types:List[str]
+    type_bindings:Map[str str]
+    variant:EnumVariant
+{
+    0 = bind_index
+    while
+    bind_index variant EnumVariant::bindings.length >
+    bind_index inner_types.length > &&
+    do
+        bind_index variant EnumVariant::bindings.get = binding_var
+        bind_index inner_types.get = binding_type
+        if binding_type type_bindings.get Option::Some (resolved) is then
+            resolved = binding_type
+        fi
+        function_opt binding_type binding_var set_binding_type
+        1 += bind_index
+    done
+}
+
+# ============================================================================
+# register_pattern_bindings — dispatch binding registration by pattern kind.
+
+fn register_pattern_bindings
+    tc:TypeChecker
+    function_opt:Option[Function]
+    op:Op
+    match_subject_type:str
+{
+    op pattern_kind match
+        PatternKind::PatStruct => {
+            op Op::value (StructPattern) = struct_pattern
+            struct_pattern function_opt tc register_struct_pattern_bindings
+        }
+        PatternKind::PatEnumVariant => {
+            if op pattern_is_wildcard then return fi
+            op Op::value (EnumVariant) = variant
+            match_subject_type variant function_opt tc register_enum_pattern_bindings
+        }
+        PatternKind::PatLiteral => 0 drop
+        PatternKind::PatWildcard => 0 drop
+    end
 }
 
 # ============================================================================
@@ -78,150 +269,37 @@ fn pattern_bindings op:Op -> List[str] {
 # stack unification, and binding-type registration for a single OpMatchArm.
 # Callers (currently check_match) delegate the entire arm body to this
 # function; start/end of the match block remain in check_match.
-# ============================================================================
 
 fn typecheck_match_op tc:TypeChecker function_opt:Option[Function] op:Op {
     if 0 tc TypeChecker::branched_stacks.length == then return fi
     tc TypeChecker::branched_stacks.length 1 - tc TypeChecker::branched_stacks.get = top_frame
     if top_frame BranchFrame::BranchMatch (match_ctx) is then
         match_ctx MatchContext::match_type = match_subject_type
-        op Op::value = pattern_ptr
         op pattern_kind = kind
         op pattern_covered_key = covered_key
         match_subject_type resolve_match_type = arm_base
         op pattern_is_wildcard = is_wildcard
         PatternKind::PatEnumVariant kind == = is_enum_pattern
 
-        # Diagnose bare enum variants written without the `Enum::` qualifier.
         if
         is_enum_pattern
         is_wildcard ! &&
         then
-            pattern_ptr (EnumVariant) = variant
-            if "" variant EnumVariant::enum_name == then
-                arm_base tc.store.enums.get = bare_enum_opt
-                if bare_enum_opt.is_some then
-                    bare_enum_opt.unwrap = bare_enum
-                    variant EnumVariant::variant_name = bare_name
-                    bare_name bare_enum CasaEnum::variants string_list_index = bare_index
-                    if 0 bare_index >= then
-                        op Op::location f"Unqualified enum variant `{bare_name}`. Did you mean `{arm_base}::{bare_name}`?" ErrorKind::TypeMismatch raise_error
-                    else
-                        op Op::location f"Expected qualified enum variant (e.g. `{arm_base}::{0 bare_enum CasaEnum::variants.get}`) or `_`, got `{bare_name}`" ErrorKind::TypeMismatch raise_error
-                    fi
-                fi
-            fi
+            op Op::value (EnumVariant) = variant
+            arm_base variant op tc diagnose_bare_enum_pattern
         fi
 
-        # Duplicate-arm detection uses the pattern's covered key.
-        if "" covered_key != then
-            0 = dup_index
-            while dup_index match_ctx MatchContext::branch_records.length > do
-                dup_index match_ctx MatchContext::branch_records.get = record
-                if covered_key record == then
-                    op Op::location f"Duplicate match arm for `{covered_key}`" ErrorKind::DuplicateName raise_error
-                fi
-                1 += dup_index
-            done
-            if covered_key match_ctx MatchContext::current_branch_label == then
-                op Op::location f"Duplicate match arm for `{covered_key}`" ErrorKind::DuplicateName raise_error
-            fi
-        fi
+        covered_key op match_ctx detect_duplicate_arm
 
-        # Match-arm stack unification.
         if match_ctx MatchContext::condition_present then
-            if "" match_ctx MatchContext::current_branch_label != then
-                match_ctx MatchContext::current_branch_label match_ctx MatchContext::branch_records.push
-            fi
-            match_ctx MatchContext::before = match_before
-            match_ctx MatchContext::after = match_after
-            if
-            match_before tc TypeChecker::live.equals
-            match_after match_before.equals &&
-            then
-                0 drop
-            else
-                match_after tc TypeChecker::live.unify_types = unified
-                if 0 unified.length != match_after match_before.equals ! && then
-                    unified match_after TypedStack::set_types
-                elif match_after match_before.equals then
-                    tc TypeChecker::live match_after.restore
-                else
-                    op Op::location "Match arms have incompatible stack effects" ErrorKind::StackMismatch add_error
-                fi
-            fi
-            match_before tc TypeChecker::live.restore
+            op match_ctx tc unify_arm_stacks
         else
             true match_ctx MatchContext::set_condition_present
             tc TypeChecker::live match_ctx MatchContext::before.restore
             tc TypeChecker::live match_ctx MatchContext::after.restore
         fi
 
-        # Set types on pattern bindings.
-        if PatternKind::PatStruct kind == then
-            pattern_ptr (StructPattern) = struct_pat2
-            struct_pat2 StructPattern::struct_name tc.store.structs.get.unwrap = matched_struct
-            struct_pat2 StructPattern::bindings.keys = binding_keys
-            0 = binding_index
-            while binding_index binding_keys.length > do
-                binding_index binding_keys.get = field_name
-                field_name struct_pat2 StructPattern::bindings.get.unwrap = bound_var
-                0 = member_index
-                while member_index matched_struct CasaStruct::members.length > do
-                    member_index matched_struct CasaStruct::members.get = member
-                    if field_name member Member::name == then
-                        function_opt member Member::typ bound_var set_binding_type
-                    fi
-                    1 += member_index
-                done
-                1 += binding_index
-            done
-        elif
-        is_enum_pattern
-        is_wildcard ! &&
-        then
-            pattern_ptr (EnumVariant) = variant
-            if 0 variant EnumVariant::bindings.length != then
-                match_subject_type resolve_match_type = base_enum_name
-                base_enum_name tc.store.enums.get = enum_opt
-                if enum_opt.is_some then
-                    enum_opt.unwrap = casa_enum
-                    variant EnumVariant::variant_name casa_enum CasaEnum::variant_types.get = inner_opt
-                    if inner_opt.is_some then
-                        inner_opt.unwrap = inner_types
-                        Map::new (Map[str str]) = type_bindings
-                        if 0 casa_enum CasaEnum::type_vars.length != then
-                            match_subject_type extract_generic_params = params_opt
-                            if params_opt.is_some then
-                                params_opt.unwrap = type_params
-                                0 = type_var_index
-                                while
-                                type_var_index casa_enum CasaEnum::type_vars.length >
-                                type_var_index type_params.length > &&
-                                do
-                                    type_var_index casa_enum CasaEnum::type_vars.get type_var_index type_params.get type_bindings.set = type_bindings
-                                    1 += type_var_index
-                                done
-                            fi
-                        fi
-                        0 = bind_index
-                        while
-                        bind_index variant EnumVariant::bindings.length >
-                        bind_index inner_types.length > &&
-                        do
-                            bind_index variant EnumVariant::bindings.get = binding_var
-                            bind_index inner_types.get = binding_type
-                            binding_type type_bindings.get = resolved_opt
-                            if resolved_opt.is_some then
-                                resolved_opt.unwrap = binding_type
-                            fi
-                            function_opt binding_type binding_var set_binding_type
-                            1 += bind_index
-                        done
-                    fi
-                fi
-            fi
-        fi
+        match_subject_type op function_opt tc register_pattern_bindings
 
         covered_key match_ctx MatchContext::set_current_branch_label
         op Op::location match_ctx MatchContext::set_current_branch_location

--- a/compiler/pattern.casa
+++ b/compiler/pattern.casa
@@ -1,0 +1,72 @@
+include "common.casa"
+
+# ============================================================================
+# pattern.casa — consolidated match-pattern module.
+#
+# Introspection primitives that every phase (parser-resolve, typechecker,
+# bytecode) can call without re-reading the legacy type_annotation tag
+# string. The tag is still the underlying storage; pattern.casa hides that
+# until the final migration commit removes it.
+# ============================================================================
+# pattern_is_wildcard: true only for a bare `_` wildcard arm.
+# Currently stored as an EnumVariant whose variant_name is "_".
+
+fn pattern_is_wildcard op:Op -> bool {
+    op pattern_kind = kind
+    if PatternKind::PatEnumVariant kind == then
+        op Op::value (EnumVariant) = variant
+        MATCH_WILDCARD variant EnumVariant::variant_name ==
+        return
+    fi
+    false
+}
+# pattern_covered_key: stable key used for duplicate-arm detection and for
+# exhaustiveness bookkeeping. Mirrors the `__covered:{...}` keys the
+# typechecker already produces.
+
+fn pattern_covered_key op:Op -> str {
+    op pattern_kind = kind
+    if PatternKind::PatStruct kind == then
+        op Op::value (StructPattern) = struct_pat
+        f"__covered:{struct_pat StructPattern::struct_name}" return
+    fi
+    if PatternKind::PatLiteral kind == then
+        op Op::value (LiteralPattern) = literal_pat
+        f"__covered:{literal_pat LiteralPattern::raw}" return
+    fi
+    if PatternKind::PatEnumVariant kind == then
+        op Op::value (EnumVariant) = variant
+        f"__covered:{variant EnumVariant::variant_name}" return
+    fi
+    ""
+}
+# pattern_bindings: names this pattern introduces into the enclosing scope.
+# Struct patterns bind field aliases; enum variants bind payload names;
+# literals and wildcards bind nothing.
+
+fn pattern_bindings op:Op -> List[str] {
+    List::new (List[str]) = out
+    op pattern_kind = kind
+    if PatternKind::PatStruct kind == then
+        op Op::value (StructPattern) = struct_pat
+        struct_pat StructPattern::bindings.keys = field_names
+        0 = binding_index
+        while binding_index field_names.length > do
+            binding_index field_names.get struct_pat StructPattern::bindings.get.unwrap = bound_name
+            bound_name out.push
+            1 += binding_index
+        done
+        out return
+    fi
+    if PatternKind::PatEnumVariant kind == then
+        op Op::value (EnumVariant) = variant
+        variant EnumVariant::bindings = names
+        0 = enum_binding_index
+        while enum_binding_index names.length > do
+            enum_binding_index names.get out.push
+            1 += enum_binding_index
+        done
+        out return
+    fi
+    out
+}

--- a/compiler/typechecker.casa
+++ b/compiler/typechecker.casa
@@ -1489,24 +1489,24 @@ fn inject_trait_fn_ptrs
                     # Use continue-safe pattern (avoid nested loop break/continue bug)
                 fi
                 if 0 method TraitMethod::default_ops.length == then
-                f"{concrete}::{method TraitMethod::name}" = fn_name
-                fn_name tc.store.functions.get = global_fn_opt
-                if global_fn_opt.is_none then
-                    location f"Function `{fn_name}` required by trait `{trait_name}` not found" ErrorKind::TypeMismatch raise_error
-                    method_index 1 - = method_index
-                    continue
-                fi
-                global_fn_opt.unwrap = global_fn
-                if global_fn Function::is_used ! then
-                    true global_fn Function::set_is_used
-                    global_fn global_fn Function::ops resolve_identifiers global_fn Function::set_ops
-                fi
-                global_fn ensure_typechecked
-                location OpKind::OpFnPush fn_name make_op_str = push_op
-                insert_pos push_op ops.insert
-                1 += insert_pos
-                1 += inserted
-                f"fn[{global_fn Function::signature signature_to_str}]" tc stack_push
+                    f"{concrete}::{method TraitMethod::name}" = fn_name
+                    fn_name tc.store.functions.get = global_fn_opt
+                    if global_fn_opt.is_none then
+                        location f"Function `{fn_name}` required by trait `{trait_name}` not found" ErrorKind::TypeMismatch raise_error
+                        method_index 1 - = method_index
+                        continue
+                    fi
+                    global_fn_opt.unwrap = global_fn
+                    if global_fn Function::is_used ! then
+                        true global_fn Function::set_is_used
+                        global_fn global_fn Function::ops resolve_identifiers global_fn Function::set_ops
+                    fi
+                    global_fn ensure_typechecked
+                    location OpKind::OpFnPush fn_name make_op_str = push_op
+                    insert_pos push_op ops.insert
+                    1 += insert_pos
+                    1 += inserted
+                    f"fn[{global_fn Function::signature signature_to_str}]" tc stack_push
                 fi
                 method_index 1 - = method_index
             done
@@ -1805,167 +1805,7 @@ fn check_match tc:TypeChecker op:Op function_opt:Option[Function] {
         match_ctx BranchFrame::BranchMatch = match_frame
         match_frame tc TypeChecker::branched_stacks.push
     elif OpKind::OpMatchArm kind == then
-        if 0 tc TypeChecker::branched_stacks.length == then return fi
-        tc TypeChecker::branched_stacks.length 1 - tc TypeChecker::branched_stacks.get = top_frame
-        if top_frame BranchFrame::BranchMatch (match_ctx) is then
-            match_ctx MatchContext::match_type = match_subject_type
-
-            # Determine pattern type from annotation tag set by parser
-            op Op::value = pattern_ptr
-            op Op::type_annotation = pattern_tag
-            "" = covered_key
-            match_subject_type resolve_match_type = arm_base
-            false = is_wildcard
-            false = is_enum_pattern
-
-            if "struct_pattern" pattern_tag == then
-                pattern_ptr (StructPattern) = struct_pat
-                f"__covered:{struct_pat StructPattern::struct_name}" = covered_key
-            elif "literal_pattern" pattern_tag == then
-                pattern_ptr (LiteralPattern) = literal_pat
-                f"__covered:{literal_pat LiteralPattern::raw}" = covered_key
-            else
-                # Enum variant (includes wildcard)
-                pattern_ptr (EnumVariant) = variant
-                true = is_enum_pattern
-                if MATCH_WILDCARD variant EnumVariant::variant_name == then
-                    true = is_wildcard
-                fi
-                f"__covered:{variant EnumVariant::variant_name}" = covered_key
-                # Check for bare variant (no enum qualifier)
-                if
-                "" variant EnumVariant::enum_name ==
-                is_wildcard ! &&
-                then
-                    arm_base tc.store.enums.get = bare_enum_opt
-                    if bare_enum_opt.is_some then
-                        bare_enum_opt.unwrap = bare_enum
-                        variant EnumVariant::variant_name = bare_name
-                        # Check if the bare name is a variant of the matched enum
-                        bare_name bare_enum CasaEnum::variants string_list_index = bare_index
-                        if 0 bare_index >= then
-                            op Op::location f"Unqualified enum variant `{bare_name}`. Did you mean `{arm_base}::{bare_name}`?" ErrorKind::TypeMismatch raise_error
-                        else
-                            op Op::location f"Expected qualified enum variant (e.g. `{arm_base}::{0 bare_enum CasaEnum::variants.get}`) or `_`, got `{bare_name}`" ErrorKind::TypeMismatch raise_error
-                        fi
-                    fi
-                fi
-            fi
-
-            # Check for duplicate arms
-            if "" covered_key != then
-                0 = dup_index
-                while dup_index match_ctx MatchContext::branch_records.length > do
-                    dup_index match_ctx MatchContext::branch_records.get = record
-                    if covered_key record == then
-                        op Op::location f"Duplicate match arm for `{covered_key}`" ErrorKind::DuplicateName raise_error
-                    fi
-                    1 += dup_index
-                done
-                if covered_key match_ctx MatchContext::current_branch_label == then
-                    op Op::location f"Duplicate match arm for `{covered_key}`" ErrorKind::DuplicateName raise_error
-                fi
-            fi
-
-            # Handle branch state
-            if match_ctx MatchContext::condition_present then
-                # Record previous arm
-                if "" match_ctx MatchContext::current_branch_label != then
-                    match_ctx MatchContext::current_branch_label match_ctx MatchContext::branch_records.push
-                fi
-                match_ctx MatchContext::before = match_before
-                match_ctx MatchContext::after = match_after
-                if
-                match_before tc TypeChecker::live.equals
-                match_after match_before.equals &&
-                then
-                    0 drop
-                else
-                    match_after tc TypeChecker::live.unify_types = unified
-                    if 0 unified.length != match_after match_before.equals ! && then
-                        unified match_after TypedStack::set_types
-                    elif match_after match_before.equals then
-                        tc TypeChecker::live match_after.restore
-                    else
-                        op Op::location "Match arms have incompatible stack effects" ErrorKind::StackMismatch add_error
-                    fi
-                fi
-                match_before tc TypeChecker::live.restore
-            else
-                true match_ctx MatchContext::set_condition_present
-                tc TypeChecker::live match_ctx MatchContext::before.restore
-                tc TypeChecker::live match_ctx MatchContext::after.restore
-            fi
-
-            # Set types on pattern bindings
-            if "struct_pattern" pattern_tag == then
-                # StructPattern bindings
-                pattern_ptr (StructPattern) = struct_pat2
-                struct_pat2 StructPattern::struct_name tc.store.structs.get.unwrap = matched_struct
-                struct_pat2 StructPattern::bindings.keys = binding_keys
-                0 = binding_index
-                while binding_index binding_keys.length > do
-                    binding_index binding_keys.get = field_name
-                    field_name struct_pat2 StructPattern::bindings.get.unwrap = bound_var
-                    0 = member_index
-                    while member_index matched_struct CasaStruct::members.length > do
-                        member_index matched_struct CasaStruct::members.get = member
-                        if field_name member Member::name == then
-                            function_opt member Member::typ bound_var set_binding_type
-                        fi
-                        1 += member_index
-                    done
-                    1 += binding_index
-                done
-            elif is_enum_pattern is_wildcard ! && then
-                pattern_ptr (EnumVariant) = variant
-                if 0 variant EnumVariant::bindings.length != then
-                    # EnumVariant bindings
-                    match_subject_type resolve_match_type = base_enum_name
-                    base_enum_name tc.store.enums.get = enum_opt
-                    if enum_opt.is_some then
-                        enum_opt.unwrap = casa_enum
-                        variant EnumVariant::variant_name casa_enum CasaEnum::variant_types.get = inner_opt
-                        if inner_opt.is_some then
-                            inner_opt.unwrap = inner_types
-                            # Resolve generic type vars from match subject
-                            Map::new (Map[str str]) = type_bindings
-                            if 0 casa_enum CasaEnum::type_vars.length != then
-                                match_subject_type extract_generic_params = params_opt
-                                if params_opt.is_some then
-                                    params_opt.unwrap = type_params
-                                    0 = type_var_index
-                                    while
-                                    type_var_index casa_enum CasaEnum::type_vars.length >
-                                    type_var_index type_params.length > &&
-                                    do
-                                        type_var_index casa_enum CasaEnum::type_vars.get type_var_index type_params.get type_bindings.set = type_bindings
-                                        1 += type_var_index
-                                    done
-                                fi
-                            fi
-                            0 = bind_index
-                            while
-                            bind_index variant EnumVariant::bindings.length >
-                            bind_index inner_types.length > &&
-                            do
-                                bind_index variant EnumVariant::bindings.get = binding_var
-                                bind_index inner_types.get = binding_type
-                                binding_type type_bindings.get = resolved_opt
-                                if resolved_opt.is_some then
-                                    resolved_opt.unwrap = binding_type
-                                fi
-                                function_opt binding_type binding_var set_binding_type
-                                1 += bind_index
-                            done
-                        fi
-                    fi
-                fi
-            fi
-
-            covered_key match_ctx MatchContext::set_current_branch_label
-            op Op::location match_ctx MatchContext::set_current_branch_location
-        fi
+        op function_opt tc typecheck_match_op
     elif OpKind::OpMatchEnd kind == then
         tc TypeChecker::branched_stacks.pop = top_frame
         if top_frame BranchFrame::BranchMatch (match_ctx) is then
@@ -2247,10 +2087,13 @@ fn check_abstract_methods_present receiver:str trait_def:CasaTrait -> bool {
     done
     true
 }
-
 false = DEFAULT_METHOD_INSTANTIATING
 
-fn instantiate_default_trait_method function_opt:Option[Function] method_name:str receiver:str -> Option[str] {
+fn instantiate_default_trait_method
+    function_opt:Option[Function]
+    method_name:str
+    receiver:str
+-> Option[str] {
     f"{receiver}::{method_name}" DEFAULT_PARSER.store.functions.get = already_opt
     if already_opt.is_some then
         f"{receiver}::{method_name}" Option::Some return
@@ -2883,3 +2726,4 @@ fn type_check_functions {
     done
     flush_errors
 }
+include "pattern.casa"

--- a/tests/compiler/test_bytecode.casa
+++ b/tests/compiler/test_bytecode.casa
@@ -2,6 +2,7 @@ include "../../compiler/common.casa"
 include "../../compiler/error.casa"
 include "../../compiler/lexer.casa"
 include "../../compiler/parser.casa"
+include "../../compiler/typechecker.casa"
 include "../../lib/test.casa"
 
 symbol_store_new = TEST_STORE

--- a/tests/compiler/test_pattern.casa
+++ b/tests/compiler/test_pattern.casa
@@ -11,10 +11,24 @@ include "../../lib/test.casa"
 # Helpers for building match-arm ops for tests
 # ============================================================================
 
-fn arm_with_tag tag:str -> Op {
-    empty_location OpKind::OpMatchArm 0 make_op = op
-    tag op Op::set_type_annotation
-    op
+fn arm_of_kind kind:PatternKind -> Op {
+    kind empty_location OpKind::OpMatchArm 0 make_op_pattern
+}
+
+fn make_enum_arm enum_name:str variant_name:str -> Op {
+    Option::None variant_name enum_name make_enum_variant = variant
+    PatternKind::PatEnumVariant empty_location OpKind::OpMatchArm variant (int) make_op_pattern
+}
+
+fn make_struct_arm struct_name:str -> Op {
+    Map::new (Map[str str]) = bindings
+    bindings struct_name StructPattern = struct_pat
+    PatternKind::PatStruct empty_location OpKind::OpMatchArm struct_pat (int) make_op_pattern
+}
+
+fn make_literal_arm raw:str -> Op {
+    raw "int" 0 LiteralPattern = literal_pat
+    PatternKind::PatLiteral empty_location OpKind::OpMatchArm literal_pat (int) make_op_pattern
 }
 
 # ============================================================================
@@ -23,32 +37,25 @@ fn arm_with_tag tag:str -> Op {
 
 fn test_pattern_kind_struct {
     "pattern_kind_struct" test_start
-    "struct_pattern" arm_with_tag = op
+    "Point" make_struct_arm = op
     "struct" PatternKind::PatStruct op pattern_kind == assert_true
 }
 
 fn test_pattern_kind_enum_variant {
     "pattern_kind_enum_variant" test_start
-    "enum_variant" arm_with_tag = op
+    "Up" "Dir" make_enum_arm = op
     "enum" PatternKind::PatEnumVariant op pattern_kind == assert_true
 }
 
 fn test_pattern_kind_literal {
     "pattern_kind_literal" test_start
-    "literal_pattern" arm_with_tag = op
+    "42" make_literal_arm = op
     "literal" PatternKind::PatLiteral op pattern_kind == assert_true
 }
 
 # ============================================================================
 # pattern_is_wildcard primitive
 # ============================================================================
-
-fn make_enum_arm enum_name:str variant_name:str -> Op {
-    Option::None variant_name enum_name make_enum_variant = variant
-    empty_location OpKind::OpMatchArm variant (int) make_op = op
-    "enum_variant" op Op::set_type_annotation
-    op
-}
 
 fn test_pattern_is_wildcard_underscore_variant {
     "pattern_is_wildcard_underscore" test_start
@@ -64,34 +71,19 @@ fn test_pattern_is_wildcard_named_variant {
 
 fn test_pattern_is_wildcard_literal {
     "pattern_is_wildcard_literal" test_start
-    "literal_pattern" arm_with_tag = op
+    "42" make_literal_arm = op
     "literal not wildcard" op pattern_is_wildcard assert_false
 }
 
 fn test_pattern_is_wildcard_struct {
     "pattern_is_wildcard_struct" test_start
-    "struct_pattern" arm_with_tag = op
+    "Point" make_struct_arm = op
     "struct not wildcard" op pattern_is_wildcard assert_false
 }
 
 # ============================================================================
 # pattern_covered_key primitive
 # ============================================================================
-
-fn make_struct_arm struct_name:str -> Op {
-    Map::new (Map[str str]) = bindings
-    bindings struct_name StructPattern = struct_pat
-    empty_location OpKind::OpMatchArm struct_pat (int) make_op = op
-    "struct_pattern" op Op::set_type_annotation
-    op
-}
-
-fn make_literal_arm raw:str -> Op {
-    raw "int" 0 LiteralPattern = literal_pat
-    empty_location OpKind::OpMatchArm literal_pat (int) make_op = op
-    "literal_pattern" op Op::set_type_annotation
-    op
-}
 
 fn test_pattern_covered_key_struct {
     "pattern_covered_key_struct" test_start
@@ -133,8 +125,7 @@ fn test_pattern_bindings_enum_with_payload {
     List::new (List[str]) = binds
     "x" binds.push
     binds variant EnumVariant::set_bindings
-    empty_location OpKind::OpMatchArm variant (int) make_op = op
-    "enum_variant" op Op::set_type_annotation
+    PatternKind::PatEnumVariant empty_location OpKind::OpMatchArm variant (int) make_op_pattern = op
     op pattern_bindings = out
     "count" 1 out.length assert_eq
     "name" "x" 0 out.get assert_str_eq
@@ -146,8 +137,7 @@ fn test_pattern_bindings_struct_fields {
     "row" "y" bindings.set drop
     "col" "x" bindings.set drop
     bindings "Point" StructPattern = struct_pat
-    empty_location OpKind::OpMatchArm struct_pat (int) make_op = op
-    "struct_pattern" op Op::set_type_annotation
+    PatternKind::PatStruct empty_location OpKind::OpMatchArm struct_pat (int) make_op_pattern = op
     op pattern_bindings = out
     "count" 2 out.length assert_eq
 }

--- a/tests/compiler/test_pattern.casa
+++ b/tests/compiler/test_pattern.casa
@@ -2,6 +2,8 @@ include "../../compiler/common.casa"
 include "../../compiler/error.casa"
 include "../../compiler/lexer.casa"
 include "../../compiler/parser.casa"
+include "../../compiler/typechecker.casa"
+include "../../compiler/bytecode.casa"
 include "../../compiler/pattern.casa"
 include "../../lib/test.casa"
 

--- a/tests/compiler/test_pattern.casa
+++ b/tests/compiler/test_pattern.casa
@@ -1,0 +1,41 @@
+include "../../compiler/common.casa"
+include "../../compiler/error.casa"
+include "../../compiler/lexer.casa"
+include "../../compiler/parser.casa"
+include "../../lib/test.casa"
+
+# ============================================================================
+# Helpers for building match-arm ops for tests
+# ============================================================================
+
+fn arm_with_tag tag:str -> Op {
+    empty_location OpKind::OpMatchArm 0 make_op = op
+    tag op Op::set_type_annotation
+    op
+}
+
+# ============================================================================
+# pattern_kind primitive
+# ============================================================================
+
+fn test_pattern_kind_struct {
+    "pattern_kind_struct" test_start
+    "struct_pattern" arm_with_tag = op
+    "struct" PatternKind::PatStruct op pattern_kind == assert_true
+}
+
+fn test_pattern_kind_enum_variant {
+    "pattern_kind_enum_variant" test_start
+    "enum_variant" arm_with_tag = op
+    "enum" PatternKind::PatEnumVariant op pattern_kind == assert_true
+}
+
+fn test_pattern_kind_literal {
+    "pattern_kind_literal" test_start
+    "literal_pattern" arm_with_tag = op
+    "literal" PatternKind::PatLiteral op pattern_kind == assert_true
+}
+test_pattern_kind_struct
+test_pattern_kind_enum_variant
+test_pattern_kind_literal
+test_summary

--- a/tests/compiler/test_pattern.casa
+++ b/tests/compiler/test_pattern.casa
@@ -2,6 +2,7 @@ include "../../compiler/common.casa"
 include "../../compiler/error.casa"
 include "../../compiler/lexer.casa"
 include "../../compiler/parser.casa"
+include "../../compiler/pattern.casa"
 include "../../lib/test.casa"
 
 # ============================================================================
@@ -35,7 +36,138 @@ fn test_pattern_kind_literal {
     "literal_pattern" arm_with_tag = op
     "literal" PatternKind::PatLiteral op pattern_kind == assert_true
 }
+
+# ============================================================================
+# pattern_is_wildcard primitive
+# ============================================================================
+
+fn make_enum_arm enum_name:str variant_name:str -> Op {
+    Option::None variant_name enum_name make_enum_variant = variant
+    empty_location OpKind::OpMatchArm variant (int) make_op = op
+    "enum_variant" op Op::set_type_annotation
+    op
+}
+
+fn test_pattern_is_wildcard_underscore_variant {
+    "pattern_is_wildcard_underscore" test_start
+    "_" "" make_enum_arm = op
+    "wildcard" op pattern_is_wildcard assert_true
+}
+
+fn test_pattern_is_wildcard_named_variant {
+    "pattern_is_wildcard_named" test_start
+    "Up" "Dir" make_enum_arm = op
+    "not wildcard" op pattern_is_wildcard assert_false
+}
+
+fn test_pattern_is_wildcard_literal {
+    "pattern_is_wildcard_literal" test_start
+    "literal_pattern" arm_with_tag = op
+    "literal not wildcard" op pattern_is_wildcard assert_false
+}
+
+fn test_pattern_is_wildcard_struct {
+    "pattern_is_wildcard_struct" test_start
+    "struct_pattern" arm_with_tag = op
+    "struct not wildcard" op pattern_is_wildcard assert_false
+}
+
+# ============================================================================
+# pattern_covered_key primitive
+# ============================================================================
+
+fn make_struct_arm struct_name:str -> Op {
+    Map::new (Map[str str]) = bindings
+    bindings struct_name StructPattern = struct_pat
+    empty_location OpKind::OpMatchArm struct_pat (int) make_op = op
+    "struct_pattern" op Op::set_type_annotation
+    op
+}
+
+fn make_literal_arm raw:str -> Op {
+    raw "int" 0 LiteralPattern = literal_pat
+    empty_location OpKind::OpMatchArm literal_pat (int) make_op = op
+    "literal_pattern" op Op::set_type_annotation
+    op
+}
+
+fn test_pattern_covered_key_struct {
+    "pattern_covered_key_struct" test_start
+    "Point" make_struct_arm = op
+    "covered" "__covered:Point" op pattern_covered_key assert_str_eq
+}
+
+fn test_pattern_covered_key_enum {
+    "pattern_covered_key_enum" test_start
+    "Up" "Dir" make_enum_arm = op
+    "covered" "__covered:Up" op pattern_covered_key assert_str_eq
+}
+
+fn test_pattern_covered_key_literal {
+    "pattern_covered_key_literal" test_start
+    "42" make_literal_arm = op
+    "covered" "__covered:42" op pattern_covered_key assert_str_eq
+}
+
+fn test_pattern_covered_key_wildcard_matches_underscore {
+    "pattern_covered_key_wildcard" test_start
+    "_" "" make_enum_arm = op
+    "covered" "__covered:_" op pattern_covered_key assert_str_eq
+}
+
+# ============================================================================
+# pattern_bindings primitive
+# ============================================================================
+
+fn test_pattern_bindings_enum_empty {
+    "pattern_bindings_enum_empty" test_start
+    "Up" "Dir" make_enum_arm = op
+    "count" 0 op pattern_bindings.length assert_eq
+}
+
+fn test_pattern_bindings_enum_with_payload {
+    "pattern_bindings_enum_with_payload" test_start
+    Option::None "Some" "Option" make_enum_variant = variant
+    List::new (List[str]) = binds
+    "x" binds.push
+    binds variant EnumVariant::set_bindings
+    empty_location OpKind::OpMatchArm variant (int) make_op = op
+    "enum_variant" op Op::set_type_annotation
+    op pattern_bindings = out
+    "count" 1 out.length assert_eq
+    "name" "x" 0 out.get assert_str_eq
+}
+
+fn test_pattern_bindings_struct_fields {
+    "pattern_bindings_struct_fields" test_start
+    Map::new (Map[str str]) = bindings
+    "row" "y" bindings.set drop
+    "col" "x" bindings.set drop
+    bindings "Point" StructPattern = struct_pat
+    empty_location OpKind::OpMatchArm struct_pat (int) make_op = op
+    "struct_pattern" op Op::set_type_annotation
+    op pattern_bindings = out
+    "count" 2 out.length assert_eq
+}
+
+fn test_pattern_bindings_literal_empty {
+    "pattern_bindings_literal_empty" test_start
+    "42" make_literal_arm = op
+    "count" 0 op pattern_bindings.length assert_eq
+}
 test_pattern_kind_struct
 test_pattern_kind_enum_variant
 test_pattern_kind_literal
+test_pattern_is_wildcard_underscore_variant
+test_pattern_is_wildcard_named_variant
+test_pattern_is_wildcard_literal
+test_pattern_is_wildcard_struct
+test_pattern_covered_key_struct
+test_pattern_covered_key_enum
+test_pattern_covered_key_literal
+test_pattern_covered_key_wildcard_matches_underscore
+test_pattern_bindings_enum_empty
+test_pattern_bindings_enum_with_payload
+test_pattern_bindings_struct_fields
+test_pattern_bindings_literal_empty
 test_summary

--- a/tests/compiler/test_pattern.casa
+++ b/tests/compiler/test_pattern.casa
@@ -147,6 +147,35 @@ fn test_pattern_bindings_literal_empty {
     "42" make_literal_arm = op
     "count" 0 op pattern_bindings.length assert_eq
 }
+
+# ============================================================================
+# Integration: exercise full parse -> resolve -> typecheck through the
+# pattern module's entry points.
+# ============================================================================
+
+fn test_mixed_match_parses_and_typechecks {
+    "mixed_match_parses_and_typechecks" test_start
+    clear_global_state
+    enable_test_mode
+    "mixed" "1 match 1 => \"one\" 2 => \"two\" _ => \"other\" end" lex_source = tokens
+    tokens DEFAULT_PARSER parse_ops = ops
+    ops DEFAULT_PARSER resolve_identifiers_global = ops
+    Option::None ops type_check_ops drop
+    "mixed-kind match typechecks" assert_no_errors
+    disable_test_mode
+}
+
+fn test_duplicate_literal_arm_detected {
+    "duplicate_literal_arm_detected" test_start
+    clear_global_state
+    enable_test_mode
+    "dup" "1 match 1 => \"a\" 1 => \"b\" _ => \"c\" end" lex_source = dup_tokens
+    dup_tokens DEFAULT_PARSER parse_ops = dup_ops
+    dup_ops DEFAULT_PARSER resolve_identifiers_global = dup_ops
+    Option::None dup_ops type_check_ops drop
+    "duplicate arm flagged" "Duplicate match arm" assert_error_contains
+    disable_test_mode
+}
 test_pattern_kind_struct
 test_pattern_kind_enum_variant
 test_pattern_kind_literal
@@ -162,4 +191,6 @@ test_pattern_bindings_enum_empty
 test_pattern_bindings_enum_with_payload
 test_pattern_bindings_struct_fields
 test_pattern_bindings_literal_empty
+test_mixed_match_parses_and_typechecks
+test_duplicate_literal_arm_detected
 test_summary


### PR DESCRIPTION
Closes #99.

## Summary

Consolidates cross-phase match-pattern handling into a dedicated `compiler/pattern.casa` module. Replaces the implicit `Op.type_annotation` string tag (`"struct_pattern"`/`"enum_variant"`/`"literal_pattern"`) with a real `PatternKind` enum field on `Op`, and collapses duplicated dispatch across parser-resolve, typechecker, and bytecode into four phase-sized entry points plus four introspection primitives.

## Public surface

Introspection primitives (pure, no compiler-state dependencies):
- `pattern_kind op:Op -> PatternKind`
- `pattern_is_wildcard op:Op -> bool`
- `pattern_covered_key op:Op -> str` (duplicate-arm detection)
- `pattern_bindings op:Op -> List[str]`

Phase entry points:
- `typecheck_match_op tc:TypeChecker function_opt:Option[Function] op:Op`
- `compile_match_op compiler:BytecodeCompiler op:Op is_last:bool next_arm:Option[int] bytecode:List[Inst]`
- `resolve_match_op parser:Parser function:Function op:Op errors:List[CasaError]`
- `parse_match_block parser:Parser token:Token cursor:TokenCursor function_name:str -> List[Op]`

## Migration sequence (9 commits)

1. `4bdc27a` Add PatternKind enum and pattern_kind accessor
2. `a700652` Add pattern.casa with introspection primitives
3. `fa50bbe` Route typechecker match-arm dispatch through pattern module
4. `f9222a1` Route bytecode match-arm dispatch through compile_match_op
5. `ac879e5` Route parser resolve-pass through resolve_match_op
6. `352c51e` Rename handle_keyword_match to parse_match_block
7. `15077e5` Drop pattern tag-string, store PatternKind on Op directly
8. `28e6b39` Add integration tests for pattern module entry points
9. `dbbcbb3` Apply STYLE.md conventions to pattern dispatch

Each commit keeps `tests/test_compiler.sh` and `tests/test_examples.sh` green.

## Test plan

- [x] `tests/test_compiler.sh` — 21 tests pass (incl. self-compilation + fixed-point)
- [x] `tests/test_examples.sh` — 37 examples pass
- [x] New `tests/compiler/test_pattern.casa` — 18 unit + integration tests covering each primitive per PatternKind, duplicate-arm detection, and mixed literal/wildcard arms
- [x] `grep -r "struct_pattern\|enum_variant\|literal_pattern" compiler/` returns zero tag-string references