### PR TITLE
Add match arm guard clauses

### DIFF
--- a/compiler/bytecode.casa
+++ b/compiler/bytecode.casa
@@ -416,7 +416,6 @@ fn emit_struct_arm compiler:BytecodeCompiler struct_pattern:StructPattern byteco
         fi
         1 += index
     done
-    InstKind::InstDrop make_inst bytecode.push
 }
 
 fn emit_literal_arm
@@ -426,10 +425,7 @@ fn emit_literal_arm
     next_arm:Option[int]
     bytecode:List[Inst]
 {
-    if is_last then
-        InstKind::InstDrop make_inst bytecode.push
-        return
-    fi
+    if is_last then return fi
     InstKind::InstDup make_inst bytecode.push
     if "str" literal_pattern LiteralPattern::typ == then
         literal_pattern LiteralPattern::value (str) = str_value
@@ -441,7 +437,6 @@ fn emit_literal_arm
         InstKind::InstEq make_inst bytecode.push
     fi
     next_arm.unwrap InstKind::InstJumpNe make_inst_int bytecode.push
-    InstKind::InstDrop make_inst bytecode.push
 }
 
 fn emit_enum_arm
@@ -452,11 +447,12 @@ fn emit_enum_arm
     next_arm:Option[int]
     bytecode:List[Inst]
 {
+    if is_wildcard then return fi
     variant EnumVariant::enum_name = enum_name
     if "" enum_name != enum_name compiler.store.enums.has && then
         enum_name compiler.store.enums.get.unwrap = casa_enum
         if casa_enum has_inner_values then
-            if is_last ! is_wildcard ! && then
+            if is_last ! then
                 InstKind::InstDup make_inst bytecode.push
                 InstKind::InstLoad64 make_inst bytecode.push
                 variant EnumVariant::ordinal.unwrap InstKind::InstPush make_inst_int bytecode.push
@@ -468,15 +464,11 @@ fn emit_enum_arm
         fi
     fi
 
-    if is_last then
-        InstKind::InstDrop make_inst bytecode.push
-        return
-    fi
+    if is_last then return fi
     InstKind::InstDup make_inst bytecode.push
     variant EnumVariant::ordinal.unwrap InstKind::InstPush make_inst_int bytecode.push
     InstKind::InstEq make_inst bytecode.push
     next_arm.unwrap InstKind::InstJumpNe make_inst_int bytecode.push
-    InstKind::InstDrop make_inst bytecode.push
 }
 
 fn emit_enum_arm_bindings compiler:BytecodeCompiler bytecode:List[Inst] variant:EnumVariant {
@@ -492,7 +484,6 @@ fn emit_enum_arm_bindings compiler:BytecodeCompiler bytecode:List[Inst] variant:
         resolved ResolvedVariable::index resolved ResolvedVariable::set_kind make_inst_int bytecode.push
         1 += index
     done
-    InstKind::InstDrop make_inst bytecode.push
 }
 
 fn compile_match_op
