### PR TITLE
lsp: deepen compilation pipeline

### DIFF
--- a/lsp.casa
+++ b/lsp.casa
@@ -79,6 +79,13 @@ struct FindOpState {
     best_len: int
 }
 
+struct CompileResult {
+    document_state: DocumentState
+    errors:         List[CasaError]
+    warnings:       List[CasaWarning]
+    source_cache:   Map[str str]
+}
+
 # ============================================================================
 # LSP constants
 # ============================================================================
@@ -279,7 +286,10 @@ fn send_notification method:str params:JsonValue {
 # Compilation pipeline
 # ============================================================================
 
-fn clear_compilation_state {
+fn compile_document file_path:str source:str open_docs:Map[str DocumentState] -> CompileResult {
+    true = RESILIENT_MODE
+
+    # Reset compiler globals
     Map::new(Map[str str]) = SOURCE_CACHE
     List::new(List[CasaError]) = ERRORS
     List::new(List[CasaWarning]) = WARNINGS
@@ -289,18 +299,13 @@ fn clear_compilation_state {
     Map::new(Map[str CasaStruct]) DEFAULT_PARSER Parser::store SymbolStore::set_structs
     Map::new(Map[str CasaTrait]) DEFAULT_PARSER Parser::store SymbolStore::set_traits
     Set::new(Set[str]) DEFAULT_PARSER Parser::set_included_files
-}
 
-fn run_pipeline file_path:str source:str -> DocumentState {
-    true = RESILIENT_MODE
-    clear_compilation_state
-
-    # Pre-populate SOURCE_CACHE with open document sources
-    DOCUMENT_STATES.keys = uris
+    # Seed SOURCE_CACHE from peer open documents
+    open_docs.keys = uris
     0 = uri_index
     while uri_index uris.length > do
         uri_index uris.get = uri
-        uri DOCUMENT_STATES.get.unwrap = cached_state
+        uri open_docs.get.unwrap = cached_state
         if cached_state DocumentState::file_path file_path != then
             cached_state DocumentState::source cached_state DocumentState::file_path SOURCE_CACHE.set = SOURCE_CACHE
         fi
@@ -321,7 +326,7 @@ fn run_pipeline file_path:str source:str -> DocumentState {
         type_check_functions
     fi
 
-    # Snapshot state
+    # Snapshot file source (post-include)
     file_path SOURCE_CACHE.get = source_opt
     if source_opt.is_some then
         source_opt.unwrap
@@ -330,6 +335,7 @@ fn run_pipeline file_path:str source:str -> DocumentState {
     fi
     = final_source
 
+    # Snapshot store maps into a DocumentState
     file_path
     final_source
     Map::new(Map[str Variable]) = vars_copy
@@ -378,20 +384,35 @@ fn run_pipeline file_path:str source:str -> DocumentState {
 
     ops
 
-    DocumentState
+    DocumentState = state
+
+    # Drain compiler globals into the result so callers never read them
+    SOURCE_CACHE
+    WARNINGS
+    ERRORS
+    state
+    CompileResult
 }
 
-fn compute_diagnostics uri:str source:str -> List[LspDiagnostic] {
+fn ingest_document uri:str source:str -> List[LspDiagnostic] {
     uri uri_to_path = path
-    source path run_pipeline = state
-    uri state DOCUMENT_STATES.set = DOCUMENT_STATES
+    DOCUMENT_STATES source path compile_document = result
+    uri result CompileResult::document_state DOCUMENT_STATES.set = DOCUMENT_STATES
+    path result diagnostics_from
+}
+
+fn diagnostics_from result:CompileResult path:str -> List[LspDiagnostic] {
+    result CompileResult::errors = errors
+    result CompileResult::warnings = warnings
+    result CompileResult::source_cache = source_cache
+    result CompileResult::document_state DocumentState::source = fallback_source
 
     List::new(List[LspDiagnostic]) = diagnostics
 
     # Convert errors
     0 = error_index
-    while error_index ERRORS.length > do
-        error_index ERRORS.get = error
+    while error_index errors.length > do
+        error_index errors.get = error
         if
         "" error CasaError::location Location::file !=
         error CasaError::location Location::file path != &&
@@ -399,11 +420,11 @@ fn compute_diagnostics uri:str source:str -> List[LspDiagnostic] {
             1 += error_index
             continue
         fi
-        error CasaError::location Location::file SOURCE_CACHE.get = source_opt
+        error CasaError::location Location::file source_cache.get = source_opt
         if source_opt.is_some then
             source_opt.unwrap = error_source
         else
-            state DocumentState::source = error_source
+            fallback_source = error_source
         fi
 
         # Build message
@@ -431,8 +452,8 @@ fn compute_diagnostics uri:str source:str -> List[LspDiagnostic] {
 
     # Convert warnings
     0 = warn_index
-    while warn_index WARNINGS.length > do
-        warn_index WARNINGS.get = warning
+    while warn_index warnings.length > do
+        warn_index warnings.get = warning
         if
         "" warning CasaWarning::location Location::file !=
         warning CasaWarning::location Location::file path != &&
@@ -440,11 +461,11 @@ fn compute_diagnostics uri:str source:str -> List[LspDiagnostic] {
             1 += warn_index
             continue
         fi
-        warning CasaWarning::location Location::file SOURCE_CACHE.get = warn_source_opt
+        warning CasaWarning::location Location::file source_cache.get = warn_source_opt
         if warn_source_opt.is_some then
             warn_source_opt.unwrap = warn_source
         else
-            state DocumentState::source = warn_source
+            fallback_source = warn_source
         fi
         DIAGNOSTIC_WARNING
         warning CasaWarning::message
@@ -456,11 +477,6 @@ fn compute_diagnostics uri:str source:str -> List[LspDiagnostic] {
     done
 
     diagnostics
-}
-
-fn run_diagnostics uri:str source:str {
-    source uri compute_diagnostics = diagnostics
-    diagnostics uri publish_diagnostics
 }
 
 fn publish_diagnostics uri:str diagnostics:List[LspDiagnostic] {
@@ -689,7 +705,8 @@ fn handle_did_open message:JsonValue {
     "textDocument" params json_get_object.unwrap = text_document
     "uri" text_document json_get_str.unwrap = uri
     "text" text_document json_get_str.unwrap = text
-    text uri run_diagnostics
+    text uri ingest_document = diagnostics
+    diagnostics uri publish_diagnostics
 }
 
 fn handle_did_change message:JsonValue {
@@ -699,7 +716,8 @@ fn handle_did_change message:JsonValue {
     "contentChanges" params json_get_array.unwrap = changes
     0 changes.get = change
     "text" change json_get_str.unwrap = text
-    text uri run_diagnostics
+    text uri ingest_document = diagnostics
+    diagnostics uri publish_diagnostics
 }
 
 fn handle_did_save message:JsonValue {
@@ -710,7 +728,8 @@ fn handle_did_save message:JsonValue {
         return
     fi
     read_result.unwrap = saved_source
-    saved_source uri run_diagnostics
+    saved_source uri ingest_document = diagnostics
+    diagnostics uri publish_diagnostics
 }
 
 # ============================================================================

--- a/lsp.casa
+++ b/lsp.casa
@@ -307,13 +307,13 @@ fn compile_document file_path:str source:str open_docs:Map[str DocumentState] ->
         uri_index uris.get = uri
         uri open_docs.get.unwrap = cached_state
         if cached_state DocumentState::file_path file_path != then
-            cached_state DocumentState::source cached_state DocumentState::file_path SOURCE_CACHE.set = SOURCE_CACHE
+            cached_state DocumentState::file_path cached_state DocumentState::source SOURCE_CACHE.set = SOURCE_CACHE
         fi
         1 += uri_index
     done
 
     # Lex
-    source file_path SOURCE_CACHE.set = SOURCE_CACHE
+    file_path source SOURCE_CACHE.set = SOURCE_CACHE
     file_path source lex_source = tokens
 
     # Parse

--- a/tests/compiler/test_lsp.casa
+++ b/tests/compiler/test_lsp.casa
@@ -10,7 +10,7 @@ fn lsp_clear_documents {
 
 fn lsp_test_state source:str -> DocumentState {
     lsp_clear_documents
-    source LSP_TEST_FILE run_pipeline
+    DOCUMENT_STATES source LSP_TEST_FILE compile_document CompileResult::document_state
 }
 
 fn lsp_test_uri -> str {
@@ -82,34 +82,6 @@ fn test_position_to_offset_third_line_mid_col {
 }
 
 # ============================================================================
-# Test: clear_compilation_state
-# ============================================================================
-
-fn test_clear_compilation_state_clears_all_global_state {
-    "clear_compilation_state_clears_all_global_state" test_start
-    # Populate state by running the pipeline
-    "fn greet { 42 print }" lsp_test_state drop
-    "has functions before" 0 DEFAULT_PARSER.store.functions.keys.length > assert_true
-    clear_compilation_state
-    "no functions" 0 DEFAULT_PARSER.store.functions.keys.length assert_eq
-    "no errors" 0 ERRORS.length assert_eq
-    "no warnings" 0 WARNINGS.length assert_eq
-}
-
-fn test_clear_compilation_state_preserves_search_paths {
-    "clear_compilation_state_preserves_search_paths" test_start
-    List::new(List[str]) = configured_paths
-    "/test/lib" configured_paths.push
-    "/test/vendor" configured_paths.push
-    configured_paths DEFAULT_PARSER Parser::set_search_paths
-    clear_compilation_state
-    "preserved length" 2 DEFAULT_PARSER.search_paths.length assert_eq
-    "preserved first" "/test/lib" 0 DEFAULT_PARSER.search_paths.get assert_str_eq
-    "preserved second" "/test/vendor" 1 DEFAULT_PARSER.search_paths.get assert_str_eq
-    List::new(List[str]) DEFAULT_PARSER Parser::set_search_paths
-}
-
-# ============================================================================
 # Test: extract_library_paths
 # ============================================================================
 
@@ -162,65 +134,91 @@ fn test_extract_library_paths_skips_non_string_entries {
     "second kept" "/also_keep" 1 result.get assert_str_eq
 }
 
-fn test_run_pipeline_unresolved_module_does_not_crash {
-    "run_pipeline_unresolved_module_does_not_crash" test_start
+fn test_compile_document_unresolved_module_does_not_crash {
+    "compile_document_unresolved_module_does_not_crash" test_start
+    lsp_clear_documents
     List::new(List[str]) DEFAULT_PARSER Parser::set_search_paths
-    "import \"this_module_does_not_exist\"\n42 print" lsp_test_state = state
+    DOCUMENT_STATES "import \"this_module_does_not_exist\"\n42 print" LSP_TEST_FILE compile_document = result
+    result CompileResult::document_state = state
     "has ops" 0 state DocumentState::ops.length > assert_true
-    "has errors" 0 ERRORS.length > assert_true
+    "has errors" 0 result CompileResult::errors.length > assert_true
 }
 
 # ============================================================================
-# Test: compute_diagnostics
+# Test: ingest_document
 # ============================================================================
 
-fn test_compute_diagnostics_valid_code_produces_no_diagnostics {
-    "compute_diagnostics_valid_code_produces_no_diagnostics" test_start
+fn test_ingest_document_valid_code_produces_no_diagnostics {
+    "ingest_document_valid_code_produces_no_diagnostics" test_start
     lsp_clear_documents
-    "42 print" lsp_test_uri compute_diagnostics = diagnostics
+    "42 print" lsp_test_uri ingest_document = diagnostics
     "no diagnostics" 0 diagnostics.length assert_eq
 }
 
-fn test_compute_diagnostics_invalid_code_produces_error_diagnostics {
-    "compute_diagnostics_invalid_code_produces_error_diagnostics" test_start
+fn test_ingest_document_invalid_code_produces_error_diagnostics {
+    "ingest_document_invalid_code_produces_error_diagnostics" test_start
     lsp_clear_documents
-    "42 \"hello\" +" lsp_test_uri compute_diagnostics = diagnostics
+    "42 \"hello\" +" lsp_test_uri ingest_document = diagnostics
     "has diagnostics" 0 diagnostics.length > assert_true
     "first is error severity" DIAGNOSTIC_ERROR 0 diagnostics.get LspDiagnostic::severity assert_eq
 }
 
+fn test_ingest_document_stores_state_in_document_states {
+    "ingest_document_stores_state_in_document_states" test_start
+    lsp_clear_documents
+    "42 print" lsp_test_uri ingest_document drop
+    "uri stored" lsp_test_uri DOCUMENT_STATES.has assert_true
+    lsp_test_uri DOCUMENT_STATES.get.unwrap = state
+    "source matches" "42 print" state DocumentState::source assert_str_eq
+}
+
 # ============================================================================
-# Test: run_pipeline
+# Test: compile_document
 # ============================================================================
 
-fn test_run_pipeline_returns_document_state {
-    "run_pipeline_returns_document_state" test_start
+fn test_compile_document_returns_document_state {
+    "compile_document_returns_document_state" test_start
     "fn greet { 42 print }\ngreet" lsp_test_state = state
     "has ops" 0 state DocumentState::ops.length > assert_true
     "has greet function" "greet" state DocumentState::functions.has assert_true
     "source matches" "fn greet { 42 print }\ngreet" state DocumentState::source assert_str_eq
     "file_path matches" LSP_TEST_FILE state DocumentState::file_path assert_str_eq
-    "no errors" 0 ERRORS.length assert_eq
 }
 
-fn test_run_pipeline_partial_failure_still_returns_ops {
-    "run_pipeline_partial_failure_still_returns_ops" test_start
+fn test_compile_document_partial_failure_still_returns_ops {
+    "compile_document_partial_failure_still_returns_ops" test_start
     "42 \"hello\" +" lsp_test_state = state
     "has ops" 0 state DocumentState::ops.length > assert_true
     "source matches" "42 \"hello\" +" state DocumentState::source assert_str_eq
-    "has errors" 0 ERRORS.length > assert_true
 }
 
-fn test_run_pipeline_populates_structs {
-    "run_pipeline_populates_structs" test_start
+fn test_compile_document_populates_structs {
+    "compile_document_populates_structs" test_start
     "struct Point {\n    x: int\n    y: int\n}" lsp_test_state = state
     "has Point struct" "Point" state DocumentState::structs.has assert_true
 }
 
-fn test_run_pipeline_populates_enums {
-    "run_pipeline_populates_enums" test_start
+fn test_compile_document_populates_enums {
+    "compile_document_populates_enums" test_start
     "enum Color { Red Green Blue }" lsp_test_state = state
     "has Color enum" "Color" state DocumentState::enums.has assert_true
+}
+
+fn test_compile_document_drains_errors_into_result {
+    "compile_document_drains_errors_into_result" test_start
+    lsp_clear_documents
+    DOCUMENT_STATES "42 \"hello\" +" LSP_TEST_FILE compile_document = result
+    "result has errors" 0 result CompileResult::errors.length > assert_true
+}
+
+fn test_compile_document_two_calls_isolated {
+    "compile_document_two_calls_isolated" test_start
+    lsp_clear_documents
+    DOCUMENT_STATES "42 \"hello\" +" LSP_TEST_FILE compile_document = first_result
+    "first has errors" 0 first_result CompileResult::errors.length > assert_true
+    DOCUMENT_STATES "42 print" LSP_TEST_FILE compile_document = second_result
+    "second has no errors" 0 second_result CompileResult::errors.length assert_eq
+    "first result still has errors after second call" 0 first_result CompileResult::errors.length > assert_true
 }
 
 # ============================================================================
@@ -1134,19 +1132,20 @@ test_position_to_offset_first_line_first_col
 test_position_to_offset_second_line
 test_position_to_offset_mid_line
 test_position_to_offset_third_line_mid_col
-test_clear_compilation_state_clears_all_global_state
-test_clear_compilation_state_preserves_search_paths
 test_extract_library_paths_returns_string_entries
 test_extract_library_paths_empty_when_params_missing
 test_extract_library_paths_empty_when_init_options_missing
 test_extract_library_paths_skips_non_string_entries
-test_run_pipeline_unresolved_module_does_not_crash
-test_compute_diagnostics_valid_code_produces_no_diagnostics
-test_compute_diagnostics_invalid_code_produces_error_diagnostics
-test_run_pipeline_returns_document_state
-test_run_pipeline_partial_failure_still_returns_ops
-test_run_pipeline_populates_structs
-test_run_pipeline_populates_enums
+test_compile_document_unresolved_module_does_not_crash
+test_ingest_document_valid_code_produces_no_diagnostics
+test_ingest_document_invalid_code_produces_error_diagnostics
+test_ingest_document_stores_state_in_document_states
+test_compile_document_returns_document_state
+test_compile_document_partial_failure_still_returns_ops
+test_compile_document_populates_structs
+test_compile_document_populates_enums
+test_compile_document_drains_errors_into_result
+test_compile_document_two_calls_isolated
 test_find_op_at_position_finds_op
 test_find_op_at_position_finds_op_in_function
 test_find_op_at_position_returns_none_for_empty_position

--- a/tests/compiler/test_lsp.casa
+++ b/tests/compiler/test_lsp.casa
@@ -221,6 +221,35 @@ fn test_compile_document_two_calls_isolated {
     "first result still has errors after second call" 0 first_result CompileResult::errors.length > assert_true
 }
 
+fn test_compile_document_source_cache_keyed_by_file_path {
+    "compile_document_source_cache_keyed_by_file_path" test_start
+    lsp_clear_documents
+    "42 print" = main_source
+    DOCUMENT_STATES main_source LSP_TEST_FILE compile_document = result
+    result CompileResult::source_cache = source_cache
+    "main file cached" LSP_TEST_FILE source_cache.has assert_true
+    "main source matches" main_source LSP_TEST_FILE source_cache.get.unwrap assert_str_eq
+}
+
+fn test_compile_document_seeds_open_docs_into_source_cache {
+    "compile_document_seeds_open_docs_into_source_cache" test_start
+    lsp_clear_documents
+    "/tmp/lsp_peer.casa" = peer_path
+    "fn peer_helper { 0 print }" = peer_source
+    List::new(List[Op]) = peer_ops
+    Map::new(Map[str Function]) = peer_fns
+    Map::new(Map[str CasaStruct]) = peer_structs
+    Map::new(Map[str CasaEnum]) = peer_enums
+    Map::new(Map[str Variable]) = peer_vars
+    peer_path peer_source peer_vars peer_enums peer_structs peer_fns peer_ops DocumentState = peer_state
+    Map::new(Map[str DocumentState]) = open_docs
+    peer_path peer_state open_docs.set = open_docs
+    open_docs "42 print" LSP_TEST_FILE compile_document = result
+    result CompileResult::source_cache = source_cache
+    "peer cached by path" peer_path source_cache.has assert_true
+    "peer source matches" peer_source peer_path source_cache.get.unwrap assert_str_eq
+}
+
 # ============================================================================
 # Test: find_op_at_position
 # ============================================================================
@@ -1146,6 +1175,8 @@ test_compile_document_populates_structs
 test_compile_document_populates_enums
 test_compile_document_drains_errors_into_result
 test_compile_document_two_calls_isolated
+test_compile_document_source_cache_keyed_by_file_path
+test_compile_document_seeds_open_docs_into_source_cache
 test_find_op_at_position_finds_op
 test_find_op_at_position_finds_op_in_function
 test_find_op_at_position_returns_none_for_empty_position


### PR DESCRIPTION
## Summary

Tracks #124. Replaces the soft-singleton `run_pipeline` / `compute_diagnostics` / `run_diagnostics` / `clear_compilation_state` quartet with two layered entry points:

- **`compile_document file_path source open_docs -> CompileResult`** — compiler-pure. Encapsulates clear/seed/lex/parse/typecheck and drains `ERRORS`, `WARNINGS`, and `SOURCE_CACHE` into the result so callers never read compiler globals.
- **`ingest_document uri source -> List[LspDiagnostic]`** — thin LSP wrapper for `handle_did_open` / `handle_did_change` / `handle_did_save`. Builds `open_docs` from `DOCUMENT_STATES`, calls `compile_document`, stores the new state, converts errors/warnings via a private `diagnostics_from` helper.

`handle_did_open` / `handle_did_change` / `handle_did_save` now call `ingest_document` directly — each handler shrinks to two lines for the compile+publish step.

## Tests

- Removed `test_clear_compilation_state_*` (tested a now-private implementation detail).
- Renamed `test_run_pipeline_*` → `test_compile_document_*`.
- Renamed `test_compute_diagnostics_*` → `test_ingest_document_*`.
- Added `test_compile_document_drains_errors_into_result` — verifies result.errors is populated independently of the global.
- Added `test_compile_document_two_calls_isolated` — verifies a second compile doesn't mutate the first result's errors list.
- Added `test_ingest_document_stores_state_in_document_states` — verifies the LSP wrapper stores the state.

## Test plan
- [x] `tests/test_compiler.sh < /dev/null` passes (24/24, test_lsp 202/202)
- [x] `tests/test_examples.sh` passes (38/38)
- [x] `casafmt` applied
- [x] Build clean

## Out of scope (separate candidates)
- Deepening `DocumentState` into a `SymbolStore` with methods.
- Iterator/predicate abstraction over `find_*`/`collect_*` families.
- JSON-RPC transport boundary.
- `SourceMap` for offset↔position translation.
- Latent `SOURCE_CACHE.set` key/value inversion in the open-docs seeding (pre-existing on main; currently inert because `lex_file` doesn't consult `SOURCE_CACHE`).