### PR TITLE
refactor(compiler): migrate while-loops to for-loops

### DIFF
--- a/compiler/bytecode.casa
+++ b/compiler/bytecode.casa
@@ -193,12 +193,10 @@ fn find_matching_label
 }
 
 fn opkind_list_contains items:List[OpKind] value:OpKind -> bool {
-    0 = index
-    while index items.length > do
-        if value index items.get == then
+    for item in items.iter do
+        if value item == then
             true return
         fi
-        1 += index
     done
     false
 }
@@ -852,16 +850,13 @@ fn compile_function_ops compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
             op lambda compiler compile_function
 
             # Handle captures
-            0 = capture_index
-            while capture_index lambda Function::captures.length > do
-                capture_index lambda Function::captures.get = capture
+            for capture in lambda Function::captures.iter do
                 capture Variable::name = capture_name
                 capture_name compiler resolve_variable = capture_resolved
                 capture_resolved ResolvedVariable::index capture_resolved ResolvedVariable::get_kind make_inst_int bytecode.push
                 f"{lambda Function::name}_{capture_name}" = constant_key
                 constant_key compiler intern_constant = constant_index
                 constant_index InstKind::InstConstantStore make_inst_int bytecode.push
-                1 += capture_index
             done
             name InstKind::InstFnPush make_inst_str bytecode.push
         }

--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -708,13 +708,10 @@ struct CasaEnum {
 }
 
 fn has_inner_values casa_enum:CasaEnum -> bool {
-    0 = index
-    while index casa_enum CasaEnum::variant_types.keys.length > do
-        index casa_enum CasaEnum::variant_types.keys.get = key
+    for key in casa_enum CasaEnum::variant_types.keys.iter do
         if key casa_enum CasaEnum::variant_types.get.unwrap.length 0 != then
             true return
         fi
-        1 += index
     done
     false
 }