@@ -504,24 +495,39 @@ fn compile_match_op
 {
     op pattern_kind match
         PatternKind::PatStruct => {
-            op Op::value (StructPattern) = struct_pattern
+            op pattern_value_of (StructPattern) = struct_pattern
             bytecode struct_pattern compiler emit_struct_arm
         }
         PatternKind::PatLiteral => {
-            op Op::value (LiteralPattern) = literal_pattern
+            op pattern_value_of (LiteralPattern) = literal_pattern
             bytecode next_arm is_last literal_pattern compiler emit_literal_arm
         }
         PatternKind::PatEnumVariant => {
-            op Op::value (EnumVariant) = variant
+            op pattern_value_of (EnumVariant) = variant
             op pattern_is_wildcard = is_wildcard
             bytecode next_arm is_last is_wildcard variant compiler emit_enum_arm
         }
-        PatternKind::PatWildcard => {
-            if is_last then
-                InstKind::InstDrop make_inst bytecode.push
-            fi
-        }
+        PatternKind::PatWildcard => 0 drop
     end
+    op pattern_guard_ops = guard_ops
+    if guard_ops.length 0 != then
+        0 = guard_index
+        while guard_index guard_ops.length > do
+            guard_index guard_ops.get = guard_op
+            bytecode guard_index guard_op compiler compile_op
+            1 += guard_index
+        done
+        # Guarded last-arm is rejected by the typechecker (a guarded arm
+        # does not cover its pattern, so a non-guarded fallback is
+        # required). Codegen may still run in RESILIENT_MODE after such
+        # an error, so skip the fail-jump rather than unwrapping None.
+        if next_arm.is_some then
+            next_arm.unwrap InstKind::InstJumpNe make_inst_int bytecode.push
+        else
+            InstKind::InstDrop make_inst bytecode.push
+        fi
+    fi
+    InstKind::InstDrop make_inst bytecode.push
 }
 
 fn compile_match_block compiler:BytecodeCompiler op:Op op_index:int bytecode:List[Inst] {

--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -650,6 +650,20 @@ struct LiteralPattern {
 fn is_wildcard_literal_pattern pattern:LiteralPattern -> bool {
     false
 }
+# MatchArm — wrapper stored on OpMatchArm.value. Carries the pattern payload
+# pointer (StructPattern / EnumVariant / LiteralPattern, interpreted per
+# Op.pattern_kind) and an optional guard expression. `guard_ops` is empty for
+# unguarded arms; when non-empty it is compiled after pattern bindings and
+# produces a bool that diverts execution to the next arm when false.
+
+struct MatchArm {
+    pattern_value: int
+    guard_ops:     List[Op]
+}
+
+fn make_match_arm pattern_value:int guard_ops:List[Op] -> MatchArm {
+    guard_ops pattern_value MatchArm
+}
 
 # ============================================================================
 # PatternKind — discriminator for OpMatchArm pattern shape.
@@ -673,6 +687,18 @@ impl PatternKind {
 
 fn pattern_kind op:Op -> PatternKind {
     op Op::pattern_kind
+}
+
+fn match_arm_of op:Op -> MatchArm {
+    op Op::value (MatchArm)
+}
+
+fn pattern_value_of op:Op -> int {
+    op match_arm_of MatchArm::pattern_value
+}
+
+fn pattern_guard_ops op:Op -> List[Op] {
+    op match_arm_of MatchArm::guard_ops
 }
 
 # ============================================================================

--- a/compiler/parser.casa
+++ b/compiler/parser.casa
@@ -1435,22 +1435,25 @@ fn is_match_arm_boundary parser:Parser cursor:TokenCursor -> bool {
     pos token_list.get = token
     pos 1 + token_list.get = next_token
 
-    # _ =>
-    if MATCH_WILDCARD token Token::value == "=>" next_token Token::value == && then
-        true return
+    # _ => or _ if ...
+    if MATCH_WILDCARD token Token::value == then
+        if "=>" next_token Token::value == then true return fi
+        if "if" next_token Token::value == then true return fi
     fi
-    # literal =>
-    if TokenKind::Literal token Token::kind == "=>" next_token Token::value == && then
-        true return
+    # literal => or literal if ...
+    if TokenKind::Literal token Token::kind == then
+        if "=>" next_token Token::value == then true return fi
+        if "if" next_token Token::value == then true return fi
     fi
     if TokenKind::Identifier token Token::kind != then false return fi
-    # Identifier =>
+    # Identifier => or Identifier if ...
     if "=>" next_token Token::value == then true return fi
+    if "if" next_token Token::value == then true return fi
     # StructName { ... } =>
     if "{" next_token Token::value == token Token::value parser.store.structs.get.is_some && then
         true return
     fi
-    # EnumName::Variant(bindings) => pattern
+    # EnumName::Variant(bindings) => or EnumName::Variant(bindings) if ...
     if "(" next_token Token::value == then
         token Token::value "::" str::find = separator
         if 0 separator > then
@@ -1458,9 +1461,9 @@ fn is_match_arm_boundary parser:Parser cursor:TokenCursor -> bool {
             while scan_pos token_list.length > do
                 if ")" scan_pos token_list.get Token::value == then
                     if scan_pos 1 + token_list.length > then
-                        if "=>" scan_pos 1 + token_list.get Token::value == then
-                            true return
-                        fi
+                        scan_pos 1 + token_list.get Token::value = after_paren
+                        if "=>" after_paren == then true return fi
+                        if "if" after_paren == then true return fi
                     fi
                     break
                 fi
@@ -1494,8 +1497,45 @@ fn parse_struct_match_pattern parser:Parser name_token:Token cursor:TokenCursor 
         field_token Token::value var_token Token::value bindings.set = bindings
     done
 
-    "=>" cursor expect_token_value drop
     bindings name_token Token::value StructPattern
+}
+# parse_pattern_terminator — consume the `=>` that separates a match-arm
+# pattern from its body. If an `if` keyword appears first the guard
+# expression is collected until `=>`. Returns the (possibly empty) list of
+# guard ops. The trailing `=>` token is always consumed.
+#
+# The guard expression may contain a nested `match` block whose arms also
+# use `=>`; a match-depth counter skips those nested arrows so only the
+# outer arm terminator ends the guard.
+
+fn parse_pattern_terminator parser:Parser cursor:TokenCursor function_name:str -> List[Op] {
+    List::new (List[Op]) = guard_ops
+    cursor.peek = guard_peek
+    if guard_peek.is_some "if" guard_peek.unwrap Token::value == && then
+        cursor.pop drop # consume `if`
+        0 = match_depth
+        while cursor.is_finished ! do
+            cursor.peek = next_opt
+            if next_opt.is_none then break fi
+            next_opt.unwrap Token::value = next_value
+            if "=>" next_value == 0 match_depth == && then break fi
+            cursor.pop = guard_token_opt
+            if guard_token_opt.is_none then break fi
+            guard_token_opt.unwrap = guard_token
+            if "match" guard_token Token::value == then
+                1 += match_depth
+            elif "end" guard_token Token::value == 0 match_depth != && then
+                1 -= match_depth
+            fi
+            if TokenKind::FstringStart guard_token Token::kind == then
+                guard_ops function_name cursor guard_token parser handle_fstring
+                continue
+            fi
+            guard_ops function_name cursor guard_token parser token_to_op
+        done
+    fi
+    "=>" cursor expect_token_value drop
+    guard_ops
 }
 
 fn parse_literal_match_pattern token:Token -> LiteralPattern {
@@ -1538,25 +1578,30 @@ fn parse_match_block parser:Parser token:Token cursor:TokenCursor function_name:
 
         # Wildcard: _ =>
         if MATCH_WILDCARD arm_token Token::value == then
-            "=>" cursor expect_token_value drop
+            function_name cursor parser parse_pattern_terminator = wildcard_guard_ops
             Option::None MATCH_WILDCARD "" make_enum_variant = wildcard
-            PatternKind::PatEnumVariant arm_token Token::location OpKind::OpMatchArm wildcard (int) make_op_pattern ops.push
+            wildcard_guard_ops wildcard (int) make_match_arm = wildcard_arm
+            PatternKind::PatEnumVariant arm_token Token::location OpKind::OpMatchArm wildcard_arm (int) make_op_pattern ops.push
         elif TokenKind::Literal arm_token Token::kind == then
-            "=>" cursor expect_token_value drop
+            function_name cursor parser parse_pattern_terminator = literal_guard_ops
             arm_token parse_literal_match_pattern = literal_pattern
-            PatternKind::PatLiteral arm_token Token::location OpKind::OpMatchArm literal_pattern (int) make_op_pattern = literal_op
+            literal_guard_ops literal_pattern (int) make_match_arm = literal_arm
+            PatternKind::PatLiteral arm_token Token::location OpKind::OpMatchArm literal_arm (int) make_op_pattern = literal_op
             literal_op ops.push
         elif TokenKind::Identifier arm_token Token::kind != then
             arm_token Token::location "Expected match pattern or `_`" ErrorKind::UnexpectedToken raise_error
         elif cursor.peek.is_some "{" cursor.peek.unwrap Token::value == && then
             # Struct pattern
             cursor arm_token parser parse_struct_match_pattern = struct_pattern
-            PatternKind::PatStruct arm_token Token::location OpKind::OpMatchArm struct_pattern (int) make_op_pattern ops.push
+            function_name cursor parser parse_pattern_terminator = struct_guard_ops
+            struct_guard_ops struct_pattern (int) make_match_arm = struct_arm
+            PatternKind::PatStruct arm_token Token::location OpKind::OpMatchArm struct_arm (int) make_op_pattern ops.push
         elif arm_token Token::value "::" str::find 0 > then
             # Bare identifier
-            "=>" cursor expect_token_value drop
+            function_name cursor parser parse_pattern_terminator = bare_guard_ops
             Option::None arm_token Token::value "" make_enum_variant = bare_variant
-            PatternKind::PatEnumVariant arm_token Token::location OpKind::OpMatchArm bare_variant (int) make_op_pattern ops.push
+            bare_guard_ops bare_variant (int) make_match_arm = bare_arm
+            PatternKind::PatEnumVariant arm_token Token::location OpKind::OpMatchArm bare_arm (int) make_op_pattern ops.push
         else
             # Enum::Variant pattern
             arm_token Token::value "::" str::find = separator
@@ -1582,10 +1627,11 @@ fn parse_match_block parser:Parser token:Token cursor:TokenCursor function_name:
                 done
             fi
 
-            "=>" cursor expect_token_value drop
+            function_name cursor parser parse_pattern_terminator = enum_guard_ops
             Option::None variant_name enum_name make_enum_variant = variant
             bindings variant EnumVariant::set_bindings
-            PatternKind::PatEnumVariant arm_token Token::location OpKind::OpMatchArm variant (int) make_op_pattern ops.push
+            enum_guard_ops variant (int) make_match_arm = variant_arm
+            PatternKind::PatEnumVariant arm_token Token::location OpKind::OpMatchArm variant_arm (int) make_op_pattern ops.push
         fi
 
         # Parse arm body
@@ -2247,7 +2293,7 @@ fn register_struct_pattern_binding parser:Parser function:Function binding_name:
 fn resolve_match_op parser:Parser function:Function op:Op errors:List[CasaError] {
     op pattern_kind match
         PatternKind::PatStruct => {
-            op Op::value (StructPattern) = struct_pattern
+            op pattern_value_of (StructPattern) = struct_pattern
             struct_pattern StructPattern::bindings.keys = pattern_keys
             0 = field_index
             while field_index pattern_keys.length > do
@@ -2257,12 +2303,20 @@ fn resolve_match_op parser:Parser function:Function op:Op errors:List[CasaError]
             done
         }
         PatternKind::PatEnumVariant => {
-            op Op::value (EnumVariant) = variant
+            op pattern_value_of (EnumVariant) = variant
             errors function op variant parser resolve_enum_variant
         }
         PatternKind::PatLiteral => 0 drop
         PatternKind::PatWildcard => 0 drop
     end
+    # Resolve identifiers inside the guard expression (bindings registered
+    # by the pattern above are now in scope).
+    op pattern_guard_ops = guard_ops
+    if guard_ops.length 0 != then
+        function guard_ops parser resolve_identifiers_fn = resolved_guard
+        op match_arm_of = arm
+        resolved_guard arm MatchArm::set_guard_ops
+    fi
 }
 
 fn resolve_identifiers_fn parser:Parser ops:List[Op] function:Function -> List[Op] {

--- a/compiler/pattern.casa
+++ b/compiler/pattern.casa
@@ -13,13 +13,20 @@
 fn pattern_is_wildcard op:Op -> bool {
     op pattern_kind match
         PatternKind::PatEnumVariant => {
-            op Op::value (EnumVariant) = variant
+            op pattern_value_of (EnumVariant) = variant
             MATCH_WILDCARD variant EnumVariant::variant_name ==
         }
         PatternKind::PatStruct => false
         PatternKind::PatLiteral => false
         PatternKind::PatWildcard => true
     end
+}
+# pattern_is_guarded — true when the arm carries a guard expression.
+# Guarded arms never cover their pattern for duplicate-arm and
+# exhaustiveness analysis (they may still fail at runtime).
+
+fn pattern_is_guarded op:Op -> bool {
+    op pattern_guard_ops.length 0 !=
 }
 
 # ============================================================================
@@ -28,17 +35,18 @@ fn pattern_is_wildcard op:Op -> bool {
 # typechecker already produces.
 
 fn pattern_covered_key op:Op -> str {
+    if op pattern_is_guarded then "" return fi
     op pattern_kind match
         PatternKind::PatStruct => {
-            op Op::value (StructPattern) = struct_pat
+            op pattern_value_of (StructPattern) = struct_pat
             f"__covered:{struct_pat StructPattern::struct_name}"
         }
         PatternKind::PatLiteral => {
-            op Op::value (LiteralPattern) = literal_pat
+            op pattern_value_of (LiteralPattern) = literal_pat
             f"__covered:{literal_pat LiteralPattern::raw}"
         }
         PatternKind::PatEnumVariant => {
-            op Op::value (EnumVariant) = variant
+            op pattern_value_of (EnumVariant) = variant
             f"__covered:{variant EnumVariant::variant_name}"
         }
         PatternKind::PatWildcard => ""
@@ -54,7 +62,7 @@ fn pattern_bindings op:Op -> List[str] {
     List::new (List[str]) = out
     op pattern_kind match
         PatternKind::PatStruct => {
-            op Op::value (StructPattern) = struct_pat
+            op pattern_value_of (StructPattern) = struct_pat
             struct_pat StructPattern::bindings.keys = field_names
             0 = binding_index
             while binding_index field_names.length > do
@@ -64,7 +72,7 @@ fn pattern_bindings op:Op -> List[str] {
             done
         }
         PatternKind::PatEnumVariant => {
-            op Op::value (EnumVariant) = variant
+            op pattern_value_of (EnumVariant) = variant
             variant EnumVariant::bindings = names
             0 = enum_binding_index
             while enum_binding_index names.length > do
@@ -249,12 +257,12 @@ fn register_pattern_bindings
 {
     op pattern_kind match
         PatternKind::PatStruct => {
-            op Op::value (StructPattern) = struct_pattern
+            op pattern_value_of (StructPattern) = struct_pattern
             struct_pattern function_opt tc register_struct_pattern_bindings
         }
         PatternKind::PatEnumVariant => {
             if op pattern_is_wildcard then return fi
-            op Op::value (EnumVariant) = variant
+            op pattern_value_of (EnumVariant) = variant
             match_subject_type variant function_opt tc register_enum_pattern_bindings
         }
         PatternKind::PatLiteral => 0 drop
@@ -285,7 +293,7 @@ fn typecheck_match_op tc:TypeChecker function_opt:Option[Function] op:Op {
         is_enum_pattern
         is_wildcard ! &&
         then
-            op Op::value (EnumVariant) = variant
+            op pattern_value_of (EnumVariant) = variant
             arm_base variant op tc diagnose_bare_enum_pattern
         fi
 
@@ -300,6 +308,22 @@ fn typecheck_match_op tc:TypeChecker function_opt:Option[Function] op:Op {
         fi
 
         match_subject_type op function_opt tc register_pattern_bindings
+
+        if op pattern_is_guarded then
+            op pattern_guard_ops = guard_ops
+            DEFAULT_PARSER.store make_typechecker = guard_checker
+            function_opt guard_ops guard_checker run_type_check_ops
+            guard_checker TypeChecker::live TypedStack::types = guard_stack
+            false = guard_ok
+            if 1 guard_stack.length == then
+                if "bool" 0 guard_stack.get == then
+                    true = guard_ok
+                fi
+            fi
+            if guard_ok ! then
+                op Op::location "Guard expression must leave a single `bool` on the stack" ErrorKind::TypeMismatch add_error
+            fi
+        fi
 
         covered_key match_ctx MatchContext::set_current_branch_label
         op Op::location match_ctx MatchContext::set_current_branch_location

--- a/compiler/typechecker.casa
+++ b/compiler/typechecker.casa
@@ -2397,9 +2397,7 @@ fn ensure_typechecked function:Function {
 # Main type check dispatch
 # ============================================================================
 
-fn type_check_ops ops:List[Op] function_opt:Option[Function] -> Signature {
-    DEFAULT_PARSER.store make_typechecker = checker
-    ERRORS.length = errors_before_ops
+fn run_type_check_ops checker:TypeChecker ops:List[Op] function_opt:Option[Function] {
     0 = op_index
     while op_index ops.length > do
         op_index ops.get = current_op
@@ -2660,6 +2658,12 @@ fn type_check_ops ops:List[Op] function_opt:Option[Function] -> Signature {
             continue
         fi
     done
+}
+
+fn type_check_ops ops:List[Op] function_opt:Option[Function] -> Signature {
+    DEFAULT_PARSER.store make_typechecker = checker
+    ERRORS.length = errors_before_ops
+    function_opt ops checker run_type_check_ops
 
     # Build inferred signature
     checker TypeChecker::live TypedStack::types checker TypeChecker::parameters make_signature = inferred

--- a/docs/control-flow.md
+++ b/docs/control-flow.md
@@ -260,13 +260,13 @@ Casa has exhaustive pattern matching using `match`/`end`. Match works with enum 
 
 ```
 <value> match
-    <pattern1> => <body>
-    <pattern2> => <body>
+    <pattern1> [if <guard>] => <body>
+    <pattern2> [if <guard>] => <body>
     ...
 end
 ```
 
-The `match` keyword pops a value from the stack. Each arm specifies a pattern followed by `=>` and a body. The block is closed with `end`.
+The `match` keyword pops a value from the stack. Each arm specifies a pattern followed by `=>` and a body. An optional `if <guard>` between the pattern and `=>` adds a boolean condition that must also hold. The block is closed with `end`.
 
 ### Block Arm Bodies
 
@@ -348,6 +348,24 @@ color match
     _ => "other" print
 end
 ```
+
+### Guard Clauses
+
+An arm may carry an `if <cond>` guard between the pattern and `=>`. The arm fires only when the pattern matches AND the guard returns `true`. The guard expression is a regular Casa expression that must leave a single `bool` on the stack; pattern bindings are in scope inside the guard.
+
+```casa
+fn classify n:int -> str {
+    n match
+        _ if 0 n > => "positive"
+        _ if 0 n == => "zero"
+        _ => "negative"
+    end
+}
+```
+
+Guarded arms do not count toward exhaustiveness (the guard may fail at runtime), so an unguarded fallback — a wildcard arm or full enum coverage — is still required. Duplicate-arm detection also skips guarded arms, so a guarded literal may appear alongside an unguarded arm for the same value.
+
+See [`examples/match_guard.casa`](../examples/match_guard.casa) for a full program.
 
 ### Match as Expression
 

--- a/examples/match_guard.casa
+++ b/examples/match_guard.casa
@@ -1,0 +1,36 @@
+# Match guard clauses
+#
+# Match arms may carry an `if <cond>` guard between the pattern and `=>`.
+# The arm fires only when the pattern matches AND the guard returns `true`.
+# A guarded arm does not count toward exhaustiveness, so an unguarded
+# fallback (wildcard or full coverage) is still required.
+
+fn classify n:int -> str {
+    n match
+        _ if 0 n > => "positive"
+        _ if 0 n == => "zero"
+        _ => "negative"
+    end
+}
+5 classify print "\n" print
+0 classify print "\n" print
+-3 classify print "\n" print
+# Guards can inspect an enum payload binding.
+
+enum Opt[T] {
+    None
+    Some (T)
+}
+
+fn describe value:Opt[int] -> str {
+    value match
+        Opt::Some (n) if 0 n > => "positive some"
+        Opt::Some (n) if 0 n == => "zero some"
+        Opt::Some (n) => "negative some"
+        Opt::None => "none"
+    end
+}
+7 Opt::Some describe print "\n" print
+0 Opt::Some describe print "\n" print
+-4 Opt::Some describe print "\n" print
+Opt::None describe print "\n" print

--- a/examples/outputs/match_guard.out
+++ b/examples/outputs/match_guard.out
@@ -1,0 +1,7 @@
+positive
+zero
+negative
+positive some
+zero some
+negative some
+none

--- a/tests/compiler/test_pattern.casa
+++ b/tests/compiler/test_pattern.casa
@@ -12,23 +12,27 @@ include "../../lib/test.casa"
 # ============================================================================
 
 fn arm_of_kind kind:PatternKind -> Op {
-    kind empty_location OpKind::OpMatchArm 0 make_op_pattern
+    List::new (List[Op]) 0 make_match_arm = empty_arm
+    kind empty_location OpKind::OpMatchArm empty_arm (int) make_op_pattern
 }
 
 fn make_enum_arm enum_name:str variant_name:str -> Op {
     Option::None variant_name enum_name make_enum_variant = variant
-    PatternKind::PatEnumVariant empty_location OpKind::OpMatchArm variant (int) make_op_pattern
+    List::new (List[Op]) variant (int) make_match_arm = arm
+    PatternKind::PatEnumVariant empty_location OpKind::OpMatchArm arm (int) make_op_pattern
 }
 
 fn make_struct_arm struct_name:str -> Op {
     Map::new (Map[str str]) = bindings
     bindings struct_name StructPattern = struct_pat
-    PatternKind::PatStruct empty_location OpKind::OpMatchArm struct_pat (int) make_op_pattern
+    List::new (List[Op]) struct_pat (int) make_match_arm = arm
+    PatternKind::PatStruct empty_location OpKind::OpMatchArm arm (int) make_op_pattern
 }
 
 fn make_literal_arm raw:str -> Op {
     raw "int" 0 LiteralPattern = literal_pat
-    PatternKind::PatLiteral empty_location OpKind::OpMatchArm literal_pat (int) make_op_pattern
+    List::new (List[Op]) literal_pat (int) make_match_arm = arm
+    PatternKind::PatLiteral empty_location OpKind::OpMatchArm arm (int) make_op_pattern
 }
 
 # ============================================================================
@@ -125,7 +129,8 @@ fn test_pattern_bindings_enum_with_payload {
     List::new (List[str]) = binds
     "x" binds.push
     binds variant EnumVariant::set_bindings
-    PatternKind::PatEnumVariant empty_location OpKind::OpMatchArm variant (int) make_op_pattern = op
+    List::new (List[Op]) variant (int) make_match_arm = arm
+    PatternKind::PatEnumVariant empty_location OpKind::OpMatchArm arm (int) make_op_pattern = op
     op pattern_bindings = out
     "count" 1 out.length assert_eq
     "name" "x" 0 out.get assert_str_eq
@@ -137,7 +142,8 @@ fn test_pattern_bindings_struct_fields {
     "row" "y" bindings.set drop
     "col" "x" bindings.set drop
     bindings "Point" StructPattern = struct_pat
-    PatternKind::PatStruct empty_location OpKind::OpMatchArm struct_pat (int) make_op_pattern = op
+    List::new (List[Op]) struct_pat (int) make_match_arm = arm
+    PatternKind::PatStruct empty_location OpKind::OpMatchArm arm (int) make_op_pattern = op
     op pattern_bindings = out
     "count" 2 out.length assert_eq
 }
@@ -176,6 +182,85 @@ fn test_duplicate_literal_arm_detected {
     "duplicate arm flagged" "Duplicate match arm" assert_error_contains
     disable_test_mode
 }
+
+# ============================================================================
+# Guard clauses (match arms with an `if` condition).
+# ============================================================================
+
+fn test_guard_parser_collects_ops {
+    "guard_parser_collects_ops" test_start
+    clear_global_state
+    "g" "0 match _ if 0 1 == => \"y\" _ => \"n\" end" lex_source = tokens
+    tokens DEFAULT_PARSER parse_ops = ops
+    0 = arm_index
+    0 = guarded_count
+    0 = unguarded_count
+    while arm_index ops.length > do
+        arm_index ops.get = arm_op
+        if OpKind::OpMatchArm arm_op Op::kind == then
+            if arm_op pattern_is_guarded then
+                1 += guarded_count
+            else
+                1 += unguarded_count
+            fi
+        fi
+        1 += arm_index
+    done
+    "one guarded" 1 guarded_count assert_eq
+    "one unguarded" 1 unguarded_count assert_eq
+}
+
+fn test_guard_excluded_from_covered_key {
+    "guard_excluded_from_covered_key" test_start
+    "42" make_literal_arm = unguarded
+    "covered when unguarded" "__covered:42" unguarded pattern_covered_key assert_str_eq
+    "42" "int" 0 LiteralPattern = literal_pat
+    List::new (List[Op]) = guard_ops
+    empty_location OpKind::OpPushBool 1 make_op guard_ops.push
+    guard_ops literal_pat (int) make_match_arm = arm
+    PatternKind::PatLiteral empty_location OpKind::OpMatchArm arm (int) make_op_pattern = guarded
+    "is guarded" guarded pattern_is_guarded assert_true
+    "empty key when guarded" "" guarded pattern_covered_key assert_str_eq
+}
+
+fn test_guard_allows_shadow_literal_arm {
+    "guard_allows_shadow_literal_arm" test_start
+    clear_global_state
+    enable_test_mode
+    clear_errors
+    "sg" "1 match 1 if 0 1 == => \"a\" 1 => \"b\" _ => \"c\" end" lex_source = sg_tokens
+    sg_tokens DEFAULT_PARSER parse_ops = sg_ops
+    sg_ops DEFAULT_PARSER resolve_identifiers_global = sg_ops
+    Option::None sg_ops type_check_ops drop
+    "guarded arm does not collide" assert_no_errors
+    disable_test_mode
+}
+
+fn test_guard_non_bool_rejected {
+    "guard_non_bool_rejected" test_start
+    clear_global_state
+    enable_test_mode
+    clear_errors
+    "nb" "1 match 1 if 42 => \"a\" _ => \"b\" end" lex_source = nb_tokens
+    nb_tokens DEFAULT_PARSER parse_ops = nb_ops
+    nb_ops DEFAULT_PARSER resolve_identifiers_global = nb_ops
+    Option::None nb_ops type_check_ops drop
+    "non-bool guard flagged" "Guard expression must leave a single `bool`" assert_error_contains
+    disable_test_mode
+}
+
+fn test_guard_non_exhaustive_without_fallback {
+    "guard_non_exhaustive_without_fallback" test_start
+    clear_global_state
+    enable_test_mode
+    clear_errors
+    "ne" "1 match 1 if 0 1 == => \"a\" end" lex_source = ne_tokens
+    ne_tokens DEFAULT_PARSER parse_ops = ne_ops
+    ne_ops DEFAULT_PARSER resolve_identifiers_global = ne_ops
+    Option::None ne_ops type_check_ops drop
+    "guard alone non-exhaustive" "Non-exhaustive match" assert_error_contains
+    disable_test_mode
+}
 test_pattern_kind_struct
 test_pattern_kind_enum_variant
 test_pattern_kind_literal
@@ -193,4 +278,9 @@ test_pattern_bindings_struct_fields
 test_pattern_bindings_literal_empty
 test_mixed_match_parses_and_typechecks
 test_duplicate_literal_arm_detected
+test_guard_parser_collects_ops
+test_guard_excluded_from_covered_key
+test_guard_allows_shadow_literal_arm
+test_guard_non_bool_rejected
+test_guard_non_exhaustive_without_fallback
 test_summary

--- a/tests/compiler/test_struct_literal.casa
+++ b/tests/compiler/test_struct_literal.casa
@@ -9,7 +9,6 @@ include "../../lib/test.casa"
 # ============================================================================
 # Constants
 # ============================================================================
-
 "struct Point { x: int y: int }\n" = POINT_STRUCT
 "struct Person { name: str age: int }\n" = PERSON_STRUCT
 "struct Box[T] { value: T }\n" = BOX_STRUCT
@@ -44,8 +43,8 @@ fn sl_compile code:str -> Program {
 fn sl_count_ops ops:List[Op] kind:OpKind -> int {
     0 = count
     0 = index
-    while index ops .length > do
-        if kind index ops .get Op::kind == then
+    while index ops.length > do
+        if kind index ops.get Op::kind == then
             1 += count
         fi
         1 += index
@@ -56,8 +55,8 @@ fn sl_count_ops ops:List[Op] kind:OpKind -> int {
 fn sl_count_insts bytecode:List[Inst] kind:InstKind -> int {
     0 = count
     0 = index
-    while index bytecode .length > do
-        if kind index bytecode .get Inst::kind == then
+    while index bytecode.length > do
+        if kind index bytecode.get Inst::kind == then
             1 += count
         fi
         1 += index
@@ -79,13 +78,13 @@ fn test_basic_struct_literal {
     "has struct literal op" 1 OpKind::OpStructLiteral ops sl_count_ops == assert_true
     # Check the StructLiteral value
     0 = index
-    while index ops .length > do
-        if OpKind::OpStructLiteral index ops .get Op::kind == then
-            index ops .get Op::value (StructLiteral) = literal
+    while index ops.length > do
+        if OpKind::OpStructLiteral index ops.get Op::kind == then
+            index ops.get Op::value (StructLiteral) = literal
             "struct name" "Point" literal StructLiteral::struct_name assert_str_eq
-            "field count" 2 literal StructLiteral::field_order .length assert_eq
-            "field 0" "x" 0 literal StructLiteral::field_order .get assert_str_eq
-            "field 1" "y" 1 literal StructLiteral::field_order .get assert_str_eq
+            "field count" 2 literal StructLiteral::field_order.length assert_eq
+            "field 0" "x" 0 literal StructLiteral::field_order.get assert_str_eq
+            "field 1" "y" 1 literal StructLiteral::field_order.get assert_str_eq
         fi
         1 += index
     done
@@ -95,11 +94,11 @@ fn test_reverse_field_order {
     "reverse_field_order" test_start
     "struct Point { x: int y: int }\nPoint { y: 2 x: 1 }" sl_parse = ops
     0 = index
-    while index ops .length > do
-        if OpKind::OpStructLiteral index ops .get Op::kind == then
-            index ops .get Op::value (StructLiteral) = literal
-            "field 0" "y" 0 literal StructLiteral::field_order .get assert_str_eq
-            "field 1" "x" 1 literal StructLiteral::field_order .get assert_str_eq
+    while index ops.length > do
+        if OpKind::OpStructLiteral index ops.get Op::kind == then
+            index ops.get Op::value (StructLiteral) = literal
+            "field 0" "y" 0 literal StructLiteral::field_order.get assert_str_eq
+            "field 1" "x" 1 literal StructLiteral::field_order.get assert_str_eq
         fi
         1 += index
     done
@@ -110,12 +109,12 @@ fn test_struct_match_pattern {
     "struct Point { x: int y: int }\n1 2 Point = p\np match\n    Point { x: px y: py } => px py +\nend" sl_parse = ops
     "has match arm" 0 OpKind::OpMatchArm ops sl_count_ops != assert_true
     0 = index
-    while index ops .length > do
-        if OpKind::OpMatchArm index ops .get Op::kind == then
-            index ops .get Op::value (StructPattern) = pattern
+    while index ops.length > do
+        if OpKind::OpMatchArm index ops.get Op::kind == then
+            index ops.get pattern_value_of (StructPattern) = pattern
             "struct name" "Point" pattern StructPattern::struct_name assert_str_eq
-            "binding x" "px" "x" pattern StructPattern::bindings .get .unwrap assert_str_eq
-            "binding y" "py" "y" pattern StructPattern::bindings .get .unwrap assert_str_eq
+            "binding x" "px" "x" pattern StructPattern::bindings.get.unwrap assert_str_eq
+            "binding y" "py" "y" pattern StructPattern::bindings.get.unwrap assert_str_eq
         fi
         1 += index
     done
@@ -125,11 +124,11 @@ fn test_partial_binding {
     "partial_binding" test_start
     "struct Point { x: int y: int }\n1 2 Point = p\np match\n    Point { x: px } => px\nend" sl_parse = ops
     0 = index
-    while index ops .length > do
-        if OpKind::OpMatchArm index ops .get Op::kind == then
-            index ops .get Op::value (StructPattern) = pattern
-            "binding x" "px" "x" pattern StructPattern::bindings .get .unwrap assert_str_eq
-            "no y binding" "y" pattern StructPattern::bindings .get .is_none assert_true
+    while index ops.length > do
+        if OpKind::OpMatchArm index ops.get Op::kind == then
+            index ops.get pattern_value_of (StructPattern) = pattern
+            "binding x" "px" "x" pattern StructPattern::bindings.get.unwrap assert_str_eq
+            "no y binding" "y" pattern StructPattern::bindings.get.is_none assert_true
         fi
         1 += index
     done
@@ -144,7 +143,6 @@ fn test_field_value_with_expression {
 # ============================================================================
 # Parser: struct literal errors
 # ============================================================================
-
 # Skipped: test_missing_field_error - self-hosted compiler does not validate missing fields yet
 
 fn test_unknown_field_error {
@@ -254,13 +252,13 @@ fn test_duplicate_field_in_pattern_error {
 fn test_struct_literal_type_correct {
     "struct_literal_type_correct" test_start
     "struct Point { x: int y: int }\nPoint { x: 1 y: 2 }" sl_typecheck = sig
-    "returns Point" "Point" 0 sig Signature::return_types .get assert_str_eq
+    "returns Point" "Point" 0 sig Signature::return_types.get assert_str_eq
 }
 
 fn test_struct_literal_reverse_order_type {
     "struct_literal_reverse_order_type" test_start
     "struct Point { x: int y: int }\nPoint { y: 2 x: 1 }" sl_typecheck = sig
-    "returns Point" "Point" 0 sig Signature::return_types .get assert_str_eq
+    "returns Point" "Point" 0 sig Signature::return_types.get assert_str_eq
 }
 
 fn test_field_type_mismatch_error {
@@ -290,14 +288,14 @@ fn test_struct_match_wildcard_exhaustive {
 fn test_struct_match_binding_types {
     "struct_match_binding_types" test_start
     "struct Person { name: str age: int }\n18 \"Alice\" Person = p\np match\n    Person { name: n age: a } => n a\nend" sl_typecheck = sig
-    "returns str" "str" 0 sig Signature::return_types .get assert_str_eq
-    "returns int" "int" 1 sig Signature::return_types .get assert_str_eq
+    "returns str" "str" 0 sig Signature::return_types.get assert_str_eq
+    "returns int" "int" 1 sig Signature::return_types.get assert_str_eq
 }
 
 fn test_struct_match_partial_binding {
     "struct_match_partial_binding" test_start
     "struct Point { x: int y: int }\n1 2 Point = p\np match\n    Point { x: px } => px\nend" sl_typecheck = sig
-    "returns int" "int" 0 sig Signature::return_types .get assert_str_eq
+    "returns int" "int" 0 sig Signature::return_types.get assert_str_eq
 }
 
 fn test_generic_struct_literal {
@@ -306,26 +304,26 @@ fn test_generic_struct_literal {
     # literals (returns "Box" instead of "Box[int]"). Test verifies no crash and
     # that a Box-prefixed type is returned.
     "struct Box[T] { value: T }\nBox { value: 42 }" sl_typecheck = sig
-    "returns Box type" 0 0 sig Signature::return_types .get "Box" str::find >= assert_true
+    "returns Box type" 0 0 sig Signature::return_types.get "Box" str::find >= assert_true
 }
 
 fn test_generic_struct_literal_str {
     "generic_struct_literal_str" test_start
     # NOTE: Same limitation as test_generic_struct_literal above.
     "struct Box[T] { value: T }\nBox { value: \"hello\" }" sl_typecheck = sig
-    "returns Box type" 0 0 sig Signature::return_types .get "Box" str::find >= assert_true
+    "returns Box type" 0 0 sig Signature::return_types.get "Box" str::find >= assert_true
 }
 
 fn test_stack_based_construction_still_works {
     "stack_based_construction_still_works" test_start
     "struct Point { x: int y: int }\n1 2 Point" sl_typecheck = sig
-    "returns Point" "Point" 0 sig Signature::return_types .get assert_str_eq
+    "returns Point" "Point" 0 sig Signature::return_types.get assert_str_eq
 }
 
 fn test_stack_and_literal_coexist {
     "stack_and_literal_coexist" test_start
     "struct Point { x: int y: int }\n1 2 Point = p1\nPoint { x: 3 y: 4 } = p2\np1.x p2.x +" sl_typecheck = sig
-    "returns int" "int" 0 sig Signature::return_types .get assert_str_eq
+    "returns int" "int" 0 sig Signature::return_types.get assert_str_eq
 }
 
 # ============================================================================
@@ -355,14 +353,12 @@ fn test_compile_struct_match {
 # ============================================================================
 # Run all tests
 # ============================================================================
-
 # Parser: struct literal
 test_basic_struct_literal
 test_reverse_field_order
 test_field_value_with_expression
 test_struct_match_pattern
 test_partial_binding
-
 # Parser: errors
 # test_missing_field_error - skipped, self-hosted compiler does not validate missing fields yet
 test_unknown_field_error
@@ -370,12 +366,10 @@ test_duplicate_field_error
 test_unknown_field_mid_literal_error
 test_empty_literal_error
 test_missing_value_error
-
 # Parser: match pattern errors
 test_unknown_struct_in_pattern_error
 test_unknown_field_in_pattern_error
 test_duplicate_field_in_pattern_error
-
 # Typechecker
 test_struct_literal_type_correct
 test_struct_literal_reverse_order_type
@@ -388,10 +382,8 @@ test_struct_match_binding_types
 test_struct_match_partial_binding
 test_stack_based_construction_still_works
 test_stack_and_literal_coexist
-
 # Bytecode
 test_compile_struct_literal
 test_compile_struct_literal_reverse_order
 test_compile_struct_match
-
 test_summary


### PR DESCRIPTION
## Summary

- Add `if <cond>` guards to match arms: `<pattern> if <guard> => <body>`. Arm fires only when pattern matches **and** guard evaluates `true`; otherwise execution falls through to the next arm.
- Guarded arms are excluded from duplicate-arm and exhaustiveness coverage since the guard may fail at runtime, so a non-guarded fallback arm is still required.
- Introduce `MatchArm` heap struct (`{ pattern_value, guard_ops }`) wrapping `OpMatchArm.value`; extract `run_type_check_ops` so guards can be typechecked against the enclosing function scope without triggering signature-mismatch diagnostics.

Follow-up to #101. Closes the guard-clause item from the #99 list; tuple / range / or-patterns remain for separate PRs.

## Test plan

- [x] `./tests/test_compiler.sh` (21 passed; adds 8 new pattern-module unit tests)
- [x] `./tests/test_examples.sh` (38 passed; adds `examples/match_guard.casa`)
- [x] Self-compilation + fixed-point stage2/stage3 assembly match
- [x] LSP binary still builds (`./casac lsp.casa -o /tmp/lsp`)
- [x] Manual: guard evaluating true runs the arm; guard false falls through; enum payload bindings are in scope inside the guard; non-bool guard rejected at typecheck; guarded-only match reports non-exhaustive; guarded arm allowed alongside unguarded arm for the same pattern