### PR TITLE
Simplify compiler: extract shared helpers and kill magic numbers

### DIFF
--- a/compiler/bytecode.casa
+++ b/compiler/bytecode.casa
@@ -361,7 +361,7 @@ fn emit_struct_arm compiler:BytecodeCompiler struct_pattern:StructPattern byteco
     0 = index
     while index casa_struct CasaStruct::members.length > do
         index casa_struct CasaStruct::members.get Member::name = field_name
-        index 8 * = offset
+        index WORD_SIZE * = offset
         if field_name struct_pattern StructPattern::bindings.get Option::Some (var_name) is then
             InstKind::InstDup make_inst bytecode.push
             if 0 offset > then
@@ -432,7 +432,7 @@ fn emit_enum_arm
 fn emit_enum_arm_bindings compiler:BytecodeCompiler bytecode:List[Inst] variant:EnumVariant {
     0 = index
     while index variant EnumVariant::bindings.length > do
-        index 1 + 8 * = offset
+        index 1 + WORD_SIZE * = offset
         InstKind::InstDup make_inst bytecode.push
         offset InstKind::InstPush make_inst_int bytecode.push
         InstKind::InstAdd make_inst bytecode.push
@@ -528,14 +528,14 @@ fn compile_match_block compiler:BytecodeCompiler op:Op op_index:int bytecode:Lis
 fn compile_struct_new compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
     op Op::value (CasaStruct) = casa_struct
     casa_struct CasaStruct::members.length = count
-    count 8 * InstKind::InstPush make_inst_int bytecode.push
+    count WORD_SIZE * InstKind::InstPush make_inst_int bytecode.push
     InstKind::InstHeapAlloc make_inst bytecode.push
     0 = index
     while index count > do
         InstKind::InstSwap make_inst bytecode.push
         InstKind::InstOver make_inst bytecode.push
         if 0 index > then
-            index 8 * InstKind::InstPush make_inst_int bytecode.push
+            index WORD_SIZE * InstKind::InstPush make_inst_int bytecode.push
             InstKind::InstAdd make_inst bytecode.push
         fi
         InstKind::InstStore64 make_inst bytecode.push
@@ -575,7 +575,7 @@ fn compile_enum_variant
     # Allocate heap
     compiler BytecodeCompiler::locals_count = ptr_local
     compiler BytecodeCompiler::locals_count 1 + compiler -> locals_count
-    slot_count 8 * InstKind::InstPush make_inst_int bytecode.push
+    slot_count WORD_SIZE * InstKind::InstPush make_inst_int bytecode.push
     InstKind::InstHeapAlloc make_inst bytecode.push
     ptr_local InstKind::InstLocalSet make_inst_int bytecode.push
 
@@ -589,7 +589,7 @@ fn compile_enum_variant
     0 = inner_index
     while inner_index inner_count > do
         inner_count 1 - inner_index - = reverse_index
-        inner_index 1 + 8 * = offset
+        inner_index 1 + WORD_SIZE * = offset
         ptr_local InstKind::InstLocalGet make_inst_int bytecode.push
         offset InstKind::InstPush make_inst_int bytecode.push
         InstKind::InstAdd make_inst bytecode.push
@@ -650,7 +650,7 @@ fn compile_is_check compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
     # Extract bindings
     0 = index
     while index variant EnumVariant::bindings.length > do
-        index 1 + 8 * = offset
+        index 1 + WORD_SIZE * = offset
         temp_ptr InstKind::InstLocalGet make_inst_int bytecode.push
         offset InstKind::InstPush make_inst_int bytecode.push
         InstKind::InstAdd make_inst bytecode.push
@@ -687,14 +687,14 @@ fn compile_struct_literal compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
     done
 
     # Allocate struct on heap
-    count 8 * InstKind::InstPush make_inst_int bytecode.push
+    count WORD_SIZE * InstKind::InstPush make_inst_int bytecode.push
     InstKind::InstHeapAlloc make_inst bytecode.push
 
     # Store each field at its correct offset
     0 = member_index
     while member_index casa_struct CasaStruct::members.length > do
         member_index casa_struct CasaStruct::members.get Member::name = member_name
-        member_index 8 * = member_offset
+        member_index WORD_SIZE * = member_offset
         InstKind::InstDup make_inst bytecode.push
         if 0 member_offset > then
             member_offset InstKind::InstPush make_inst_int bytecode.push
@@ -726,7 +726,7 @@ fn compile_push_array compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
     # Allocate memory: header (data_ptr + length) + elements
     compiler BytecodeCompiler::locals_count = list_local
     compiler BytecodeCompiler::locals_count 1 + compiler -> locals_count
-    length 2 + 8 * InstKind::InstPush make_inst_int bytecode.push
+    length 2 + WORD_SIZE * InstKind::InstPush make_inst_int bytecode.push
     InstKind::InstHeapAlloc make_inst bytecode.push
     list_local InstKind::InstLocalSet make_inst_int bytecode.push
 
@@ -756,7 +756,7 @@ fn compile_push_array compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
     # while index limit > do
     start_label InstKind::InstLabel make_inst_int bytecode.push
     index_local InstKind::InstLocalGet make_inst_int bytecode.push
-    length 2 + 8 * InstKind::InstPush make_inst_int bytecode.push
+    length 2 + WORD_SIZE * InstKind::InstPush make_inst_int bytecode.push
     InstKind::InstGt make_inst bytecode.push
     end_label InstKind::InstJumpNe make_inst_int bytecode.push
 

--- a/compiler/bytecode.casa
+++ b/compiler/bytecode.casa
@@ -737,10 +737,10 @@ fn compile_push_array compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
     list_local InstKind::InstLocalGet make_inst_int bytecode.push
     InstKind::InstStore64 make_inst bytecode.push
 
-    # Store length at offset 8
+    # Store length at offset WORD_SIZE
     length InstKind::InstPush make_inst_int bytecode.push
     list_local InstKind::InstLocalGet make_inst_int bytecode.push
-    8 InstKind::InstPush make_inst_int bytecode.push
+    WORD_SIZE InstKind::InstPush make_inst_int bytecode.push
     InstKind::InstAdd make_inst bytecode.push
     InstKind::InstStore64 make_inst bytecode.push
 
@@ -766,9 +766,9 @@ fn compile_push_array compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
     InstKind::InstAdd make_inst bytecode.push
     InstKind::InstStore64 make_inst bytecode.push
 
-    # 8 += index
+    # WORD_SIZE += index
     index_local InstKind::InstLocalGet make_inst_int bytecode.push
-    8 InstKind::InstPush make_inst_int bytecode.push
+    WORD_SIZE InstKind::InstPush make_inst_int bytecode.push
     InstKind::InstAdd make_inst bytecode.push
     index_local InstKind::InstLocalSet make_inst_int bytecode.push
 

--- a/compiler/bytecode.casa
+++ b/compiler/bytecode.casa
@@ -465,7 +465,7 @@ fn compile_match_op
             op pattern_is_wildcard = is_wildcard
             bytecode next_arm is_last is_wildcard variant compiler emit_enum_arm
         }
