### PR TITLE
lsp: support libraryPaths initialization option

### DIFF
--- a/compiler/parser.casa
+++ b/compiler/parser.casa
@@ -2553,6 +2553,11 @@ fn resolve_identifiers_fn parser:Parser ops:List[Op] function:Function -> List[O
         # IMPORT_FILE: process imported file
         if OpKind::OpImportFile op_kind == then
             current_op op_str_value = import_path
+            # Resilient mode may produce an empty path when resolve_import
+            # already reported a "module not found" error; skip the read.
+            if 0 import_path.length == then
+                continue
+            fi
             if import_path parser.included_files.has ! then
                 import_path parser.included_files.add drop
                 import_path lex_file = import_tokens

--- a/docs/language-server.md
+++ b/docs/language-server.md
@@ -155,6 +155,26 @@ The server provides full semantic token highlighting. Each token is classified i
 
 Intrinsics are highlighted as `macro` to visually distinguish them from user-defined functions. The `fn` keyword before function definitions is highlighted as a keyword.
 
+## Initialization options
+
+Clients may pass these LSP `initializationOptions` to the server:
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `libraryPaths` | `string[]` | Directories searched for module-style imports (`import "name"`). Equivalent to passing `-L path` to `casac`. Missing or empty means no extra search paths. Non-string entries are ignored. |
+
+The configured paths persist across buffer changes; the server preserves them when it resets compilation state.
+
+Example `initialize` request body:
+
+```json
+{
+  "initializationOptions": {
+    "libraryPaths": ["/path/to/casa/lib", "/abs/vendor"]
+  }
+}
+```
+
 ## Editor Configuration
 
 ### Neovim (nvim-lspconfig)

--- a/lsp.casa
+++ b/lsp.casa
@@ -289,7 +289,6 @@ fn clear_compilation_state {
     Map::new(Map[str CasaStruct]) DEFAULT_PARSER Parser::store SymbolStore::set_structs
     Map::new(Map[str CasaTrait]) DEFAULT_PARSER Parser::store SymbolStore::set_traits
     Set::new(Set[str]) DEFAULT_PARSER Parser::set_included_files
-    List::new(List[str]) DEFAULT_PARSER Parser::set_search_paths
 }
 
 fn run_pipeline file_path:str source:str -> DocumentState {
@@ -2343,8 +2342,30 @@ fi
 # Server initialization and main loop
 # ============================================================================
 
+fn extract_library_paths message:JsonValue -> List[str] {
+    List::new(List[str]) = paths
+    "params" message json_get_object = params_option
+    if params_option.is_none then paths return fi
+    "initializationOptions" params_option.unwrap json_get_object = init_options_option
+    if init_options_option.is_none then paths return fi
+    "libraryPaths" init_options_option.unwrap json_get_array = library_paths_option
+    if library_paths_option.is_none then paths return fi
+    library_paths_option.unwrap = library_paths_array
+    0 = path_index
+    while path_index library_paths_array.length > do
+        path_index library_paths_array.get = path_value
+        if path_value JsonValue::JsonString(path_string) is then
+            path_string paths.push
+        fi
+        1 += path_index
+    done
+    paths
+}
+
 fn handle_initialize message:JsonValue {
     "id" message json_get_value.unwrap = request_id
+
+    message extract_library_paths DEFAULT_PARSER Parser::set_search_paths
 
     # Build semantic tokens legend
     List::new(List[JsonValue]) = token_types

--- a/tests/compiler/test_lsp.casa
+++ b/tests/compiler/test_lsp.casa
@@ -96,6 +96,72 @@ fn test_clear_compilation_state_clears_all_global_state {
     "no warnings" 0 WARNINGS.length assert_eq
 }
 
+fn test_clear_compilation_state_preserves_search_paths {
+    "clear_compilation_state_preserves_search_paths" test_start
+    List::new(List[str]) = configured_paths
+    "/test/lib" configured_paths.push
+    "/test/vendor" configured_paths.push
+    configured_paths DEFAULT_PARSER Parser::set_search_paths
+    clear_compilation_state
+    "preserved length" 2 DEFAULT_PARSER.search_paths.length assert_eq
+    "preserved first" "/test/lib" 0 DEFAULT_PARSER.search_paths.get assert_str_eq
+    "preserved second" "/test/vendor" 1 DEFAULT_PARSER.search_paths.get assert_str_eq
+    List::new(List[str]) DEFAULT_PARSER Parser::set_search_paths
+}
+
+# ============================================================================
+# Test: extract_library_paths
+# ============================================================================
+
+fn lsp_make_library_paths_message path_values:List[JsonValue] -> JsonValue {
+    json_object
+    "libraryPaths" path_values JsonValue::JsonArray json_set
+    JsonValue::JsonObject = init_options_value
+    json_object
+    "initializationOptions" init_options_value json_set
+    JsonValue::JsonObject = params_value
+    json_object
+    "params" params_value json_set
+    JsonValue::JsonObject
+}
+
+fn test_extract_library_paths_returns_string_entries {
+    "extract_library_paths_returns_string_entries" test_start
+    List::new(List[JsonValue]) = path_values
+    "/abs/lib1" JsonValue::JsonString path_values.push
+    "/abs/lib2" JsonValue::JsonString path_values.push
+    path_values lsp_make_library_paths_message extract_library_paths = result
+    "length 2" 2 result.length assert_eq
+    "first path" "/abs/lib1" 0 result.get assert_str_eq
+    "second path" "/abs/lib2" 1 result.get assert_str_eq
+}
+
+fn test_extract_library_paths_empty_when_params_missing {
+    "extract_library_paths_empty_when_params_missing" test_start
+    json_object JsonValue::JsonObject extract_library_paths = result
+    "empty" 0 result.length assert_eq
+}
+
+fn test_extract_library_paths_empty_when_init_options_missing {
+    "extract_library_paths_empty_when_init_options_missing" test_start
+    json_object
+    "params" json_object JsonValue::JsonObject json_set
+    JsonValue::JsonObject extract_library_paths = result
+    "empty" 0 result.length assert_eq
+}
+
+fn test_extract_library_paths_skips_non_string_entries {
+    "extract_library_paths_skips_non_string_entries" test_start
+    List::new(List[JsonValue]) = path_values
+    "/keep" JsonValue::JsonString path_values.push
+    42 JsonValue::JsonInt path_values.push
+    "/also_keep" JsonValue::JsonString path_values.push
+    path_values lsp_make_library_paths_message extract_library_paths = result
+    "length 2" 2 result.length assert_eq
+    "first kept" "/keep" 0 result.get assert_str_eq
+    "second kept" "/also_keep" 1 result.get assert_str_eq
+}
+
 # ============================================================================
 # Test: compute_diagnostics
 # ============================================================================
@@ -1061,6 +1127,11 @@ test_position_to_offset_second_line
 test_position_to_offset_mid_line
 test_position_to_offset_third_line_mid_col
 test_clear_compilation_state_clears_all_global_state
+test_clear_compilation_state_preserves_search_paths
+test_extract_library_paths_returns_string_entries
+test_extract_library_paths_empty_when_params_missing
+test_extract_library_paths_empty_when_init_options_missing
+test_extract_library_paths_skips_non_string_entries
 test_compute_diagnostics_valid_code_produces_no_diagnostics
 test_compute_diagnostics_invalid_code_produces_error_diagnostics
 test_run_pipeline_returns_document_state

--- a/tests/compiler/test_lsp.casa
+++ b/tests/compiler/test_lsp.casa
@@ -162,6 +162,14 @@ fn test_extract_library_paths_skips_non_string_entries {
     "second kept" "/also_keep" 1 result.get assert_str_eq
 }
 
+fn test_run_pipeline_unresolved_module_does_not_crash {
+    "run_pipeline_unresolved_module_does_not_crash" test_start
+    List::new(List[str]) DEFAULT_PARSER Parser::set_search_paths
+    "import \"this_module_does_not_exist\"\n42 print" lsp_test_state = state
+    "has ops" 0 state DocumentState::ops.length > assert_true
+    "has errors" 0 ERRORS.length > assert_true
+}
+
 # ============================================================================
 # Test: compute_diagnostics
 # ============================================================================
@@ -1132,6 +1140,7 @@ test_extract_library_paths_returns_string_entries
 test_extract_library_paths_empty_when_params_missing
 test_extract_library_paths_empty_when_init_options_missing
 test_extract_library_paths_skips_non_string_entries
+test_run_pipeline_unresolved_module_does_not_crash
 test_compute_diagnostics_valid_code_produces_no_diagnostics
 test_compute_diagnostics_invalid_code_produces_error_diagnostics
 test_run_pipeline_returns_document_state


### PR DESCRIPTION
## Summary
- Parse `initializationOptions.libraryPaths` from the LSP `initialize` request and forward to `DEFAULT_PARSER.search_paths` so module-style imports (`import "std"`) resolve in open buffers.
- `clear_compilation_state` no longer resets `search_paths`, so the configured paths persist across buffer changes.
- Added 5 unit tests for the helper and preservation behavior; documented the new option in `docs/language-server.md`.

Closes #113.
Closes #106.

## Test plan
- [x] `tests/test_compiler.sh </dev/null` — 24 passed
- [x] `tests/test_examples.sh` — 38 passed
- [x] casafmt clean on `lsp.casa` and `tests/compiler/test_lsp.casa`
- [x] Self-compilation + fixed-point pass