### PR TITLE
feat: migrate examples and lib to module-style imports

### DIFF
--- a/compiler/parser.casa
+++ b/compiler/parser.casa
@@ -1731,6 +1731,7 @@ fn dir_of_path path:str -> str {
 
 fn resolve_import parser:Parser importing_file:str spec:str location:Location -> str {
     importing_file dir_of_path = source_dir
+    importing_file normalize_path = importing_normalized
     # Path-style: keep existing semantics (no existence check).
     if spec is_path_specifier then
         if spec "/" str::starts_with then
@@ -1741,9 +1742,12 @@ fn resolve_import parser:Parser importing_file:str spec:str location:Location ->
         return
     fi
     # Module-style: probe source dir, then each search path. First hit wins.
+    # Skip a same-dir match that resolves to the importing file itself, so an
+    # example named `argparse.casa` importing "argparse" still finds the
+    # library copy via -L.
     # `searched` accumulates probed dirs for the not-found error message.
     f"{source_dir}{spec}.casa" normalize_path = source_candidate
-    if source_candidate file::exists then
+    if source_candidate file::exists source_candidate importing_normalized != && then
         source_candidate
         return
     fi

--- a/docs/standard-library.md
+++ b/docs/standard-library.md
@@ -38,7 +38,7 @@ A specifier without `/` and without a `.casa` suffix is treated as a module name
 1. the directory of the importing file, then
 2. each directory passed via `-L` / `--library-path`, in CLI order.
 
-The first existing match wins. If no candidate exists, the compiler reports an error listing every directory searched.
+The first existing match wins. A same-directory candidate that resolves to the importing file itself is skipped, so an example file `examples/argparse.casa` can `import "argparse"` and reach the library copy via `-L`. If no candidate exists, the compiler reports an error listing every directory searched.
 
 ### `-L` / `--library-path`
 

--- a/examples/argparse.casa
+++ b/examples/argparse.casa
@@ -1,7 +1,7 @@
 # Argument parser
 # Demonstrates declarative CLI argument parsing with auto-generated help.
 # Usage: ./argparse [--name NAME] [-g GREETING] [-v] [-L PATH ...]
-import "../lib/argparse.casa"
+import "argparse"
 
 ArgParser::new = parser
 "name to greet" "--name" "-n" "name" parser.add_option

--- a/examples/command_line_args.casa
+++ b/examples/command_line_args.casa
@@ -1,13 +1,11 @@
 # Command-line arguments
 # Demonstrates argc, argv, and get_arg
 # Usage: ./command_line_args hello world
-
-import "../lib/std.casa"
+import "std"
 
 # Print number of user arguments (excluding program name)
 argc 1 - = num_args
 f"number of arguments: {num_args}" print "\n" print
-
 # Print each user argument
 1 = i
 while i argc > do
@@ -15,7 +13,6 @@ while i argc > do
     f"  arg {i 1 -}: {arg}" print "\n" print
     1 += i
 done
-
 # Check if a specific argument was given
 if 0 num_args == then
     "no arguments provided" print "\n" print

--- a/examples/dynamic_list.casa
+++ b/examples/dynamic_list.casa
@@ -1,15 +1,13 @@
-import "../lib/std.casa"
+import "std"
 
 "=== Create list with items [1, 2, 3] ===" print "\n" print
-[1, 2, 3] List::from_array = list
+[1 , 2 , 3] List::from_array = list
 list.print_metadata
-
 "=== Push 4 to the list ===" print "\n" print
 4 list.push
 list.print_metadata
-
 "=== Shrink list size to 1 ===" print "\n" print
-1 list->size
+1 list -> size
 list.print_metadata
 
 impl List {

--- a/examples/file_io.casa
+++ b/examples/file_io.casa
@@ -1,6 +1,6 @@
 # File I/O operations
 # Demonstrates file reading, writing, and low-level file operations
-import "../lib/std.casa"
+import "std"
 
 # High-level: write and read a file
 "=== write_all ===" print "\n" print

--- a/examples/for_loop.casa
+++ b/examples/for_loop.casa
@@ -2,7 +2,7 @@
 #
 # A `for x in <iter> do <body> done` loop calls `<iter_type>::next` until it
 # returns `Option::None`. Any type with a matching `next` method works.
-import "../lib/std.casa"
+import "std"
 
 # Iterating an array
 [1 2 3 4 5] = nums
@@ -40,7 +40,7 @@ impl Counter {
             Option::None (Option[int]) return
         fi
         self Counter::value = current
-        self Counter::value 1 + self->value
+        self Counter::value 1 + self -> value
         current Option::Some
     }
 }

--- a/examples/fstring.casa
+++ b/examples/fstring.casa
@@ -1,43 +1,35 @@
 # F-string interpolation examples
-
-import "../lib/std.casa"
+import "std"
 
 # Basic f-string with a variable
 "world" = greeting
 f"hello {greeting}\n" print
-
 # Multiple expressions in one f-string
 "Alice" = first
 "Smith" = last
 f"{first} {last}\n" print
-
 # Escaped braces produce literal braces
 f"\{braces\}\n" print
-
 # F-string inside a function
+
 fn greet name:str -> str {
     f"hi {name}"
 }
 "Bob" greet print "\n" print
-
 # Nested string concatenation via f-strings
 "casa" = lang
 "f-strings" = feature
 f"{lang} supports {feature}\n" print
-
 # F-string with escape sequences
 f"col1\tcol2\n" print
-
 # F-string with no expressions is just a string
 f"plain string\n" print
-
 # Arbitrary types that satisfy the Display trait are auto-converted
 42 = count
 'A' = letter
 true = ready
 f"count={count} letter={letter} ready={ready}\n" print
-
 # Containers and Option[T] also satisfy Display
-[1, 2, 3] (array[int]) = nums
+[1 , 2 , 3] (array[int]) = nums
 5 Option::Some = maybe
 f"nums={nums} maybe={maybe}\n" print

--- a/examples/game_of_life.casa
+++ b/examples/game_of_life.casa
@@ -1,20 +1,16 @@
 # Conway's Game of Life
 # Runs fullscreen in the terminal with toroidal wrapping.
 # Adapts to terminal resize. Exit with Ctrl+C.
-
-import "../lib/std.casa"
-
+import "std"
 
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
-
 16 = SYS_IOCTL
 35 = SYS_NANOSLEEP
 21523 = TIOCGWINSZ
 64 = ALIVE_THRESHOLD
 200 = FRAME_DELAY_MS
-
 
 # ---------------------------------------------------------------------------
 # Terminal helpers
@@ -23,7 +19,6 @@ import "../lib/std.casa"
 fn write_stdout text:str {
     text 1 file::write drop
 }
-
 
 # ---------------------------------------------------------------------------
 # Random
@@ -47,7 +42,6 @@ fn randomize_grid grid:ptr size:int {
         1 += index
     done
 }
-
 
 # ---------------------------------------------------------------------------
 # Neighbor counting (toroidal wrap)
@@ -73,44 +67,40 @@ fn count_neighbors grid:ptr grid_width:int grid_height:int x:int y:int -> int {
     neighbor_count
 }
 
-
 # ---------------------------------------------------------------------------
 # Rendering
 # ---------------------------------------------------------------------------
 
 fn render grid:ptr grid_width:int grid_height:int {
     StringBuilder::new = frame
-    "\x1b[H" frame .append
+    "\x1b[H" frame.append
     0 = render_row
     while render_row grid_height > do
         0 = render_col
         while render_col grid_width > do
             if 0 grid render_row grid_width * render_col + + load8 != then
-                "\xe2\x96\x88" frame .append
+                "\xe2\x96\x88" frame.append
             else
-                " " frame .append
+                " " frame.append
             fi
             1 += render_col
         done
         if render_row grid_height 1 - != then
-            "\n" frame .append
+            "\n" frame.append
         fi
         1 += render_row
     done
-    frame .build write_stdout
+    frame.build write_stdout
 }
-
 
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
-
 # Allocate reusable buffers for ioctl and nanosleep
 8 alloc = winsize_buf
 16 alloc = timespec_buf
 0 timespec_buf (ptr) store64
 FRAME_DELAY_MS 1000000 * timespec_buf (ptr) 8 + store64
-
 # Get initial terminal size (exit if stdout is not a terminal)
 winsize_buf (int) TIOCGWINSZ 1 SYS_IOCTL syscall3 = ioctl_result
 if 0 ioctl_result < then
@@ -119,15 +109,12 @@ fi
 winsize_buf 2 + load16 = width
 winsize_buf load16 = height
 width height * = grid_size
-
 # Allocate and initialize grids
 grid_size alloc = current
 grid_size alloc = next_grid
 grid_size current randomize_grid
-
 # Clear screen
 "\x1b[2J" write_stdout
-
 # Game loop
 while true do
     # Check for terminal resize
@@ -136,8 +123,8 @@ while true do
     winsize_buf load16 = new_height
 
     if
-        new_width width !=
-        new_height height != ||
+    new_width width !=
+    new_height height != ||
     then
         new_width new_height * = new_grid_size
 

--- a/examples/hash_map.casa
+++ b/examples/hash_map.casa
@@ -1,54 +1,46 @@
-import "../lib/std.casa"
+import "std"
 
 # Create a Map[str int]
 Map::new (Map[str int]) = m
-
 # Set some key-value pairs
 # fn set[K: Hashable, V] self:Map[K V] value:V key:K -> Map[K V]
 # Stack order (bottom to top): key, value, self
 "one" 1 m.set = m
 "two" 2 m.set = m
 "three" 3 m.set = m
-
 # Get values
-"one" m.get .unwrap print
+"one" m.get.unwrap print
 "\n" print
-"two" m.get .unwrap print
+"two" m.get.unwrap print
 "\n" print
-"three" m.get .unwrap print
+"three" m.get.unwrap print
 "\n" print
-
 # Check length
 m.length print
 "\n" print
-
 # Check has
 "one" m.has print
 "\n" print
 "four" m.has print
 "\n" print
-
 # Update existing key
 "one" 42 m.set = m
-"one" m.get .unwrap print
+"one" m.get.unwrap print
 "\n" print
-
 # Delete a key
 "two" m.delete = m
 m.length print
 "\n" print
 "two" m.has print
 "\n" print
-
 # Create a Map[int str]
 Map::new (Map[int str]) = m2
 1 "hello" m2.set = m2
 2 "world" m2.set = m2
-1 m2.get .unwrap print
+1 m2.get.unwrap print
 "\n" print
-2 m2.get .unwrap print
+2 m2.get.unwrap print
 "\n" print
-
 # Create a Set[str]
 Set::new (Set[str]) = s
 "apple" s.add = s
@@ -60,7 +52,6 @@ s.length print
 "\n" print
 "grape" s.has print
 "\n" print
-
 # Remove from set
 "banana" s.remove = s
 s.length print

--- a/examples/iterable.casa
+++ b/examples/iterable.casa
@@ -3,41 +3,34 @@
 # Types that implement `fn next self:self -> Option[T]` automatically gain
 # default methods from the `Iterable[T]` trait: collect, map, filter, fold,
 # count, any, all, and find. Call `.iter` on a collection to get an iterator.
-import "../lib/std.casa"
+import "std"
 
 # collect — gather all elements into a List
-[10 20 30] (array[int]) .iter .collect = collected
+[10 20 30] (array[int]).iter.collect = collected
 f"collect: {collected}" println
-
 # map — transform each element
-{ 2 * } [1 2 3] (array[int]) .iter .map = doubled
+{ 2 * }[1 2 3] (array[int]).iter.map = doubled
 f"map: {doubled}" println
-
 # filter — keep elements matching a predicate
-{ 2 % 0 == } [1 2 3 4 5 6] (array[int]) .iter .filter = evens
+{ 2 % 0 == }[1 2 3 4 5 6] (array[int]).iter.filter = evens
 f"filter: {evens}" println
-
 # fold — reduce to a single value with an accumulator
-{ + } 0 [1 2 3 4 5] (array[int]) .iter .fold = sum
+{ + } 0[1 2 3 4 5] (array[int]).iter.fold = sum
 f"fold: {sum}" println
-
 # count — number of elements
-[1 2 3 4 5] (array[int]) .iter .count = cnt
+[1 2 3 4 5] (array[int]).iter.count = cnt
 f"count: {cnt}" println
-
 # any — true if any element matches
-{ 3 == } [1 2 3 4 5] (array[int]) .iter .any = found_three
+{ 3 == }[1 2 3 4 5] (array[int]).iter.any = found_three
 f"any 3: {found_three}" println
-
 # all — true if all elements match
-{ 0 < } [1 2 3 4 5] (array[int]) .iter .all = all_positive
+{ 0 < }[1 2 3 4 5] (array[int]).iter.all = all_positive
 f"all positive: {all_positive}" println
-
 # find — first matching element
-{ 3 < } [1 2 3 4 5] (array[int]) .iter .find = big
+{ 3 < }[1 2 3 4 5] (array[int]).iter.find = big
 f"find >3: {big}" println
-
 # Custom iterator with default methods
+
 struct Counter {
     value: int
     limit: int
@@ -49,10 +42,9 @@ impl Counter {
             Option::None (Option[int]) return
         fi
         self Counter::value = current
-        self Counter::value 1 + self->value
+        self Counter::value 1 + self -> value
         current Option::Some
     }
 }
-
-{ 2 * } Counter { value: 0 limit: 5 } .map = counter_doubled
+{ 2 * } Counter { value: 0 limit: 5 }.map = counter_doubled
 f"counter map: {counter_doubled}" println

--- a/examples/log.casa
+++ b/examples/log.casa
@@ -1,15 +1,12 @@
 # Logging library
 # Demonstrates leveled logging to stderr with configurable log levels.
-
-import "../lib/log.casa"
+import "log"
 
 # Default level is Warning — Info and Debug are suppressed
 "this info is hidden" log_info
 "this warning is visible" log_warning
-
 # Raise the level to Info
 LogLevel::Info log_set_level
 "now info is visible" log_info
-
 # Print to stdout to confirm the program ran
 "done\n" print

--- a/examples/option.casa
+++ b/examples/option.casa
@@ -2,50 +2,44 @@
 #
 # Option::Some wraps a value into Option[T], Option::None creates an empty option.
 # Methods: is_some, is_none, unwrap, unwrap_or
-
-import "../lib/std.casa"
+import "std"
 
 # Creating options
-42 Option::Some = maybe_int       # Option[int]
-"hello" Option::Some = maybe_str  # Option[str]
-Option::None = empty              # Option[T] (compatible with any Option[T])
-
+42 Option::Some = maybe_int # Option[int]
+"hello" Option::Some = maybe_str # Option[str]
+Option::None = empty # Option[T] (compatible with any Option[T])
 # Checking presence
 if maybe_int.is_some then
     "maybe_int has a value\n" print
 fi
-
 if empty.is_none then
     "empty has no value\n" print
 fi
-
 # Unwrapping values
-maybe_int.unwrap print "\n" print     # 42
-maybe_str.unwrap print "\n" print     # hello
-
+maybe_int.unwrap print "\n" print # 42
+maybe_str.unwrap print "\n" print # hello
 # unwrap_or provides a default when the option is none
 # default value is pushed before the option
-0 empty.unwrap_or print "\n" print     # 0 (fallback for none)
+0 empty.unwrap_or print "\n" print # 0 (fallback for none)
 0 maybe_int.unwrap_or print "\n" print # 42 (has a value, default ignored)
-
 # Using options with generic functions
-fn id[T] T -> T { }
-42 Option::Some id .unwrap print "\n" print    # 42
 
+fn id[T] T -> T { }
+
+42 Option::Some id.unwrap print "\n" print # 42
 # Branching with option types
+
 fn safe_head arr:array[int] -> Option[int] {
-    if 0 arr .length > then
+    if 0 arr.length > then
         0 arr array::nth Option::Some
     else
         Option::None
     fi
 }
-
-[1, 2, 3] safe_head .unwrap print "\n" print  # 1
-[] (array[int]) safe_head .is_none print "\n" print  # 1 (true)
-
+[1 , 2 , 3] safe_head.unwrap print "\n" print # 1
+[] (array[int]) safe_head.is_none print "\n" print # 1 (true)
 # Match on option
 42 Option::Some match
-    Option::Some(value) => value print "\n" print
+    Option::Some (value) => value print "\n" print
     Option::None => "nothing\n" print
 end

--- a/examples/parser.casa
+++ b/examples/parser.casa
@@ -2,52 +2,44 @@
 #
 # Demonstrates Cursor struct, helper functions, and high-level parsers
 # for integers, identifiers, quoted strings, and char literals.
-
-import "../lib/std.casa"
-import "../lib/parser.casa"
+import "std"
+import "parser"
 
 # Cursor basics: peek and advance
 "hello" Cursor::new = cursor
 cursor.peek.unwrap print "\n" print
 cursor.advance drop
 cursor.peek.unwrap print "\n" print
-
 # take_while: collect matching characters
 "abc123" Cursor::new = tw_cursor
-{ .is_alpha } tw_cursor.take_while = letters
-{ .is_digit } tw_cursor.take_while = digits
+{.is_alpha } tw_cursor.take_while = letters
+{.is_digit } tw_cursor.take_while = digits
 "letters: " print letters print "\n" print
 "digits: " print digits print "\n" print
-
 # save and restore for backtracking
 "test123" Cursor::new = sr_cursor
 sr_cursor.save = saved_pos
 &is_ident_char sr_cursor.take_while = full_token
 "full: " print full_token print "\n" print
 saved_pos sr_cursor.restore
-{ .is_alpha } sr_cursor.take_while = alpha_part
+{.is_alpha } sr_cursor.take_while = alpha_part
 "alpha only: " print alpha_part print "\n" print
-
 # skip_whitespace
 "   hello" Cursor::new = ws_cursor
 ws_cursor skip_whitespace
 "after skip: " print ws_cursor.pos print "\n" print
-
 # starts_with
 "hello world" Cursor::new = sw_cursor
 "starts hello: " print "hello" sw_cursor.starts_with print "\n" print
 "starts xyz: " print "xyz" sw_cursor.starts_with print "\n" print
-
 # parse_int
-"42" Cursor::new parse_int .unwrap = parsed_int
+"42" Cursor::new parse_int.unwrap = parsed_int
 "int: " print parsed_int print "\n" print
-"-7" Cursor::new parse_int .unwrap = parsed_neg
+"-7" Cursor::new parse_int.unwrap = parsed_neg
 "neg: " print parsed_neg print "\n" print
-
 # parse_identifier
-"my_var" Cursor::new parse_identifier .unwrap = parsed_id
+"my_var" Cursor::new parse_identifier.unwrap = parsed_id
 "id: " print parsed_id print "\n" print
-
 # parse_quoted_string (input: "hello world" with surrounding quotes)
 34 alloc (str) = qs_input
 13 qs_input (ptr) store64
@@ -65,16 +57,13 @@ ws_cursor skip_whitespace
 'd' 11 qs_input.set
 '"' 12 qs_input.set
 '\0' 13 qs_input.set
-qs_input Cursor::new parse_quoted_string .unwrap = parsed_str
+qs_input Cursor::new parse_quoted_string.unwrap = parsed_str
 "str: " print parsed_str print "\n" print
-
 # parse_char_literal
-"'Z'" Cursor::new parse_char_literal .unwrap = parsed_char
+"'Z'" Cursor::new parse_char_literal.unwrap = parsed_char
 "char: " print parsed_char print "\n" print
-
 # str_to_int helper
 "str_to_int: " print "456" str_to_int print "\n" print
-
 # Error handling
 "xyz" Cursor::new parse_int = int_err
 "int error: " print int_err.unwrap_error.message print "\n" print

--- a/examples/result.casa
+++ b/examples/result.casa
@@ -2,32 +2,27 @@
 #
 # Result::Ok wraps a value into Result[T E], Result::Error wraps an error.
 # Methods: is_ok, is_error, unwrap, unwrap_error, unwrap_or
-
-import "../lib/std.casa"
+import "std"
 
 # Creating results
-42 Result::Ok = success            # Result[int E]
-"not found" Result::Error = failure  # Result[T str]
-
+42 Result::Ok = success # Result[int E]
+"not found" Result::Error = failure # Result[T str]
 # Checking status
 if success.is_ok then
     "success is ok\n" print
 fi
-
 if failure.is_error then
     "failure is error\n" print
 fi
-
 # Unwrapping values
-success.unwrap print "\n" print        # 42
-failure.unwrap_error print "\n" print    # not found
-
+success.unwrap print "\n" print # 42
+failure.unwrap_error print "\n" print # not found
 # unwrap_or provides a default when the result is error
 # default value is pushed before the result
-0 failure.unwrap_or print "\n" print   # 0 (fallback for error)
-0 success.unwrap_or print "\n" print   # 42 (has a value, default ignored)
-
+0 failure.unwrap_or print "\n" print # 0 (fallback for error)
+0 success.unwrap_or print "\n" print # 42 (has a value, default ignored)
 # Function returning a result
+
 fn divide dividend:int divisor:int -> Result[int str] {
     if 0 divisor == then
         "division by zero" Result::Error
@@ -35,20 +30,17 @@ fn divide dividend:int divisor:int -> Result[int str] {
         dividend divisor / Result::Ok
     fi
 }
-
 # Branching on result
 2 10 divide = quotient
 if quotient.is_ok then
     quotient.unwrap print "\n" print
 fi
-
 0 10 divide = zero_div
 if zero_div.is_error then
     zero_div.unwrap_error print "\n" print
 fi
-
 # Match on result
 5 Result::Ok match
-    Result::Ok(value) => value print "\n" print
-    Result::Error(err) => err print "\n" print
+    Result::Ok (value) => value print "\n" print
+    Result::Error (err) => err print "\n" print
 end

--- a/examples/run_command.casa
+++ b/examples/run_command.casa
@@ -1,16 +1,13 @@
 # Running external commands
 # Demonstrates run_command which uses fork + execve
-
-import "../lib/std.casa"
+import "std"
 
 # Run echo
-["/usr/bin/env", "echo", "hello", "from", "casa"] List::from_array run_command = echo_code
+["/usr/bin/env" , "echo" , "hello" , "from" , "casa"] List::from_array run_command = echo_code
 f"echo exit code: {echo_code}" print "\n" print
-
 # Run true (exits 0)
-["/usr/bin/env", "true"] List::from_array run_command = true_code
+["/usr/bin/env" , "true"] List::from_array run_command = true_code
 f"true exit code: {true_code}" print "\n" print
-
 # Run false (exits 1)
-["/usr/bin/env", "false"] List::from_array run_command = false_code
+["/usr/bin/env" , "false"] List::from_array run_command = false_code
 f"false exit code: {false_code}" print "\n" print

--- a/examples/sized_memory.casa
+++ b/examples/sized_memory.casa
@@ -1,23 +1,19 @@
-import "../lib/std.casa"
+import "std"
 
 # Allocate 32 bytes of memory
 32 alloc = buf
-
 # Store and load a 64-bit value
 42 buf (ptr) store64
 buf (ptr) load64 print
 "\n" print
-
 # Store and load an 8-bit value at byte offset 8
 255 buf (ptr) 8 + store8
 buf (ptr) 8 + load8 print
 "\n" print
-
 # Store and load a 16-bit value at byte offset 16
 65535 buf (ptr) 16 + store16
 buf (ptr) 16 + load16 print
 "\n" print
-
 # Store and load a 32-bit value at byte offset 24
 100000 buf (ptr) 24 + store32
 buf (ptr) 24 + load32 print

--- a/examples/string_operations.casa
+++ b/examples/string_operations.casa
@@ -1,55 +1,45 @@
 # String operations
 # Demonstrates string methods, char type, and cstr type
-
-import "../lib/std.casa"
+import "std"
 
 # String length
 "=== length ===" print "\n" print
-"hello" .length print "\n" print
-"" .length print "\n" print
-
+"hello".length print "\n" print
+"".length print "\n" print
 # Char access
 "=== at ===" print "\n" print
 0 "hello".at print "\n" print
 4 "hello".at print "\n" print
-
 # Char literals
 "=== char ===" print "\n" print
 'A' print "\n" print
 '\n' (int) print "\n" print
-
 # String equality (== and != compare by content)
 "=== eq ===" print "\n" print
 "hello" "hello" == print "\n" print
 "hello" "world" == print "\n" print
 "" "" == print "\n" print
 "hello" "world" != print "\n" print
-
 # String concatenation
 "=== concat ===" print "\n" print
 "hello" " world" str::concat print "\n" print
 "" "test" str::concat print "\n" print
-
 # Substring extraction
 "=== substring ===" print "\n" print
 "hello world" 0 5 str::substring print "\n" print
 "hello world" 6 5 str::substring print "\n" print
-
 # String find
 "=== find ===" print "\n" print
 "hello world" "world" str::find print "\n" print
 "hello world" "xyz" str::find print "\n" print
 "hello world" "hello" str::find print "\n" print
-
 # Starts with and ends with
 "=== starts_with ===" print "\n" print
 "hello world" "hello" str::starts_with print "\n" print
 "hello world" "world" str::starts_with print "\n" print
-
 "=== ends_with ===" print "\n" print
 "hello world" "world" str::ends_with print "\n" print
 "hello world" "hello" str::ends_with print "\n" print
-
 # Building a string with alloc and store
 "=== alloc + store ===" print "\n" print
 14 alloc (str) = greeting
@@ -61,11 +51,9 @@ import "../lib/std.casa"
 'o' 4 greeting.set
 '\0' 5 greeting.set
 greeting print "\n" print
-
 # cstr conversion
 "=== as_cstr ===" print "\n" print
-"hello" .as_cstr print "\n" print
-
+"hello".as_cstr print "\n" print
 # Character classification
 "=== char classification ===" print "\n" print
 '5'.is_digit print "\n" print

--- a/examples/timer.casa
+++ b/examples/timer.casa
@@ -1,17 +1,14 @@
-import "../lib/timer.casa"
+import "timer"
 
 # Create a timer
 Timer::new = timer
-
 # Display formatting always ends with 's'
-timer .to_str = elapsed_str
-elapsed_str .length 1 - elapsed_str .at = last_char
-f"Ends with s: {last_char 's' == }" println
-
+timer.to_str = elapsed_str
+elapsed_str.length 1 - elapsed_str.at = last_char
+f"Ends with s: {last_char 's' ==}" println
 # Elapsed values are non-negative
-f"Elapsed ms non-negative: {0 timer .elapsed_ms >= }" println
-f"Elapsed ns non-negative: {0 timer .elapsed_ns >= }" println
-
+f"Elapsed ms non-negative: {0 timer.elapsed_ms >=}" println
+f"Elapsed ns non-negative: {0 timer.elapsed_ns >=}" println
 # Global timer
 timer_start
-f"Global ms non-negative: {0 timer_elapsed_ms >= }" println
+f"Global ms non-negative: {0 timer_elapsed_ms >=}" println

--- a/examples/type_annotations.casa
+++ b/examples/type_annotations.casa
@@ -2,44 +2,37 @@
 #
 # The = name:type syntax allows explicit type annotation when assigning variables.
 # This is useful for narrowing 'any' or bare 'option' types to concrete types.
-
-import "../lib/std.casa"
+import "std"
 
 # Basic type annotations
-42 = x:int
-"hello" = greeting:str
-true = flag:bool
-
+42 = x: int
+"hello" = greeting: str
+true = flag: bool
 # Print annotated variables
 x print "\n" print
 greeting print "\n" print
 flag print "\n" print
-
 # Type annotations with option types
-42 Option::Some = maybe_val:Option[int]
-Option::None = empty_val:Option[int]
-
+42 Option::Some = maybe_val: Option[int]
+Option::None = empty_val: Option[int]
 # Check option values
 if maybe_val.is_some then
     "maybe_val has value: " print
     maybe_val.unwrap print "\n" print
 fi
-
 if empty_val.is_none then
     "empty_val is none\n" print
 fi
-
 # Type annotations in functions
+
 fn make_pair a:int b:int -> int int {
-    a = first:int
-    b = second:int
+    a = first: int
+    b = second: int
     first second
 }
-
-10 20 make_pair = y:int = z:int
+10 20 make_pair = y: int = z: int
 z print "\n" print
 y print "\n" print
-
 # Reassignment with annotated variable
 100 = x
 x print "\n" print

--- a/examples/vec.casa
+++ b/examples/vec.casa
@@ -2,8 +2,7 @@
 #
 # Shows all List methods: new, push, get, set, pop, length,
 # from_array, slice, to_array
-
-import "../lib/std.casa"
+import "std"
 
 # Create empty list and push elements
 "=== List::new and push ===" print "\n" print
@@ -15,32 +14,27 @@ List::new = v
 "[0]: " print 0 v.get print "\n" print
 "[1]: " print 1 v.get print "\n" print
 "[2]: " print 2 v.get print "\n" print
-
 # Set element at index
 "=== set ===" print "\n" print
 99 1 v.set
 "[1] after set: " print 1 v.get print "\n" print
-
 # Pop last element
 "=== pop ===" print "\n" print
 v.pop = popped
 "Popped: " print popped print "\n" print
 "Length after pop: " print v.length print "\n" print
-
 # Create list from array
 "=== from_array ===" print "\n" print
-[100, 200, 300, 400, 500] List::from_array = v2
+[100 , 200 , 300 , 400 , 500] List::from_array = v2
 "Length: " print v2.length print "\n" print
 "[0]: " print 0 v2.get print "\n" print
 "[4]: " print 4 v2.get print "\n" print
-
 # Slice returns an array view
 "=== slice ===" print "\n" print
 3 1 v2.slice = sliced
 "Slice length: " print sliced.length print "\n" print
 "Slice[0]: " print 0 sliced array::nth print "\n" print
 "Slice[1]: " print 1 sliced array::nth print "\n" print
-
 # Convert entire list to array
 "=== to_array ===" print "\n" print
 v2.to_array = arr

--- a/lib/argparse.casa
+++ b/lib/argparse.casa
@@ -2,7 +2,7 @@
 #
 # Provides a declarative API for defining and parsing CLI arguments,
 # with auto-generated help output similar to Python's argparse.
-import "std.casa"
+import "std"
 
 # ---------------------------------------------------------------------------
 # Types

--- a/lib/io.casa
+++ b/lib/io.casa
@@ -2,18 +2,14 @@
 #
 # Provides a buffered reader for stdin and a writer for stdout,
 # used by the language server for JSON-RPC communication.
-
-import "std.casa"
-
+import "std"
 
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
-
 4096 = IO_BUFFER_SIZE
-0    = STDIN_FD
-1    = STDOUT_FD
-
+0 = STDIN_FD
+1 = STDOUT_FD
 
 # ---------------------------------------------------------------------------
 # StdinReader
@@ -72,13 +68,13 @@ fn stdin_read_line reader:StdinReader -> str {
         if '\n' (int) line_byte == then
             break
         fi
-        line_byte (char) line_builder .append_char
+        line_byte (char) line_builder.append_char
     done
-    line_builder .build = line_string
+    line_builder.build = line_string
     # Strip trailing \r if present
-    if 0 line_string .length != then
-        if '\r' line_string .length 1 - line_string .at == then
-            line_string 0 line_string .length 1 - str::substring = line_string
+    if 0 line_string.length != then
+        if '\r' line_string.length 1 - line_string.at == then
+            line_string 0 line_string.length 1 - str::substring = line_string
         fi
     fi
     line_string
@@ -94,16 +90,16 @@ fn stdin_read_exact reader:StdinReader count:int -> str {
         if 0 current_byte < then
             # EOF before expected bytes - store what we have
             read_index read_buffer (ptr) store64
-            0 (char) read_index read_buffer .set
+            0 (char) read_index read_buffer.set
             read_buffer return
         fi
-        current_byte (char) read_index read_buffer .set
+        current_byte (char) read_index read_buffer.set
         1 += read_index
     done
-    0 (char) count read_buffer .set
+    0 (char) count read_buffer.set
     read_buffer
 }
 
 fn stdout_write text:str {
-    text .length text .as_cstr (ptr) STDOUT_FD 1 syscall3 drop
+    text.length text.as_cstr (ptr) STDOUT_FD 1 syscall3 drop
 }

--- a/lib/json.casa
+++ b/lib/json.casa
@@ -2,10 +2,8 @@
 #
 # Provides parsing of JSON text into a JsonValue tree and serialization
 # back to JSON text. Used by the language server for JSON-RPC communication.
-
-import "std.casa"
-import "parser.casa"
-
+import "std"
+import "parser"
 
 # ============================================================================
 # JsonValue enum
@@ -13,86 +11,85 @@ import "parser.casa"
 
 enum JsonValue {
     JsonNull
-    JsonBool(bool)
-    JsonInt(int)
-    JsonString(str)
-    JsonArray(List[JsonValue])
-    JsonObject(Map[str JsonValue])
+    JsonBool (bool)
+    JsonInt (int)
+    JsonString (str)
+    JsonArray (List[JsonValue])
+    JsonObject (Map[str JsonValue])
 }
-
 
 # ============================================================================
 # JSON parsing
 # ============================================================================
 
 fn json_skip_whitespace cursor:Cursor {
-    while cursor .is_eof ! do
-        cursor .peek .unwrap = character
+    while cursor.is_eof ! do
+        cursor.peek.unwrap = character
         if
-            ' ' character !=
-            '\t' character != &&
-            '\n' character != &&
-            '\r' character != &&
+        ' ' character !=
+        '\t' character != &&
+        '\n' character != &&
+        '\r' character != &&
         then
             break
         fi
-        cursor .advance drop
+        cursor.advance drop
     done
 }
 
 fn json_parse_string cursor:Cursor -> Result[str ParseError] {
-    cursor .save = start
-    '"' cursor .expect_char = open_result
-    if open_result .is_error then
-        start cursor .restore
-        open_result .unwrap_error Result::Error
+    cursor.save = start
+    '"' cursor.expect_char = open_result
+    if open_result.is_error then
+        start cursor.restore
+        open_result.unwrap_error Result::Error
         return
     fi
     open_result drop
     List::new (List[char]) = chars
-    while cursor .is_eof ! do
-        cursor .peek .unwrap = character
+    while cursor.is_eof ! do
+        cursor.peek.unwrap = character
         if character '"' == then
-            cursor .advance drop
+            cursor.advance drop
             chars chars_to_str Result::Ok
             return
         elif character '\\' == then
-            cursor .advance drop
-            if cursor .is_eof then
-                start cursor .restore
+            cursor.advance drop
+            if cursor.is_eof then
+                start cursor.restore
                 start "unexpected EOF in string escape" ParseError Result::Error
                 return
             fi
-            cursor .peek .unwrap = escape
-            cursor .advance drop
+            cursor.peek.unwrap = escape
+            cursor.advance drop
             escape match
-                '"'  => '"' chars .push
-                '\\' => '\\' chars .push
-                '/'  => '/' chars .push
-                'n'  => '\n' chars .push
-                't'  => '\t' chars .push
-                'r'  => '\r' chars .push
-                'b'  => '\0' chars .push
-                'f'  => '\0' chars .push
-                'u'  => {
+                '"' => '"' chars.push
+                '\\' => '\\' chars.push
+                '/' => '/' chars.push
+                'n' => '\n' chars.push
+                't' => '\t' chars.push
+                'r' => '\r' chars.push
+                'b' => '\0' chars.push
+                'f' => '\0' chars.push
+                'u' => {
                     # \uXXXX: skip 4 hex digits, store as '?'
                     0 = unicode_index
                     while unicode_index 4 > do
-                        if cursor .is_eof ! then
-                            cursor .advance drop
+                        if cursor.is_eof ! then
+                            cursor.advance drop
                         fi
                         1 += unicode_index
                     done
-                    '?' chars .push
+                    '?' chars.push
                 }
-                _ => escape chars .push
+                _ => escape chars.push
             end
         else
-            cursor .advance drop
-            character chars .push
+            cursor.advance drop
+            character chars.push
         fi
     done
-    start cursor .restore
+    start cursor.restore
     start "unterminated JSON string" ParseError Result::Error
 }
 
@@ -101,32 +98,32 @@ fn json_parse_number cursor:Cursor -> Result[int ParseError] {
 }
 
 fn json_parse_bool cursor:Cursor -> Result[bool ParseError] {
-    if "true" cursor .starts_with then
-        4 cursor .skip
+    if "true" cursor.starts_with then
+        4 cursor.skip
         true Result::Ok
-    elif "false" cursor .starts_with then
-        5 cursor .skip
+    elif "false" cursor.starts_with then
+        5 cursor.skip
         false Result::Ok
     else
-        cursor .pos "expected 'true' or 'false'" ParseError Result::Error
+        cursor.pos "expected 'true' or 'false'" ParseError Result::Error
     fi
 }
 
 fn json_parse_null cursor:Cursor -> Result[JsonValue ParseError] {
-    if "null" cursor .starts_with then
-        4 cursor .skip
+    if "null" cursor.starts_with then
+        4 cursor.skip
         JsonValue::JsonNull Result::Ok
     else
-        cursor .pos "expected 'null'" ParseError Result::Error
+        cursor.pos "expected 'null'" ParseError Result::Error
     fi
 }
 
 fn json_parse_array cursor:Cursor -> Result[JsonValue ParseError] {
-    cursor .save = start
-    '[' cursor .expect_char = open_result
-    if open_result .is_error then
-        start cursor .restore
-        open_result .unwrap_error Result::Error
+    cursor.save = start
+    '[' cursor.expect_char = open_result
+    if open_result.is_error then
+        start cursor.restore
+        open_result.unwrap_error Result::Error
         return
     fi
     open_result drop
@@ -134,9 +131,9 @@ fn json_parse_array cursor:Cursor -> Result[JsonValue ParseError] {
     cursor json_skip_whitespace
 
     # Empty array
-    if cursor .is_eof ! then
-        if cursor .peek .unwrap ']' == then
-            cursor .advance drop
+    if cursor.is_eof ! then
+        if cursor.peek.unwrap ']' == then
+            cursor.advance drop
             items JsonValue::JsonArray Result::Ok
             return
         fi
@@ -145,29 +142,29 @@ fn json_parse_array cursor:Cursor -> Result[JsonValue ParseError] {
     while true do
         cursor json_skip_whitespace
         cursor json_parse = value_result
-        if value_result .is_error then
-            start cursor .restore
-            value_result .unwrap_error Result::Error
+        if value_result.is_error then
+            start cursor.restore
+            value_result.unwrap_error Result::Error
             return
         fi
-        value_result .unwrap items .push
+        value_result.unwrap items.push
         cursor json_skip_whitespace
 
-        if cursor .is_eof then
-            start cursor .restore
+        if cursor.is_eof then
+            start cursor.restore
             start "unterminated JSON array" ParseError Result::Error
             return
         fi
-        cursor .peek .unwrap = next_char
+        cursor.peek.unwrap = next_char
         if next_char ']' == then
-            cursor .advance drop
+            cursor.advance drop
             items JsonValue::JsonArray Result::Ok
             return
         elif next_char ',' == then
-            cursor .advance drop
+            cursor.advance drop
         else
-            start cursor .restore
-            cursor .pos "expected ',' or ']' in array" ParseError Result::Error
+            start cursor.restore
+            cursor.pos "expected ',' or ']' in array" ParseError Result::Error
             return
         fi
     done
@@ -175,11 +172,11 @@ fn json_parse_array cursor:Cursor -> Result[JsonValue ParseError] {
 }
 
 fn json_parse_object cursor:Cursor -> Result[JsonValue ParseError] {
-    cursor .save = start
-    '{' cursor .expect_char = open_result
-    if open_result .is_error then
-        start cursor .restore
-        open_result .unwrap_error Result::Error
+    cursor.save = start
+    '{' cursor.expect_char = open_result
+    if open_result.is_error then
+        start cursor.restore
+        open_result.unwrap_error Result::Error
         return
     fi
     open_result drop
@@ -187,9 +184,9 @@ fn json_parse_object cursor:Cursor -> Result[JsonValue ParseError] {
     cursor json_skip_whitespace
 
     # Empty object
-    if cursor .is_eof ! then
-        if cursor .peek .unwrap '}' == then
-            cursor .advance drop
+    if cursor.is_eof ! then
+        if cursor.peek.unwrap '}' == then
+            cursor.advance drop
             entries JsonValue::JsonObject Result::Ok
             return
         fi
@@ -199,47 +196,47 @@ fn json_parse_object cursor:Cursor -> Result[JsonValue ParseError] {
         cursor json_skip_whitespace
         # Parse key
         cursor json_parse_string = key_result
-        if key_result .is_error then
-            start cursor .restore
-            key_result .unwrap_error Result::Error
+        if key_result.is_error then
+            start cursor.restore
+            key_result.unwrap_error Result::Error
             return
         fi
-        key_result .unwrap = key_str
+        key_result.unwrap = key_str
 
         cursor json_skip_whitespace
-        ':' cursor .expect_char = colon_result
-        if colon_result .is_error then
-            start cursor .restore
-            colon_result .unwrap_error Result::Error
+        ':' cursor.expect_char = colon_result
+        if colon_result.is_error then
+            start cursor.restore
+            colon_result.unwrap_error Result::Error
             return
         fi
         colon_result drop
 
         cursor json_skip_whitespace
         cursor json_parse = value_result
-        if value_result .is_error then
-            start cursor .restore
-            value_result .unwrap_error Result::Error
+        if value_result.is_error then
+            start cursor.restore
+            value_result.unwrap_error Result::Error
             return
         fi
-        key_str value_result .unwrap entries .set = entries
+        key_str value_result.unwrap entries.set = entries
 
         cursor json_skip_whitespace
-        if cursor .is_eof then
-            start cursor .restore
+        if cursor.is_eof then
+            start cursor.restore
             start "unterminated JSON object" ParseError Result::Error
             return
         fi
-        cursor .peek .unwrap = next_char
+        cursor.peek.unwrap = next_char
         if next_char '}' == then
-            cursor .advance drop
+            cursor.advance drop
             entries JsonValue::JsonObject Result::Ok
             return
         elif next_char ',' == then
-            cursor .advance drop
+            cursor.advance drop
         else
-            start cursor .restore
-            cursor .pos "expected ',' or '}' in object" ParseError Result::Error
+            start cursor.restore
+            cursor.pos "expected ',' or '}' in object" ParseError Result::Error
             return
         fi
     done
@@ -248,17 +245,17 @@ fn json_parse_object cursor:Cursor -> Result[JsonValue ParseError] {
 
 fn json_parse cursor:Cursor -> Result[JsonValue ParseError] {
     cursor json_skip_whitespace
-    if cursor .is_eof then
-        cursor .pos "unexpected EOF" ParseError Result::Error
+    if cursor.is_eof then
+        cursor.pos "unexpected EOF" ParseError Result::Error
         return
     fi
-    cursor .peek .unwrap = character
+    cursor.peek.unwrap = character
     if character '"' == then
         cursor json_parse_string = string_result
-        if string_result .is_error then
-            string_result .unwrap_error Result::Error
+        if string_result.is_error then
+            string_result.unwrap_error Result::Error
         else
-            string_result .unwrap JsonValue::JsonString Result::Ok
+            string_result.unwrap JsonValue::JsonString Result::Ok
         fi
     elif character '{' == then
         cursor json_parse_object
@@ -266,25 +263,24 @@ fn json_parse cursor:Cursor -> Result[JsonValue ParseError] {
         cursor json_parse_array
     elif character 't' == character 'f' == || then
         cursor json_parse_bool = bool_result
-        if bool_result .is_error then
-            bool_result .unwrap_error Result::Error
+        if bool_result.is_error then
+            bool_result.unwrap_error Result::Error
         else
-            bool_result .unwrap JsonValue::JsonBool Result::Ok
+            bool_result.unwrap JsonValue::JsonBool Result::Ok
         fi
     elif character 'n' == then
         cursor json_parse_null
-    elif character .is_digit character '-' == || then
+    elif character.is_digit character '-' == || then
         cursor json_parse_number = number_result
-        if number_result .is_error then
-            number_result .unwrap_error Result::Error
+        if number_result.is_error then
+            number_result.unwrap_error Result::Error
         else
-            number_result .unwrap JsonValue::JsonInt Result::Ok
+            number_result.unwrap JsonValue::JsonInt Result::Ok
         fi
     else
-        cursor .pos "unexpected character in JSON" ParseError Result::Error
+        cursor.pos "unexpected character in JSON" ParseError Result::Error
     fi
 }
-
 
 # ============================================================================
 # JSON serialization
@@ -293,75 +289,74 @@ fn json_parse cursor:Cursor -> Result[JsonValue ParseError] {
 fn json_escape_string text:str -> str {
     StringBuilder::new = builder
     0 = index
-    while index text .length > do
-        index text .at = character
+    while index text.length > do
+        index text.at = character
         character match
-            '"'  => "\\\"" builder .append
-            '\\' => "\\\\" builder .append
-            '\n' => "\\n" builder .append
-            '\t' => "\\t" builder .append
-            '\r' => "\\r" builder .append
-            _    => character builder .append_char
+            '"' => "\\\"" builder.append
+            '\\' => "\\\\" builder.append
+            '\n' => "\\n" builder.append
+            '\t' => "\\t" builder.append
+            '\r' => "\\r" builder.append
+            _ => character builder.append_char
         end
         1 += index
     done
-    builder .build
+    builder.build
 }
 
 fn json_serialize value:JsonValue -> str {
     value match
         JsonValue::JsonNull => "null"
-        JsonValue::JsonBool(bool_value) => {
+        JsonValue::JsonBool (bool_value) => {
             if bool_value then "true" else "false" fi
         }
-        JsonValue::JsonInt(int_value) => int_value .to_str
-        JsonValue::JsonString(str_value) => {
+        JsonValue::JsonInt (int_value) => int_value.to_str
+        JsonValue::JsonString (str_value) => {
             f"\"{str_value json_escape_string}\""
         }
-        JsonValue::JsonArray(array_items) => {
+        JsonValue::JsonArray (array_items) => {
             StringBuilder::new = array_builder
-            "[" array_builder .append
+            "[" array_builder.append
             0 = array_index
-            while array_index array_items .length > do
+            while array_index array_items.length > do
                 if 0 array_index != then
-                    "," array_builder .append
+                    "," array_builder.append
                 fi
-                array_index array_items .get json_serialize array_builder .append
+                array_index array_items.get json_serialize array_builder.append
                 1 += array_index
             done
-            "]" array_builder .append
-            array_builder .build
+            "]" array_builder.append
+            array_builder.build
         }
-        JsonValue::JsonObject(object_map) => {
+        JsonValue::JsonObject (object_map) => {
             StringBuilder::new = object_builder
-            "{" object_builder .append
-            object_map .keys = keys
+            "{" object_builder.append
+            object_map.keys = keys
             0 = key_index
-            while key_index keys .length > do
+            while key_index keys.length > do
                 if 0 key_index != then
-                    "," object_builder .append
+                    "," object_builder.append
                 fi
-                key_index keys .get = key
-                f"\"{key json_escape_string}\":" object_builder .append
-                key object_map .get .unwrap json_serialize object_builder .append
+                key_index keys.get = key
+                f"\"{key json_escape_string}\":" object_builder.append
+                key object_map.get.unwrap json_serialize object_builder.append
                 1 += key_index
             done
-            "}" object_builder .append
-            object_builder .build
+            "}" object_builder.append
+            object_builder.build
         }
     end
 }
-
 
 # ============================================================================
 # JSON helper accessors
 # ============================================================================
 
 fn json_get_str value:JsonValue key:str -> Option[str] {
-    if value JsonValue::JsonObject(entries) is then
-        key entries (Map[str JsonValue]) .get = entry_option
-        if entry_option .is_some then
-            if entry_option .unwrap JsonValue::JsonString(string_value) is then
+    if value JsonValue::JsonObject (entries) is then
+        key entries (Map[str JsonValue]).get = entry_option
+        if entry_option.is_some then
+            if entry_option.unwrap JsonValue::JsonString (string_value) is then
                 string_value Option::Some
                 return
             fi
@@ -371,10 +366,10 @@ fn json_get_str value:JsonValue key:str -> Option[str] {
 }
 
 fn json_get_int value:JsonValue key:str -> Option[int] {
-    if value JsonValue::JsonObject(entries) is then
-        key entries (Map[str JsonValue]) .get = entry_option
-        if entry_option .is_some then
-            if entry_option .unwrap JsonValue::JsonInt(int_value) is then
+    if value JsonValue::JsonObject (entries) is then
+        key entries (Map[str JsonValue]).get = entry_option
+        if entry_option.is_some then
+            if entry_option.unwrap JsonValue::JsonInt (int_value) is then
                 int_value Option::Some
                 return
             fi
@@ -384,10 +379,10 @@ fn json_get_int value:JsonValue key:str -> Option[int] {
 }
 
 fn json_get_bool value:JsonValue key:str -> Option[bool] {
-    if value JsonValue::JsonObject(entries) is then
-        key entries (Map[str JsonValue]) .get = entry_option
-        if entry_option .is_some then
-            if entry_option .unwrap JsonValue::JsonBool(bool_value) is then
+    if value JsonValue::JsonObject (entries) is then
+        key entries (Map[str JsonValue]).get = entry_option
+        if entry_option.is_some then
+            if entry_option.unwrap JsonValue::JsonBool (bool_value) is then
                 bool_value Option::Some
                 return
             fi
@@ -397,11 +392,11 @@ fn json_get_bool value:JsonValue key:str -> Option[bool] {
 }
 
 fn json_get_object value:JsonValue key:str -> Option[JsonValue] {
-    if value JsonValue::JsonObject(entries) is then
-        key entries (Map[str JsonValue]) .get = entry_option
-        if entry_option .is_some then
-            if entry_option .unwrap JsonValue::JsonObject(inner) is then
-                entry_option .unwrap Option::Some
+    if value JsonValue::JsonObject (entries) is then
+        key entries (Map[str JsonValue]).get = entry_option
+        if entry_option.is_some then
+            if entry_option.unwrap JsonValue::JsonObject (inner) is then
+                entry_option.unwrap Option::Some
                 return
             fi
         fi
@@ -410,10 +405,10 @@ fn json_get_object value:JsonValue key:str -> Option[JsonValue] {
 }
 
 fn json_get_array value:JsonValue key:str -> Option[List[JsonValue]] {
-    if value JsonValue::JsonObject(entries) is then
-        key entries (Map[str JsonValue]) .get = entry_option
-        if entry_option .is_some then
-            if entry_option .unwrap JsonValue::JsonArray(array_value) is then
+    if value JsonValue::JsonObject (entries) is then
+        key entries (Map[str JsonValue]).get = entry_option
+        if entry_option.is_some then
+            if entry_option.unwrap JsonValue::JsonArray (array_value) is then
                 array_value Option::Some
                 return
             fi
@@ -423,13 +418,12 @@ fn json_get_array value:JsonValue key:str -> Option[List[JsonValue]] {
 }
 
 fn json_get_value value:JsonValue key:str -> Option[JsonValue] {
-    if value JsonValue::JsonObject(entries) is then
-        key entries (Map[str JsonValue]) .get
+    if value JsonValue::JsonObject (entries) is then
+        key entries (Map[str JsonValue]).get
     else
         Option::None (Option[JsonValue])
     fi
 }
-
 
 # ============================================================================
 # JSON builder helpers
@@ -440,5 +434,5 @@ fn json_object -> Map[str JsonValue] {
 }
 
 fn json_set value:JsonValue key:str map:Map[str JsonValue] -> Map[str JsonValue] {
-    key value map .set
+    key value map.set
 }

--- a/lib/log.casa
+++ b/lib/log.casa
@@ -8,9 +8,7 @@
 #   LogLevel::Info log_set_level
 #   "starting up" log_info
 #   "something odd" log_warning
-
-import "std.casa"
-
+import "std"
 
 # ---------------------------------------------------------------------------
 # Log levels (higher ordinal = more verbose)
@@ -23,13 +21,10 @@ enum LogLevel {
     Debug
 }
 
-
 # ---------------------------------------------------------------------------
 # Global state
 # ---------------------------------------------------------------------------
-
 LogLevel::Warning = LOG_LEVEL
-
 
 # ---------------------------------------------------------------------------
 # Configuration
@@ -39,17 +34,16 @@ fn log_set_level level:LogLevel {
     level = LOG_LEVEL
 }
 
-
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
 
 fn log_level_to_str level:LogLevel -> str {
     level match
-        LogLevel::Error   => "ERROR"
+        LogLevel::Error => "ERROR"
         LogLevel::Warning => "WARNING"
-        LogLevel::Info    => "INFO"
-        LogLevel::Debug   => "DEBUG"
+        LogLevel::Info => "INFO"
+        LogLevel::Debug => "DEBUG"
     end
 }
 
@@ -59,7 +53,6 @@ fn log_print level:LogLevel message:str {
         f"[{level_str}] {message}" eprintln
     fi
 }
-
 
 # ---------------------------------------------------------------------------
 # Logging functions

--- a/lib/parser.casa
+++ b/lib/parser.casa
@@ -3,9 +3,7 @@
 # Provides a Cursor struct for scanning text character by character,
 # and high-level parsers for common patterns like integers, identifiers,
 # quoted strings, and char literals.
-
-import "std.casa"
-
+import "std"
 
 # ---------------------------------------------------------------------------
 # Structs
@@ -20,7 +18,6 @@ struct ParseError {
     message: str
     pos:     int
 }
-
 
 # ---------------------------------------------------------------------------
 # Cursor methods
@@ -57,7 +54,7 @@ impl Cursor {
             Option::None (Option[char])
         else
             self.pos self.source.at Option::Some
-            self.pos 1 + self->pos
+            self.pos 1 + self -> pos
         fi
     }
 
@@ -85,7 +82,7 @@ impl Cursor {
         else
             self.pos self.source.at = actual
             if actual expected == then
-                self.pos 1 + self->pos
+                self.pos 1 + self -> pos
                 actual Result::Ok
             else
                 self.pos "unexpected character" ParseError Result::Error
@@ -94,7 +91,7 @@ impl Cursor {
     }
 
     fn skip self:Cursor count:int {
-        self.pos count + self->pos
+        self.pos count + self -> pos
     }
 
     fn take_string self:Cursor target:str -> Result[str ParseError] {
@@ -127,10 +124,9 @@ impl Cursor {
     }
 
     fn restore self:Cursor saved:int {
-        saved self->pos
+        saved self -> pos
     }
 }
-
 
 # ---------------------------------------------------------------------------
 # Helper functions
@@ -161,13 +157,12 @@ fn is_ident_char character:char -> bool {
     character.is_alpha character.is_digit || character '_' == ||
 }
 
-
 # ---------------------------------------------------------------------------
 # High-level parsers
 # ---------------------------------------------------------------------------
 
 fn skip_whitespace cursor:Cursor {
-    { .is_space } cursor.skip_while
+    {.is_space } cursor.skip_while
 }
 
 fn parse_int cursor:Cursor -> Result[int ParseError] {
@@ -179,7 +174,7 @@ fn parse_int cursor:Cursor -> Result[int ParseError] {
             cursor.advance drop
         fi
     fi
-    { .is_digit } cursor.take_while = digits
+    {.is_digit } cursor.take_while = digits
     if digits.length 0 == then
         start cursor.restore
         start "expected integer" ParseError Result::Error
@@ -201,18 +196,18 @@ fn parse_identifier cursor:Cursor -> Result[str ParseError] {
 }
 
 fn parse_escape cursor:Cursor -> Result[char ParseError] {
-    if cursor.advance Option::Some(character) is then
+    if cursor.advance Option::Some (character) is then
         character match
-            'n'  => '\n' Result::Ok
-            't'  => '\t' Result::Ok
+            'n' => '\n' Result::Ok
+            't' => '\t' Result::Ok
             '\\' => '\\' Result::Ok
-            '"'  => '"' Result::Ok
+            '"' => '"' Result::Ok
             '\'' => '\'' Result::Ok
-            '0'  => '\0' Result::Ok
-            'r'  => '\r' Result::Ok
-            '{'  => '{' Result::Ok
-            '}'  => '}' Result::Ok
-            _    => cursor.pos "unknown escape sequence" ParseError Result::Error
+            '0' => '\0' Result::Ok
+            'r' => '\r' Result::Ok
+            '{' => '{' Result::Ok
+            '}' => '}' Result::Ok
+            _ => cursor.pos "unknown escape sequence" ParseError Result::Error
         end
     else
         cursor.pos "unexpected EOF in escape" ParseError Result::Error
@@ -262,7 +257,7 @@ fn parse_char_literal cursor:Cursor -> Result[char ParseError] {
         return
     fi
     open_result drop
-    if cursor.advance Option::Some(character) is then
+    if cursor.advance Option::Some (character) is then
         if character '\\' == then
             cursor parse_escape = escape_result
             if escape_result.is_error then

--- a/lib/test.casa
+++ b/lib/test.casa
@@ -17,11 +17,10 @@
 #   assert_error_contains / assert_error_kind
 #   assert_warning_count / assert_warning_contains
 #   clear_global_state
+import "std"
 
-import "std.casa"
-
-0  = test_pass_count
-0  = test_fail_count
+0 = test_pass_count
+0 = test_fail_count
 "" = test_current_name
 
 fn test_start name:str {
@@ -66,7 +65,6 @@ fn test_summary {
     fi
 }
 
-
 # ---------------------------------------------------------------------------
 # Compiler test helpers
 #
@@ -92,22 +90,22 @@ fn clear_warnings {
 }
 
 fn assert_has_errors message:str {
-    message 0 ERRORS .length != assert_true
+    message 0 ERRORS.length != assert_true
 }
 
 fn assert_no_errors message:str {
-    message 0 ERRORS .length == assert_true
+    message 0 ERRORS.length == assert_true
 }
 
 fn assert_error_count expected:int message:str {
-    message expected ERRORS .length assert_eq
+    message expected ERRORS.length assert_eq
 }
 
 fn assert_error_contains needle:str message:str {
     false = error_found
     0 = error_index
-    while error_index ERRORS .length > do
-        error_index ERRORS .get CasaError::message = error_message
+    while error_index ERRORS.length > do
+        error_index ERRORS.get CasaError::message = error_message
         error_message needle str::find = match_pos
         if 0 match_pos >= then
             true = error_found
@@ -120,8 +118,8 @@ fn assert_error_contains needle:str message:str {
 fn assert_error_kind expected_kind:ErrorKind message:str {
     false = kind_found
     0 = error_index
-    while error_index ERRORS .length > do
-        if expected_kind error_index ERRORS .get CasaError::kind == then
+    while error_index ERRORS.length > do
+        if expected_kind error_index ERRORS.get CasaError::kind == then
             true = kind_found
         fi
         1 += error_index
@@ -130,14 +128,14 @@ fn assert_error_kind expected_kind:ErrorKind message:str {
 }
 
 fn assert_warning_count expected:int message:str {
-    message expected WARNINGS .length assert_eq
+    message expected WARNINGS.length assert_eq
 }
 
 fn assert_warning_contains needle:str message:str {
     false = warning_found
     0 = warning_index
-    while warning_index WARNINGS .length > do
-        warning_index WARNINGS .get CasaWarning::message = warning_message
+    while warning_index WARNINGS.length > do
+        warning_index WARNINGS.get CasaWarning::message = warning_message
         warning_message needle str::find = match_pos
         if 0 match_pos >= then
             true = warning_found

--- a/lib/timer.casa
+++ b/lib/timer.casa
@@ -7,20 +7,16 @@
 #   Timer::new = timer
 #   # ... do work ...
 #   timer .elapsed_ms println   # prints elapsed milliseconds
-
-import "std.casa"
-
+import "std"
 
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
-
-1          = CLOCK_MONOTONIC
-228        = SYS_CLOCK_GETTIME
-16         = TIMESPEC_SIZE
+1 = CLOCK_MONOTONIC
+228 = SYS_CLOCK_GETTIME
+16 = TIMESPEC_SIZE
 1000000000 = NS_PER_SEC
-1000000    = NS_PER_MS
-
+1000000 = NS_PER_MS
 
 # ---------------------------------------------------------------------------
 # Timer struct
@@ -49,11 +45,11 @@ impl Timer {
     }
 
     fn elapsed_ms self:Timer -> int {
-        self .elapsed_ns NS_PER_MS /
+        self.elapsed_ns NS_PER_MS /
     }
 
     fn to_str self:Timer -> str {
-        self .elapsed_ms = total_ms
+        self.elapsed_ms = total_ms
         total_ms 1000 / = total_seconds
         total_ms 1000 % = remaining_millis
         if 10 remaining_millis < then
@@ -66,11 +62,9 @@ impl Timer {
     }
 }
 
-
 # ---------------------------------------------------------------------------
 # Global convenience functions
 # ---------------------------------------------------------------------------
-
 Option::None (Option[Timer]) = GLOBAL_TIMER
 
 fn timer_start {
@@ -78,8 +72,8 @@ fn timer_start {
 }
 
 fn timer_elapsed_ns -> int {
-    if GLOBAL_TIMER Option::Some(global_timer) is then
-        global_timer .elapsed_ns
+    if GLOBAL_TIMER Option::Some (global_timer) is then
+        global_timer.elapsed_ns
     else
         "error: timer_start must be called before timer_elapsed_ns\n" eprint
         1 exit
@@ -88,8 +82,8 @@ fn timer_elapsed_ns -> int {
 }
 
 fn timer_elapsed_ms -> int {
-    if GLOBAL_TIMER Option::Some(global_timer) is then
-        global_timer .elapsed_ms
+    if GLOBAL_TIMER Option::Some (global_timer) is then
+        global_timer.elapsed_ms
     else
         "error: timer_start must be called before timer_elapsed_ms\n" eprint
         1 exit

--- a/tests/compiler/test_parser.casa
+++ b/tests/compiler/test_parser.casa
@@ -12,54 +12,54 @@ fn test_parse_integer {
     "parse_integer" test_start
     "test" "42" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "count" 1 ops .length assert_eq
-    "kind" OpKind::OpPushInt 0 ops .get Op::kind == assert_true
-    "value" 42 0 ops .get Op::value assert_eq
+    "count" 1 ops.length assert_eq
+    "kind" OpKind::OpPushInt 0 ops.get Op::kind == assert_true
+    "value" 42 0 ops.get Op::value assert_eq
 }
 
 fn test_parse_negative_integer {
     "parse_negative_integer" test_start
     "test" "-7" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "count" 1 ops .length assert_eq
-    "kind" OpKind::OpPushInt 0 ops .get Op::kind == assert_true
-    "value" 0 7 - 0 ops .get Op::value assert_eq
+    "count" 1 ops.length assert_eq
+    "kind" OpKind::OpPushInt 0 ops.get Op::kind == assert_true
+    "value" 0 7 - 0 ops.get Op::value assert_eq
 }
 
 fn test_parse_bool_true {
     "parse_bool_true" test_start
     "test" "true" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "count" 1 ops .length assert_eq
-    "kind" OpKind::OpPushBool 0 ops .get Op::kind == assert_true
-    "value" 1 0 ops .get Op::value assert_eq
+    "count" 1 ops.length assert_eq
+    "kind" OpKind::OpPushBool 0 ops.get Op::kind == assert_true
+    "value" 1 0 ops.get Op::value assert_eq
 }
 
 fn test_parse_bool_false {
     "parse_bool_false" test_start
     "test" "false" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "count" 1 ops .length assert_eq
-    "kind" OpKind::OpPushBool 0 ops .get Op::kind == assert_true
-    "value" 0 0 ops .get Op::value assert_eq
+    "count" 1 ops.length assert_eq
+    "kind" OpKind::OpPushBool 0 ops.get Op::kind == assert_true
+    "value" 0 0 ops.get Op::value assert_eq
 }
 
 fn test_parse_string {
     "parse_string" test_start
     "test" "\"hello\"" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "count" 1 ops .length assert_eq
-    "kind" OpKind::OpPushStr 0 ops .get Op::kind == assert_true
-    "value" "hello" 0 ops .get op_str_value assert_str_eq
+    "count" 1 ops.length assert_eq
+    "kind" OpKind::OpPushStr 0 ops.get Op::kind == assert_true
+    "value" "hello" 0 ops.get op_str_value assert_str_eq
 }
 
 fn test_parse_char {
     "parse_char" test_start
     "test" "'A'" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "count" 1 ops .length assert_eq
-    "kind" OpKind::OpPushChar 0 ops .get Op::kind == assert_true
-    "value" 65 0 ops .get Op::value assert_eq
+    "count" 1 ops.length assert_eq
+    "kind" OpKind::OpPushChar 0 ops.get Op::kind == assert_true
+    "value" 65 0 ops.get Op::value assert_eq
 }
 
 # ============================================================================
@@ -70,56 +70,56 @@ fn test_parse_keyword_if {
     "parse_keyword_if" test_start
     "test" "if" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpIfStart 0 ops .get Op::kind == assert_true
+    "kind" OpKind::OpIfStart 0 ops.get Op::kind == assert_true
 }
 
 fn test_parse_keyword_then {
     "parse_keyword_then" test_start
     "test" "then" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpIfCondition 0 ops .get Op::kind == assert_true
+    "kind" OpKind::OpIfCondition 0 ops.get Op::kind == assert_true
 }
 
 fn test_parse_keyword_else {
     "parse_keyword_else" test_start
     "test" "else" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpIfElse 0 ops .get Op::kind == assert_true
+    "kind" OpKind::OpIfElse 0 ops.get Op::kind == assert_true
 }
 
 fn test_parse_keyword_fi {
     "parse_keyword_fi" test_start
     "test" "fi" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpIfEnd 0 ops .get Op::kind == assert_true
+    "kind" OpKind::OpIfEnd 0 ops.get Op::kind == assert_true
 }
 
 fn test_parse_keyword_while {
     "parse_keyword_while" test_start
     "test" "while" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpWhileStart 0 ops .get Op::kind == assert_true
+    "kind" OpKind::OpWhileStart 0 ops.get Op::kind == assert_true
 }
 
 fn test_parse_keyword_do {
     "parse_keyword_do" test_start
     "test" "do" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpWhileCondition 0 ops .get Op::kind == assert_true
+    "kind" OpKind::OpWhileCondition 0 ops.get Op::kind == assert_true
 }
 
 fn test_parse_keyword_done {
     "parse_keyword_done" test_start
     "test" "done" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpWhileEnd 0 ops .get Op::kind == assert_true
+    "kind" OpKind::OpWhileEnd 0 ops.get Op::kind == assert_true
 }
 
 fn test_parse_keyword_return {
     "parse_keyword_return" test_start
     "test" "return" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpFnReturn 0 ops .get Op::kind == assert_true
+    "kind" OpKind::OpFnReturn 0 ops.get Op::kind == assert_true
 }
 
 # ============================================================================
@@ -130,42 +130,42 @@ fn test_parse_operator_add {
     "parse_operator_add" test_start
     "test" "+" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpAdd 0 ops .get Op::kind == assert_true
+    "kind" OpKind::OpAdd 0 ops.get Op::kind == assert_true
 }
 
 fn test_parse_operator_sub {
     "parse_operator_sub" test_start
     "test" "1 -" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpSub 1 ops .get Op::kind == assert_true
+    "kind" OpKind::OpSub 1 ops.get Op::kind == assert_true
 }
 
 fn test_parse_operator_eq {
     "parse_operator_eq" test_start
     "test" "==" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpEq 0 ops .get Op::kind == assert_true
+    "kind" OpKind::OpEq 0 ops.get Op::kind == assert_true
 }
 
 fn test_parse_operator_not {
     "parse_operator_not" test_start
     "test" "!" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpNot 0 ops .get Op::kind == assert_true
+    "kind" OpKind::OpNot 0 ops.get Op::kind == assert_true
 }
 
 fn test_parse_operator_and {
     "parse_operator_and" test_start
     "test" "&&" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpAnd 0 ops .get Op::kind == assert_true
+    "kind" OpKind::OpAnd 0 ops.get Op::kind == assert_true
 }
 
 fn test_parse_operator_or {
     "parse_operator_or" test_start
     "test" "||" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpOr 0 ops .get Op::kind == assert_true
+    "kind" OpKind::OpOr 0 ops.get Op::kind == assert_true
 }
 
 # ============================================================================
@@ -176,28 +176,28 @@ fn test_parse_intrinsic_drop {
     "parse_intrinsic_drop" test_start
     "test" "drop" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpDrop 0 ops .get Op::kind == assert_true
+    "kind" OpKind::OpDrop 0 ops.get Op::kind == assert_true
 }
 
 fn test_parse_intrinsic_dup {
     "parse_intrinsic_dup" test_start
     "test" "dup" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpDup 0 ops .get Op::kind == assert_true
+    "kind" OpKind::OpDup 0 ops.get Op::kind == assert_true
 }
 
 fn test_parse_intrinsic_swap {
     "parse_intrinsic_swap" test_start
     "test" "swap" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpSwap 0 ops .get Op::kind == assert_true
+    "kind" OpKind::OpSwap 0 ops.get Op::kind == assert_true
 }
 
 fn test_parse_intrinsic_print {
     "parse_intrinsic_print" test_start
     "test" "print" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpPrint 0 ops .get Op::kind == assert_true
+    "kind" OpKind::OpPrint 0 ops.get Op::kind == assert_true
 }
 
 # ============================================================================
@@ -208,17 +208,17 @@ fn test_parse_type_cast {
     "parse_type_cast" test_start
     "test" "(int)" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "count" 1 ops .length assert_eq
-    "kind" OpKind::OpTypeCast 0 ops .get Op::kind == assert_true
-    "value" "int" 0 ops .get op_str_value assert_str_eq
+    "count" 1 ops.length assert_eq
+    "kind" OpKind::OpTypeCast 0 ops.get Op::kind == assert_true
+    "value" "int" 0 ops.get op_str_value assert_str_eq
 }
 
 fn test_parse_type_cast_str {
     "parse_type_cast_str" test_start
     "test" "(str)" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpTypeCast 0 ops .get Op::kind == assert_true
-    "value" "str" 0 ops .get op_str_value assert_str_eq
+    "kind" OpKind::OpTypeCast 0 ops.get Op::kind == assert_true
+    "value" "str" 0 ops.get op_str_value assert_str_eq
 }
 
 # ============================================================================
@@ -229,19 +229,19 @@ fn test_parse_variable_assign {
     "parse_variable_assign" test_start
     "test" "42 = foo" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "count" 2 ops .length assert_eq
-    "push kind" OpKind::OpPushInt 0 ops .get Op::kind == assert_true
-    "assign kind" OpKind::OpAssignVar 1 ops .get Op::kind == assert_true
-    "assign name" "foo" 1 ops .get op_str_value assert_str_eq
+    "count" 2 ops.length assert_eq
+    "push kind" OpKind::OpPushInt 0 ops.get Op::kind == assert_true
+    "assign kind" OpKind::OpAssignVar 1 ops.get Op::kind == assert_true
+    "assign name" "foo" 1 ops.get op_str_value assert_str_eq
 }
 
 fn test_parse_variable_inc {
     "parse_variable_inc" test_start
     "test" "1 += counter" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "push kind" OpKind::OpPushInt 0 ops .get Op::kind == assert_true
-    "inc kind" OpKind::OpAssignInc 1 ops .get Op::kind == assert_true
-    "inc name" "counter" 1 ops .get op_str_value assert_str_eq
+    "push kind" OpKind::OpPushInt 0 ops.get Op::kind == assert_true
+    "inc kind" OpKind::OpAssignInc 1 ops.get Op::kind == assert_true
+    "inc name" "counter" 1 ops.get op_str_value assert_str_eq
 }
 
 # ============================================================================
@@ -252,16 +252,16 @@ fn test_parse_method_call {
     "parse_method_call" test_start
     "test" ".length" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpMethodCall 0 ops .get Op::kind == assert_true
-    "value" "length" 0 ops .get op_str_value assert_str_eq
+    "kind" OpKind::OpMethodCall 0 ops.get Op::kind == assert_true
+    "value" "length" 0 ops.get op_str_value assert_str_eq
 }
 
 fn test_parse_setter_call {
     "parse_setter_call" test_start
     "test" "->name" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpMethodCall 0 ops .get Op::kind == assert_true
-    "value" "set_name" 0 ops .get op_str_value assert_str_eq
+    "kind" OpKind::OpMethodCall 0 ops.get Op::kind == assert_true
+    "value" "set_name" 0 ops.get op_str_value assert_str_eq
 }
 
 # ============================================================================
@@ -272,8 +272,8 @@ fn test_parse_identifier {
     "parse_identifier" test_start
     "test" "foo" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpIdentifier 0 ops .get Op::kind == assert_true
-    "value" "foo" 0 ops .get op_str_value assert_str_eq
+    "kind" OpKind::OpIdentifier 0 ops.get Op::kind == assert_true
+    "value" "foo" 0 ops.get op_str_value assert_str_eq
 }
 
 # ============================================================================
@@ -285,12 +285,12 @@ fn test_parse_function_def {
     "test" "fn add a:int b:int -> int { a b + }" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
     # parse_ops should register the function in DEFAULT_PARSER.store.functions
-    "fn registered" "add" DEFAULT_PARSER.store.functions .get .is_some assert_true
-    "add" DEFAULT_PARSER.store.functions .get .unwrap = add_fn
+    "fn registered" "add" DEFAULT_PARSER.store.functions.get.is_some assert_true
+    "add" DEFAULT_PARSER.store.functions.get.unwrap = add_fn
     "fn name" "add" add_fn Function::name assert_str_eq
-    "param count" 2 add_fn Function::signature Signature::parameters .length assert_eq
-    "return count" 1 add_fn Function::signature Signature::return_types .length assert_eq
-    "return type" "int" 0 add_fn Function::signature Signature::return_types .get assert_str_eq
+    "param count" 2 add_fn Function::signature Signature::parameters.length assert_eq
+    "return count" 1 add_fn Function::signature Signature::return_types.length assert_eq
+    "return type" "int" 0 add_fn Function::signature Signature::return_types.get assert_str_eq
 }
 
 # ============================================================================
@@ -301,12 +301,12 @@ fn test_parse_enum_def {
     "parse_enum_def" test_start
     "test" "enum Color { Red Green Blue }" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "enum registered" "Color" DEFAULT_PARSER.store.enums .get .is_some assert_true
-    "Color" DEFAULT_PARSER.store.enums .get .unwrap = color_enum
-    "variant count" 3 color_enum CasaEnum::variants .length assert_eq
-    "variant 0" "Red" 0 color_enum CasaEnum::variants .get assert_str_eq
-    "variant 1" "Green" 1 color_enum CasaEnum::variants .get assert_str_eq
-    "variant 2" "Blue" 2 color_enum CasaEnum::variants .get assert_str_eq
+    "enum registered" "Color" DEFAULT_PARSER.store.enums.get.is_some assert_true
+    "Color" DEFAULT_PARSER.store.enums.get.unwrap = color_enum
+    "variant count" 3 color_enum CasaEnum::variants.length assert_eq
+    "variant 0" "Red" 0 color_enum CasaEnum::variants.get assert_str_eq
+    "variant 1" "Green" 1 color_enum CasaEnum::variants.get assert_str_eq
+    "variant 2" "Blue" 2 color_enum CasaEnum::variants.get assert_str_eq
 }
 
 # ============================================================================
@@ -317,13 +317,13 @@ fn test_parse_struct_def {
     "parse_struct_def" test_start
     "test" "struct Point { x: int y: int }" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "struct registered" "Point" DEFAULT_PARSER.store.structs .get .is_some assert_true
-    "Point" DEFAULT_PARSER.store.structs .get .unwrap = point_struct
-    "member count" 2 point_struct CasaStruct::members .length assert_eq
-    "member 0 name" "x" 0 point_struct CasaStruct::members .get Member::name assert_str_eq
-    "member 0 type" "int" 0 point_struct CasaStruct::members .get Member::typ assert_str_eq
-    "getter registered" "Point::x" DEFAULT_PARSER.store.functions .get .is_some assert_true
-    "setter registered" "Point::set_x" DEFAULT_PARSER.store.functions .get .is_some assert_true
+    "struct registered" "Point" DEFAULT_PARSER.store.structs.get.is_some assert_true
+    "Point" DEFAULT_PARSER.store.structs.get.unwrap = point_struct
+    "member count" 2 point_struct CasaStruct::members.length assert_eq
+    "member 0 name" "x" 0 point_struct CasaStruct::members.get Member::name assert_str_eq
+    "member 0 type" "int" 0 point_struct CasaStruct::members.get Member::typ assert_str_eq
+    "getter registered" "Point::x" DEFAULT_PARSER.store.functions.get.is_some assert_true
+    "setter registered" "Point::set_x" DEFAULT_PARSER.store.functions.get.is_some assert_true
 }
 
 # ============================================================================
@@ -334,24 +334,24 @@ fn test_parse_if_construct {
     "parse_if_construct" test_start
     "test" "if true then 42 else 0 fi" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "if" OpKind::OpIfStart 0 ops .get Op::kind == assert_true
-    "true" OpKind::OpPushBool 1 ops .get Op::kind == assert_true
-    "then" OpKind::OpIfCondition 2 ops .get Op::kind == assert_true
-    "42" OpKind::OpPushInt 3 ops .get Op::kind == assert_true
-    "else" OpKind::OpIfElse 4 ops .get Op::kind == assert_true
-    "0" OpKind::OpPushInt 5 ops .get Op::kind == assert_true
-    "fi" OpKind::OpIfEnd 6 ops .get Op::kind == assert_true
+    "if" OpKind::OpIfStart 0 ops.get Op::kind == assert_true
+    "true" OpKind::OpPushBool 1 ops.get Op::kind == assert_true
+    "then" OpKind::OpIfCondition 2 ops.get Op::kind == assert_true
+    "42" OpKind::OpPushInt 3 ops.get Op::kind == assert_true
+    "else" OpKind::OpIfElse 4 ops.get Op::kind == assert_true
+    "0" OpKind::OpPushInt 5 ops.get Op::kind == assert_true
+    "fi" OpKind::OpIfEnd 6 ops.get Op::kind == assert_true
 }
 
 fn test_parse_while_construct {
     "parse_while_construct" test_start
     "test" "while true do break done" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "while" OpKind::OpWhileStart 0 ops .get Op::kind == assert_true
-    "true" OpKind::OpPushBool 1 ops .get Op::kind == assert_true
-    "do" OpKind::OpWhileCondition 2 ops .get Op::kind == assert_true
-    "break" OpKind::OpWhileBreak 3 ops .get Op::kind == assert_true
-    "done" OpKind::OpWhileEnd 4 ops .get Op::kind == assert_true
+    "while" OpKind::OpWhileStart 0 ops.get Op::kind == assert_true
+    "true" OpKind::OpPushBool 1 ops.get Op::kind == assert_true
+    "do" OpKind::OpWhileCondition 2 ops.get Op::kind == assert_true
+    "break" OpKind::OpWhileBreak 3 ops.get Op::kind == assert_true
+    "done" OpKind::OpWhileEnd 4 ops.get Op::kind == assert_true
 }
 
 # ============================================================================
@@ -362,7 +362,7 @@ fn test_parse_match_construct {
     "parse_match_construct" test_start
     "test" "enum Dir { Up Down }\nmatch Up => 1 Down => 2 end" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "match start" OpKind::OpMatchStart 0 ops .get Op::kind == assert_true
+    "match start" OpKind::OpMatchStart 0 ops.get Op::kind == assert_true
 }
 
 # ============================================================================
@@ -373,11 +373,11 @@ fn test_parse_multiple_ops {
     "parse_multiple_ops" test_start
     "test" "1 2 + = result" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "count" 4 ops .length assert_eq
-    "push 1" OpKind::OpPushInt 0 ops .get Op::kind == assert_true
-    "push 2" OpKind::OpPushInt 1 ops .get Op::kind == assert_true
-    "add" OpKind::OpAdd 2 ops .get Op::kind == assert_true
-    "assign" OpKind::OpAssignVar 3 ops .get Op::kind == assert_true
+    "count" 4 ops.length assert_eq
+    "push 1" OpKind::OpPushInt 0 ops.get Op::kind == assert_true
+    "push 2" OpKind::OpPushInt 1 ops.get Op::kind == assert_true
+    "add" OpKind::OpAdd 2 ops.get Op::kind == assert_true
+    "assign" OpKind::OpAssignVar 3 ops.get Op::kind == assert_true
 }
 
 # ============================================================================
@@ -388,63 +388,63 @@ fn test_parse_operator_mul {
     "parse_operator_mul" test_start
     "test" "1 2 *" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpMul 2 ops .get Op::kind == assert_true
+    "kind" OpKind::OpMul 2 ops.get Op::kind == assert_true
 }
 
 fn test_parse_operator_div {
     "parse_operator_div" test_start
     "test" "1 2 /" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpDiv 2 ops .get Op::kind == assert_true
+    "kind" OpKind::OpDiv 2 ops.get Op::kind == assert_true
 }
 
 fn test_parse_operator_mod {
     "parse_operator_mod" test_start
     "test" "1 2 %" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpMod 2 ops .get Op::kind == assert_true
+    "kind" OpKind::OpMod 2 ops.get Op::kind == assert_true
 }
 
 fn test_parse_operator_lt {
     "parse_operator_lt" test_start
     "test" "1 2 <" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpLt 2 ops .get Op::kind == assert_true
+    "kind" OpKind::OpLt 2 ops.get Op::kind == assert_true
 }
 
 fn test_parse_operator_gt {
     "parse_operator_gt" test_start
     "test" "1 2 >" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpGt 2 ops .get Op::kind == assert_true
+    "kind" OpKind::OpGt 2 ops.get Op::kind == assert_true
 }
 
 fn test_parse_operator_le {
     "parse_operator_le" test_start
     "test" "1 2 <=" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpLe 2 ops .get Op::kind == assert_true
+    "kind" OpKind::OpLe 2 ops.get Op::kind == assert_true
 }
 
 fn test_parse_operator_ge {
     "parse_operator_ge" test_start
     "test" "1 2 >=" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpGe 2 ops .get Op::kind == assert_true
+    "kind" OpKind::OpGe 2 ops.get Op::kind == assert_true
 }
 
 fn test_parse_operator_ne {
     "parse_operator_ne" test_start
     "test" "1 2 !=" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpNe 2 ops .get Op::kind == assert_true
+    "kind" OpKind::OpNe 2 ops.get Op::kind == assert_true
 }
 
 fn test_parse_operator_bit_not {
     "parse_operator_bit_not" test_start
     "test" "1 ~" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpBitNot 1 ops .get Op::kind == assert_true
+    "kind" OpKind::OpBitNot 1 ops.get Op::kind == assert_true
 }
 
 # ============================================================================
@@ -455,28 +455,28 @@ fn test_parse_intrinsic_over {
     "parse_intrinsic_over" test_start
     "test" "over" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpOver 0 ops .get Op::kind == assert_true
+    "kind" OpKind::OpOver 0 ops.get Op::kind == assert_true
 }
 
 fn test_parse_intrinsic_rot {
     "parse_intrinsic_rot" test_start
     "test" "rot" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpRot 0 ops .get Op::kind == assert_true
+    "kind" OpKind::OpRot 0 ops.get Op::kind == assert_true
 }
 
 fn test_parse_intrinsic_typeof {
     "parse_intrinsic_typeof" test_start
     "test" "typeof" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpTypeof 0 ops .get Op::kind == assert_true
+    "kind" OpKind::OpTypeof 0 ops.get Op::kind == assert_true
 }
 
 fn test_parse_intrinsic_alloc {
     "parse_intrinsic_alloc" test_start
     "test" "alloc" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpHeapAlloc 0 ops .get Op::kind == assert_true
+    "kind" OpKind::OpHeapAlloc 0 ops.get Op::kind == assert_true
 }
 
 # ============================================================================
@@ -487,9 +487,9 @@ fn test_parse_variable_dec {
     "parse_variable_dec" test_start
     "test" "1 -= counter" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "push kind" OpKind::OpPushInt 0 ops .get Op::kind == assert_true
-    "dec kind" OpKind::OpAssignDec 1 ops .get Op::kind == assert_true
-    "dec name" "counter" 1 ops .get op_str_value assert_str_eq
+    "push kind" OpKind::OpPushInt 0 ops.get Op::kind == assert_true
+    "dec kind" OpKind::OpAssignDec 1 ops.get Op::kind == assert_true
+    "dec name" "counter" 1 ops.get op_str_value assert_str_eq
 }
 
 # ============================================================================
@@ -500,7 +500,7 @@ fn test_parse_keyword_elif {
     "parse_keyword_elif" test_start
     "test" "elif" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpIfElif 0 ops .get Op::kind == assert_true
+    "kind" OpKind::OpIfElif 0 ops.get Op::kind == assert_true
 }
 
 # ============================================================================
@@ -511,14 +511,14 @@ fn test_parse_keyword_break {
     "parse_keyword_break" test_start
     "test" "break" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpWhileBreak 0 ops .get Op::kind == assert_true
+    "kind" OpKind::OpWhileBreak 0 ops.get Op::kind == assert_true
 }
 
 fn test_parse_keyword_continue {
     "parse_keyword_continue" test_start
     "test" "continue" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpWhileContinue 0 ops .get Op::kind == assert_true
+    "kind" OpKind::OpWhileContinue 0 ops.get Op::kind == assert_true
 }
 
 fn test_parse_keyword_import {
@@ -526,9 +526,9 @@ fn test_parse_keyword_import {
     # Absolute path bypasses base-file directory resolution.
     "test" "import \"/foo.casa\"" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "count" 1 ops .length assert_eq
-    "kind" OpKind::OpImportFile 0 ops .get Op::kind == assert_true
-    "path" "/foo.casa" 0 ops .get op_str_value assert_str_eq
+    "count" 1 ops.length assert_eq
+    "kind" OpKind::OpImportFile 0 ops.get Op::kind == assert_true
+    "path" "/foo.casa" 0 ops.get op_str_value assert_str_eq
 }
 
 # ============================================================================
@@ -573,52 +573,66 @@ fn test_dir_of_path_root {
 fn test_resolve_import_path_absolute {
     "resolve_import_path_absolute" test_start
     "resolved"
-        "/abs/foo.casa"
-        empty_location "/abs/foo.casa" "casa.casa" DEFAULT_PARSER resolve_import
+    "/abs/foo.casa"
+    empty_location "/abs/foo.casa" "casa.casa" DEFAULT_PARSER resolve_import
     assert_str_eq
 }
 
 fn test_resolve_import_path_relative {
     "resolve_import_path_relative" test_start
     "resolved"
-        "lib/std.casa"
-        empty_location "lib/std.casa" "casa.casa" DEFAULT_PARSER resolve_import
+    "lib/std.casa"
+    empty_location "lib/std.casa" "casa.casa" DEFAULT_PARSER resolve_import
     assert_str_eq
 }
 
 fn test_resolve_import_module_in_source_dir {
     "resolve_import_module_in_source_dir" test_start
-    # Importing from lib/std.casa, module "std" resolves to lib/std.casa.
+    # Importing "std" from a sibling lib file resolves to lib/std.casa.
     "resolved"
-        "lib/std.casa"
-        empty_location "std" "lib/std.casa" DEFAULT_PARSER resolve_import
+    "lib/std.casa"
+    empty_location "std" "lib/io.casa" DEFAULT_PARSER resolve_import
     assert_str_eq
+}
+
+fn test_resolve_import_module_skips_self_match {
+    "resolve_import_module_skips_self_match" test_start
+    # Importing "argparse" from examples/argparse.casa must skip the same-dir
+    # self-match and resolve via the lib/ search path instead.
+    List::new (List[str]) = paths
+    "lib" paths.push
+    paths DEFAULT_PARSER -> search_paths
+    "resolved"
+    "lib/argparse.casa"
+    empty_location "argparse" "examples/argparse.casa" DEFAULT_PARSER resolve_import
+    assert_str_eq
+    List::new (List[str]) DEFAULT_PARSER -> search_paths
 }
 
 fn test_resolve_import_module_via_search_path {
     "resolve_import_module_via_search_path" test_start
     # No std.casa in tests/compiler/, so resolver falls through to "lib".
     List::new (List[str]) = paths
-    "lib" paths .push
-    paths DEFAULT_PARSER ->search_paths
+    "lib" paths.push
+    paths DEFAULT_PARSER -> search_paths
     "resolved"
-        "lib/std.casa"
-        empty_location "std" "tests/compiler/test_parser.casa" DEFAULT_PARSER resolve_import
+    "lib/std.casa"
+    empty_location "std" "tests/compiler/test_parser.casa" DEFAULT_PARSER resolve_import
     assert_str_eq
-    List::new (List[str]) DEFAULT_PARSER ->search_paths
+    List::new (List[str]) DEFAULT_PARSER -> search_paths
 }
 
 fn test_resolve_import_search_paths_skips_missing {
     "resolve_import_search_paths_skips_missing" test_start
     List::new (List[str]) = paths
-    "no_such_dir" paths .push
-    "lib" paths .push
-    paths DEFAULT_PARSER ->search_paths
+    "no_such_dir" paths.push
+    "lib" paths.push
+    paths DEFAULT_PARSER -> search_paths
     "resolved"
-        "lib/std.casa"
-        empty_location "std" "tests/compiler/test_parser.casa" DEFAULT_PARSER resolve_import
+    "lib/std.casa"
+    empty_location "std" "tests/compiler/test_parser.casa" DEFAULT_PARSER resolve_import
     assert_str_eq
-    List::new (List[str]) DEFAULT_PARSER ->search_paths
+    List::new (List[str]) DEFAULT_PARSER -> search_paths
 }
 
 # ============================================================================
@@ -629,15 +643,14 @@ fn test_parse_string_with_escapes {
     "parse_string_with_escapes" test_start
     "test" "\"hello\\nworld\"" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "count" 1 ops .length assert_eq
-    "kind" OpKind::OpPushStr 0 ops .get Op::kind == assert_true
-    "value" "hello\nworld" 0 ops .get op_str_value assert_str_eq
+    "count" 1 ops.length assert_eq
+    "kind" OpKind::OpPushStr 0 ops.get Op::kind == assert_true
+    "value" "hello\nworld" 0 ops.get op_str_value assert_str_eq
 }
 
 # ============================================================================
 # Run all tests
 # ============================================================================
-
 test_parse_integer
 test_parse_negative_integer
 test_parse_bool_true
@@ -704,6 +717,7 @@ test_dir_of_path_root
 test_resolve_import_path_absolute
 test_resolve_import_path_relative
 test_resolve_import_module_in_source_dir
+test_resolve_import_module_skips_self_match
 test_resolve_import_module_via_search_path
 test_resolve_import_search_paths_skips_missing
 test_parse_string_with_escapes

--- a/tests/test_examples.sh
+++ b/tests/test_examples.sh
@@ -33,7 +33,7 @@ for f in "$EXAMPLES_DIR"/*.casa; do
 
     # Examples with .err files are expected to fail compilation
     if [ -f "$err_file" ]; then
-        error_output=$("$COMPILER" "$f" -o "$binary" 2>&1 || true)
+        error_output=$("$COMPILER" -L "$ROOT_DIR/lib" "$f" -o "$binary" 2>&1 || true)
         if echo "$error_output" | diff -u - "$err_file"; then
             echo "${GREEN}[OK]${RESET} Passed: $base (expected error)"
             pass=$((pass+1))
@@ -46,7 +46,7 @@ for f in "$EXAMPLES_DIR"/*.casa; do
     fi
 
     # Compile
-    "$COMPILER" "$f" -o "$binary"
+    "$COMPILER" -L "$ROOT_DIR/lib" "$f" -o "$binary"
 
     # Run and capture output (1s timeout for interactive examples)
     output=$(timeout 1 "$binary") || true


### PR DESCRIPTION
## Summary

- Migrate `lib/*.casa` cross-imports from `import "X.casa"` to bare module names. Same-dir resolution finds siblings; no `-L` needed (closes #112).
- Migrate `examples/*.casa` from `import "../lib/X.casa"` to bare module names; pass `-L lib` from `tests/test_examples.sh` (closes #111).
- Fix resolver to skip a same-dir candidate that equals the importing file, so an example whose name collides with a lib module (`argparse`, `log`, `parser`, `timer`) reaches the lib copy via `-L`.

## Test plan

- [x] `tests/test_compiler.sh </dev/null` — 24 passed
- [x] `tests/test_examples.sh` — 38 passed
- [x] `casac casa.casa` self-build still succeeds
- [x] New unit test `test_resolve_import_module_skips_self_match` covers the self-skip path