### PR TITLE
lexer/parser: rename include keyword to import

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Start with the core language docs (1-8), then explore the library and tooling do
 
 | Document | Topics |
 |----------|--------|
-| [Standard Library](docs/standard-library.md) | `include`, `memcpy`, arrays (`map`, `filter`, `reduce`), `Option[T]`, `Result[T E]` |
+| [Standard Library](docs/standard-library.md) | `import`, `memcpy`, arrays (`map`, `filter`, `reduce`), `Option[T]`, `Result[T E]` |
 | [Collections](docs/collections.md) | `List[T]`, `Map[K V]`, `Set[K]`, `StringBuilder` |
 | [Strings and IO](docs/strings-and-io.md) | String methods, file I/O, character classification, type conversions |
 | [Utilities](docs/utilities.md) | Logging, timer, argument parsing, process execution |

--- a/casa.casa
+++ b/casa.casa
@@ -1,18 +1,18 @@
 # Casa compiler
 
-include "lib/std.casa"
-include "lib/parser.casa"
-include "lib/argparse.casa"
-include "lib/log.casa"
-include "compiler/common.casa"
-include "compiler/error.casa"
-include "compiler/lexer.casa"
-include "compiler/parser.casa"
-include "compiler/typechecker.casa"
-include "compiler/bytecode.casa"
-include "compiler/emitter.casa"
-include "compiler/build.casa"
-include "lib/timer.casa"
+import "lib/std.casa"
+import "lib/parser.casa"
+import "lib/argparse.casa"
+import "lib/log.casa"
+import "compiler/common.casa"
+import "compiler/error.casa"
+import "compiler/lexer.casa"
+import "compiler/parser.casa"
+import "compiler/typechecker.casa"
+import "compiler/bytecode.casa"
+import "compiler/emitter.casa"
+import "compiler/build.casa"
+import "lib/timer.casa"
 
 # ============================================================================
 # CLI argument parsing

