### PR TITLE
stdlib: file ops return Result with FileError

### DIFF
--- a/compiler/build.casa
+++ b/compiler/build.casa
@@ -15,7 +15,11 @@ fn compile_binary asm_source:str output_name:str keep_asm:bool {
     f"{output_name}.o" = obj_file
 
     # Write assembly to file
-    asm_source asm_file file::write_all drop
+    asm_source asm_file file::write_all = write_result
+    if write_result Result::Error (write_err) is then
+        f"error: cannot write {asm_file}: {write_err.to_str}" eprintln
+        1 exit
+    fi
 
     # Assemble
     List::new (List[str]) = assembler_args

--- a/compiler/lexer.casa
+++ b/compiler/lexer.casa
@@ -532,7 +532,12 @@ fn lex_source code:str file:str -> List[Token] {
 }
 
 fn lex_file path:str -> List[Token] {
-    path file::read_all = code
+    path file::read_all = read_result
+    if read_result Result::Error (read_err) is then
+        f"error: cannot read {path}: {read_err.to_str}" eprintln
+        1 exit
+    fi
+    read_result.unwrap = code
     path code SOURCE_CACHE.set = SOURCE_CACHE
     path code Lexer::new.lex
 }

--- a/docs/strings-and-io.md
+++ b/docs/strings-and-io.md
@@ -225,26 +225,48 @@ Closes a file descriptor. Returns 0 on success, or a negative value on error.
 fd file::close drop
 ```
 
-### `file::read_all`
+### `FileError`
 
-Reads the entire contents of a file into a string. Prints an error and exits if the file cannot be opened.
-
-**Signature:** `file::read_all path:str -> str`
-
-**Stack effect:** `str -> str`
+The high-level file operations (`file::read_all`, `file::write_all`, `file::remove`) report failures through a `FileError` enum wrapped in `Result`:
 
 ```casa
-"input.txt" file::read_all = content
-content print
+enum FileError {
+    NotFound
+    PermissionDenied
+    AlreadyExists
+    IsDirectory
+    NotDirectory
+    BadFd
+    Other (int)    # raw errno for cases not covered above
+}
 ```
+
+`FileError` implements `Display`, so it can be printed with `to_str` or interpolated in f-strings. The free function `errno_to_file_error` converts a negative syscall return value to the appropriate `FileError`.
+
+### `file::read_all`
+
+Reads the entire contents of a file into a string. Returns `Result::Ok(content)` on success or `Result::Error(FileError)` if the file cannot be opened or read.
+
+**Signature:** `file::read_all path:str -> Result[str FileError]`
+
+**Stack effect:** `str -> Result[str FileError]`
+
+```casa
+"input.txt" file::read_all match
+    Result::Ok(content)  => content print
+    Result::Error(read_err) => f"read failed: {read_err.to_str}\n" eprint
+end
+```
+
+Match directly on the `Result` rather than probing with `file::exists` first; the latter introduces a TOCTOU race because the file can disappear between the two calls.
 
 ### `file::write_all`
 
-Writes a string to a file, creating or truncating it. Returns `true` on success, `false` if the file cannot be opened.
+Writes a string to a file, creating or truncating it. Returns `Result::Ok(true)` on success or `Result::Error(FileError)` if the file cannot be opened.
 
-**Signature:** `file::write_all path:str content:str -> bool`
+**Signature:** `file::write_all path:str content:str -> Result[bool FileError]`
 
-**Stack effect:** `str str -> bool`
+**Stack effect:** `str str -> Result[bool FileError]`
 
 ```casa
 "Hello, world!\n" "output.txt" file::write_all drop
@@ -252,11 +274,11 @@ Writes a string to a file, creating or truncating it. Returns `true` on success,
 
 ### `file::remove`
 
-Deletes a file. Returns 0 on success, or a negative value on error.
+Deletes a file. Returns `Result::Ok(true)` on success or `Result::Error(FileError)` if the syscall fails (e.g. the file is missing).
 
-**Signature:** `file::remove path:str -> int`
+**Signature:** `file::remove path:str -> Result[bool FileError]`
 
-**Stack effect:** `str -> int`
+**Stack effect:** `str -> Result[bool FileError]`
 
 ```casa
 "temp.txt" file::remove drop
@@ -264,16 +286,14 @@ Deletes a file. Returns 0 on success, or a negative value on error.
 
 ### `file::exists`
 
-Returns `true` when the path can be opened for reading, `false` otherwise (missing file, permission denied). Does not abort the process on a missing file, so it is safe to use as a probe (unlike `file::read_all`).
+Returns `true` when the path can be opened for reading, `false` otherwise (missing file, permission denied). Safe to use as a probe when the existence check is needed for control flow that does not later read the file (to read the file, match on `file::read_all` directly to avoid a TOCTOU race).
 
 **Signature:** `file::exists path:str -> bool`
 
 **Stack effect:** `str -> bool`
 
 ```casa
-if "config.toml" file::exists then
-    "config.toml" file::read_all = config
-fi
+"/tmp/casa.lock" file::exists.to_str print
 ```
 
 See [`examples/file_io.casa`](../examples/file_io.casa) for a full program using file I/O.

--- a/examples/file_io.casa
+++ b/examples/file_io.casa
@@ -4,9 +4,9 @@ import "../lib/std.casa"
 
 # High-level: write and read a file
 "=== write_all ===" print "\n" print
-"Hello, File I/O!\n" "/tmp/casa_fio_test1.txt" file::write_all.to_str print "\n" print
+"Hello, File I/O!\n" "/tmp/casa_fio_test1.txt" file::write_all.is_ok.to_str print "\n" print
 "=== read_all ===" print "\n" print
-"/tmp/casa_fio_test1.txt" file::read_all = content
+"/tmp/casa_fio_test1.txt" file::read_all.unwrap = content
 content print
 "=== content verification ===" print "\n" print
 "Hello, File I/O!\n" content str::eq.to_str print "\n" print
@@ -16,7 +16,7 @@ content print
 "Line 1\n" fd file::write drop
 "Line 2\n" fd file::write drop
 fd file::close drop
-"/tmp/casa_fio_test2.txt" file::read_all print
+"/tmp/casa_fio_test2.txt" file::read_all.unwrap print
 # Low-level: read with buffer
 "=== low-level read ===" print "\n" print
 "ABCDE" "/tmp/casa_fio_test3.txt" file::write_all drop
@@ -31,6 +31,12 @@ rfd file::close drop
 "=== exists ===" print "\n" print
 "/tmp/casa_fio_test1.txt" file::exists.to_str print "\n" print
 "/tmp/casa_fio_no_such_file.txt" file::exists.to_str print "\n" print
+# Match on Result for a missing file
+"=== read_all on missing ===" print "\n" print
+"/tmp/casa_fio_no_such_file.txt" file::read_all match
+    Result::Ok (_) => "unexpected ok\n" print
+    Result::Error (read_err) => f"{read_err.to_str}\n" print
+end
 # Clean up temp files
 "=== remove ===" print "\n" print
 "/tmp/casa_fio_test1.txt" file::remove drop

--- a/examples/outputs/file_io.out
+++ b/examples/outputs/file_io.out
@@ -14,6 +14,8 @@ E
 === exists ===
 true
 false
+=== read_all on missing ===
+file not found
 === remove ===
 false
 files cleaned up

--- a/lib/std.casa
+++ b/lib/std.casa
@@ -399,35 +399,45 @@ impl file {
         fd 3 syscall1
     }
 
-    fn read_all path:str -> str {
+    fn read_all path:str -> Result[str FileError] {
         0 O_RDONLY path file::open = file_fd
         if 0 file_fd < then
-            "error: could not open file\n" print
-            1 60 syscall1 drop
+            file_fd errno_to_file_error Result::Error return
         fi
         2 0 file_fd 8 syscall3 = file_size
         0 0 file_fd 8 syscall3 drop
         file_size 9 + alloc (str) = result_buf
         file_size result_buf (ptr) store64
-        file_size result_buf.as_cstr (ptr) file_fd 0 syscall3 drop
+        file_size result_buf.as_cstr (ptr) file_fd 0 syscall3 = bytes_read
+        if 0 bytes_read < then
+            file_fd file::close drop
+            bytes_read errno_to_file_error Result::Error return
+        fi
         0 (char) file_size result_buf.set
         file_fd file::close drop
-        result_buf
+        result_buf Result::Ok
     }
 
-    fn write_all path:str content:str -> bool {
+    fn write_all path:str content:str -> Result[bool FileError] {
         420 O_WRONLY O_CREAT | O_TRUNC | path file::open = file_fd
         if 0 file_fd < then
-            false
-        else
-            content file_fd file::write drop
-            file_fd file::close drop
-            true
+            file_fd errno_to_file_error Result::Error return
         fi
+        content file_fd file::write = bytes_written
+        if 0 bytes_written < then
+            file_fd file::close drop
+            bytes_written errno_to_file_error Result::Error return
+        fi
+        file_fd file::close drop
+        true Result::Ok
     }
 
-    fn remove path:str -> int {
-        path.as_cstr (ptr) 87 syscall1
+    fn remove path:str -> Result[bool FileError] {
+        path.as_cstr (ptr) 87 syscall1 = remove_result
+        if 0 remove_result < then
+            remove_result errno_to_file_error Result::Error return
+        fi
+        true Result::Ok
     }
 
     fn exists path:str -> bool {
@@ -438,6 +448,47 @@ impl file {
         fi
         file_fd file::close drop
         true
+    }
+}
+
+# ---------------------------------------------------------------------------
+# File errors
+# ---------------------------------------------------------------------------
+
+enum FileError {
+    NotFound
+    PermissionDenied
+    AlreadyExists
+    IsDirectory
+    NotDirectory
+    BadFd
+    Other (int)
+}
+
+fn errno_to_file_error syscall_result:int -> FileError {
+    # `syscall_result` is the negative syscall return; negate to errno.
+    0 syscall_result - = errno
+    if 2 errno == then FileError::NotFound return fi
+    if 13 errno == then FileError::PermissionDenied return fi
+    if 1 errno == then FileError::PermissionDenied return fi
+    if 17 errno == then FileError::AlreadyExists return fi
+    if 21 errno == then FileError::IsDirectory return fi
+    if 20 errno == then FileError::NotDirectory return fi
+    if 9 errno == then FileError::BadFd return fi
+    errno FileError::Other
+}
+
+impl FileError {
+    fn to_str self:FileError -> str {
+        self match
+            FileError::NotFound => "file not found"
+            FileError::PermissionDenied => "permission denied"
+            FileError::AlreadyExists => "file already exists"
+            FileError::IsDirectory => "is a directory"
+            FileError::NotDirectory => "not a directory"
+            FileError::BadFd => "bad file descriptor"
+            FileError::Other (errno) => f"errno {errno.to_str}"
+        end
     }
 }
 

--- a/lsp.casa
+++ b/lsp.casa
@@ -706,7 +706,12 @@ fn handle_did_change message:JsonValue {
 
 fn handle_did_save message:JsonValue {
     message extract_uri = uri
-    uri uri_to_path file::read_all = saved_source
+    uri uri_to_path file::read_all = read_result
+    if read_result Result::Error (read_err) is then
+        f"error: handle_did_save read failed for {uri}: {read_err.to_str}" eprintln
+        return
+    fi
+    read_result.unwrap = saved_source
     saved_source uri run_diagnostics
 }
 

--- a/tests/compiler/test_file.casa
+++ b/tests/compiler/test_file.casa
@@ -12,10 +12,37 @@ fn fe_assert_true condition:bool message:str {
 fn fe_assert_false condition:bool message:str {
     if condition then message fe_fail fi
 }
-
 # file::exists returns true for an existing file
 "contents" "/tmp/casa_file_exists_test.txt" file::write_all drop
 "existing path" "/tmp/casa_file_exists_test.txt" file::exists fe_assert_true
 "/tmp/casa_file_exists_test.txt" file::remove drop
 # file::exists returns false for a missing path (no process abort)
 "missing path" "/tmp/casa_file_exists_definitely_not_a_real_path.xyz" file::exists fe_assert_false
+# file::read_all returns Ok with the file content
+"hello world" "/tmp/casa_read_all_ok.txt" file::write_all drop
+"/tmp/casa_read_all_ok.txt" file::read_all = read_ok_result
+"read_all ok on existing" read_ok_result.is_ok fe_assert_true
+"read_all content matches" "hello world" read_ok_result.unwrap str::eq fe_assert_true
+"/tmp/casa_read_all_ok.txt" file::remove drop
+# file::read_all returns Error(NotFound) for a missing file
+"/tmp/casa_read_all_definitely_not_a_real_path.xyz" file::read_all = read_missing_result
+"read_all error on missing" read_missing_result.is_error fe_assert_true
+"read_all error is NotFound" "file not found" read_missing_result.unwrap_error.to_str str::eq fe_assert_true
+# file::write_all returns Ok(true) for a writable path
+"data" "/tmp/casa_write_all_ok.txt" file::write_all = write_ok_result
+"write_all ok on writable path" write_ok_result.is_ok fe_assert_true
+"write_all returns true" write_ok_result.unwrap fe_assert_true
+"/tmp/casa_write_all_ok.txt" file::remove drop
+# file::write_all returns Error(NotFound) when target dir does not exist
+"data" "/tmp/casa_no_such_dir_xyz/file.txt" file::write_all = write_bad_result
+"write_all error on missing dir" write_bad_result.is_error fe_assert_true
+"write_all error is NotFound" "file not found" write_bad_result.unwrap_error.to_str str::eq fe_assert_true
+# file::remove returns Ok(true) for an existing file
+"data" "/tmp/casa_remove_ok.txt" file::write_all drop
+"/tmp/casa_remove_ok.txt" file::remove = remove_ok_result
+"remove ok on existing" remove_ok_result.is_ok fe_assert_true
+"remove returns true" remove_ok_result.unwrap fe_assert_true
+# file::remove returns Error(NotFound) for a missing file
+"/tmp/casa_remove_definitely_not_a_real_path.xyz" file::remove = remove_bad_result
+"remove error on missing" remove_bad_result.is_error fe_assert_true
+"remove error is NotFound" "file not found" remove_bad_result.unwrap_error.to_str str::eq fe_assert_true


### PR DESCRIPTION
## Summary

- Convert `file::read_all`, `file::write_all`, and `file::remove` to return `Result[T FileError]` so callers can branch on failure instead of crashing or losing the syscall return.
- Add `FileError` enum (`NotFound`, `PermissionDenied`, `AlreadyExists`, `IsDirectory`, `NotDirectory`, `BadFd`, `Other(int)`) with `Display` impl and `errno_to_file_error` helper.
- Update callers (`lex_file`, `compile_binary`, `handle_did_save`) to handle the new `Result`. `compile_binary` now reports a write failure to stderr and exits instead of silently dropping it.
- Refresh `examples/file_io.casa` (with a `match` arm demoing the error path), regenerate expected output, extend `tests/compiler/test_file.casa` to cover `Ok`/`Error` paths for all three ops, and update `docs/strings-and-io.md` (signatures, FileError section, TOCTOU note).

## Test plan

- [x] `tests/test_compiler.sh` (24 passed, 0 failed)
- [x] `tests/test_examples.sh` (38 passed, 0 failed)
- [x] Manually compile and run `examples/file_io.casa`; output matches `examples/outputs/file_io.out`