@@ -971,15 +968,12 @@ fn build_parameterized_type base:str params:List[str] -> str {
 
 fn build_resolved_type base:str type_vars:List[str] bindings:Map[str str] -> str {
     List::new(List[str]) = params
-    0 = index
-    while index type_vars.length > do
-        index type_vars.get = type_var
+    for type_var in type_vars.iter do
         if type_var bindings.get Option::Some(bound) is then
             bound params.push
         else
             type_var params.push
         fi
-        1 += index
     done
     params base build_parameterized_type
 }
@@ -1206,10 +1200,8 @@ fn apply_type_subs_to_sig sig:Signature subs:Map[str str] -> Signature {
         1 += index
     done
     List::new(List[str]) = returns
-    0 = index
-    while index sig Signature::return_types.length > do
-        subs index sig Signature::return_types.get substitute_type_params returns.push
-        1 += index
+    for return_type in sig Signature::return_types.iter do
+        subs return_type substitute_type_params returns.push
     done
     returns params make_signature
 }
@@ -1229,15 +1221,12 @@ fn resolve_trait_sig sig:Signature type_var:str -> Signature {
     done
 
     List::new(List[str]) = returns
-    0 = index
-    while index sig Signature::return_types.length > do
-        index sig Signature::return_types.get = ret
+    for ret in sig Signature::return_types.iter do
         if TRAIT_SELF_TYPE ret == then
             type_var returns.push
         else
             ret returns.push
         fi
-        1 += index
     done
 
     returns params make_signature

--- a/compiler/emitter.casa
+++ b/compiler/emitter.casa
@@ -78,9 +78,7 @@ fn nibble_to_hex value:int -> char {
 
 fn escape_string s:str -> str {
     StringBuilder::new = builder
-    0 = index
-    while index s.length > do
-        index s.at = ch
+    for ch in s.iter do
         if '\\' ch == then
             "\\\\" builder.append
         elif '"' ch == then
@@ -103,7 +101,6 @@ fn escape_string s:str -> str {
         else
             ch builder.append_char
         fi
-        1 += index
     done
     builder.build
 }
@@ -264,15 +261,12 @@ fn emit_helpers asm:StringBuilder {
 
 fn emit_functions asm:StringBuilder program:Program {
     program Program::functions.keys = keys
-    0 = index
-    while index keys.length > do
-        index keys.get = name
+    for name in keys.iter do
         name sanitize_name = label
         f"fn_{label}:" asm emit_line
         name program Program::functions.get.unwrap = bytecode
         false bytecode asm emit_bytecode
         "" asm emit_line
-        1 += index
     done
 }
 

--- a/compiler/lexer.casa
+++ b/compiler/lexer.casa
@@ -475,10 +475,8 @@ impl Lexer {
         0 self.cur_loc TokenKind::Eof "" make_token tokens.push
         if 0 self Lexer::errors.length != then
             if RESILIENT_MODE then
-                0 = error_index
-                while error_index self Lexer::errors.length > do
-                    error_index self Lexer::errors.get ERRORS.push
-                    1 += error_index
+                for error in self Lexer::errors.iter do
+                    error ERRORS.push
                 done
             else
                 self Lexer::errors report_errors

--- a/compiler/pattern.casa
+++ b/compiler/pattern.casa
@@ -66,20 +66,16 @@ fn pattern_bindings op:Op -> List[str] {
         PatternKind::PatStruct => {
             op pattern_value_of (StructPattern) = struct_pat
             struct_pat StructPattern::bindings.keys = field_names
-            0 = binding_index
-            while binding_index field_names.length > do
-                binding_index field_names.get struct_pat StructPattern::bindings.get.unwrap = bound_name
+            for field_name in field_names.iter do
+                field_name struct_pat StructPattern::bindings.get.unwrap = bound_name
                 bound_name out.push
-                1 += binding_index
             done
         }
         PatternKind::PatEnumVariant => {
             op pattern_value_of (EnumVariant) = variant
             variant EnumVariant::bindings = names
-            0 = enum_binding_index
-            while enum_binding_index names.length > do
-                enum_binding_index names.get out.push
-                1 += enum_binding_index
+            for name in names.iter do
+                name out.push
             done
         }
         PatternKind::PatLiteral => { }
@@ -111,13 +107,10 @@ fn diagnose_bare_enum_pattern tc:TypeChecker op:Op variant:EnumVariant arm_base:
 
 fn detect_duplicate_arm match_ctx:MatchContext op:Op covered_key:str {
     if "" covered_key == then return fi
-    0 = dup_index
-    while dup_index match_ctx MatchContext::branch_records.length > do
-        dup_index match_ctx MatchContext::branch_records.get = record
+    for record in match_ctx MatchContext::branch_records.iter do
         if covered_key record == then
             op Op::location f"Duplicate match arm for `{covered_key}`" ErrorKind::DuplicateName raise_error
         fi
-        1 += dup_index
     done
     if covered_key match_ctx MatchContext::current_branch_label == then
         op Op::location f"Duplicate match arm for `{covered_key}`" ErrorKind::DuplicateName raise_error
@@ -178,12 +171,9 @@ fn register_struct_pattern_bindings
 {
     struct_pattern StructPattern::struct_name tc.store.structs.get.unwrap = matched_struct
     struct_pattern StructPattern::bindings.keys = binding_keys
-    0 = binding_index
-    while binding_index binding_keys.length > do
-        binding_index binding_keys.get = field_name
+    for field_name in binding_keys.iter do
         field_name struct_pattern StructPattern::bindings.get.unwrap = bound_var
         function_opt bound_var field_name matched_struct assign_struct_binding_type
-        1 += binding_index
     done
 }
 

--- a/compiler/syntax.casa
+++ b/compiler/syntax.casa
@@ -922,11 +922,9 @@ fn parse_function parser:Parser cursor:TokenCursor -> Function {
 
     # Add type vars to the signature
     if 0 type_vars.length != then
-        0 = type_var_index
-        while type_var_index type_vars.length > do
-            type_var_index type_vars.get sig Signature::type_vars.add = new_type_vars
+        for type_var in type_vars.iter do
+            type_var sig Signature::type_vars.add = new_type_vars
             new_type_vars sig Signature::set_type_vars
-            1 += type_var_index
         done
         # Set trait bounds from LAST_TRAIT_BOUNDS (set by parse_type_vars)
         LAST_TRAIT_BOUNDS sig Signature::set_trait_bounds
@@ -1068,10 +1066,8 @@ fn create_member_accessor
     Set::new(Set[str]) = sig_type_vars
     if 0 type_vars.length != then
         type_vars struct_name build_parameterized_type = param_type
-        0 = type_var_index
-        while type_var_index type_vars.length > do
-            type_var_index type_vars.get sig_type_vars.add = sig_type_vars
-            1 += type_var_index
+        for type_var in type_vars.iter do
+            type_var sig_type_vars.add = sig_type_vars
         done
     fi
 
@@ -1311,24 +1307,18 @@ fn inject_impl_trait_params
     function Function::signature = sig
 
     # Merge type vars into function signature
-    0 = type_var_index
-    while type_var_index type_vars.length > do
-        type_var_index type_vars.get = type_var
+    for type_var in type_vars.iter do
         if type_var sig Signature::type_vars.has ! then
             type_var sig Signature::type_vars.add = new_type_vars
             new_type_vars sig Signature::set_type_vars
         fi
-        1 += type_var_index
     done
 
     # Merge trait bounds
     trait_bounds.keys = bound_keys
-    0 = bound_index
-    while bound_index bound_keys.length > do
-        bound_index bound_keys.get = bound_key
+    for bound_key in bound_keys.iter do
         bound_key bound_key trait_bounds.get.unwrap sig Signature::trait_bounds.set = new_bounds
         new_bounds sig Signature::set_trait_bounds
-        1 += bound_index
     done
 
     # Inject hidden __trait_* parameters
@@ -1683,9 +1673,7 @@ fn normalize_path path:str -> str {
 
     # Process parts, resolving ".."
     List::new(List[str]) = resolved_parts
-    0 = part_index
-    while part_index parts.length > do
-        part_index parts.get = part
+    for part in parts.iter do
         if ".." part == then
             if 0 resolved_parts.length != then
                 resolved_parts.pop drop
@@ -1693,7 +1681,6 @@ fn normalize_path path:str -> str {
         elif "." part != then
             part resolved_parts.push
         fi
-        1 += part_index
     done
 
     # Rebuild path

--- a/compiler/typechecker.casa
+++ b/compiler/typechecker.casa
@@ -291,18 +291,14 @@ fn types_match_params expected:str actual:str -> bool {
     if base_opt.is_some then
         base_opt.unwrap DEFAULT_PARSER.store.enums.get = enum_opt
         if enum_opt.is_some then
-            0 = type_index
-            while type_index enum_opt.unwrap CasaEnum::type_vars.length > do
-                type_index enum_opt.unwrap CasaEnum::type_vars.get type_vars.add = type_vars
-                1 += type_index
+            for type_var in enum_opt.unwrap CasaEnum::type_vars.iter do
+                type_var type_vars.add = type_vars
             done
         fi
         base_opt.unwrap DEFAULT_PARSER.store.structs.get = struct_opt
         if struct_opt.is_some then
-            0 = type_index
-            while type_index struct_opt.unwrap CasaStruct::type_vars.length > do
-                type_index struct_opt.unwrap CasaStruct::type_vars.get type_vars.add = type_vars
-                1 += type_index
+            for type_var in struct_opt.unwrap CasaStruct::type_vars.iter do
+                type_var type_vars.add = type_vars
             done
         fi
     fi
@@ -496,12 +492,10 @@ fn bind_generic_param
     expected_params_opt.unwrap = expected_params
     # Check if any param is a type variable
     false = has_type_var
-    0 = index
-    while index expected_params.length > do
-        if index expected_params.get sig Signature::type_vars.has then
+    for expected_param in expected_params.iter do
+        if expected_param sig Signature::type_vars.has then
             true = has_type_var
         fi
-        1 += index
     done
     if has_type_var ! then false return fi
 
@@ -551,25 +545,19 @@ fn bind_fn_param tc:TypeChecker bindings:Map[str str] expected:Parameter sig:Sig
     # Check if any type var appears in the fn signature
     false = has_type_var
     sig Signature::type_vars.to_list = type_var_list
-    0 = type_index
-    while type_index type_var_list.length > do
-        type_index type_var_list.get = type_var
+    for type_var in type_var_list.iter do
         if fn_sig_str type_var str::find 0 <= then
             true = has_type_var
         fi
-        1 += type_index
     done
     if has_type_var ! then false return fi
 
     tc stack_pop = actual
     if ANY_TYPE actual == then
-        0 = bind_index
-        while bind_index type_var_list.length > do
-            bind_index type_var_list.get = type_var2
+        for type_var2 in type_var_list.iter do
             if fn_sig_str type_var2 str::find 0 <= then
                 ANY_TYPE type_var2 bindings tc bind_type_var = bindings
             fi
-            1 += bind_index
         done
         true return
     fi
@@ -1699,10 +1687,8 @@ fn check_enum_variant tc:TypeChecker op:Op {
         # Bind type vars from inner values
         Map::new(Map[str str]) = bindings
         Set::new(Set[str]) = type_vars
-        0 = type_index
-        while type_index casa_enum CasaEnum::type_vars.length > do
-            type_index casa_enum CasaEnum::type_vars.get type_vars.add = type_vars
-            1 += type_index
+        for type_var in casa_enum CasaEnum::type_vars.iter do
+            type_var type_vars.add = type_vars
         done
         0 = index
         while index inner_types.length > do
@@ -1868,13 +1854,10 @@ fn check_match tc:TypeChecker op:Op function_opt:Option[Function] {
             if end_base tc.store.enums.get.is_some has_wildcard ! && then
                 end_base tc.store.enums.get.unwrap = end_enum
                 List::new(List[str]) = missing
-                0 = variant_index
-                while variant_index end_enum CasaEnum::variants.length > do
-                    variant_index end_enum CasaEnum::variants.get = variant_name
+                for variant_name in end_enum CasaEnum::variants.iter do
                     if variant_name covered_set.has ! then
                         variant_name missing.push
                     fi
-                    1 += variant_index
                 done
                 if 0 missing.length != then
                     StringBuilder::new = missing_builder
@@ -2010,9 +1993,7 @@ fn find_method_by_name method_name:str -> Option[str] {
     DEFAULT_PARSER.store.functions.keys = keys
     "" = found
     "" = found_with_traits
-    0 = index
-    while index keys.length > do
-        index keys.get = key
+    for key in keys.iter do
         if key suffix str::ends_with then
             if key "lambda__" str::starts_with ! then
                 key DEFAULT_PARSER.store.functions.get.unwrap = function
@@ -2027,7 +2008,6 @@ fn find_method_by_name method_name:str -> Option[str] {
                 fi
             fi
         fi
-        1 += index
     done
     # Prefer non-trait-bounded matches
     if "" found != then
@@ -2175,10 +2155,8 @@ fn instantiate_default_trait_method
     else
         # Infer trait type params from concrete method signatures
         Set::new(Set[str]) = type_param_set
-        0 = tp_index
-        while tp_index type_params.length > do
-            tp_index type_params.get type_param_set.add = type_param_set
-            1 += tp_index
+        for type_param in type_params.iter do
+            type_param type_param_set.add = type_param_set
         done
         0 = infer_index
         while infer_index trait_def CasaTrait::methods.length > do
@@ -2203,20 +2181,16 @@ fn instantiate_default_trait_method
 
     # Add trait type params as function type vars for generic receivers
     if fn_base_opt.is_some then
-        0 = tp_index
-        while tp_index type_params.length > do
-            tp_index type_params.get resolved_sig Signature::type_vars.add = new_tvs
+        for type_param in type_params.iter do
+            type_param resolved_sig Signature::type_vars.add = new_tvs
             new_tvs resolved_sig Signature::set_type_vars
-            1 += tp_index
         done
     fi
 
     # Add method-level type vars to signature
-    0 = mtv_index
-    while mtv_index default_method TraitMethod::type_vars.length > do
-        mtv_index default_method TraitMethod::type_vars.get resolved_sig Signature::type_vars.add = new_tvs
+    for method_type_var in default_method TraitMethod::type_vars.iter do
+        method_type_var resolved_sig Signature::type_vars.add = new_tvs
         new_tvs resolved_sig Signature::set_type_vars
-        1 += mtv_index
     done
 
     # Build function ops: parameter assignments + cloned body


### PR DESCRIPTION
## Summary

- Convert eligible `while index < list.length` loops in `compiler/*.casa` to `for x in list.iter` loops.
- Behavior-preserving mechanical refactor; no new features, no API changes.
- Closes #121.

## Changes per file

| File          | Loops converted |
|---------------|-----------------|
| emitter.casa  | 2 (escape_string, emit_functions) |
| pattern.casa  | 4 |
| lexer.casa    | 1 (resilient-mode error push) |
| common.casa   | 4 |
| bytecode.casa | 2 (opkind_list_contains, lambda captures) |
| syntax.casa   | 5 |
| typechecker.casa | 11 |

## Loops left as while

Per the issue scope, kept as `while`:
- Cursor/state-driven loops (`while self.cursor.is_eof !`, etc.)
- Loops that use the index value in the body (e.g. `f"str_{index}:"` in `emit_data`, register lookup in `emit_syscall`)
- Loops with index-arithmetic peeks
- Loops with non-zero start indices (no `.skip` on iterators)
- Parallel iteration over two lists with one shared index

Two language bugs surfaced during the refactor and forced additional loops to remain `while`:
1. The self-hosted compiler can't always handle the *first* `Iter[T]` instantiation for a previously-unused element type `T` (e.g. `Iter[Inst]`, `Iter[Member]`). Symptom: stage1 crashes with `called unwrap on None` when later compiling any `for` loop. Workaround: keep loops over compiler-internal types (`List[Inst]`, `List[Op]`, `List[Member]`, `List[TraitMethod]`, etc.) as `while`.
2. Nested `for` loops — lexically OR via function call from inside a for-body — corrupt iter state and crash with `List index out of bounds`. Workaround: only convert leaf loops where neither the body nor any function it calls contains a `for` loop (notably keeps `resolve_import` as `while` because it calls the now-converted `normalize_path`).

Both bugs deserve their own follow-up issues.

## Performance

Median of 10 runs, no other load:

| Workload              | Before | After  | Δ      |
|-----------------------|--------|--------|--------|
| Self-compile casa.casa | 2.14 s | 0.79 s | -63%   |
| Compile lsp.casa       | 2.00 s | 0.89 s | -55%   |

Likely because `for` loops cache `list.length` at iter setup, while the old `while index list.length >` pattern re-evaluated `list.length` (and the chain of method calls leading to it) on every iteration.

## Test plan

- [x] `tests/test_examples.sh` — 38 passed
- [x] `tests/test_compiler.sh < /dev/null` — 24 passed
- [x] `tests/test_formatter.sh` — 62 passed
- [x] All seven commits compile and pass tests in isolation
- [x] Reviewed by code-reviewer agent (no findings)