--- a/compiler/bytecode.casa
+++ b/compiler/bytecode.casa
@@ -962,7 +962,7 @@ fn compile_op compiler:BytecodeCompiler op:Op op_index:int bytecode:List[Inst] {
     OpKind::OpIfStart kind == ||
     then
         bytecode op_index op compiler compile_if_block
-    elif OpKind::OpIncludeFile kind == OpKind::OpTypeCast kind == || then
+    elif OpKind::OpImportFile kind == OpKind::OpTypeCast kind == || then
         # No instruction emitted
     elif OpKind::OpPushEnumVariant kind == then
         op Op::value (EnumVariant) = variant

--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -1,6 +1,6 @@
 # Shared types, enums, and data structures used across the Casa compiler.
-include "../lib/std.casa"
-include "../lib/parser.casa"
+import "../lib/std.casa"
+import "../lib/parser.casa"
 
 # ============================================================================
 # TokenKind enum (14 variants)
@@ -80,7 +80,7 @@ enum KeywordKind {
     End
     Match
     Is
-    Include
+    Import
     For
     In
 }
@@ -238,8 +238,8 @@ enum OpKind {
     OpStructLiteral
     # Types
     OpTypeCast
-    # Include
-    OpIncludeFile
+    # Import
+    OpImportFile
     # F-strings
     OpFstringConcat
     OpFstringToStr
@@ -1267,7 +1267,7 @@ Map::new (Map[str KeywordKind]) = KEYWORD_MAP
 "end" KeywordKind::End KEYWORD_MAP.set = KEYWORD_MAP
 "match" KeywordKind::Match KEYWORD_MAP.set = KEYWORD_MAP
 "is" KeywordKind::Is KEYWORD_MAP.set = KEYWORD_MAP
-"include" KeywordKind::Include KEYWORD_MAP.set = KEYWORD_MAP
+"import" KeywordKind::Import KEYWORD_MAP.set = KEYWORD_MAP
 "for" KeywordKind::For KEYWORD_MAP.set = KEYWORD_MAP
 "in" KeywordKind::In KEYWORD_MAP.set = KEYWORD_MAP
 

--- a/compiler/parser.casa
+++ b/compiler/parser.casa
@@ -1651,7 +1651,7 @@ fn parse_match_block parser:Parser token:Token cursor:TokenCursor function_name:
 }
 
 # ============================================================================
-# _handle_keyword_include - parse include path
+# _handle_keyword_import - parse import path
 # ============================================================================
 
 fn normalize_path path:str -> str {
@@ -1706,11 +1706,11 @@ fn normalize_path path:str -> str {
     builder.build
 }
 
-fn handle_keyword_include token:Token cursor:TokenCursor -> Op {
+fn handle_keyword_import token:Token cursor:TokenCursor -> Op {
     TokenKind::Literal cursor expect_token_kind = path_token
     path_token get_op_literal = literal_op
     if OpKind::OpPushStr literal_op Op::kind != then
-        path_token Token::location "Expected string literal for include path" ErrorKind::UnexpectedToken raise_error
+        path_token Token::location "Expected string literal for import path" ErrorKind::UnexpectedToken raise_error
     fi
     literal_op op_str_value = path
 
@@ -1737,7 +1737,7 @@ fn handle_keyword_include token:Token cursor:TokenCursor -> Op {
         f"{directory}{path}" normalize_path = resolved
     fi
 
-    path_token Token::location OpKind::OpIncludeFile resolved make_op_str
+    path_token Token::location OpKind::OpImportFile resolved make_op_str
 }
 
 # ============================================================================
@@ -1904,9 +1904,9 @@ fn get_op_keyword parser:Parser token:Token cursor:TokenCursor function_name:str
         return
     fi
 
-    # include
-    if KeywordKind::Include keyword == then
-        cursor token handle_keyword_include ops.push
+    # import
+    if KeywordKind::Import keyword == then
+        cursor token handle_keyword_import ops.push
         return
     fi
 
@@ -2502,15 +2502,15 @@ fn resolve_identifiers_fn parser:Parser ops:List[Op] function:Function -> List[O
             continue
         fi
 
-        # INCLUDE_FILE: process included file
-        if OpKind::OpIncludeFile op_kind == then
-            current_op op_str_value = include_path
-            if include_path parser.included_files.has ! then
-                include_path parser.included_files.add drop
-                include_path lex_file = include_tokens
-                include_tokens parser parse_ops = include_ops
-                # Splice included ops at current position (before remaining ops)
-                # Build: ops[:op_index] + inc_ops + ops[op_index:]
+        # IMPORT_FILE: process imported file
+        if OpKind::OpImportFile op_kind == then
+            current_op op_str_value = import_path
+            if import_path parser.included_files.has ! then
+                import_path parser.included_files.add drop
+                import_path lex_file = import_tokens
+                import_tokens parser parse_ops = import_ops
+                # Splice imported ops at current position (before remaining ops)
+                # Build: ops[:op_index] + imp_ops + ops[op_index:]
                 List::new (List[Op]) = new_ops
                 # Copy ops before current position (already processed)
                 0 = name_index
@@ -2518,10 +2518,10 @@ fn resolve_identifiers_fn parser:Parser ops:List[Op] function:Function -> List[O
                     name_index ops.get new_ops.push
                     1 += name_index
                 done
-                # Insert included ops
+                # Insert imported ops
                 0 = inner_index
-                while inner_index include_ops.length > do
-                    inner_index include_ops.get new_ops.push
+                while inner_index import_ops.length > do
+                    inner_index import_ops.get new_ops.push
                     1 += inner_index
                 done
                 # Copy remaining ops
@@ -2531,7 +2531,7 @@ fn resolve_identifiers_fn parser:Parser ops:List[Op] function:Function -> List[O
                     1 += name_index
                 done
                 new_ops = ops
-                # op_index now points past the included ops (don't re-process the include)
+                # op_index now points past the imported ops (don't re-process the import)
             fi
             continue
         fi

--- a/compiler/typechecker.casa
+++ b/compiler/typechecker.casa
@@ -2647,8 +2647,8 @@ fn run_type_check_ops checker:TypeChecker ops:List[Op] function_opt:Option[Funct
             continue
         fi
 
-        # Include file (no-op in typechecker)
-        if OpKind::OpIncludeFile op_kind == then
+        # Import file (no-op in typechecker)
+        if OpKind::OpImportFile op_kind == then
             continue
         fi
 
@@ -2740,4 +2740,4 @@ fn type_check_functions {
     done
     flush_errors
 }
-include "pattern.casa"
+import "pattern.casa"

--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -34,16 +34,16 @@ fn fizzbuzz number:int {
 ## Blank lines
 
 - **1 blank line** before and after top-level definitions (`fn`, `struct`, `enum`,
-  `impl`, `trait`) and include groups.
+  `impl`, `trait`) and import groups.
 - Consecutive plain top-level statements (global assignments, map `.set` chains)
   are grouped **without** blank lines.
-- Consecutive `include` statements are grouped **without** blank lines.
+- Consecutive `import` statements are grouped **without** blank lines.
 - **1 blank line** immediately before a section separator comment.
 - Inside a function body, no more than **1 consecutive blank line** (SHOULD).
 
 ```casa
-include "path/to/lib/std.casa"
-include "path/to/lib/io.casa"
+import "path/to/lib/std.casa"
+import "path/to/lib/io.casa"
 
 16 = BUFFER_SIZE
 

--- a/docs/collections.md
+++ b/docs/collections.md
@@ -1,6 +1,6 @@
 # Collections
 
-Casa provides generic container types for dynamic data. All collections are defined in `lib/std.casa` and available via `include`.
+Casa provides generic container types for dynamic data. All collections are defined in `lib/std.casa` and available via `import`.
 
 ## `List[T]`
 
@@ -137,7 +137,7 @@ arr.length print    # 3
 ### Complete Example
 
 ```casa
-include "path/to/lib/std.casa"
+import "path/to/lib/std.casa"
 
 List::new = v
 10 v.push
@@ -282,7 +282,7 @@ m.values = val_list
 ### Complete Example
 
 ```casa
-include "path/to/lib/std.casa"
+import "path/to/lib/std.casa"
 
 # Create a map from strings to ints
 Map::new (Map[str int]) = m
@@ -407,7 +407,7 @@ s.to_list = elements
 ### Complete Example
 
 ```casa
-include "path/to/lib/std.casa"
+import "path/to/lib/std.casa"
 
 # Create a set of strings
 Set::new (Set[str]) = s
@@ -500,6 +500,6 @@ Returns the number of characters in the builder.
 
 ## See Also
 
-- [Standard Library](standard-library.md) -- arrays, Option, Result, and the `include` directive
+- [Standard Library](standard-library.md) -- arrays, Option, Result, and the `import` directive
 - [Strings and IO](strings-and-io.md) -- string methods, file I/O, and type conversions
 - [Traits](traits.md) -- the `Hashable` trait required by Map and Set keys

--- a/docs/intrinsics.md
+++ b/docs/intrinsics.md
@@ -1,6 +1,6 @@
 # Built-in Intrinsics
 
-Intrinsics are operations built into the compiler. They are available in every Casa program without any `include` directive.
+Intrinsics are operations built into the compiler. They are available in every Casa program without any `import` directive.
 
 ## Stack Intrinsics
 

--- a/docs/language-server.md
+++ b/docs/language-server.md
@@ -32,7 +32,7 @@ The server runs the full compiler pipeline (lex, parse, resolve, type check) on 
 
 Errors appear with severity **Error** and warnings with severity **Warning**. All diagnostics include the source location (line, column, span) so the editor can underline the problematic code.
 
-When a file uses `include`, only diagnostics originating from the open file are shown. Errors in included files are filtered out.
+When a file uses `import`, only diagnostics originating from the open file are shown. Errors in imported files are filtered out.
 
 ### Error details
 

--- a/docs/parser.md
+++ b/docs/parser.md
@@ -1,9 +1,9 @@
 # Parser Library
 
-The parser library provides cursor-based text scanning primitives for building parsers in Casa. It is in `lib/parser.casa`. Include it with:
+The parser library provides cursor-based text scanning primitives for building parsers in Casa. It is in `lib/parser.casa`. Import it with:
 
 ```casa
-include "path/to/lib/parser.casa"
+import "path/to/lib/parser.casa"
 ```
 
 The parser library includes the standard library (`lib/std.casa`) automatically.
@@ -311,8 +311,8 @@ Parses a single-quoted character literal with escape sequences. Consumes the ope
 ## Complete Example
 
 ```casa
-include "path/to/lib/std.casa"
-include "path/to/lib/parser.casa"
+import "path/to/lib/std.casa"
+import "path/to/lib/parser.casa"
 
 # Parse integers and identifiers from input
 "abc123" Cursor::new = cursor

--- a/docs/standard-library.md
+++ b/docs/standard-library.md
@@ -1,22 +1,22 @@
 # Standard Library
 
-The standard library provides core types and functions used by most Casa programs. It is in `lib/std.casa`. Include it with:
+The standard library provides core types and functions used by most Casa programs. It is in `lib/std.casa`. Import it with:
 
 ```casa
-include "path/to/lib/std.casa"
+import "path/to/lib/std.casa"
 ```
 
 The path is relative to the source file. Adjust it based on your project layout.
 
-## `include` Directive
+## `import` Directive
 
-`include` loads another Casa source file. Each file is included at most once, regardless of how many times it appears.
+`import` loads another Casa source file. Each file is imported at most once, regardless of how many times it appears.
 
 ```casa
-include "relative/path/to/file.casa"
+import "relative/path/to/file.casa"
 ```
 
-Paths are resolved relative to the file containing the `include` directive. All functions, structs, and global variables defined in the included file become available.
+Paths are resolved relative to the file containing the `import` directive. All functions, structs, and global variables defined in the imported file become available.
 
 ## `memcpy`
 

--- a/docs/strings-and-io.md
+++ b/docs/strings-and-io.md
@@ -1,6 +1,6 @@
 # Strings and IO
 
-String operations, character classification, file I/O, output functions, and type conversions. All functions are defined in `lib/std.casa` and available via `include`.
+String operations, character classification, file I/O, output functions, and type conversions. All functions are defined in `lib/std.casa` and available via `import`.
 
 ## String Methods
 
@@ -522,7 +522,7 @@ Returns the absolute value of an integer, for use as a hash.
 
 ## See Also
 
-- [Standard Library](standard-library.md) -- arrays, Option, Result, and the `include` directive
+- [Standard Library](standard-library.md) -- arrays, Option, Result, and the `import` directive
 - [Collections](collections.md) -- List, Map, Set, and StringBuilder
 - [Traits](traits.md) -- the `Display` trait used by type conversions
 - [Types and Literals](types-and-literals.md) -- primitive type definitions

--- a/docs/utilities.md
+++ b/docs/utilities.md
@@ -4,10 +4,10 @@ Application-level utilities for logging, timing, command-line argument parsing, 
 
 ## Logging
 
-The logging library is in `lib/log.casa`. Include it with:
+The logging library is in `lib/log.casa`. Import it with:
 
 ```casa
-include "path/to/lib/log.casa"
+import "path/to/lib/log.casa"
 ```
 
 It provides leveled logging to stderr. Messages above the current log level (more verbose) are suppressed. The default level is `LogLevel::Warning`.
@@ -90,7 +90,7 @@ f"token count: {count .to_str}" log_debug
 ### Complete Example
 
 ```casa
-include "path/to/lib/log.casa"
+import "path/to/lib/log.casa"
 
 # Default level is Warning — only Error and Warning are shown
 "this is hidden" log_info
@@ -104,10 +104,10 @@ LogLevel::Info log_set_level
 
 ## Timer
 
-The timer library is in `lib/timer.casa`. Include it with:
+The timer library is in `lib/timer.casa`. Import it with:
 
 ```casa
-include "path/to/lib/timer.casa"
+import "path/to/lib/timer.casa"
 ```
 
 It provides high-resolution timing using `clock_gettime` with `CLOCK_MONOTONIC`. Timer implements the `Display` trait, formatting elapsed time as fractional seconds (e.g., `"1.042s"`).
@@ -191,7 +191,7 @@ Returns elapsed nanoseconds from the global timer. Exits with an error if `timer
 ### Complete Example
 
 ```casa
-include "path/to/lib/timer.casa"
+import "path/to/lib/timer.casa"
 
 Timer::new = timer
 
@@ -242,10 +242,10 @@ Returns the nth command-line argument as a string (zero-indexed). Prints an erro
 
 ## Argument Parser
 
-The argument parser library is in `lib/argparse.casa`. Include it with:
+The argument parser library is in `lib/argparse.casa`. Import it with:
 
 ```casa
-include "path/to/lib/argparse.casa"
+import "path/to/lib/argparse.casa"
 ```
 
 It provides a declarative API for defining and parsing CLI arguments, with auto-generated help output similar to Python's `argparse`.
@@ -338,7 +338,7 @@ Returns `true` if the flag was set, `false` otherwise.
 ### Complete Example
 
 ```casa
-include "path/to/lib/argparse.casa"
+import "path/to/lib/argparse.casa"
 
 ArgParser::new = parser
 "input file" "input" parser .add_positional
@@ -394,6 +394,6 @@ Converts a `List[char]` to a `str`. Used internally by `StringBuilder::build`.
 
 ## See Also
 
-- [Standard Library](standard-library.md) -- arrays, Option, Result, and the `include` directive
+- [Standard Library](standard-library.md) -- arrays, Option, Result, and the `import` directive
 - [Collections](collections.md) -- List, Map, Set, and StringBuilder
 - [Strings and IO](strings-and-io.md) -- string methods and file I/O

--- a/examples/argparse.casa
+++ b/examples/argparse.casa
@@ -2,7 +2,7 @@
 # Demonstrates declarative CLI argument parsing with auto-generated help.
 # Usage: ./argparse [--name NAME] [-g GREETING] [-v]
 
-include "../lib/argparse.casa"
+import "../lib/argparse.casa"
 
 ArgParser::new = parser
 "name to greet" "--name" "-n" "name" parser .add_option

--- a/examples/command_line_args.casa
+++ b/examples/command_line_args.casa
@@ -2,7 +2,7 @@
 # Demonstrates argc, argv, and get_arg
 # Usage: ./command_line_args hello world
 
-include "../lib/std.casa"
+import "../lib/std.casa"
 
 # Print number of user arguments (excluding program name)
 argc 1 - = num_args

--- a/examples/dynamic_list.casa
+++ b/examples/dynamic_list.casa
@@ -1,4 +1,4 @@
-include "../lib/std.casa"
+import "../lib/std.casa"
 
 "=== Create list with items [1, 2, 3] ===" print "\n" print
 [1, 2, 3] List::from_array = list

--- a/examples/file_io.casa
+++ b/examples/file_io.casa
@@ -1,7 +1,7 @@
 # File I/O operations
 # Demonstrates file reading, writing, and low-level file operations
 
-include "../lib/std.casa"
+import "../lib/std.casa"
 
 # High-level: write and read a file
 "=== write_all ===" print "\n" print

--- a/examples/for_loop.casa
+++ b/examples/for_loop.casa
@@ -2,7 +2,7 @@
 #
 # A `for x in <iter> do <body> done` loop calls `<iter_type>::next` until it
 # returns `Option::None`. Any type with a matching `next` method works.
-include "../lib/std.casa"
+import "../lib/std.casa"
 
 # Iterating an array
 [1 2 3 4 5] = nums

--- a/examples/fstring.casa
+++ b/examples/fstring.casa
@@ -1,6 +1,6 @@
 # F-string interpolation examples
 
-include "../lib/std.casa"
+import "../lib/std.casa"
 
 # Basic f-string with a variable
 "world" = greeting

--- a/examples/game_of_life.casa
+++ b/examples/game_of_life.casa
@@ -2,7 +2,7 @@
 # Runs fullscreen in the terminal with toroidal wrapping.
 # Adapts to terminal resize. Exit with Ctrl+C.
 
-include "../lib/std.casa"
+import "../lib/std.casa"
 
 
 # ---------------------------------------------------------------------------

--- a/examples/hash_map.casa
+++ b/examples/hash_map.casa
@@ -1,4 +1,4 @@
-include "../lib/std.casa"
+import "../lib/std.casa"
 
 # Create a Map[str int]
 Map::new (Map[str int]) = m

--- a/examples/iterable.casa
+++ b/examples/iterable.casa
@@ -3,7 +3,7 @@
 # Types that implement `fn next self:self -> Option[T]` automatically gain
 # default methods from the `Iterable[T]` trait: collect, map, filter, fold,
 # count, any, all, and find. Call `.iter` on a collection to get an iterator.
-include "../lib/std.casa"
+import "../lib/std.casa"
 
 # collect — gather all elements into a List
 [10 20 30] (array[int]) .iter .collect = collected

--- a/examples/log.casa
+++ b/examples/log.casa
@@ -1,7 +1,7 @@
 # Logging library
 # Demonstrates leveled logging to stderr with configurable log levels.
 
-include "../lib/log.casa"
+import "../lib/log.casa"
 
 # Default level is Warning — Info and Debug are suppressed
 "this info is hidden" log_info

--- a/examples/option.casa
+++ b/examples/option.casa
@@ -3,7 +3,7 @@
 # Option::Some wraps a value into Option[T], Option::None creates an empty option.
 # Methods: is_some, is_none, unwrap, unwrap_or
 
-include "../lib/std.casa"
+import "../lib/std.casa"
 
 # Creating options
 42 Option::Some = maybe_int       # Option[int]

--- a/examples/parser.casa
+++ b/examples/parser.casa
@@ -3,8 +3,8 @@
 # Demonstrates Cursor struct, helper functions, and high-level parsers
 # for integers, identifiers, quoted strings, and char literals.
 
-include "../lib/std.casa"
-include "../lib/parser.casa"
+import "../lib/std.casa"
+import "../lib/parser.casa"
 
 # Cursor basics: peek and advance
 "hello" Cursor::new = cursor

--- a/examples/result.casa
+++ b/examples/result.casa
@@ -3,7 +3,7 @@
 # Result::Ok wraps a value into Result[T E], Result::Error wraps an error.
 # Methods: is_ok, is_error, unwrap, unwrap_error, unwrap_or
 
-include "../lib/std.casa"
+import "../lib/std.casa"
 
 # Creating results
 42 Result::Ok = success            # Result[int E]

--- a/examples/run_command.casa
+++ b/examples/run_command.casa
@@ -1,7 +1,7 @@
 # Running external commands
 # Demonstrates run_command which uses fork + execve
 
-include "../lib/std.casa"
+import "../lib/std.casa"
 
 # Run echo
 ["/usr/bin/env", "echo", "hello", "from", "casa"] List::from_array run_command = echo_code

--- a/examples/sized_memory.casa
+++ b/examples/sized_memory.casa
@@ -1,4 +1,4 @@
-include "../lib/std.casa"
+import "../lib/std.casa"
 
 # Allocate 32 bytes of memory
 32 alloc = buf

--- a/examples/string_operations.casa
+++ b/examples/string_operations.casa
@@ -1,7 +1,7 @@
 # String operations
 # Demonstrates string methods, char type, and cstr type
 
-include "../lib/std.casa"
+import "../lib/std.casa"
 
 # String length
 "=== length ===" print "\n" print

--- a/examples/timer.casa
+++ b/examples/timer.casa
@@ -1,4 +1,4 @@
-include "../lib/timer.casa"
+import "../lib/timer.casa"
 
 # Create a timer
 Timer::new = timer

--- a/examples/type_annotations.casa
+++ b/examples/type_annotations.casa
@@ -3,7 +3,7 @@
 # The = name:type syntax allows explicit type annotation when assigning variables.
 # This is useful for narrowing 'any' or bare 'option' types to concrete types.
 
-include "../lib/std.casa"
+import "../lib/std.casa"
 
 # Basic type annotations
 42 = x:int

--- a/examples/vec.casa
+++ b/examples/vec.casa
@@ -3,7 +3,7 @@
 # Shows all List methods: new, push, get, set, pop, length,
 # from_array, slice, to_array
 
-include "../lib/std.casa"
+import "../lib/std.casa"
 
 # Create empty list and push elements
 "=== List::new and push ===" print "\n" print

--- a/formatter/format.casa
+++ b/formatter/format.casa
@@ -7,11 +7,11 @@
 #   ./casac casa.casa -o casac-stage1
 #   ./casac-stage1 formatter/format.casa -o casafmt
 
-include "../lib/std.casa"
-include "../lib/io.casa"
-include "../compiler/common.casa"
-include "../compiler/error.casa"
-include "../compiler/lexer.casa"
+import "../lib/std.casa"
+import "../lib/io.casa"
+import "../compiler/common.casa"
+import "../compiler/error.casa"
+import "../compiler/lexer.casa"
 
 
 # ============================================================================
@@ -534,7 +534,7 @@ fn format_tokens tokens:List[Token] source:str -> str {
     false = prev_was_comment
     false = prev_was_section_comment
     false = prev_was_definition
-    false = prev_was_include
+    false = prev_was_import
 
     while pos tokens .length > do
         pos tokens .get = token
@@ -593,7 +593,7 @@ fn format_tokens tokens:List[Token] source:str -> str {
                     fi
                 elif 0 depth == then
                     if first_value is_toplevel_definition prev_was_definition || then
-                        if "include" first_value == prev_was_include && ! then
+                        if "import" first_value == prev_was_import && ! then
                             1 = allowed_blanks
                         fi
                     fi
@@ -607,7 +607,7 @@ fn format_tokens tokens:List[Token] source:str -> str {
                             1 = allowed_blanks
                         fi
                     elif first_value is_toplevel_definition prev_was_definition || then
-                        if "include" first_value == prev_was_include && ! then
+                        if "import" first_value == prev_was_import && ! then
                             1 = allowed_blanks
                         fi
                     fi
@@ -757,17 +757,17 @@ fn format_tokens tokens:List[Token] source:str -> str {
                 false = prev_was_section_comment
             fi
 
-            # Track if this was a top-level definition or include
+            # Track if this was a top-level definition or import
             if 0 depth == then
-                if first_value is_toplevel_definition "include" first_value == || then
+                if first_value is_toplevel_definition "import" first_value == || then
                     true = prev_was_definition
                 else
                     false = prev_was_definition
                 fi
-                "include" first_value == = prev_was_include
+                "import" first_value == = prev_was_import
             else
                 false = prev_was_definition
-                false = prev_was_include
+                false = prev_was_import
             fi
 
             # else keyword: restore depth for body

--- a/lib/argparse.casa
+++ b/lib/argparse.casa
@@ -3,7 +3,7 @@
 # Provides a declarative API for defining and parsing CLI arguments,
 # with auto-generated help output similar to Python's argparse.
 
-include "std.casa"
+import "std.casa"
 
 
 # ---------------------------------------------------------------------------

--- a/lib/io.casa
+++ b/lib/io.casa
@@ -3,7 +3,7 @@
 # Provides a buffered reader for stdin and a writer for stdout,
 # used by the language server for JSON-RPC communication.
 
-include "std.casa"
+import "std.casa"
 
 
 # ---------------------------------------------------------------------------

--- a/lib/json.casa
+++ b/lib/json.casa
@@ -3,8 +3,8 @@
 # Provides parsing of JSON text into a JsonValue tree and serialization
 # back to JSON text. Used by the language server for JSON-RPC communication.
 
-include "std.casa"
-include "parser.casa"
+import "std.casa"
+import "parser.casa"
 
 
 # ============================================================================

--- a/lib/log.casa
+++ b/lib/log.casa
@@ -4,12 +4,12 @@
 # Messages above the current level (more verbose) are suppressed.
 #
 # Usage:
-#   include "../lib/log.casa"
+#   import "../lib/log.casa"
 #   LogLevel::Info log_set_level
 #   "starting up" log_info
 #   "something odd" log_warning
 
-include "std.casa"
+import "std.casa"
 
 
 # ---------------------------------------------------------------------------

--- a/lib/parser.casa
+++ b/lib/parser.casa
@@ -4,7 +4,7 @@
 # and high-level parsers for common patterns like integers, identifiers,
 # quoted strings, and char literals.
 
-include "std.casa"
+import "std.casa"
 
 
 # ---------------------------------------------------------------------------

--- a/lib/test.casa
+++ b/lib/test.casa
@@ -18,7 +18,7 @@
 #   assert_warning_count / assert_warning_contains
 #   clear_global_state
 
-include "std.casa"
+import "std.casa"
 
 0  = test_pass_count
 0  = test_fail_count

--- a/lib/timer.casa
+++ b/lib/timer.casa
@@ -3,12 +3,12 @@
 # Provides high-resolution timing using clock_gettime (CLOCK_MONOTONIC).
 #
 # Usage:
-#   include "../lib/timer.casa"
+#   import "../lib/timer.casa"
 #   Timer::new = timer
 #   # ... do work ...
 #   timer .elapsed_ms println   # prints elapsed milliseconds
 
-include "std.casa"
+import "std.casa"
 
 
 # ---------------------------------------------------------------------------

--- a/lsp.casa
+++ b/lsp.casa
@@ -4,15 +4,15 @@
 # go-to-definition, hover, completion, references, rename, and semantic tokens.
 # Communicates via JSON-RPC over stdin/stdout.
 
-include "lib/std.casa"
-include "lib/parser.casa"
-include "lib/json.casa"
-include "lib/io.casa"
-include "compiler/common.casa"
-include "compiler/error.casa"
-include "compiler/lexer.casa"
-include "compiler/parser.casa"
-include "compiler/typechecker.casa"
+import "lib/std.casa"
+import "lib/parser.casa"
+import "lib/json.casa"
+import "lib/io.casa"
+import "compiler/common.casa"
+import "compiler/error.casa"
+import "compiler/lexer.casa"
+import "compiler/parser.casa"
+import "compiler/typechecker.casa"
 
 # ============================================================================
 # LSP structs
@@ -2269,7 +2269,7 @@ fn keyword_name kind:KeywordKind -> str {
     elif KeywordKind::End kind == then "end"
     elif KeywordKind::Match kind == then "match"
     elif KeywordKind::Is kind == then "is"
-    elif KeywordKind::Include kind == then "include"
+    elif KeywordKind::Import kind == then "import"
     else "unknown"
     fi
 }

--- a/tests/compiler/test_argv.casa
+++ b/tests/compiler/test_argv.casa
@@ -1,11 +1,11 @@
-include "../../compiler/common.casa"
-include "../../compiler/error.casa"
-include "../../compiler/lexer.casa"
-include "../../compiler/parser.casa"
-include "../../compiler/typechecker.casa"
-include "../../compiler/bytecode.casa"
-include "../../compiler/emitter.casa"
-include "../../lib/test.casa"
+import "../../compiler/common.casa"
+import "../../compiler/error.casa"
+import "../../compiler/lexer.casa"
+import "../../compiler/parser.casa"
+import "../../compiler/typechecker.casa"
+import "../../compiler/bytecode.casa"
+import "../../compiler/emitter.casa"
+import "../../lib/test.casa"
 
 # ============================================================================
 # Helpers

--- a/tests/compiler/test_array_methods.casa
+++ b/tests/compiler/test_array_methods.casa
@@ -1,11 +1,11 @@
-include "../../compiler/common.casa"
-include "../../compiler/error.casa"
-include "../../compiler/lexer.casa"
-include "../../compiler/parser.casa"
-include "../../compiler/typechecker.casa"
-include "../../compiler/bytecode.casa"
-include "../../compiler/emitter.casa"
-include "../../lib/test.casa"
+import "../../compiler/common.casa"
+import "../../compiler/error.casa"
+import "../../compiler/lexer.casa"
+import "../../compiler/parser.casa"
+import "../../compiler/typechecker.casa"
+import "../../compiler/bytecode.casa"
+import "../../compiler/emitter.casa"
+import "../../lib/test.casa"
 
 # ============================================================================
 # Array method tests

--- a/tests/compiler/test_bytecode.casa
+++ b/tests/compiler/test_bytecode.casa
@@ -1,13 +1,13 @@
-include "../../compiler/common.casa"
-include "../../compiler/error.casa"
-include "../../compiler/lexer.casa"
-include "../../compiler/parser.casa"
-include "../../compiler/typechecker.casa"
-include "../../lib/test.casa"
+import "../../compiler/common.casa"
+import "../../compiler/error.casa"
+import "../../compiler/lexer.casa"
+import "../../compiler/parser.casa"
+import "../../compiler/typechecker.casa"
+import "../../lib/test.casa"
 
 symbol_store_new = TEST_STORE
 
-include "../../compiler/bytecode.casa"
+import "../../compiler/bytecode.casa"
 
 # ============================================================================
 # Test helpers
@@ -241,17 +241,17 @@ fn test_compile_type_cast_no_output {
     "type cast produces no inst" 1 bytecode .length assert_eq
 }
 
-fn test_compile_include_no_output {
-    "compile_include_no_output" test_start
+fn test_compile_import_no_output {
+    "compile_import_no_output" test_start
     reset_labels
     List::new (List[Op]) = ops
-    OpKind::OpIncludeFile 0 test_make_op ops .push
+    OpKind::OpImportFile 0 test_make_op ops .push
 
     ops TEST_STORE make_compiler = compiler
     List::new (List[Inst]) = bytecode
     bytecode compiler compile_ops
 
-    "include produces no inst" 1 bytecode .length assert_eq
+    "import produces no inst" 1 bytecode .length assert_eq
 }
 
 fn test_op_index_to_label_stability {
@@ -698,7 +698,7 @@ test_compile_variable_assign_and_push
 test_compile_local_variable
 test_compile_fstring_concat
 test_compile_type_cast_no_output
-test_compile_include_no_output
+test_compile_import_no_output
 test_op_index_to_label_stability
 test_compile_if_block
 test_compile_while_block

--- a/tests/compiler/test_common.casa
+++ b/tests/compiler/test_common.casa
@@ -1,8 +1,8 @@
-include "../../compiler/common.casa"
-include "../../compiler/error.casa"
-include "../../compiler/lexer.casa"
-include "../../compiler/parser.casa"
-include "../../lib/test.casa"
+import "../../compiler/common.casa"
+import "../../compiler/error.casa"
+import "../../compiler/lexer.casa"
+import "../../compiler/parser.casa"
+import "../../lib/test.casa"
 
 fn test_extract_generic_base {
     "extract_generic_base" test_start

--- a/tests/compiler/test_display.casa
+++ b/tests/compiler/test_display.casa
@@ -1,9 +1,9 @@
-include "../../compiler/common.casa"
-include "../../compiler/error.casa"
-include "../../compiler/lexer.casa"
-include "../../compiler/parser.casa"
-include "../../compiler/typechecker.casa"
-include "../../lib/test.casa"
+import "../../compiler/common.casa"
+import "../../compiler/error.casa"
+import "../../compiler/lexer.casa"
+import "../../compiler/parser.casa"
+import "../../compiler/typechecker.casa"
+import "../../lib/test.casa"
 
 # ============================================================================
 # Constants

--- a/tests/compiler/test_emitter.casa
+++ b/tests/compiler/test_emitter.casa
@@ -1,9 +1,9 @@
-include "../../compiler/common.casa"
-include "../../compiler/error.casa"
-include "../../compiler/lexer.casa"
-include "../../compiler/parser.casa"
-include "../../compiler/emitter.casa"
-include "../../lib/test.casa"
+import "../../compiler/common.casa"
+import "../../compiler/error.casa"
+import "../../compiler/lexer.casa"
+import "../../compiler/parser.casa"
+import "../../compiler/emitter.casa"
+import "../../lib/test.casa"
 
 # Helper: check that a string contains a substring
 fn assert_contains needle:str haystack:str msg:str {

--- a/tests/compiler/test_enum.casa
+++ b/tests/compiler/test_enum.casa
@@ -1,11 +1,11 @@
-include "../../compiler/common.casa"
-include "../../compiler/error.casa"
-include "../../compiler/lexer.casa"
-include "../../compiler/parser.casa"
-include "../../compiler/typechecker.casa"
-include "../../compiler/bytecode.casa"
-include "../../compiler/emitter.casa"
-include "../../lib/test.casa"
+import "../../compiler/common.casa"
+import "../../compiler/error.casa"
+import "../../compiler/lexer.casa"
+import "../../compiler/parser.casa"
+import "../../compiler/typechecker.casa"
+import "../../compiler/bytecode.casa"
+import "../../compiler/emitter.casa"
+import "../../lib/test.casa"
 
 # ============================================================================
 # Constants

--- a/tests/compiler/test_enum_variant_hint.casa
+++ b/tests/compiler/test_enum_variant_hint.casa
@@ -1,9 +1,9 @@
-include "../../compiler/common.casa"
-include "../../compiler/error.casa"
-include "../../compiler/lexer.casa"
-include "../../compiler/parser.casa"
-include "../../compiler/typechecker.casa"
-include "../../lib/test.casa"
+import "../../compiler/common.casa"
+import "../../compiler/error.casa"
+import "../../compiler/lexer.casa"
+import "../../compiler/parser.casa"
+import "../../compiler/typechecker.casa"
+import "../../lib/test.casa"
 
 "enum Color { Red Green Blue }\n" = EVH_COLOR_ENUM
 "enum Direction { North South East West }\n" = EVH_DIRECTION_ENUM

--- a/tests/compiler/test_error.casa
+++ b/tests/compiler/test_error.casa
@@ -1,8 +1,8 @@
-include "../../compiler/common.casa"
-include "../../compiler/error.casa"
-include "../../compiler/lexer.casa"
-include "../../compiler/parser.casa"
-include "../../lib/test.casa"
+import "../../compiler/common.casa"
+import "../../compiler/error.casa"
+import "../../compiler/lexer.casa"
+import "../../compiler/parser.casa"
+import "../../lib/test.casa"
 
 fn test_offset_to_line_col {
     "offset_to_line_col" test_start

--- a/tests/compiler/test_generic_structs.casa
+++ b/tests/compiler/test_generic_structs.casa
@@ -1,11 +1,11 @@
-include "../../compiler/common.casa"
-include "../../compiler/error.casa"
-include "../../compiler/lexer.casa"
-include "../../compiler/parser.casa"
-include "../../compiler/typechecker.casa"
-include "../../compiler/bytecode.casa"
-include "../../compiler/emitter.casa"
-include "../../lib/test.casa"
+import "../../compiler/common.casa"
+import "../../compiler/error.casa"
+import "../../compiler/lexer.casa"
+import "../../compiler/parser.casa"
+import "../../compiler/typechecker.casa"
+import "../../compiler/bytecode.casa"
+import "../../compiler/emitter.casa"
+import "../../lib/test.casa"
 
 # ============================================================================
 # Helpers

--- a/tests/compiler/test_lexer.casa
+++ b/tests/compiler/test_lexer.casa
@@ -1,8 +1,8 @@
-include "../../compiler/common.casa"
-include "../../compiler/error.casa"
-include "../../compiler/lexer.casa"
-include "../../compiler/parser.casa"
-include "../../lib/test.casa"
+import "../../compiler/common.casa"
+import "../../compiler/error.casa"
+import "../../compiler/lexer.casa"
+import "../../compiler/parser.casa"
+import "../../lib/test.casa"
 
 fn test_integer_literal {
     "integer_literal" test_start
@@ -150,8 +150,8 @@ fn test_all_keywords {
     "match" TokenKind::Keyword 0 tokens .get Token::kind == assert_true
     "test" "is" lex_source = tokens
     "is" TokenKind::Keyword 0 tokens .get Token::kind == assert_true
-    "test" "include" lex_source = tokens
-    "include" TokenKind::Keyword 0 tokens .get Token::kind == assert_true
+    "test" "import" lex_source = tokens
+    "import" TokenKind::Keyword 0 tokens .get Token::kind == assert_true
 }
 
 fn test_all_operators {
@@ -900,11 +900,11 @@ fn test_is_keyword {
     "value" "is" 0 tokens .get Token::value assert_str_eq
 }
 
-fn test_include_keyword {
-    "include_keyword" test_start
-    "test" "include" lex_source = tokens
+fn test_import_keyword {
+    "import_keyword" test_start
+    "test" "import" lex_source = tokens
     "kind" TokenKind::Keyword 0 tokens .get Token::kind == assert_true
-    "value" "include" 0 tokens .get Token::value assert_str_eq
+    "value" "import" 0 tokens .get Token::value assert_str_eq
 }
 
 # ============================================================================
@@ -1004,5 +1004,5 @@ test_struct_keyword
 test_trait_keyword
 test_match_keyword
 test_is_keyword
-test_include_keyword
+test_import_keyword
 test_summary

--- a/tests/compiler/test_lsp.casa
+++ b/tests/compiler/test_lsp.casa
@@ -1,5 +1,5 @@
-include "../../lsp.casa"
-include "../../lib/test.casa"
+import "../../lsp.casa"
+import "../../lib/test.casa"
 
 # Synthetic file path used for tests that don't need a real file on disk.
 "/tmp/lsp_test.casa" = LSP_TEST_FILE

--- a/tests/compiler/test_match_underflow.casa
+++ b/tests/compiler/test_match_underflow.casa
@@ -1,9 +1,9 @@
-include "../../compiler/common.casa"
-include "../../compiler/error.casa"
-include "../../compiler/lexer.casa"
-include "../../compiler/parser.casa"
-include "../../compiler/typechecker.casa"
-include "../../lib/test.casa"
+import "../../compiler/common.casa"
+import "../../compiler/error.casa"
+import "../../compiler/lexer.casa"
+import "../../compiler/parser.casa"
+import "../../compiler/typechecker.casa"
+import "../../lib/test.casa"
 
 # ============================================================================
 # Helper: lex + parse + resolve + typecheck a source string

--- a/tests/compiler/test_parser.casa
+++ b/tests/compiler/test_parser.casa
@@ -1,8 +1,8 @@
-include "../../compiler/common.casa"
-include "../../compiler/error.casa"
-include "../../compiler/lexer.casa"
-include "../../compiler/parser.casa"
-include "../../lib/test.casa"
+import "../../compiler/common.casa"
+import "../../compiler/error.casa"
+import "../../compiler/lexer.casa"
+import "../../compiler/parser.casa"
+import "../../lib/test.casa"
 
 # ============================================================================
 # Literal parsing tests

--- a/tests/compiler/test_parser.casa
+++ b/tests/compiler/test_parser.casa
@@ -521,6 +521,16 @@ fn test_parse_keyword_continue {
     "kind" OpKind::OpWhileContinue 0 ops .get Op::kind == assert_true
 }
 
+fn test_parse_keyword_import {
+    "parse_keyword_import" test_start
+    # Absolute path bypasses base-file directory resolution.
+    "test" "import \"/foo.casa\"" lex_source = tokens
+    tokens DEFAULT_PARSER parse_ops = ops
+    "count" 1 ops .length assert_eq
+    "kind" OpKind::OpImportFile 0 ops .get Op::kind == assert_true
+    "path" "/foo.casa" 0 ops .get op_str_value assert_str_eq
+}
+
 # ============================================================================
 # String with escapes test
 # ============================================================================
@@ -593,5 +603,6 @@ test_parse_variable_dec
 test_parse_keyword_elif
 test_parse_keyword_break
 test_parse_keyword_continue
+test_parse_keyword_import
 test_parse_string_with_escapes
 test_summary

--- a/tests/compiler/test_pattern.casa
+++ b/tests/compiler/test_pattern.casa
@@ -1,11 +1,11 @@
-include "../../compiler/common.casa"
-include "../../compiler/error.casa"
-include "../../compiler/lexer.casa"
-include "../../compiler/parser.casa"
-include "../../compiler/typechecker.casa"
-include "../../compiler/bytecode.casa"
-include "../../compiler/pattern.casa"
-include "../../lib/test.casa"
+import "../../compiler/common.casa"
+import "../../compiler/error.casa"
+import "../../compiler/lexer.casa"
+import "../../compiler/parser.casa"
+import "../../compiler/typechecker.casa"
+import "../../compiler/bytecode.casa"
+import "../../compiler/pattern.casa"
+import "../../lib/test.casa"
 
 # ============================================================================
 # Helpers for building match-arm ops for tests

--- a/tests/compiler/test_struct_literal.casa
+++ b/tests/compiler/test_struct_literal.casa
@@ -1,10 +1,10 @@
-include "../../compiler/common.casa"
-include "../../compiler/error.casa"
-include "../../compiler/lexer.casa"
-include "../../compiler/parser.casa"
-include "../../compiler/typechecker.casa"
-include "../../compiler/bytecode.casa"
-include "../../lib/test.casa"
+import "../../compiler/common.casa"
+import "../../compiler/error.casa"
+import "../../compiler/lexer.casa"
+import "../../compiler/parser.casa"
+import "../../compiler/typechecker.casa"
+import "../../compiler/bytecode.casa"
+import "../../lib/test.casa"
 
 # ============================================================================
 # Constants

--- a/tests/compiler/test_traits.casa
+++ b/tests/compiler/test_traits.casa
@@ -1,9 +1,9 @@
-include "../../compiler/common.casa"
-include "../../compiler/error.casa"
-include "../../compiler/lexer.casa"
-include "../../compiler/parser.casa"
-include "../../compiler/typechecker.casa"
-include "../../lib/test.casa"
+import "../../compiler/common.casa"
+import "../../compiler/error.casa"
+import "../../compiler/lexer.casa"
+import "../../compiler/parser.casa"
+import "../../compiler/typechecker.casa"
+import "../../lib/test.casa"
 
 # ============================================================================
 # Constants

--- a/tests/compiler/test_type_annotations.casa
+++ b/tests/compiler/test_type_annotations.casa
@@ -1,9 +1,9 @@
-include "../../compiler/common.casa"
-include "../../compiler/error.casa"
-include "../../compiler/lexer.casa"
-include "../../compiler/parser.casa"
-include "../../compiler/typechecker.casa"
-include "../../lib/test.casa"
+import "../../compiler/common.casa"
+import "../../compiler/error.casa"
+import "../../compiler/lexer.casa"
+import "../../compiler/parser.casa"
+import "../../compiler/typechecker.casa"
+import "../../lib/test.casa"
 
 # ============================================================================
 # Constants

--- a/tests/compiler/test_typechecker.casa
+++ b/tests/compiler/test_typechecker.casa
@@ -1,9 +1,9 @@
-include "../../compiler/common.casa"
-include "../../compiler/error.casa"
-include "../../compiler/lexer.casa"
-include "../../compiler/parser.casa"
-include "../../compiler/typechecker.casa"
-include "../../lib/test.casa"
+import "../../compiler/common.casa"
+import "../../compiler/error.casa"
+import "../../compiler/lexer.casa"
+import "../../compiler/parser.casa"
+import "../../compiler/typechecker.casa"
+import "../../lib/test.casa"
 
 # ============================================================================
 # Helper: create ops list and type check it

--- a/tests/compiler/test_typeof.casa
+++ b/tests/compiler/test_typeof.casa
@@ -1,11 +1,11 @@
-include "../../compiler/common.casa"
-include "../../compiler/error.casa"
-include "../../compiler/lexer.casa"
-include "../../compiler/parser.casa"
-include "../../compiler/typechecker.casa"
-include "../../compiler/bytecode.casa"
-include "../../compiler/emitter.casa"
-include "../../lib/test.casa"
+import "../../compiler/common.casa"
+import "../../compiler/error.casa"
+import "../../compiler/lexer.casa"
+import "../../compiler/parser.casa"
+import "../../compiler/typechecker.casa"
+import "../../compiler/bytecode.casa"
+import "../../compiler/emitter.casa"
+import "../../lib/test.casa"
 
 # ============================================================================
 # Helpers

--- a/tests/formatter/blank_lines.expected.casa
+++ b/tests/formatter/blank_lines.expected.casa
@@ -1,4 +1,4 @@
-include "../lib/std.casa"
+import "../lib/std.casa"
 
 16 = BUFFER_SIZE
 

--- a/tests/formatter/blank_lines.input.casa
+++ b/tests/formatter/blank_lines.input.casa
@@ -1,4 +1,4 @@
-include "../lib/std.casa"
+import "../lib/std.casa"
 16 = BUFFER_SIZE
 fn foo {
     1 = a


### PR DESCRIPTION
## Summary
- Mechanical rename of the Casa keyword `include` → `import` everywhere.
- Closes #109. First slice of module-system PRD #106.
- Pure rename, no semantic change. Path-style imports only; module-style and `-L` come in a later slice.

## Scope
- Compiler internals: `KeywordKind::Import`, `OpKind::OpImportFile`, `handle_keyword_import`, parser locals `import_*`, error string, comments.
- Surface: every `.casa` source (`casa.casa`, `compiler/`, `formatter/`, `lib/`, `examples/`, `tests/`, `lsp.casa`).
- Tests: `test_import_keyword`, `test_compile_import_no_output`.
- Docs: `README.md`, `docs/standard-library.md`, `docs/utilities.md`, `docs/parser.md`, `docs/collections.md`, `docs/strings-and-io.md`, `docs/intrinsics.md`, `docs/language-server.md`, `docs/FORMAT.md`.

## Bootstrap caveat
The shipped `./casac` binary was built before this rename and parses the old `include` keyword only. Reviewers must rebuild locally (`./casac casa.casa -o casac && ./casac formatter/format.casa -o casafmt`). No binary committed.

## Out of scope (intentionally not renamed)
- `Parser.included_files` field / `Parser::set_included_files` setter — internal, not in PRD scope.
- LSP protocol parameter `includeDeclaration` and locals `include_decl*` — LSP spec name.
- Generic English uses of "include"/"included" in narrative comments (e.g. "Casa includes an LSP server").

## Test plan
- [x] `tests/test_compiler.sh </dev/null` — 22 passed
- [x] `tests/test_examples.sh` — 38 passed
- [x] `casafmt` idempotent on `tests/formatter/blank_lines.input.casa`
- [x] Self-host fixed-point (stage2.s == stage3.s)