### PR TITLE
parser: module-style imports and -L search-path flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,13 @@ Compile with a custom output name:
 ## CLI Usage
 
 ```
-./casac <file> [-o name] [--keep-asm] [-r] [-v]
+./casac <file> [-o name] [-L path]... [--keep-asm] [-r] [-v]
 ```
 
 | Flag | Description |
 |------|-------------|
 | `-o`, `--output` | Output binary name (default: input file stem) |
+| `-L`, `--library-path` | Add a directory to the module import search path (repeatable, e.g. `-L lib`) |
 | `--keep-asm` | Keep the generated `.s` assembly file |
 | `-r`, `--run` | Execute the binary after compilation |
 | `-v`, `--verbose` | Enable verbose logging |

--- a/casa.casa
+++ b/casa.casa
@@ -22,6 +22,7 @@ fn parse_cli_args -> ParsedArgs {
     ArgParser::new = parser
     "input file" "input" parser .add_positional
     "output binary name" "--output" "-o" "output" parser .add_option
+    "library search path (repeatable)" "--library-path" "-L" "library_path" parser .add_multi_option
     "keep the .s file after linking" "" "--keep-asm" "keep-asm" parser .add_flag
     "run after compiling" "--run" "-r" "run" parser .add_flag
     "verbose output" "--verbose" "-v" "verbose" parser .add_flag
@@ -49,6 +50,8 @@ fn main {
     "keep-asm" args .get_flag = CLI_KEEP_ASM
     "run" args .get_flag = CLI_RUN
     "verbose" args .get_flag = CLI_VERBOSE
+
+    "library_path" args .get_multi .unwrap DEFAULT_PARSER ->search_paths
 
     # Configure logging
     if CLI_VERBOSE then

--- a/compiler/parser.casa
+++ b/compiler/parser.casa
@@ -14,9 +14,11 @@
 struct Parser {
     store:          SymbolStore
     included_files: Set[str]
+    search_paths:   List[str]
 }
 
 fn make_parser store:SymbolStore -> Parser {
+    List::new (List[str])
     Set::new (Set[str])
     store
     Parser
@@ -1706,38 +1708,80 @@ fn normalize_path path:str -> str {
     builder.build
 }
 
-fn handle_keyword_import token:Token cursor:TokenCursor -> Op {
+fn is_path_specifier spec:str -> bool {
+    spec ".casa" str::ends_with
+    spec "/" str::contains ||
+}
+
+fn dir_of_path path:str -> str {
+    -1 = last_slash
+    0 = scan
+    while scan path.length > do
+        if '/' scan path.at == then
+            scan = last_slash
+        fi
+        1 += scan
+    done
+    if 0 last_slash >= then
+        path 0 last_slash 1 + str::substring
+        return
+    fi
+    ""
+}
+
+fn resolve_import parser:Parser importing_file:str spec:str location:Location -> str {
+    importing_file dir_of_path = source_dir
+    # Path-style: keep existing semantics (no existence check).
+    if spec is_path_specifier then
+        if spec "/" str::starts_with then
+            spec
+            return
+        fi
+        f"{source_dir}{spec}" normalize_path
+        return
+    fi
+    # Module-style: probe source dir, then each search path. First hit wins.
+    # `searched` accumulates probed dirs for the not-found error message.
+    f"{source_dir}{spec}.casa" normalize_path = source_candidate
+    if source_candidate file::exists then
+        source_candidate
+        return
+    fi
+    if 0 source_dir.length == then
+        "."
+    else
+        source_dir
+    fi
+    = first_dir
+    f"\n  {first_dir}" = searched
+    0 = path_index
+    while path_index parser.search_paths.length > do
+        path_index parser.search_paths.get = base
+        f"{searched}\n  {base}" = searched
+        f"{base}/{spec}.casa" normalize_path = candidate
+        if candidate file::exists then
+            candidate
+            return
+        fi
+        1 += path_index
+    done
+    location f"module `{spec}` not found, searched:{searched}" ErrorKind::Syntax raise_error
+    ""
+}
+
+fn handle_keyword_import parser:Parser cursor:TokenCursor -> Op {
     TokenKind::Literal cursor expect_token_kind = path_token
     path_token get_op_literal = literal_op
     if OpKind::OpPushStr literal_op Op::kind != then
         path_token Token::location "Expected string literal for import path" ErrorKind::UnexpectedToken raise_error
     fi
-    literal_op op_str_value = path
+    literal_op op_str_value = spec
 
-    # Resolve relative path from the token's file location
-    token Token::location Location::file = base_file
-    # Find the directory part of the base file (last / position)
-    -1 = last_slash
-    0 = file_index
-    while file_index base_file.length > do
-        if '/' file_index base_file.at == then
-            file_index = last_slash
-        fi
-        1 += file_index
-    done
-    if 0 last_slash >= then
-        base_file 0 last_slash 1 + str::substring = directory
-    else
-        "" = directory
-    fi
-    # Only prepend directory for relative paths
-    if path "/" str::starts_with then
-        path = resolved
-    else
-        f"{directory}{path}" normalize_path = resolved
-    fi
+    path_token Token::location = path_location
+    path_location Location::file = importing_file
+    path_location spec importing_file parser resolve_import = resolved
 
-    path_token Token::location OpKind::OpImportFile resolved make_op_str
+    path_location OpKind::OpImportFile resolved make_op_str
 }
 
 # ============================================================================
@@ -1906,7 +1950,7 @@ fn get_op_keyword parser:Parser token:Token cursor:TokenCursor function_name:str
 
     # import
     if KeywordKind::Import keyword == then
-        cursor token handle_keyword_import ops.push
+        cursor parser handle_keyword_import ops.push
         return
     fi
 

--- a/docs/standard-library.md
+++ b/docs/standard-library.md
@@ -1,22 +1,53 @@
 # Standard Library
 
-The standard library provides core types and functions used by most Casa programs. It is in `lib/std.casa`. Import it with:
+The standard library provides core types and functions used by most Casa programs. It is in `lib/std.casa`. Import it as a module:
+
+```casa
+import "std"
+```
+
+…and pass `-L path/to/lib` to `casac`. Or import by path:
 
 ```casa
 import "path/to/lib/std.casa"
 ```
 
-The path is relative to the source file. Adjust it based on your project layout.
-
 ## `import` Directive
 
-`import` loads another Casa source file. Each file is imported at most once, regardless of how many times it appears.
+`import` loads another Casa source file. Each file is imported at most once, regardless of how many times it appears, and the deduplication uses the canonicalized resolved path.
+
+There are two forms:
+
+### Path-style
 
 ```casa
 import "relative/path/to/file.casa"
+import "/absolute/path/to/file.casa"
 ```
 
-Paths are resolved relative to the file containing the `import` directive. All functions, structs, and global variables defined in the imported file become available.
+A specifier is treated as a path when it contains `/` or ends with `.casa`. Relative paths resolve from the directory of the importing file. Absolute paths are used as-is. No search is performed.
+
+### Module-style
+
+```casa
+import "std"
+```
+
+A specifier without `/` and without a `.casa` suffix is treated as a module name. The resolver looks for `<module>.casa` in:
+
+1. the directory of the importing file, then
+2. each directory passed via `-L` / `--library-path`, in CLI order.
+
+The first existing match wins. If no candidate exists, the compiler reports an error listing every directory searched.
+
+### `-L` / `--library-path`
+
+Repeatable. Adds a directory to the module search path:
+
+```sh
+casac -L lib program.casa
+casac -L lib -L vendor program.casa
+```
 
 ## `memcpy`
 

--- a/docs/strings-and-io.md
+++ b/docs/strings-and-io.md
@@ -262,6 +262,20 @@ Deletes a file. Returns 0 on success, or a negative value on error.
 "temp.txt" file::remove drop
 ```
 
+### `file::exists`
+
+Returns `true` when the path can be opened for reading, `false` otherwise (missing file, permission denied). Does not abort the process on a missing file, so it is safe to use as a probe (unlike `file::read_all`).
+
+**Signature:** `file::exists path:str -> bool`
+
+**Stack effect:** `str -> bool`
+
+```casa
+if "config.toml" file::exists then
+    "config.toml" file::read_all = config
+fi
+```
+
 See [`examples/file_io.casa`](../examples/file_io.casa) for a full program using file I/O.
 
 ## Character Classification

--- a/docs/utilities.md
+++ b/docs/utilities.md
@@ -298,6 +298,18 @@ Adds an option that takes a string value.
 "output binary name" "--output" "-o" "output" parser .add_option
 ```
 
+### `ArgParser::add_multi_option`
+
+Adds an option that takes a string value and may appear multiple times. Each occurrence appends its value to a list retrieved with `ParsedArgs::get_multi`.
+
+**Signature:** `ArgParser::add_multi_option self:ArgParser name:str short_flag:str long_flag:str help_text:str`
+
+**Stack effect:** `ArgParser str str str str -> None`
+
+```casa
+"library search path" "--library-path" "-L" "library_path" parser .add_multi_option
+```
+
 ### `ArgParser::parse_args`
 
 Parses `argc`/`argv` and returns the results. Automatically handles `-h`/`--help` (prints help and exits). Prints a usage error and exits on unrecognized arguments or missing positionals.
@@ -333,6 +345,18 @@ Returns `true` if the flag was set, `false` otherwise.
 
 ```casa
 "verbose" args .get_flag = is_verbose
+```
+
+### `ParsedArgs::get_multi`
+
+Returns `Option::Some` wrapping the collected `List[str]` for a registered multi-option (the list is empty if the flag was never given). Returns `Option::None` if the name was never registered as a multi-option, mirroring `ParsedArgs::get`.
+
+**Signature:** `ParsedArgs::get_multi self:ParsedArgs name:str -> Option[List[str]]`
+
+**Stack effect:** `ParsedArgs str -> Option[List[str]]`
+
+```casa
+"library_path" args .get_multi .unwrap = library_paths
 ```
 
 ### Complete Example

--- a/examples/argparse.casa
+++ b/examples/argparse.casa
@@ -1,34 +1,37 @@
 # Argument parser
 # Demonstrates declarative CLI argument parsing with auto-generated help.
-# Usage: ./argparse [--name NAME] [-g GREETING] [-v]
-
+# Usage: ./argparse [--name NAME] [-g GREETING] [-v] [-L PATH ...]
 import "../lib/argparse.casa"
 
 ArgParser::new = parser
-"name to greet" "--name" "-n" "name" parser .add_option
-"greeting prefix" "--greeting" "-g" "greeting" parser .add_option
-"verbose output" "--verbose" "-v" "verbose" parser .add_flag
-parser .parse_args = args
-
+"name to greet" "--name" "-n" "name" parser.add_option
+"greeting prefix" "--greeting" "-g" "greeting" parser.add_option
+"verbose output" "--verbose" "-v" "verbose" parser.add_flag
+"library search path (repeatable)" "--library-path" "-L" "library_path" parser.add_multi_option
+parser.parse_args = args
 # Use provided name or default
-if "name" args .get Option::Some(name_val) is then
+if "name" args.get Option::Some (name_val) is then
     name_val
 else
     "world"
 fi
 = name
-
 # Use provided greeting or default
-if "greeting" args .get Option::Some(greeting_val) is then
+if "greeting" args.get Option::Some (greeting_val) is then
     greeting_val
 else
     "Hello"
 fi
 = greeting
-
 f"{greeting}, {name}!\n" print
-
-if "verbose" args .get_flag then
+if "verbose" args.get_flag then
     f"  name={name}\n" print
     f"  greeting={greeting}\n" print
 fi
+"library_path" args.get_multi.unwrap = library_paths
+0 = path_index
+while path_index library_paths.length > do
+    path_index library_paths.get = library_path
+    f"  library_path={library_path}\n" print
+    1 += path_index
+done

--- a/examples/file_io.casa
+++ b/examples/file_io.casa
@@ -1,19 +1,15 @@
 # File I/O operations
 # Demonstrates file reading, writing, and low-level file operations
-
 import "../lib/std.casa"
 
 # High-level: write and read a file
 "=== write_all ===" print "\n" print
-"Hello, File I/O!\n" "/tmp/casa_fio_test1.txt" file::write_all .to_str print "\n" print
-
+"Hello, File I/O!\n" "/tmp/casa_fio_test1.txt" file::write_all.to_str print "\n" print
 "=== read_all ===" print "\n" print
 "/tmp/casa_fio_test1.txt" file::read_all = content
 content print
-
 "=== content verification ===" print "\n" print
-"Hello, File I/O!\n" content str::eq .to_str print "\n" print
-
+"Hello, File I/O!\n" content str::eq.to_str print "\n" print
 # Low-level: open, write, close
 "=== low-level write ===" print "\n" print
 420 O_WRONLY O_CREAT | O_TRUNC | "/tmp/casa_fio_test2.txt" file::open = fd
@@ -21,7 +17,6 @@ content print
 "Line 2\n" fd file::write drop
 fd file::close drop
 "/tmp/casa_fio_test2.txt" file::read_all print
-
 # Low-level: read with buffer
 "=== low-level read ===" print "\n" print
 "ABCDE" "/tmp/casa_fio_test3.txt" file::write_all drop
@@ -32,10 +27,14 @@ bytes_read print "\n" print
 buf load8 (char) print "\n" print
 buf 4 + load8 (char) print "\n" print
 rfd file::close drop
-
+# Probe for file existence without aborting
+"=== exists ===" print "\n" print
+"/tmp/casa_fio_test1.txt" file::exists.to_str print "\n" print
+"/tmp/casa_fio_no_such_file.txt" file::exists.to_str print "\n" print
 # Clean up temp files
 "=== remove ===" print "\n" print
 "/tmp/casa_fio_test1.txt" file::remove drop
 "/tmp/casa_fio_test2.txt" file::remove drop
 "/tmp/casa_fio_test3.txt" file::remove drop
+"/tmp/casa_fio_test1.txt" file::exists.to_str print "\n" print
 "files cleaned up" print "\n" print

--- a/examples/outputs/file_io.out
+++ b/examples/outputs/file_io.out
@@ -11,5 +11,9 @@ Line 2
 5
 A
 E
+=== exists ===
+true
+false
 === remove ===
+false
 files cleaned up

--- a/lib/argparse.casa
+++ b/lib/argparse.casa
@@ -2,9 +2,7 @@
 #
 # Provides a declarative API for defining and parsing CLI arguments,
 # with auto-generated help output similar to Python's argparse.
-
 import "std.casa"
-
 
 # ---------------------------------------------------------------------------
 # Types
@@ -14,6 +12,7 @@ enum ArgKind {
     Positional
     Flag
     Option
+    MultiOption
 }
 
 struct ArgDef {
@@ -30,16 +29,14 @@ struct ArgParser {
 }
 
 struct ParsedArgs {
-    values: Map[str str]
+    values:       Map[str str]
+    multi_values: Map[str List[str]]
 }
-
 
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
-
 22 = ARGPARSE_HELP_INDENT
-
 
 # ---------------------------------------------------------------------------
 # ArgParser
@@ -49,49 +46,62 @@ impl ArgParser {
     fn new -> ArgParser {
         # Derive program name from basename of argv[0] (like Python's argparse)
         0 get_arg "/" str::split = path_parts
-        path_parts.length 1 - path_parts .get = program_name
+        path_parts.length 1 - path_parts.get = program_name
         List::new (List[ArgDef]) program_name ArgParser
     }
 
     fn add_positional self:ArgParser name:str help_text:str {
         ArgDef {
-            name:       name
+            name: name
             short_flag: ""
-            long_flag:  ""
-            help_text:  help_text
-            kind:       ArgKind::Positional
-        } self.definitions .push
+            long_flag: ""
+            help_text: help_text
+            kind: ArgKind::Positional
+        } self.definitions.push
     }
 
     fn add_flag self:ArgParser name:str short_flag:str long_flag:str help_text:str {
         ArgDef {
-            name:       name
+            name: name
             short_flag: short_flag
-            long_flag:  long_flag
-            help_text:  help_text
-            kind:       ArgKind::Flag
-        } self.definitions .push
+            long_flag: long_flag
+            help_text: help_text
+            kind: ArgKind::Flag
+        } self.definitions.push
     }
 
     fn add_option self:ArgParser name:str short_flag:str long_flag:str help_text:str {
         ArgDef {
-            name:       name
+            name: name
             short_flag: short_flag
-            long_flag:  long_flag
-            help_text:  help_text
-            kind:       ArgKind::Option
-        } self.definitions .push
+            long_flag: long_flag
+            help_text: help_text
+            kind: ArgKind::Option
+        } self.definitions.push
+    }
+
+    fn add_multi_option self:ArgParser name:str short_flag:str long_flag:str help_text:str {
+        ArgDef {
+            name: name
+            short_flag: short_flag
+            long_flag: long_flag
+            help_text: help_text
+            kind: ArgKind::MultiOption
+        } self.definitions.push
     }
 
     fn parse_args self:ArgParser -> ParsedArgs {
         Map::new (Map[str str]) = values
+        Map::new (Map[str List[str]]) = multi_values
 
-        # Initialize flag defaults
+        # Initialize flag defaults and multi-option lists
         0 = init_index
         while init_index self.definitions.length > do
             init_index self.definitions.get = init_def
             if init_def.kind ArgKind::Flag == then
-                init_def.name "0" values .set = values
+                init_def.name "0" values.set = values
+            elif init_def.kind ArgKind::MultiOption == then
+                init_def.name List::new (List[str]) multi_values.set = multi_values
             fi
             1 += init_index
         done
@@ -101,39 +111,52 @@ impl ArgParser {
         while arg_index argc > do
             arg_index get_arg = arg_value
             if
-                "-h" arg_value ==
-                "--help" arg_value == ||
+            "-h" arg_value ==
+            "--help" arg_value == ||
             then
-                self .print_help
+                self.print_help
                 0 exit
             fi
             if arg_value "-" str::starts_with then
-                arg_value arg_index values self .handle_named = arg_index = values
+                arg_value arg_index multi_values values self.handle_named = arg_index = multi_values = values
             else
-                arg_value pos_index values self .assign_positional = pos_index = values
+                arg_value pos_index values self.assign_positional = pos_index = values
             fi
             1 += arg_index
         done
 
-        pos_index self .verify_positionals
-        values ParsedArgs
+        pos_index self.verify_positionals
+        multi_values values ParsedArgs
     }
 
-    fn handle_named self:ArgParser values:Map[str str] arg_index:int arg_value:str -> Map[str str] int {
-        if arg_value self .find_def Option::Some(matched_def) is then
+    fn handle_named
+        self:ArgParser
+        values:Map[str str]
+        multi_values:Map[str List[str]]
+        arg_index:int
+        arg_value:str
+    -> Map[str str] Map[str List[str]] int {
+        if arg_value self.find_def Option::Some (matched_def) is then
             if matched_def.kind ArgKind::Flag == then
-                matched_def.name "1" values .set = values
+                matched_def.name "1" values.set = values
             elif matched_def.kind ArgKind::Option == then
                 1 += arg_index
                 if argc arg_index >= then
-                    f"argument {arg_value}: expected one argument" self .print_usage_error
+                    f"argument {arg_value}: expected one argument" self.print_usage_error
                 fi
-                matched_def.name arg_index get_arg values .set = values
+                matched_def.name arg_index get_arg values.set = values
+            elif matched_def.kind ArgKind::MultiOption == then
+                1 += arg_index
+                if argc arg_index >= then
+                    f"argument {arg_value}: expected one argument" self.print_usage_error
+                fi
+                matched_def.name multi_values.get.unwrap = multi_list
+                arg_index get_arg multi_list.push
             fi
         else
-            f"unrecognized arguments: {arg_value}" self .print_usage_error
+            f"unrecognized arguments: {arg_value}" self.print_usage_error
         fi
-        values arg_index
+        values multi_values arg_index
     }
 
     fn find_def self:ArgParser arg_value:str -> Option[ArgDef] {
@@ -141,8 +164,8 @@ impl ArgParser {
         while find_index self.definitions.length > do
             find_index self.definitions.get = find_def
             if
-                arg_value find_def.short_flag ==
-                arg_value find_def.long_flag == ||
+            arg_value find_def.short_flag ==
+            arg_value find_def.long_flag == ||
             then
                 find_def Option::Some
                 return
@@ -152,12 +175,17 @@ impl ArgParser {
         Option::None (Option[ArgDef])
     }
 
-    fn assign_positional self:ArgParser values:Map[str str] pos_index:int arg_value:str -> Map[str str] int {
-        pos_index self .nth_positional_name = target_name
+    fn assign_positional
+        self:ArgParser
+        values:Map[str str]
+        pos_index:int
+        arg_value:str
+    -> Map[str str] int {
+        pos_index self.nth_positional_name = target_name
         if "" target_name == then
-            f"unrecognized arguments: {arg_value}" self .print_usage_error
+            f"unrecognized arguments: {arg_value}" self.print_usage_error
         fi
-        target_name arg_value values .set = values
+        target_name arg_value values.set = values
         values pos_index 1 +
     }
 
@@ -191,17 +219,17 @@ impl ArgParser {
     }
 
     fn verify_positionals self:ArgParser pos_index:int {
-        self .count_positionals = total_positionals
+        self.count_positionals = total_positionals
         if total_positionals pos_index != then
-            pos_index self .nth_positional_name = missing_name
-            f"the following arguments are required: {missing_name}" self .print_usage_error
+            pos_index self.nth_positional_name = missing_name
+            f"the following arguments are required: {missing_name}" self.print_usage_error
         fi
     }
 
     fn build_usage_line self:ArgParser -> str {
         StringBuilder::new = usage_sb
-        f"usage: {self.program_name}" usage_sb .append
-        " [-h]" usage_sb .append
+        f"usage: {self.program_name}" usage_sb.append
+        " [-h]" usage_sb.append
         # Optional arguments
         0 = usage_index
         while usage_index self.definitions.length > do
@@ -216,11 +244,11 @@ impl ArgParser {
         while usage_index self.definitions.length > do
             usage_index self.definitions.get = usage_def
             if usage_def.kind ArgKind::Positional == then
-                f" {usage_def.name}" usage_sb .append
+                f" {usage_def.name}" usage_sb.append
             fi
             1 += usage_index
         done
-        usage_sb .build
+        usage_sb.build
     }
 
     fn print_help_positionals self:ArgParser {
@@ -247,24 +275,23 @@ impl ArgParser {
     }
 
     fn print_help self:ArgParser {
-        self .build_usage_line print "\n" print
+        self.build_usage_line print "\n" print
 
-        if 0 self .count_positionals != then
+        if 0 self.count_positionals != then
             "\npositional arguments:\n" print
-            self .print_help_positionals
+            self.print_help_positionals
         fi
 
         "\noptions:\n" print
-        self .print_help_options
+        self.print_help_options
     }
 
     fn print_usage_error self:ArgParser message:str {
-        self .build_usage_line eprintln
+        self.build_usage_line eprintln
         f"{self.program_name}: error: {message}" eprintln
         2 exit
     }
 }
-
 
 # ---------------------------------------------------------------------------
 # ParsedArgs
@@ -272,72 +299,81 @@ impl ArgParser {
 
 impl ParsedArgs {
     fn get self:ParsedArgs name:str -> Option[str] {
-        name self.values .get
+        name self.values.get
     }
 
     fn get_flag self:ParsedArgs name:str -> bool {
-        name self.values .get .unwrap "1" ==
+        name self.values.get.unwrap "1" ==
+    }
+
+    fn get_multi self:ParsedArgs name:str -> Option[List[str]] {
+        name self.multi_values.get
     }
 }
-
 
 # ---------------------------------------------------------------------------
 # Free helpers
 # ---------------------------------------------------------------------------
 
 fn append_usage_optional usage_sb:StringBuilder definition:ArgDef {
-    " [" usage_sb .append
+    " [" usage_sb.append
     if "" definition.short_flag != then
-        definition.short_flag usage_sb .append
+        definition.short_flag usage_sb.append
     else
-        definition.long_flag usage_sb .append
+        definition.long_flag usage_sb.append
     fi
-    if definition.kind ArgKind::Option == then
-        " " usage_sb .append
-        definition.name metavar usage_sb .append
+    if
+    definition.kind ArgKind::Option ==
+    definition.kind ArgKind::MultiOption == ||
+    then
+        " " usage_sb.append
+        definition.name metavar usage_sb.append
     fi
-    "]" usage_sb .append
+    "]" usage_sb.append
 }
 
 fn metavar name:str -> str {
     StringBuilder::new = meta_sb
     0 = meta_index
     while meta_index name.length > do
-        meta_index name .at = meta_char
+        meta_index name.at = meta_char
         if meta_char '-' == then
-            '_' meta_sb .append_char
-        elif meta_char .is_lower then
-            meta_char (int) 'a' (int) - 'A' (int) + (char) meta_sb .append_char
+            '_' meta_sb.append_char
+        elif meta_char.is_lower then
+            meta_char (int) 'a' (int) - 'A' (int) + (char) meta_sb.append_char
         else
-            meta_char meta_sb .append_char
+            meta_char meta_sb.append_char
         fi
         1 += meta_index
     done
-    meta_sb .build
+    meta_sb.build
 }
 
 fn build_flag_column definition:ArgDef -> str {
     StringBuilder::new = col_sb
     if "" definition.short_flag != then
-        definition.short_flag col_sb .append
+        definition.short_flag col_sb.append
         if "" definition.long_flag != then
-            ", " col_sb .append
+            ", " col_sb.append
         fi
     fi
     if "" definition.long_flag != then
-        definition.long_flag col_sb .append
+        definition.long_flag col_sb.append
     fi
-    if definition.kind ArgKind::Option == then
-        " " col_sb .append
-        definition.name metavar col_sb .append
+    if
+    definition.kind ArgKind::Option ==
+    definition.kind ArgKind::MultiOption == ||
+    then
+        " " col_sb.append
+        definition.name metavar col_sb.append
     fi
-    col_sb .build
+    col_sb.build
 }
 
 fn print_help_line label:str help_text:str {
     "  " print
     label print
-    label .length = label_len
+    label.length = label_len
     if label_len 2 + ARGPARSE_HELP_INDENT >= then
         # Label fits, pad with spaces
         ARGPARSE_HELP_INDENT label_len 2 + - = pad_count

--- a/lib/std.casa
+++ b/lib/std.casa
@@ -21,7 +21,6 @@ impl array {
         # Data pointer is at offset 0 in the header
         array (ptr) load64 (ptr) n 8 * + load64 (T)
     }
-
 }
 
 struct List {
@@ -61,13 +60,13 @@ impl List {
 
     fn push[T] self:List[T] item:T {
         if self.capacity self.size >= then
-            self.capacity 2 * self->capacity
+            self.capacity 2 * self -> capacity
             self.capacity 8 * alloc = new_data
             self.size 8 * self.data new_data memcpy
-            new_data self->data
+            new_data self -> data
         fi
         item self.data self.size 8 * + store64
-        self.size 1 + self->size
+        self.size 1 + self -> size
     }
 
     fn pop[T] self:List[T] -> T {
@@ -75,7 +74,7 @@ impl List {
             "error: pop from empty List\n" print
             1 60 syscall1 drop
         fi
-        self.size 1 - self->size
+        self.size 1 - self -> size
         self.data self.size 8 * + load64 (T)
     }
 
@@ -86,10 +85,10 @@ impl List {
         fi
         # Ensure capacity
         if self.capacity self.size >= then
-            self.capacity 2 * self->capacity
+            self.capacity 2 * self -> capacity
             self.capacity 8 * alloc = new_data
             self.size 8 * self.data new_data memcpy
-            new_data self->data
+            new_data self -> data
         fi
         # Shift elements right from end to index
         self.size = i
@@ -99,7 +98,7 @@ impl List {
         done
         # Store item at index
         item self.data index 8 * + store64
-        self.size 1 + self->size
+        self.size 1 + self -> size
     }
 
     fn slice[T] self:List[T] start:int stop:int -> array[T] {
@@ -121,8 +120,9 @@ impl List {
 # ---------------------------------------------------------------------------
 # Type conversions
 # ---------------------------------------------------------------------------
+
 fn digit_to_str d:int -> str {
-    d ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"] array::nth (str)
+    d["0" , "1" , "2" , "3" , "4" , "5" , "6" , "7" , "8" , "9"] array::nth (str)
 }
 
 impl int {
@@ -163,15 +163,15 @@ impl str {
     }
 
     fn eq b:str a:str -> bool {
-        a .length = length_a
-        b .length = length_b
+        a.length = length_a
+        b.length = length_b
         if length_a length_b != then
             false
         else
             true = all_equal
             0 = compare_index
             while compare_index length_a > do
-                if compare_index a .at compare_index b .at != then
+                if compare_index a.at compare_index b.at != then
                     false = all_equal
                     break
                 fi
@@ -189,7 +189,7 @@ impl str {
         # Copy bytes
         0 = copy_index
         while copy_index len > do
-            start copy_index + s .at copy_index result_buf.set
+            start copy_index + s.at copy_index result_buf.set
             1 += copy_index
         done
         # Store null terminator
@@ -198,8 +198,8 @@ impl str {
     }
 
     fn find needle:str s:str -> int {
-        s .length = source_length
-        needle .length = needle_length
+        s.length = source_length
+        needle.length = needle_length
         if needle_length source_length < then
             0 1 -
         else
@@ -209,7 +209,7 @@ impl str {
                 true = all_match
                 0 = match_index
                 while match_index needle_length > do
-                    if search_index match_index + s .at match_index needle .at != then
+                    if search_index match_index + s.at match_index needle.at != then
                         false = all_match
                         break
                     fi
@@ -226,15 +226,15 @@ impl str {
     }
 
     fn starts_with prefix:str s:str -> bool {
-        s .length = source_length
-        prefix .length = prefix_length
+        s.length = source_length
+        prefix.length = prefix_length
         if prefix_length source_length < then
             false
         else
             true = all_match
             0 = compare_index
             while compare_index prefix_length > do
-                if compare_index s .at compare_index prefix .at != then
+                if compare_index s.at compare_index prefix.at != then
                     false = all_match
                     break
                 fi
@@ -245,8 +245,8 @@ impl str {
     }
 
     fn ends_with suffix:str s:str -> bool {
-        s .length = source_length
-        suffix .length = suffix_length
+        s.length = source_length
+        suffix.length = suffix_length
         if suffix_length source_length < then
             false
         else
@@ -254,7 +254,7 @@ impl str {
             true = all_match
             0 = compare_index
             while compare_index suffix_length > do
-                if offset compare_index + s .at compare_index suffix .at != then
+                if offset compare_index + s.at compare_index suffix.at != then
                     false = all_match
                     break
                 fi
@@ -274,19 +274,19 @@ impl str {
 
     fn split delimiter:str s:str -> List[str] {
         List::new (List[str]) = parts
-        delimiter .length = delim_length
+        delimiter.length = delim_length
         0 = scan_pos
-        while scan_pos s .length >= do
+        while scan_pos s.length >= do
             # Search for delimiter starting from scan_pos
-            s scan_pos s .length scan_pos - str::substring = remaining
+            s scan_pos s.length scan_pos - str::substring = remaining
             remaining delimiter str::find = found_index
             if 0 found_index < then
                 # No more delimiters, push the rest and stop
-                remaining parts .push
+                remaining parts.push
                 break
             else
                 # Push substring before delimiter
-                s scan_pos found_index str::substring parts .push
+                s scan_pos found_index str::substring parts.push
                 found_index delim_length + scan_pos + = scan_pos
             fi
         done
@@ -294,15 +294,15 @@ impl str {
     }
 
     fn trim s:str -> str {
-        s .length = source_length
+        s.length = source_length
         0 = trim_start
         while trim_start source_length > do
-            trim_start s .at = character
+            trim_start s.at = character
             if
-                ' ' character !=
-                '\t' character != &&
-                '\n' character != &&
-                '\r' character != &&
+            ' ' character !=
+            '\t' character != &&
+            '\n' character != &&
+            '\r' character != &&
             then
                 break
             fi
@@ -310,12 +310,12 @@ impl str {
         done
         source_length = trim_end
         while trim_start trim_end > do
-            trim_end 1 - s .at = character
+            trim_end 1 - s.at = character
             if
-                ' ' character !=
-                '\t' character != &&
-                '\n' character != &&
-                '\r' character != &&
+            ' ' character !=
+            '\t' character != &&
+            '\n' character != &&
+            '\r' character != &&
             then
                 break
             fi
@@ -329,26 +329,26 @@ impl str {
     }
 
     fn replace old:str new_str:str s:str -> str {
-        old .length = old_length
+        old.length = old_length
         StringBuilder::new = builder
         0 = scan_pos
-        while scan_pos s .length >= do
-            s scan_pos s .length scan_pos - str::substring = remaining
+        while scan_pos s.length >= do
+            s scan_pos s.length scan_pos - str::substring = remaining
             remaining old str::find = found_index
             if 0 found_index < then
                 # No more occurrences, append the rest
-                remaining builder .append
-                s .length = scan_pos
+                remaining builder.append
+                s.length = scan_pos
             else
                 # Append part before match
                 if 0 found_index != then
-                    s scan_pos found_index str::substring builder .append
+                    s scan_pos found_index str::substring builder.append
                 fi
-                new_str builder .append
+                new_str builder.append
                 found_index old_length + scan_pos + = scan_pos
             fi
         done
-        builder .build
+        builder.build
     }
 }
 
@@ -392,7 +392,7 @@ impl file {
     }
 
     fn write fd:int data:str -> int {
-        data .length data.as_cstr (ptr) fd 1 syscall3
+        data.length data.as_cstr (ptr) fd 1 syscall3
     }
 
     fn close fd:int -> int {
@@ -429,11 +429,22 @@ impl file {
     fn remove path:str -> int {
         path.as_cstr (ptr) 87 syscall1
     }
+
+    fn exists path:str -> bool {
+        0 O_RDONLY path file::open = file_fd
+        if 0 file_fd < then
+            false
+            return
+        fi
+        file_fd file::close drop
+        true
+    }
 }
 
 # ---------------------------------------------------------------------------
 # Character classification
 # ---------------------------------------------------------------------------
+
 impl char {
     fn is_digit c:char -> bool {
         '0' c >= '9' c <= &&
@@ -448,7 +459,7 @@ impl char {
     }
 
     fn is_alpha c:char -> bool {
-        c .is_upper c .is_lower ||
+        c.is_upper c.is_lower ||
     }
 
     fn is_space c:char -> bool {
@@ -457,17 +468,19 @@ impl char {
 }
 
 impl ptr {
-    fn to_str p:ptr -> str { p (int) .to_str }
+    fn to_str p:ptr -> str { p (int).to_str }
 }
 
 # ---------------------------------------------------------------------------
 # Option and Result enums
 # ---------------------------------------------------------------------------
 # None=0, Some=1 so is_some checks ordinal==1
-enum Option[T] { None Some(T) }
+
+enum Option[T] { None Some (T) }
 
 # Error=0, Ok=1 so is_ok checks ordinal==1
-enum Result[T E] { Error(E) Ok(T) }
+
+enum Result[T E] { Error (E) Ok (T) }
 
 impl Option {
     fn is_some self:Option -> bool {
@@ -525,8 +538,10 @@ impl Result {
 # ---------------------------------------------------------------------------
 # Traits
 # ---------------------------------------------------------------------------
+
 trait Hashable {
     fn hash self:self -> int
+
     fn eq self:self other:self -> bool
 }
 
@@ -619,7 +634,7 @@ impl[T] Iter[T] {
             Option::None (Option[T]) return
         fi
         self Iter::index self Iter::get (fn[int -> T]) exec = iter_value
-        self Iter::index 1 + self->index
+        self Iter::index 1 + self -> index
         iter_value Option::Some
     }
 }
@@ -645,11 +660,12 @@ impl str {
 # ---------------------------------------------------------------------------
 # Hash helpers
 # ---------------------------------------------------------------------------
+
 fn str_hash s:str -> int {
     5381 = hash
     0 = index
-    while index s .length > do
-        hash 5 << hash + index s .at (int) + = hash
+    while index s.length > do
+        hash 5 << hash + index s.at (int) + = hash
         1 += index
     done
     if 0 hash < then
@@ -684,7 +700,7 @@ struct Map {
     capacity: int
 }
 
-impl[K: Hashable, V] Map[K V] {
+impl[K: Hashable , V] Map[K V] {
     fn new -> Map[K V] {
         MAP_INITIAL_CAP 8 * alloc = mb
         0 = bucket_index
@@ -714,7 +730,7 @@ impl[K: Hashable, V] Map[K V] {
     }
 
     fn has self:Map[K V] key:K -> bool {
-        key self.get .is_some
+        key self.get.is_some
     }
 
     fn set self:Map[K V] value:V key:K -> Map[K V] {
@@ -735,7 +751,7 @@ impl[K: Hashable, V] Map[K V] {
         value new_node (ptr) 8 + store64
         self.buckets bucket_index 8 * + load64 new_node (ptr) 16 + store64
         new_node self.buckets bucket_index 8 * + store64
-        self.size 1 + self->size
+        self.size 1 + self -> size
         # Resize at 75% load
         if self.capacity 3 * 4 / self.size >= then
             self Map::resize
@@ -760,7 +776,7 @@ impl[K: Hashable, V] Map[K V] {
             else
                 next_entry prev_entry (ptr) 16 + store64
             fi
-            self.size 1 - self->size
+            self.size 1 - self -> size
             self (Map[K V])
             return
         done
@@ -787,8 +803,8 @@ impl[K: Hashable, V] Map[K V] {
             done
             1 += rehash_index
         done
-        new_buckets self->buckets
-        new_capacity self->capacity
+        new_buckets self -> buckets
+        new_capacity self -> capacity
     }
 
     fn keys self:Map[K V] -> List[K] {
@@ -823,6 +839,7 @@ impl[K: Hashable, V] Map[K V] {
 # ---------------------------------------------------------------------------
 # Set[K] - Hash set backed by Map
 # ---------------------------------------------------------------------------
+
 struct Set[K] {
     map: Map[K int]
 }
@@ -841,12 +858,12 @@ impl[K: Hashable] Set[K] {
     }
 
     fn add self:Set[K] key:K -> Set[K] {
-        key 0 self.map.set self->map
+        key 0 self.map.set self -> map
         self
     }
 
     fn remove self:Set[K] key:K -> Set[K] {
-        key self.map.delete self->map
+        key self.map.delete self -> map
         self
     }
 
@@ -858,6 +875,7 @@ impl[K: Hashable] Set[K] {
 # ---------------------------------------------------------------------------
 # Command-line arguments
 # ---------------------------------------------------------------------------
+
 fn get_arg n:int -> str {
     if argc n >= then
         "error: argument index out of bounds\n" eprint
@@ -869,6 +887,7 @@ fn get_arg n:int -> str {
 # ---------------------------------------------------------------------------
 # Stdout output
 # ---------------------------------------------------------------------------
+
 fn println msg:str {
     msg print "\n" print
 }
@@ -876,6 +895,7 @@ fn println msg:str {
 # ---------------------------------------------------------------------------
 # Stderr output
 # ---------------------------------------------------------------------------
+
 fn eprint msg:str {
     msg.length msg.as_cstr (ptr) 2 1 syscall3 drop
 }
@@ -887,6 +907,7 @@ fn eprintln msg:str {
 # ---------------------------------------------------------------------------
 # StringBuilder
 # ---------------------------------------------------------------------------
+
 fn chars_to_str chars:List[char] -> str {
     chars.length = length
     length 9 + alloc (str) = buffer
@@ -912,13 +933,13 @@ impl StringBuilder {
     fn append self:StringBuilder s:str {
         0 = append_index
         while append_index s.length > do
-            append_index s.at self.chars .push
+            append_index s.at self.chars.push
             1 += append_index
         done
     }
 
     fn append_char self:StringBuilder c:char {
-        c self.chars .push
+        c self.chars.push
     }
 
     fn build self:StringBuilder -> str {
@@ -926,13 +947,14 @@ impl StringBuilder {
     }
 
     fn length self:StringBuilder -> int {
-        self.chars .length
+        self.chars.length
     }
 }
 
 # ---------------------------------------------------------------------------
 # Process execution
 # ---------------------------------------------------------------------------
+
 fn run_command args:List[str] -> int {
     # fork()
     57 syscall0 = child_pid
@@ -945,7 +967,7 @@ fn run_command args:List[str] -> int {
         args.length 1 + 8 * alloc = argv_buf
         0 = argv_index
         while argv_index args.length > do
-            argv_index args.get .as_cstr (ptr) argv_buf argv_index 8 * + store64
+            argv_index args.get.as_cstr (ptr) argv_buf argv_index 8 * + store64
             1 += argv_index
         done
         # Null terminator
@@ -965,6 +987,7 @@ fn run_command args:List[str] -> int {
 # ---------------------------------------------------------------------------
 # Display implementations for container and enum types
 # ---------------------------------------------------------------------------
+
 impl char {
     fn to_str c:char -> str {
         10 alloc (str) = char_buf
@@ -978,36 +1001,36 @@ impl char {
 impl[T: Display] array[T] {
     fn to_str self:array[T] -> str {
         StringBuilder::new = builder
-        "[" builder .append
+        "[" builder.append
         0 = element_index
         self.length = element_count
         while element_index element_count > do
             if 0 element_index > then
-                ", " builder .append
+                ", " builder.append
             fi
-            element_index self.nth T::to_str builder .append
+            element_index self.nth T::to_str builder.append
             1 += element_index
         done
-        "]" builder .append
-        builder .build
+        "]" builder.append
+        builder.build
     }
 }
 
 impl[T: Display] List[T] {
     fn to_str self:List[T] -> str {
         StringBuilder::new = list_builder
-        "[" list_builder .append
+        "[" list_builder.append
         0 = list_index
         self.size = list_length
         while list_index list_length > do
             if 0 list_index > then
-                ", " list_builder .append
+                ", " list_builder.append
             fi
-            list_index self.get T::to_str list_builder .append
+            list_index self.get T::to_str list_builder.append
             1 += list_index
         done
-        "]" list_builder .append
-        list_builder .build
+        "]" list_builder.append
+        list_builder.build
     }
 }
 
@@ -1015,29 +1038,27 @@ impl[T: Display] Option[T] {
     fn to_str self:Option[T] -> str {
         if self.is_some then
             StringBuilder::new = option_builder
-            "Some(" option_builder .append
-            self.unwrap T::to_str option_builder .append
-            ")" option_builder .append
-            option_builder .build
+            "Some(" option_builder.append
+            self.unwrap T::to_str option_builder.append
+            ")" option_builder.append
+            option_builder.build
             return
         fi
         "None"
     }
 }
 
-impl[T: Display, E: Display] Result[T E] {
+impl[T: Display , E: Display] Result[T E] {
     fn to_str self:Result[T E] -> str {
         StringBuilder::new = result_builder
         if self.is_ok then
-            "Ok(" result_builder .append
-            self.unwrap T::to_str result_builder .append
+            "Ok(" result_builder.append
+            self.unwrap T::to_str result_builder.append
         else
-            "Error(" result_builder .append
-            self.unwrap_error E::to_str result_builder .append
+            "Error(" result_builder.append
+            self.unwrap_error E::to_str result_builder.append
         fi
-        ")" result_builder .append
-        result_builder .build
+        ")" result_builder.append
+        result_builder.build
     }
 }
-
-

--- a/lib/test.casa
+++ b/lib/test.casa
@@ -154,6 +154,7 @@ fn clear_global_state {
     Map::new (Map[str CasaStruct]) DEFAULT_PARSER Parser::store SymbolStore::set_structs
     Map::new (Map[str CasaTrait]) DEFAULT_PARSER Parser::store SymbolStore::set_traits
     Set::new (Set[str]) DEFAULT_PARSER Parser::set_included_files
+    List::new (List[str]) DEFAULT_PARSER Parser::set_search_paths
     Map::new (Map[str str]) = SOURCE_CACHE
     List::new (List[CasaError]) = ERRORS
     List::new (List[CasaWarning]) = WARNINGS

--- a/lsp.casa
+++ b/lsp.casa
@@ -296,6 +296,7 @@ fn clear_compilation_state {
     Map::new (Map[str CasaStruct]) DEFAULT_PARSER Parser::store SymbolStore::set_structs
     Map::new (Map[str CasaTrait]) DEFAULT_PARSER Parser::store SymbolStore::set_traits
     Set::new (Set[str]) DEFAULT_PARSER Parser::set_included_files
+    List::new (List[str]) DEFAULT_PARSER Parser::set_search_paths
 }
 
 fn run_pipeline file_path:str source:str -> DocumentState {

--- a/tests/compiler/test_argparse.casa
+++ b/tests/compiler/test_argparse.casa
@@ -1,0 +1,48 @@
+import "../../lib/argparse.casa"
+
+fn ap_fail message:str {
+    f"FAIL: {message}\n" eprint
+    1 exit
+}
+
+fn ap_assert_true condition:bool message:str {
+    if condition ! then message ap_fail fi
+}
+
+fn ap_assert_eq actual:int expected:int message:str {
+    if expected actual != then
+        f"{message} (expected {expected}, got {actual})" ap_fail
+    fi
+}
+
+fn ap_assert_str_eq actual:str expected:str message:str {
+    if expected actual != then
+        f"{message} (expected '{expected}', got '{actual}')" ap_fail
+    fi
+}
+# add_multi_option registers a MultiOption-kind ArgDef
+ArgParser::new = parser
+"library path" "--library-path" "-L" "library_path" parser.add_multi_option
+"definitions length" 1 parser.definitions.length ap_assert_eq
+0 parser.definitions.get = registered_def
+"kind is MultiOption" registered_def.kind ArgKind::MultiOption == ap_assert_true
+"name" "library_path" registered_def.name ap_assert_str_eq
+"short_flag" "-L" registered_def.short_flag ap_assert_str_eq
+"long_flag" "--library-path" registered_def.long_flag ap_assert_str_eq
+"help_text" "library path" registered_def.help_text ap_assert_str_eq
+# parse_args with no argv yields empty get_multi list
+ArgParser::new = parser2
+"library path" "--library-path" "-L" "library_path" parser2.add_multi_option
+parser2.parse_args = parsed_no_args
+"get_multi some" "library_path" parsed_no_args.get_multi.is_some ap_assert_true
+"get_multi empty list" 0 "library_path" parsed_no_args.get_multi.unwrap.length ap_assert_eq
+"get_multi none for unregistered" "missing" parsed_no_args.get_multi.is_none ap_assert_true
+# build_flag_column for MultiOption renders like Option (flag + metavar)
+ArgParser::new = parser3
+"library path" "--library-path" "-L" "library_path" parser3.add_multi_option
+0 parser3.definitions.get = multi_def
+"flag column" "-L, --library-path LIBRARY_PATH" multi_def build_flag_column ap_assert_str_eq
+# append_usage_optional for MultiOption renders ` [-L LIBRARY_PATH]`
+StringBuilder::new = usage_sb
+multi_def usage_sb append_usage_optional
+"usage optional" " [-L LIBRARY_PATH]" usage_sb.build ap_assert_str_eq

--- a/tests/compiler/test_file.casa
+++ b/tests/compiler/test_file.casa
@@ -1,0 +1,21 @@
+import "../../lib/std.casa"
+
+fn fe_fail message:str {
+    f"FAIL: {message}\n" eprint
+    1 exit
+}
+
+fn fe_assert_true condition:bool message:str {
+    if condition ! then message fe_fail fi
+}
+
+fn fe_assert_false condition:bool message:str {
+    if condition then message fe_fail fi
+}
+
+# file::exists returns true for an existing file
+"contents" "/tmp/casa_file_exists_test.txt" file::write_all drop
+"existing path" "/tmp/casa_file_exists_test.txt" file::exists fe_assert_true
+"/tmp/casa_file_exists_test.txt" file::remove drop
+# file::exists returns false for a missing path (no process abort)
+"missing path" "/tmp/casa_file_exists_definitely_not_a_real_path.xyz" file::exists fe_assert_false

--- a/tests/compiler/test_parser.casa
+++ b/tests/compiler/test_parser.casa
@@ -532,6 +532,96 @@ fn test_parse_keyword_import {
 }
 
 # ============================================================================
+# Import resolver tests
+# ============================================================================
+
+fn test_is_path_specifier_casa_extension {
+    "is_path_specifier_casa_extension" test_start
+    "result" "foo.casa" is_path_specifier assert_true
+}
+
+fn test_is_path_specifier_slash {
+    "is_path_specifier_slash" test_start
+    "result" "lib/std" is_path_specifier assert_true
+}
+
+fn test_is_path_specifier_module {
+    "is_path_specifier_module" test_start
+    "result" "std" is_path_specifier ! assert_true
+}
+
+fn test_dir_of_path_with_dir {
+    "dir_of_path_with_dir" test_start
+    "dir" "compiler/" "compiler/parser.casa" dir_of_path assert_str_eq
+}
+
+fn test_dir_of_path_nested {
+    "dir_of_path_nested" test_start
+    "dir" "examples/sub/" "examples/sub/foo.casa" dir_of_path assert_str_eq
+}
+
+fn test_dir_of_path_no_dir {
+    "dir_of_path_no_dir" test_start
+    "dir" "" "foo.casa" dir_of_path assert_str_eq
+}
+
+fn test_dir_of_path_root {
+    "dir_of_path_root" test_start
+    "dir" "/" "/abs.casa" dir_of_path assert_str_eq
+}
+
+fn test_resolve_import_path_absolute {
+    "resolve_import_path_absolute" test_start
+    "resolved"
+        "/abs/foo.casa"
+        empty_location "/abs/foo.casa" "casa.casa" DEFAULT_PARSER resolve_import
+    assert_str_eq
+}
+
+fn test_resolve_import_path_relative {
+    "resolve_import_path_relative" test_start
+    "resolved"
+        "lib/std.casa"
+        empty_location "lib/std.casa" "casa.casa" DEFAULT_PARSER resolve_import
+    assert_str_eq
+}
+
+fn test_resolve_import_module_in_source_dir {
+    "resolve_import_module_in_source_dir" test_start
+    # Importing from lib/std.casa, module "std" resolves to lib/std.casa.
+    "resolved"
+        "lib/std.casa"
+        empty_location "std" "lib/std.casa" DEFAULT_PARSER resolve_import
+    assert_str_eq
+}
+
+fn test_resolve_import_module_via_search_path {
+    "resolve_import_module_via_search_path" test_start
+    # No std.casa in tests/compiler/, so resolver falls through to "lib".
+    List::new (List[str]) = paths
+    "lib" paths .push
+    paths DEFAULT_PARSER ->search_paths
+    "resolved"
+        "lib/std.casa"
+        empty_location "std" "tests/compiler/test_parser.casa" DEFAULT_PARSER resolve_import
+    assert_str_eq
+    List::new (List[str]) DEFAULT_PARSER ->search_paths
+}
+
+fn test_resolve_import_search_paths_skips_missing {
+    "resolve_import_search_paths_skips_missing" test_start
+    List::new (List[str]) = paths
+    "no_such_dir" paths .push
+    "lib" paths .push
+    paths DEFAULT_PARSER ->search_paths
+    "resolved"
+        "lib/std.casa"
+        empty_location "std" "tests/compiler/test_parser.casa" DEFAULT_PARSER resolve_import
+    assert_str_eq
+    List::new (List[str]) DEFAULT_PARSER ->search_paths
+}
+
+# ============================================================================
 # String with escapes test
 # ============================================================================
 
@@ -604,5 +694,17 @@ test_parse_keyword_elif
 test_parse_keyword_break
 test_parse_keyword_continue
 test_parse_keyword_import
+test_is_path_specifier_casa_extension
+test_is_path_specifier_slash
+test_is_path_specifier_module
+test_dir_of_path_with_dir
+test_dir_of_path_nested
+test_dir_of_path_no_dir
+test_dir_of_path_root
+test_resolve_import_path_absolute
+test_resolve_import_path_relative
+test_resolve_import_module_in_source_dir
+test_resolve_import_module_via_search_path
+test_resolve_import_search_paths_skips_missing
 test_parse_string_with_escapes
 test_summary

--- a/tests/test_compiler.sh
+++ b/tests/test_compiler.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env sh
 set -eu
 
-ROOT_DIR=$(git rev-parse --show-toplevel)
+ROOT_DIR=$(cd "$(dirname "$0")/.." && pwd)
 TESTS_DIR="$ROOT_DIR/tests/compiler"
+cd "$ROOT_DIR"
 
 # Accept optional compiler path as first argument
 if [ $# -ge 1 ]; then


### PR DESCRIPTION
## Summary

- Adds module-style `import "name"` resolution alongside existing path-style imports.
- New `-L` / `--library-path` CLI flag (repeatable) supplies module search paths.
- Module-style imports probe the importing file's directory first, then each `-L` directory in CLI order; first match wins.
- Missing module produces a multi-line error listing every directory searched.
- Path-style imports (`"foo.casa"`, contains `/`, or absolute) keep current semantics.

Closes #110.

## Implementation notes

`compiler/parser.casa`:
- `Parser` gains `search_paths: List[str]`; `make_parser` initializes empty.
- Helpers `is_path_specifier` and `dir_of_path` (extracted from inline code).
- New `resolve_import parser:Parser importing_file:str spec:str location:Location -> str` implements the rule. Module-style probes use `file::exists` + `normalize_path`; results are canonicalized so `included_files` dedup keeps working across alternate specifiers.
- `handle_keyword_import` now takes the parser handle and derives the importing file from the literal token's location.

`casa.casa`: registers `MultiOption` for `-L` / `--library-path`; `main` reads via `args .get_multi .unwrap` and sets `DEFAULT_PARSER.search_paths`.

`lsp.casa` and `lib/test.casa`: clear hooks reset `search_paths` for hermeticity.

`tests/test_compiler.sh`: derives `ROOT_DIR` from the script location and `cd`s there so tests work from any cwd (resolver tests rely on `lib/std.casa` being reachable as a relative path).

`docs/standard-library.md`, `README.md`: document both import forms and the `-L` flag.

## Test plan

- [x] `tests/test_compiler.sh` (24 suites, all green; self-compile + fixed-point pass)
- [x] `tests/test_examples.sh` (38 examples, all green)
- [x] 12 new unit tests in `tests/compiler/test_parser.casa` cover `is_path_specifier`, `dir_of_path` (with-dir, nested, no-dir, root), and `resolve_import` (path absolute, path relative, module via source dir, module via `-L`, search-path skip-missing).
- [x] Smoke: `casac -L lib program.casa` with `import "std"` resolves and runs.
- [x] Smoke: missing module without `-L` reports `module \`x\` not found, searched:` listing the source dir; with `-L` lists every `-L` entry too.

## Bootstrap note

After merge, the shipped `./casac` binary is stale relative to the new resolver code. Local rebuild only — no binary commit.