-        PatternKind::PatWildcard => 0 drop
+        PatternKind::PatWildcard => { }
     end
     op pattern_guard_ops = guard_ops
     if guard_ops.length 0 != then

--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -855,6 +855,7 @@ struct Program {
 "any" = ANY_TYPE
 "_" = MATCH_WILDCARD
 "self" = TRAIT_SELF_TYPE
+8 = WORD_SIZE
 
 # ============================================================================
 # Type utility functions

--- a/compiler/emitter.casa
+++ b/compiler/emitter.casa
@@ -113,10 +113,10 @@ fn escape_string s:str -> str {
 fn emit_bss asm:StringBuilder program:Program {
     ".section .bss" asm emit_line
     if 0 program Program::globals_count > then
-        f"globals: .skip {program Program::globals_count 8 *}" asm emit_line
+        f"globals: .skip {program Program::globals_count WORD_SIZE *}" asm emit_line
     fi
     if 0 program Program::constants_count > then
-        f"constants: .skip {program Program::constants_count 8 *}" asm emit_line
+        f"constants: .skip {program Program::constants_count WORD_SIZE *}" asm emit_line
     fi
     f"return_stack: .skip {RETURN_STACK_SIZE}" asm emit_line
     f"heap: .skip {HEAP_SIZE}" asm emit_line
@@ -519,12 +519,12 @@ fn emit_control_flow asm:StringBuilder inst:Inst is_global:bool {
             # Nothing needed, BSS handles it
         }
         InstKind::InstGlobalGet => {
-            inst Inst::int_arg 8 * = offset
+            inst Inst::int_arg WORD_SIZE * = offset
             f"movq globals+{offset}(%rip), %rax" asm emit_indent
             "pushq %rax" asm emit_indent
         }
         InstKind::InstGlobalSet => {
-            inst Inst::int_arg 8 * = offset
+            inst Inst::int_arg WORD_SIZE * = offset
             "popq %rax" asm emit_indent
             f"movq %rax, globals+{offset}(%rip)" asm emit_indent
         }
@@ -535,32 +535,32 @@ fn emit_control_flow asm:StringBuilder inst:Inst is_global:bool {
                 f"movq ${count}, %rcx" asm emit_indent
                 "xorq %rax, %rax" asm emit_indent
                 "rep stosq" asm emit_indent
-                f"addq ${count 8 *}, %r14" asm emit_indent
+                f"addq ${count WORD_SIZE *}, %r14" asm emit_indent
             fi
         }
         InstKind::InstLocalsUninit => {
             inst Inst::int_arg = count
             if 0 count != then
-                f"subq ${count 8 *}, %r14" asm emit_indent
+                f"subq ${count WORD_SIZE *}, %r14" asm emit_indent
             fi
         }
         InstKind::InstLocalGet => {
-            inst Inst::int_arg 1 + 8 * = offset
+            inst Inst::int_arg 1 + WORD_SIZE * = offset
             f"movq -{offset}(%r14), %rax" asm emit_indent
             "pushq %rax" asm emit_indent
         }
         InstKind::InstLocalSet => {
-            inst Inst::int_arg 1 + 8 * = offset
+            inst Inst::int_arg 1 + WORD_SIZE * = offset
             "popq %rax" asm emit_indent
             f"movq %rax, -{offset}(%r14)" asm emit_indent
         }
         InstKind::InstConstantLoad => {
-            inst Inst::int_arg 8 * = offset
+            inst Inst::int_arg WORD_SIZE * = offset
             f"movq constants+{offset}(%rip), %rax" asm emit_indent
             "pushq %rax" asm emit_indent
         }
         InstKind::InstConstantStore => {
-            inst Inst::int_arg 8 * = offset
+            inst Inst::int_arg WORD_SIZE * = offset
             "popq %rax" asm emit_indent
             f"movq %rax, constants+{offset}(%rip)" asm emit_indent
         }

--- a/compiler/emitter.casa
+++ b/compiler/emitter.casa
@@ -335,6 +335,37 @@ fn emit_syscall arg_count:int asm:StringBuilder {
 }
 
 # ============================================================================
+# Emit call-via-return-stack: push a return address onto r14, jump to target,
+# then emit the return label. Shared by FnCall, PrintInt, PrintStr, and
+# FstringConcat (all of which funnel into a shared asm subroutine).
+# ============================================================================
+
+fn emit_call_via_return_stack asm:StringBuilder jump_target:str label_prefix:str {
+    emit_uid = uid
+    f"leaq .L{label_prefix}_{uid}(%rip), %rax" asm emit_indent
+    "movq %rax, (%r14)" asm emit_indent
+    "addq $8, %r14" asm emit_indent
+    f"jmp {jump_target}" asm emit_indent
+    f".L{label_prefix}_{uid}:" asm emit_line
+}
+
+# ============================================================================
+# Emit memory load/store shared helpers
+# ============================================================================
+
+fn emit_load asm:StringBuilder mov_op:str dst_reg:str {
+    "popq %rax" asm emit_indent
+    f"{mov_op} (%rax), {dst_reg}" asm emit_indent
+    "pushq %rax" asm emit_indent
+}
+
+fn emit_store asm:StringBuilder mov_op:str src_reg:str {
+    "popq %rax" asm emit_indent
+    "popq %rbx" asm emit_indent
+    f"{mov_op} {src_reg}, (%rax)" asm emit_indent
+}
+
+# ============================================================================
 # Emit stack operations
 # ============================================================================
 
@@ -535,12 +566,7 @@ fn emit_control_flow asm:StringBuilder inst:Inst is_global:bool {
         }
         InstKind::InstFnCall => {
             inst Inst::str_arg sanitize_name = label
-            emit_uid = uid
-            f"leaq .Lret_{uid}(%rip), %rax" asm emit_indent
-            "movq %rax, (%r14)" asm emit_indent
-            "addq $8, %r14" asm emit_indent
-            f"jmp fn_{label}" asm emit_indent
-            f".Lret_{uid}:" asm emit_line
+            "ret" f"fn_{label}" asm emit_call_via_return_stack
         }
         InstKind::InstFnExec => {
             emit_uid = uid
@@ -588,46 +614,14 @@ fn emit_memory asm:StringBuilder inst:Inst {
             "addq %rax, %rcx" asm emit_indent
             "movq %rcx, heap_ptr(%rip)" asm emit_indent
         }
-        InstKind::InstLoad8 => {
-            "popq %rax" asm emit_indent
-            "movzbl (%rax), %eax" asm emit_indent
-            "pushq %rax" asm emit_indent
-        }
-        InstKind::InstLoad16 => {
-            "popq %rax" asm emit_indent
-            "movzwl (%rax), %eax" asm emit_indent
-            "pushq %rax" asm emit_indent
-        }
-        InstKind::InstLoad32 => {
-            "popq %rax" asm emit_indent
-            "movl (%rax), %eax" asm emit_indent
-            "pushq %rax" asm emit_indent
-        }
-        InstKind::InstLoad64 => {
-            "popq %rax" asm emit_indent
-            "movq (%rax), %rax" asm emit_indent
-            "pushq %rax" asm emit_indent
-        }
-        InstKind::InstStore8 => {
-            "popq %rax" asm emit_indent
-            "popq %rbx" asm emit_indent
-            "movb %bl, (%rax)" asm emit_indent
-        }
-        InstKind::InstStore16 => {
-            "popq %rax" asm emit_indent
-            "popq %rbx" asm emit_indent
-            "movw %bx, (%rax)" asm emit_indent
-        }
-        InstKind::InstStore32 => {
-            "popq %rax" asm emit_indent
-            "popq %rbx" asm emit_indent
-            "movl %ebx, (%rax)" asm emit_indent
-        }
-        InstKind::InstStore64 => {
-            "popq %rax" asm emit_indent
-            "popq %rbx" asm emit_indent
-            "movq %rbx, (%rax)" asm emit_indent
-        }
+        InstKind::InstLoad8 => "%eax" "movzbl" asm emit_load
+        InstKind::InstLoad16 => "%eax" "movzwl" asm emit_load
+        InstKind::InstLoad32 => "%eax" "movl" asm emit_load
+        InstKind::InstLoad64 => "%rax" "movq" asm emit_load
+        InstKind::InstStore8 => "%bl" "movb" asm emit_store
+        InstKind::InstStore16 => "%bx" "movw" asm emit_store
+        InstKind::InstStore32 => "%ebx" "movl" asm emit_store
+        InstKind::InstStore64 => "%rbx" "movq" asm emit_store
         _ => {
             "Internal error: emit_memory called with non-memory InstKind\n" eprint
             1 exit
@@ -642,13 +636,8 @@ fn emit_memory asm:StringBuilder inst:Inst {
 fn emit_io_ops asm:StringBuilder inst:Inst {
     inst Inst::kind match
         InstKind::InstPrintInt => {
-            emit_uid = uid
             "popq %rdi" asm emit_indent
-            f"leaq .Lprint_done_{uid}(%rip), %rax" asm emit_indent
-            "movq %rax, (%r14)" asm emit_indent
-            "addq $8, %r14" asm emit_indent
-            "jmp print_int" asm emit_indent
-            f".Lprint_done_{uid}:" asm emit_line
+            "print_done" "print_int" asm emit_call_via_return_stack
         }
         InstKind::InstPrintBool => {
             emit_uid = uid
@@ -667,13 +656,8 @@ fn emit_io_ops asm:StringBuilder inst:Inst {
             "syscall" asm emit_indent
         }
         InstKind::InstPrintStr => {
-            emit_uid = uid
             "popq %rdi" asm emit_indent
-            f"leaq .Lprint_done_{uid}(%rip), %rax" asm emit_indent
-            "movq %rax, (%r14)" asm emit_indent
-            "addq $8, %r14" asm emit_indent
-            "jmp print_str" asm emit_indent
-            f".Lprint_done_{uid}:" asm emit_line
+            "print_done" "print_str" asm emit_call_via_return_stack
         }
         InstKind::InstPrintChar => {
             "popq %rax" asm emit_indent
@@ -702,13 +686,8 @@ fn emit_io_ops asm:StringBuilder inst:Inst {
             "syscall" asm emit_indent
         }
         InstKind::InstFstringConcat => {
-            emit_uid = uid
             f"movq ${inst Inst::int_arg}, %rdi" asm emit_indent
-            f"leaq .Lconcat_done_{uid}(%rip), %rax" asm emit_indent
-            "movq %rax, (%r14)" asm emit_indent
-            "addq $8, %r14" asm emit_indent
-            "jmp str_concat" asm emit_indent
-            f".Lconcat_done_{uid}:" asm emit_line
+            "concat_done" "str_concat" asm emit_call_via_return_stack
         }
         _ => {
             "Internal error: emit_io_ops called with non-IO InstKind\n" eprint

--- a/compiler/parser.casa
+++ b/compiler/parser.casa
@@ -2291,8 +2291,8 @@ fn resolve_match_op parser:Parser function:Function op:Op errors:List[CasaError]
             op pattern_value_of (EnumVariant) = variant
             errors function op variant parser resolve_enum_variant
         }
-        PatternKind::PatLiteral => 0 drop
-        PatternKind::PatWildcard => 0 drop
+        PatternKind::PatLiteral => { }
+        PatternKind::PatWildcard => { }
     end
     # Resolve identifiers inside the guard expression (bindings registered
     # by the pattern above are now in scope).

--- a/compiler/parser.casa
+++ b/compiler/parser.casa
@@ -758,6 +758,20 @@ fn parse_type_vars parser:Parser cursor:TokenCursor -> List[str] {
 # ============================================================================
 # parse_parameters - parse name:type parameter pairs
 # ============================================================================
+# Given an identifier `token` just popped from `cursor`, produce either a
+# named parameter (`name:type`) if the next token is `:`, or an unnamed
+# parameter by rewinding and re-parsing as a type expression.
+
+fn parse_parameter_maybe_named cursor:TokenCursor token:Token -> Parameter {
+    cursor.peek = next_opt
+    if next_opt.is_some ":" next_opt.unwrap Token::value == && then
+        cursor.advance # consume :
+        cursor parse_type = param_type
+        token Token::value param_type make_named_param return
+    fi
+    cursor.retreat
+    cursor parse_type make_param
+}
 
 fn parse_parameters cursor:TokenCursor -> List[Parameter] {
     List::new (List[Parameter]) = params
@@ -785,20 +799,7 @@ fn parse_parameters cursor:TokenCursor -> List[Parameter] {
             token Token::location "Unexpected token in parameter list" ErrorKind::UnexpectedToken raise_error
         fi
 
-        # Check if named parameter: name:type
-        cursor.peek = next_opt
-        if next_opt.is_some then
-            if ":" next_opt.unwrap Token::value == then
-                cursor.advance # consume :
-                cursor parse_type = param_type
-                token Token::value param_type make_named_param params.push
-                continue
-            fi
-        fi
-
-        # Unnamed parameter - might be parameterized
-        cursor.retreat
-        cursor parse_type make_param params.push
+        token cursor parse_parameter_maybe_named params.push
     done
     params
 }
@@ -1181,15 +1182,7 @@ fn parse_trait_method_signature cursor:TokenCursor -> Signature {
             peek Token::location "Unexpected token in trait method parameter list" ErrorKind::UnexpectedToken raise_error
         fi
 
-        cursor.peek = next_opt
-        if next_opt.is_some ":" next_opt.unwrap Token::value == && then
-            cursor.pop drop # consume :
-            cursor parse_type = param_type
-            peek Token::value param_type make_named_param params.push
-        else
-            cursor.retreat
-            cursor parse_type make_param params.push
-        fi
+        peek cursor parse_parameter_maybe_named params.push
     done
 
     List::new (List[str]) = returns
@@ -1214,31 +1207,35 @@ fn parse_trait_method_signature cursor:TokenCursor -> Signature {
 
     returns params make_signature
 }
+# Parse a bracket-delimited identifier-only type-parameter list:
+# `[T1 T2 ...]`. `context` (e.g. "trait", "trait method") is interpolated
+# into error messages. Does *not* accept trait bounds; for those use
+# `parse_type_vars`.
 
-fn parse_method_type_vars cursor:TokenCursor -> List[str] {
+fn parse_simple_type_vars cursor:TokenCursor context:str -> List[str] {
     cursor.pop drop # consume [
-    List::new (List[str]) = mtv_vars
-    true = mtv_loop
-    while mtv_loop do
-        cursor.peek = mtv_opt
-        if mtv_opt.is_none then
-            empty_location "Unclosed method type parameter list" ErrorKind::UnmatchedBlock raise_error
-            false = mtv_loop
+    List::new (List[str]) = collected
+    true = loop_flag
+    while loop_flag do
+        cursor.peek = token_opt
+        if token_opt.is_none then
+            empty_location f"Unclosed {context} type parameter list" ErrorKind::UnmatchedBlock raise_error
+            false = loop_flag
         else
-            mtv_opt.unwrap = mtv_tok
-            if "]" mtv_tok Token::value == then
+            token_opt.unwrap = token
+            if "]" token Token::value == then
                 cursor.pop drop
-                false = mtv_loop
-            elif TokenKind::Identifier mtv_tok Token::kind != then
-                mtv_tok Token::location "Expected type parameter in trait method" ErrorKind::UnexpectedToken raise_error
-                false = mtv_loop
+                false = loop_flag
+            elif TokenKind::Identifier token Token::kind != then
+                token Token::location f"Expected type parameter identifier in {context}" ErrorKind::UnexpectedToken raise_error
+                false = loop_flag
             else
                 cursor.pop drop
-                mtv_tok Token::value mtv_vars.push
+                token Token::value collected.push
             fi
         fi
     done
-    mtv_vars
+    collected
 }
 
 fn parse_trait parser:Parser cursor:TokenCursor -> CasaTrait {
@@ -1248,25 +1245,7 @@ fn parse_trait parser:Parser cursor:TokenCursor -> CasaTrait {
     List::new (List[str]) = type_params
     cursor.peek = bracket_opt
     if bracket_opt.is_some "[" bracket_opt.unwrap Token::value == && then
-        cursor.pop drop # consume [
-        while true do
-            cursor.peek = tp_opt
-            if tp_opt.is_none then
-                name_token Token::location "Unclosed trait type parameter list" ErrorKind::UnmatchedBlock raise_error
-                break
-            fi
-            tp_opt.unwrap = tp_tok
-            if "]" tp_tok Token::value == then
-                cursor.pop drop
-                break
-            fi
-            if TokenKind::Identifier tp_tok Token::kind != then
-                tp_tok Token::location "Expected type parameter identifier in trait" ErrorKind::UnexpectedToken raise_error
-                break
-            fi
-            cursor.pop drop
-            tp_tok Token::value type_params.push
-        done
+        "trait" cursor parse_simple_type_vars = type_params
     fi
 
     List::new (List[TraitMethod]) = methods
@@ -1292,7 +1271,7 @@ fn parse_trait parser:Parser cursor:TokenCursor -> CasaTrait {
             List::new (List[str]) = method_type_vars
             if cursor.peek Option::Some (mtv_bracket) is then
                 if "[" mtv_bracket Token::value == then
-                    cursor parse_method_type_vars = method_type_vars
+                    "trait method" cursor parse_simple_type_vars = method_type_vars
                 fi
             fi
 

--- a/compiler/parser.casa
+++ b/compiler/parser.casa
@@ -1055,7 +1055,7 @@ fn create_member_accessor
     location:Location
     type_vars:List[str]
 {
-    member_index 8 * = offset
+    member_index WORD_SIZE * = offset
 
     # Parameterize the struct name when the struct has type vars
     struct_name = param_type

--- a/compiler/parser.casa
+++ b/compiler/parser.casa
@@ -2383,6 +2383,55 @@ fn try_resolve_trait_method_call parser:Parser function:Function op:Op ident:str
     "trait_exec" op Op::set_type_annotation
     true
 }
+# Resolve a bare identifier after `&`-ref, enum-variant, and trait-method
+# attempts have already failed. Rewrites `op` in place to the matching op
+# kind or pushes an `UndefinedName` error.
+
+fn resolve_plain_identifier
+    parser:Parser
+    function:Function
+    op:Op
+    ident:str
+    resolve_errors:List[CasaError]
+{
+    if ident function Function::variables variable_list_contains then
+        OpKind::OpPushVar op Op::set_kind
+        return
+    fi
+
+    ident parser.store.functions.get = generic_fn_opt
+    if generic_fn_opt.is_some then
+        OpKind::OpFnCall op Op::set_kind
+        true generic_fn_opt.unwrap Function::set_is_used
+        return
+    fi
+
+    if ident function Function::captures variable_list_contains then
+        OpKind::OpPushCapture op Op::set_kind
+        return
+    fi
+
+    if ident parser.store.variables.get.is_some then
+        OpKind::OpPushVar op Op::set_kind
+        return
+    fi
+
+    ident parser.store.structs.get = struct_opt
+    if struct_opt.is_some then
+        OpKind::OpStructNew op Op::set_kind
+        struct_opt.unwrap (int) op Op::set_value
+        return
+    fi
+
+    ident parser.store.enums.get = resolved_enum_opt
+    if resolved_enum_opt.is_some then
+        OpKind::OpPushInt op Op::set_kind
+        resolved_enum_opt.unwrap CasaEnum::variants.length op Op::set_value
+        return
+    fi
+
+    op Op::location f"Identifier `{ident}` is not defined" ErrorKind::UndefinedName make_error resolve_errors.push
+}
 
 fn resolve_identifiers_fn parser:Parser ops:List[Op] function:Function -> List[Op] {
     0 = op_index
@@ -2436,50 +2485,7 @@ fn resolve_identifiers_fn parser:Parser ops:List[Op] function:Function -> List[O
             if resolve_errors ident current_op function parser try_resolve_fn_ref then continue fi
             if resolve_errors ident current_op parser try_resolve_enum_variant_ident then continue fi
             if ident current_op function parser try_resolve_trait_method_call then continue fi
-
-            # Local variable
-            if ident function Function::variables variable_list_contains then
-                OpKind::OpPushVar current_op Op::set_kind
-                continue
-            fi
-
-            # Global function
-            ident parser.store.functions.get = generic_fn_opt
-            if generic_fn_opt.is_some then
-                OpKind::OpFnCall current_op Op::set_kind
-                true generic_fn_opt.unwrap Function::set_is_used
-                continue
-            fi
-
-            # Captured variable
-            if ident function Function::captures variable_list_contains then
-                OpKind::OpPushCapture current_op Op::set_kind
-                continue
-            fi
-
-            # Global variable
-            if ident parser.store.variables.get.is_some then
-                OpKind::OpPushVar current_op Op::set_kind
-                continue
-            fi
-
-            # Struct constructor
-            ident parser.store.structs.get = struct_opt
-            if struct_opt.is_some then
-                OpKind::OpStructNew current_op Op::set_kind
-                struct_opt.unwrap (int) current_op Op::set_value
-                continue
-            fi
-
-            # Enum name -> variant count
-            ident parser.store.enums.get = resolved_enum2_opt
-            if resolved_enum2_opt.is_some then
-                OpKind::OpPushInt current_op Op::set_kind
-                resolved_enum2_opt.unwrap CasaEnum::variants.length current_op Op::set_value
-                continue
-            fi
-
-            current_op Op::location f"Identifier `{ident}` is not defined" ErrorKind::UndefinedName make_error resolve_errors.push
+            resolve_errors ident current_op function parser resolve_plain_identifier
             continue
         fi
 

--- a/compiler/pattern.casa
+++ b/compiler/pattern.casa
@@ -80,8 +80,8 @@ fn pattern_bindings op:Op -> List[str] {
                 1 += enum_binding_index
             done
         }
-        PatternKind::PatLiteral => 0 drop
-        PatternKind::PatWildcard => 0 drop
+        PatternKind::PatLiteral => { }
+        PatternKind::PatWildcard => { }
     end
     out
 }
@@ -135,10 +135,8 @@ fn unify_arm_stacks tc:TypeChecker match_ctx:MatchContext op:Op {
     match_ctx MatchContext::after = match_after
     if
     match_before tc TypeChecker::live.equals
-    match_after match_before.equals &&
+    match_after match_before.equals && !
     then
-        0 drop
-    else
         match_after tc TypeChecker::live.unify_types = unified
         if 0 unified.length != match_after match_before.equals ! && then
             unified match_after TypedStack::set_types
@@ -265,8 +263,8 @@ fn register_pattern_bindings
             op pattern_value_of (EnumVariant) = variant
             match_subject_type variant function_opt tc register_enum_pattern_bindings
         }
-        PatternKind::PatLiteral => 0 drop
-        PatternKind::PatWildcard => 0 drop
+        PatternKind::PatLiteral => { }
+        PatternKind::PatWildcard => { }
     end
 }
 

--- a/compiler/typechecker.casa
+++ b/compiler/typechecker.casa
@@ -151,6 +151,11 @@ fn make_typechecker store:SymbolStore -> TypeChecker {
     TypedStack::new # live
     TypeChecker
 }
+# Raise a TypeMismatch error at the type checker's current location.
+
+fn raise_type_mismatch tc:TypeChecker message:str {
+    tc TypeChecker::current_location message ErrorKind::TypeMismatch raise_error
+}
 
 # ============================================================================
 # Stack operations
@@ -459,7 +464,7 @@ fn bind_type_var tc:TypeChecker bindings:Map[str str] type_var:str actual:str ->
     ANY_TYPE bound != &&
     actual is_enum_type_var ! &&
     then
-        tc TypeChecker::current_location f"Type variable `{type_var}` bound to `{bound}` but got `{actual}`" ErrorKind::TypeMismatch raise_error
+        f"Type variable `{type_var}` bound to `{bound}` but got `{actual}`" tc raise_type_mismatch
     fi
     bindings
 }
@@ -516,7 +521,7 @@ fn bind_generic_param
                     true return
                 fi
             fi
-            tc TypeChecker::current_location "Type mismatch" ErrorKind::TypeMismatch raise_error
+            "Type mismatch" tc raise_type_mismatch
         fi
     fi
     if base actual == ANY_TYPE actual == || then
@@ -530,7 +535,7 @@ fn bind_generic_param
         done
         true return
     fi
-    tc TypeChecker::current_location "Type mismatch" ErrorKind::TypeMismatch raise_error
+    "Type mismatch" tc raise_type_mismatch
     true
 }
 
@@ -565,7 +570,7 @@ fn bind_fn_param tc:TypeChecker bindings:Map[str str] expected:Parameter sig:Sig
         true return
     fi
     if actual is_fn_type ! then
-        tc TypeChecker::current_location "Type mismatch" ErrorKind::TypeMismatch raise_error
+        "Type mismatch" tc raise_type_mismatch
         true return
     fi
     actual extract_fn_signature_str = actual_sig_opt
@@ -694,7 +699,7 @@ fn check_comparison tc:TypeChecker op:Op {
     base2 tc.store.enums.get.is_some = is_enum2
     if is_enum1 is_enum2 || then
         if type1 type2 != then
-            tc TypeChecker::current_location f"Cannot compare `{type2}` with `{type1}`" ErrorKind::TypeMismatch raise_error
+            f"Cannot compare `{type2}` with `{type1}`" tc raise_type_mismatch
         fi
         # Annotate for bytecode: data-carrying enums need heap tag comparison
         if is_enum1 then
@@ -705,13 +710,13 @@ fn check_comparison tc:TypeChecker op:Op {
         fi
     elif "str" type1 == "str" type2 == || then
         if type1 type2 != then
-            tc TypeChecker::current_location f"Cannot compare `{type2}` with `{type1}`" ErrorKind::TypeMismatch raise_error
+            f"Cannot compare `{type2}` with `{type1}`" tc raise_type_mismatch
         fi
         if
         OpKind::OpEq op Op::kind !=
         OpKind::OpNe op Op::kind != &&
         then
-            tc TypeChecker::current_location "Type `str` only supports `==` and `!=` comparison" ErrorKind::TypeMismatch raise_error
+            "Type `str` only supports `==` and `!=` comparison" tc raise_type_mismatch
         fi
         "str" op Op::set_type_annotation
     fi
@@ -819,6 +824,24 @@ fn check_memory tc:TypeChecker op:Op {
 # ============================================================================
 # Check assignment operations
 # ============================================================================
+# Unify the stored type of `variable` with the type being assigned to it.
+# `scope` ("local" / "global") is only used in the error message.
+
+fn unify_variable_assignment op:Op variable:Variable effective_type:str scope:str {
+    op op_str_value = var_name
+    if
+    "" variable Variable::typ ==
+    ANY_TYPE variable Variable::typ == effective_type ANY_TYPE != && ||
+    then
+        effective_type variable Variable::set_typ
+    fi
+    variable Variable::typ effective_type unify_type = unified
+    if "" unified == then
+        op Op::location f"Cannot override {scope} variable `{var_name}` of type `{variable Variable::typ}` with other type `{effective_type}`" ErrorKind::InvalidVariable add_error
+    else
+        unified variable Variable::set_typ
+    fi
+}
 
 fn check_assignment tc:TypeChecker op:Op function_opt:Option[Function] {
     if
@@ -842,18 +865,7 @@ fn check_assignment tc:TypeChecker op:Op function_opt:Option[Function] {
         var_name function Function::variables variable_list_index = local_index
         if 0 local_index >= then
             local_index function Function::variables.get = local_var
-            if
-            "" local_var Variable::typ ==
-            ANY_TYPE local_var Variable::typ == effective_type ANY_TYPE != && ||
-            then
-                effective_type local_var Variable::set_typ
-            fi
-            local_var Variable::typ effective_type unify_type = unified
-            if "" unified == then
-                op Op::location f"Cannot override local variable `{var_name}` of type `{local_var Variable::typ}` with other type `{effective_type}`" ErrorKind::InvalidVariable add_error
-            else
-                unified local_var Variable::set_typ
-            fi
+            "local" effective_type local_var op unify_variable_assignment
             effective_type tc expect_type drop
             return
         fi
@@ -863,18 +875,7 @@ fn check_assignment tc:TypeChecker op:Op function_opt:Option[Function] {
     var_name tc.store.variables.get = global_opt
     if global_opt.is_some then
         global_opt.unwrap = global_var
-        if
-        "" global_var Variable::typ ==
-        ANY_TYPE global_var Variable::typ == effective_type ANY_TYPE != && ||
-        then
-            effective_type global_var Variable::set_typ
-        fi
-        global_var Variable::typ effective_type unify_type = unified
-        if "" unified == then
-            op Op::location f"Cannot override global variable `{var_name}` of type `{global_var Variable::typ}` with other type `{effective_type}`" ErrorKind::InvalidVariable add_error
-        else
-            unified global_var Variable::set_typ
-        fi
+        "global" effective_type global_var op unify_variable_assignment
         effective_type tc expect_type drop
         return
     fi
@@ -1731,7 +1732,7 @@ fn check_is tc:TypeChecker op:Op {
     tc stack_pop = typ
     typ resolve_match_type = base
     if base tc.store.enums.get.is_none then
-        tc TypeChecker::current_location f"`is` requires an enum type, got `{typ}`" ErrorKind::TypeMismatch raise_error
+        f"`is` requires an enum type, got `{typ}`" tc raise_type_mismatch
         "bool" tc stack_push
         return
     fi
@@ -1740,7 +1741,7 @@ fn check_is tc:TypeChecker op:Op {
     # Validate the variant belongs to the correct enum
     if "" variant EnumVariant::enum_name != then
         if variant EnumVariant::enum_name casa_enum CasaEnum::name != then
-            tc TypeChecker::current_location f"Cannot check `{variant EnumVariant::enum_name}::{variant EnumVariant::variant_name}` on value of type `{typ}`" ErrorKind::TypeMismatch raise_error
+            f"Cannot check `{variant EnumVariant::enum_name}::{variant EnumVariant::variant_name}` on value of type `{typ}`" tc raise_type_mismatch
         fi
     fi
     # Validate binding count for data-carrying variants
@@ -1749,7 +1750,7 @@ fn check_is tc:TypeChecker op:Op {
         if inner_opt.is_some then
             inner_opt.unwrap = inner_types
             if variant EnumVariant::bindings.length inner_types.length != then
-                tc TypeChecker::current_location f"Variant `{variant EnumVariant::enum_name}::{variant EnumVariant::variant_name}` has {inner_types.length} inner value(s), but {variant EnumVariant::bindings.length} binding(s) provided" ErrorKind::TypeMismatch raise_error
+                f"Variant `{variant EnumVariant::enum_name}::{variant EnumVariant::variant_name}` has {inner_types.length} inner value(s), but {variant EnumVariant::bindings.length} binding(s) provided" tc raise_type_mismatch
             fi
         fi
     fi

--- a/compiler/typechecker.casa
+++ b/compiler/typechecker.casa
@@ -1831,10 +1831,8 @@ fn check_match tc:TypeChecker op:Op function_opt:Option[Function] {
                 match_ctx MatchContext::after = match_after
                 if
                 match_before tc TypeChecker::live.equals
-                match_after match_before.equals &&
+                match_after match_before.equals && !
                 then
-                    0 drop
-                else
                     match_after tc TypeChecker::live.unify_types = last_unified
                     if 0 last_unified.length != match_after match_before.equals ! && then
                         last_unified match_after TypedStack::set_types


### PR DESCRIPTION
## Summary

Ruthless dedup pass across `compiler/`. Each commit is a focused refactor; all
behavior is preserved and `tests/test_examples.sh` (38 tests) and
`tests/test_compiler.sh` (22 tests) pass at every step.

Net change: 6 files, **-38 lines**.

## Commits

1. **emitter.casa** — Extract `emit_load`, `emit_store`, and
   `emit_call_via_return_stack`. Collapses the four Load and four Store size
   variants plus the four call-with-return sequences (FnCall, PrintInt,
   PrintStr, FstringConcat).
2. **typechecker.casa** — Add `raise_type_mismatch` (10 call sites) and
   `unify_variable_assignment` (merges the near-duplicate local/global
   branches of `check_assignment`).
3. **parser.casa** — Extract `parse_simple_type_vars` (unifies the
   `[T1 T2 …]` loops in `parse_method_type_vars` and `parse_trait`) and
   `parse_parameter_maybe_named` (shared by `parse_parameters` and
   `parse_trait_method_signature`).
4. **parser.casa** — Extract `resolve_plain_identifier` so the
   `OpIdentifier` branch of `resolve_identifiers_fn` reads as four
   one-liners.
5. **common.casa + compiler/** — Introduce `WORD_SIZE` constant; replace
   24 bare `8` / `8 *` byte-per-word literals.
6. **pattern.casa / parser.casa / bytecode.casa** — Replace `=> 0 drop`
   no-op match arms with `=> { }`; invert two `if … then 0 drop else …`
   guards into early-skip form.
7. Review-fix follow-up: two missed `8` literals and one remaining
   `then 0 drop else` guard.

## Test plan

- [x] `./casafmt` applied to every touched file
- [x] `./casac casa.casa && gcc -nostdlib -static -o casac-new casa.o` succeeds
- [x] `tests/test_examples.sh ./casac-new` → 38 passed, 0 failed
- [x] `tests/test_compiler.sh ./casac-new < /dev/null` → 22 passed, 0 failed