### PR TITLE
refactor: migrate eligible while-loops to for-loops

### DIFF
--- a/.github/workflows/test-compiler.yml
+++ b/.github/workflows/test-compiler.yml
@@ -14,13 +14,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5
+    - uses: actions/checkout@v5
+      with:
+        ref: main
+        path: main-src
     - name: Download casac release binary
       run: |
         curl --silent --location --fail \
-          --output casac \
+          --output casac-release \
           "https://github.com/frendsick/casa/releases/latest/download/casac"
-        chmod +x casac
-    - name: Bootstrap compiler from source
-      run: ./casac -L lib casa.casa -o casac-stage1
+        chmod +x casac-release
+    - name: Bootstrap stage0 compiler from main
+      run: |
+        cd main-src
+        ../casac-release -L lib casa.casa -o ../casac-main
+    - name: Bootstrap stage1 compiler from branch
+      run: ./casac-main -L lib casa.casa -o casac-stage1
     - name: Run compiler tests
       run: ./tests/test_compiler.sh ./casac-stage1

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -14,13 +14,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5
+    - uses: actions/checkout@v5
+      with:
+        ref: main
+        path: main-src
     - name: Download casac release binary
       run: |
         curl --silent --location --fail \
-          --output casac \
+          --output casac-release \
           "https://github.com/frendsick/casa/releases/latest/download/casac"
-        chmod +x casac
-    - name: Bootstrap compiler from source
-      run: ./casac -L lib casa.casa -o casac-stage1
+        chmod +x casac-release
+    - name: Bootstrap stage0 compiler from main
+      run: |
+        cd main-src
+        ../casac-release -L lib casa.casa -o ../casac-main
+    - name: Bootstrap stage1 compiler from branch
+      run: ./casac-main -L lib casa.casa -o casac-stage1
     - name: Test example programs
       run: ./tests/test_examples.sh ./casac-stage1

--- a/compiler/bytecode.casa
+++ b/compiler/bytecode.casa
@@ -807,14 +807,11 @@ fn compile_function compiler:BytecodeCompiler function:Function op:Op {
         List::new(List[Inst]) = final_bytecode
         locals_count InstKind::InstLocalsInit make_inst_int final_bytecode.push
 
-        0 = index
-        while index function_bytecode.length > do
-            index function_bytecode.get = inst
+        for inst in function_bytecode.iter do
             if InstKind::InstFnReturn inst Inst::kind == then
                 locals_count InstKind::InstLocalsUninit make_inst_int final_bytecode.push
             fi
             inst final_bytecode.push
-            1 += index
         done
         locals_count InstKind::InstLocalsUninit make_inst_int final_bytecode.push
         InstKind::InstFnReturn make_inst final_bytecode.push
@@ -824,10 +821,8 @@ fn compile_function compiler:BytecodeCompiler function:Function op:Op {
     fi
 
     # Store bytecode on the function
-    0 = bytecode_index
-    while bytecode_index function_bytecode.length > do
-        bytecode_index function_bytecode.get function Function::bytecode.push
-        1 += bytecode_index
+    for inst in function_bytecode.iter do
+        inst function Function::bytecode.push
     done
 }
 
@@ -1080,10 +1075,8 @@ fn compile_bytecode store:SymbolStore ops:List[Op] -> Program {
     if locals_count 0 < then
         List::new(List[Inst]) = final_bytecode
         locals_count InstKind::InstLocalsInit make_inst_int final_bytecode.push
-        0 = index
-        while index bytecode.length > do
-            index bytecode.get final_bytecode.push
-            1 += index
+        for inst in bytecode.iter do
+            inst final_bytecode.push
         done
         locals_count InstKind::InstLocalsUninit make_inst_int final_bytecode.push
         final_bytecode = bytecode
@@ -1092,14 +1085,11 @@ fn compile_bytecode store:SymbolStore ops:List[Op] -> Program {
     # Compile all used functions
     Map::new(Map[str List[Inst]]) = functions
     compiler.store.functions.keys = function_names
-    0 = function_index
-    while function_index function_names.length > do
-        function_index function_names.get = function_name
+    for function_name in function_names.iter do
         function_name compiler.store.functions.get.unwrap = function
         if 0 function Function::bytecode.length != then
             function_name function Function::bytecode functions.set = functions
         fi
-        1 += function_index
     done
 
     compiler BytecodeCompiler::constants_table.length

--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -489,19 +489,14 @@ fn make_op_pattern value:int kind:OpKind location:Location pattern_kind:PatternK
 
 fn clone_ops ops:List[Op] -> List[Op] {
     List::new(List[Op]) = result
-    0 = clone_index
-    while clone_index ops.length > do
-        clone_index ops.get = source_op
+    for source_op in ops.iter do
         source_op Op::pattern_kind source_op Op::deferred_return_type source_op Op::type_annotation source_op Op::location source_op Op::kind source_op Op::value Op result.push
-        1 += clone_index
     done
     result
 }
 
 fn substitute_ops_types ops:List[Op] subs:Map[str str] {
-    0 = sub_op_index
-    while sub_op_index ops.length > do
-        sub_op_index ops.get = sub_op
+    for sub_op in ops.iter do
         if OpKind::OpTypeCast sub_op Op::kind == then
             subs sub_op op_str_value substitute_type_params = new_cast_type
             new_cast_type (int) sub_op Op::set_value
@@ -514,7 +509,6 @@ fn substitute_ops_types ops:List[Op] subs:Map[str str] {
             subs sub_op Op::deferred_return_type substitute_type_params = new_deferred
             new_deferred sub_op Op::set_deferred_return_type
         fi
-        1 += sub_op_index
     done
 }
 
@@ -898,9 +892,7 @@ fn split_type_tokens s:str -> List[str] {
     List::new(List[str]) = tokens
     StringBuilder::new = current
     0 = depth
-    0 = index
-    while index s.length > do
-        index s.at = ch
+    for ch in s.iter do
         if '[' ch == then
             1 += depth
             ch current.append_char
@@ -915,7 +907,6 @@ fn split_type_tokens s:str -> List[str] {
         else
             ch current.append_char
         fi
-        1 += index
     done
     if 0 current.length != then
         current.build tokens.push
@@ -1196,12 +1187,9 @@ fn apply_type_subs_to_sig sig:Signature subs:Map[str str] -> Signature {
         sig return
     fi
     List::new(List[Parameter]) = params
-    0 = index
-    while index sig Signature::parameters.length > do
-        index sig Signature::parameters.get = param
+    for param in sig Signature::parameters.iter do
         subs param Parameter::typ substitute_type_params = new_typ
         param Parameter::name new_typ make_named_param params.push
-        1 += index
     done
     List::new(List[str]) = returns
     for return_type in sig Signature::return_types.iter do
@@ -1213,15 +1201,12 @@ fn apply_type_subs_to_sig sig:Signature subs:Map[str str] -> Signature {
 fn resolve_trait_sig sig:Signature type_var:str -> Signature {
     # Replace 'self' type with type_var in a trait method signature.
     List::new(List[Parameter]) = params
-    0 = index
-    while index sig Signature::parameters.length > do
-        index sig Signature::parameters.get = param
+    for param in sig Signature::parameters.iter do
         param Parameter::typ = typ
         if TRAIT_SELF_TYPE typ == then
             type_var = typ
         fi
         param Parameter::name typ make_named_param params.push
-        1 += index
     done
 
     List::new(List[str]) = returns

--- a/compiler/emitter.casa
+++ b/compiler/emitter.casa
@@ -319,11 +319,8 @@ fn emit_start asm:StringBuilder program:Program {
 # ============================================================================
 
 fn emit_bytecode asm:StringBuilder bytecode:List[Inst] is_global:bool {
-    0 = index
-    while index bytecode.length > do
-        index bytecode.get = inst
+    for inst in bytecode.iter do
         is_global inst asm emit_inst
-        1 += index
     done
 }
 

--- a/compiler/error.casa
+++ b/compiler/error.casa
@@ -241,9 +241,7 @@ fn format_error error:CasaError -> str {
     fi
 
     # Notes
-    0 = index
-    while index error CasaError::notes.length > do
-        index error CasaError::notes.get = note
+    for note in error CasaError::notes.iter do
         "\n  Note: " builder.append
         note CasaNote::message builder.append
         if "" note CasaNote::location Location::file != then
@@ -257,7 +255,6 @@ fn format_error error:CasaError -> str {
                 format_source_context builder.append
             fi
         fi
-        1 += index
     done
 
     builder.build
@@ -268,19 +265,15 @@ fn format_error error:CasaError -> str {
 # ============================================================================
 
 fn report_errors errors:List[CasaError] {
-    0 = index
-    while index errors.length > do
-        index errors.get format_error eprintln
+    for error in errors.iter do
+        error format_error eprintln
         "" eprintln
-        1 += index
     done
     f"Found {errors.length} error(s)." eprintln
 }
 
 fn report_warnings {
-    0 = index
-    while index WARNINGS.length > do
-        index WARNINGS.get = warning
+    for warning in WARNINGS.iter do
         StringBuilder::new = builder
         "warning[" builder.append
         warning CasaWarning::kind match
@@ -290,7 +283,6 @@ fn report_warnings {
         "]: " builder.append
         warning CasaWarning::message builder.append
         builder.build eprintln
-        1 += index
     done
 }
 

--- a/compiler/pattern.casa
+++ b/compiler/pattern.casa
@@ -154,13 +154,10 @@ fn assign_struct_binding_type
     bound_var:str
     function_opt:Option[Function]
 {
-    0 = member_index
-    while member_index matched_struct CasaStruct::members.length > do
-        member_index matched_struct CasaStruct::members.get = member
+    for member in matched_struct CasaStruct::members.iter do
         if field_name member Member::name == then
             function_opt member Member::typ bound_var set_binding_type
         fi
-        1 += member_index
     done
 }
 

--- a/compiler/syntax.casa
+++ b/compiler/syntax.casa
@@ -864,9 +864,7 @@ fn build_hidden_trait_methods
 -> List[HiddenTraitMethod] {
     List::new(List[HiddenTraitMethod]) = result
     trait_bounds.keys = bound_keys
-    0 = bound_index
-    while bound_index bound_keys.length > do
-        bound_index bound_keys.get = bound_type_var
+    for bound_type_var in bound_keys.iter do
         bound_type_var trait_bounds.get.unwrap = bound
         bound TraitBound::name parser.store.traits.get = bound_trait_opt
         if bound_trait_opt.is_some then
@@ -883,9 +881,7 @@ fn build_hidden_trait_methods
                     1 += bhtm_sub_index
                 done
             fi
-            0 = method_index
-            while method_index bound_trait CasaTrait::methods.length > do
-                method_index bound_trait CasaTrait::methods.get = bound_method
+            for bound_method in bound_trait CasaTrait::methods.iter do
                 # Skip default methods — only abstract methods need hidden fn ptrs
                 if 0 bound_method TraitMethod::default_ops.length == then
                     f"__trait_{bound_type_var}_{bound_method TraitMethod::name}" = hidden_name
@@ -893,10 +889,8 @@ fn build_hidden_trait_methods
                     f"fn[{hidden_sig signature_to_str}]" = hidden_type
                     hidden_type hidden_name HiddenTraitMethod result.push
                 fi
-                1 += method_index
             done
         fi
-        1 += bound_index
     done
     result
 }
@@ -936,43 +930,33 @@ fn parse_function parser:Parser cursor:TokenCursor -> Function {
     if 0 sig Signature::trait_bounds.keys.length != then
         List::new(List[Parameter]) = hidden_params
         sig Signature::trait_bounds parser build_hidden_trait_methods = hidden_methods
-        0 = hidden_index
-        while hidden_index hidden_methods.length > do
-            hidden_index hidden_methods.get = hidden
+        for hidden in hidden_methods.iter do
             hidden HiddenTraitMethod::var_name = hidden_name
             hidden HiddenTraitMethod::fn_type = hidden_type
             hidden_name hidden_type make_named_param hidden_params.push
             hidden_type hidden_name Variable variables.push
             name_token Token::location OpKind::OpAssignVar hidden_name make_op_str ops.push
-            1 += hidden_index
         done
         # Prepend hidden params to signature parameters
-        0 = param_index
-        while param_index sig Signature::parameters.length > do
-            param_index sig Signature::parameters.get hidden_params.push
-            1 += param_index
+        for sig_parameter in sig Signature::parameters.iter do
+            sig_parameter hidden_params.push
         done
         hidden_params sig Signature::set_parameters
     fi
 
     # Register named parameters as variables and generate assign ops
-    0 = param_iter
-    while param_iter sig Signature::parameters.length > do
-        param_iter sig Signature::parameters.get = param
+    for param in sig Signature::parameters.iter do
         if "" param Parameter::name != then
             if param Parameter::name "__trait_" str::starts_with ! then
                 param Parameter::typ param Parameter::name Variable variables.push
                 name_token Token::location OpKind::OpAssignVar param Parameter::name make_op_str ops.push
             fi
         fi
-        1 += param_iter
     done
 
     name_token Token::value cursor parser parse_block_ops = body_ops
-    0 = body_index
-    while body_index body_ops.length > do
-        body_index body_ops.get ops.push
-        1 += body_index
+    for body_op in body_ops.iter do
+        body_op ops.push
     done
 
     sig name_token Token::location ops name_token Token::value make_function_with_sig = function
@@ -1325,9 +1309,7 @@ fn inject_impl_trait_params
     List::new(List[Parameter]) = hidden_params
     0 = insert_pos
     sig Signature::trait_bounds parser build_hidden_trait_methods = hidden_methods
-    0 = hidden_index
-    while hidden_index hidden_methods.length > do
-        hidden_index hidden_methods.get = hidden
+    for hidden in hidden_methods.iter do
         hidden HiddenTraitMethod::var_name = hidden_name
         hidden HiddenTraitMethod::fn_type = hidden_type
         hidden_name hidden_type make_named_param hidden_params.push
@@ -1335,15 +1317,12 @@ fn inject_impl_trait_params
         function Function::location OpKind::OpAssignVar hidden_name make_op_str = assign_op
         insert_pos assign_op function Function::ops.insert
         1 += insert_pos
-        1 += hidden_index
     done
 
     # Prepend hidden params to existing signature parameters
     if 0 hidden_params.length != then
-        0 = existing_index
-        while existing_index sig Signature::parameters.length > do
-            existing_index sig Signature::parameters.get hidden_params.push
-            1 += existing_index
+        for existing_param in sig Signature::parameters.iter do
+            existing_param hidden_params.push
         done
         hidden_params sig Signature::set_parameters
     fi
@@ -1606,10 +1585,8 @@ fn parse_match_arm_body parser:Parser cursor:TokenCursor function_name:str ops:L
     cursor.peek = body_peek
     if body_peek.is_some "{" body_peek.unwrap Token::value == && then
         function_name cursor parser parse_block_ops = block_ops
-        0 = block_index
-        while block_index block_ops.length > do
-            block_index block_ops.get ops.push
-            1 += block_index
+        for block_op in block_ops.iter do
+            block_op ops.push
         done
         return
     fi
@@ -1749,16 +1726,13 @@ fn resolve_import parser:Parser importing_file:str spec:str location:Location ->
     fi
     = first_dir
     f"\n  {first_dir}" = searched
-    0 = path_index
-    while path_index parser.search_paths.length > do
-        path_index parser.search_paths.get = base
+    for base in parser.search_paths.iter do
         f"{searched}\n  {base}" = searched
         f"{base}/{spec}.casa" normalize_path = candidate
         if candidate file::exists then
             candidate
             return
         fi
-        1 += path_index
     done
     location f"module `{spec}` not found, searched:{searched}" ErrorKind::Syntax raise_error
     ""
@@ -1957,10 +1931,8 @@ fn get_op_keyword parser:Parser token:Token cursor:TokenCursor function_name:str
     # match
     if KeywordKind::Match keyword == then
         function_name cursor token parser parse_match_block = match_ops
-        0 = match_index
-        while match_index match_ops.length > do
-            match_index match_ops.get ops.push
-            1 += match_index
+        for match_op in match_ops.iter do
+            match_op ops.push
         done
         return
     fi
@@ -2045,10 +2017,8 @@ fn parse_struct_literal
     "{" cursor expect_token_value drop
     name_token Token::value parser.store.structs.get.unwrap = casa_struct
     List::new(List[str]) = member_names
-    0 = member_index
-    while member_index casa_struct CasaStruct::members.length > do
-        member_index casa_struct CasaStruct::members.get Member::name member_names.push
-        1 += member_index
+    for member in casa_struct CasaStruct::members.iter do
+        member Member::name member_names.push
     done
 
     List::new(List[str]) = field_order
@@ -2132,10 +2102,8 @@ fn token_to_op parser:Parser token:Token cursor:TokenCursor function_name:str op
             if "{" next_opt.unwrap Token::value == then
                 if token Token::value parser.store.structs.get.is_some then
                     function_name cursor token parser parse_struct_literal = struct_literal_ops
-                    0 = struct_index
-                    while struct_index struct_literal_ops.length > do
-                        struct_index struct_literal_ops.get ops.push
-                        1 += struct_index
+                    for struct_op in struct_literal_ops.iter do
+                        struct_op ops.push
                     done
                     return
                 fi
@@ -2195,25 +2163,20 @@ fn parse_ops parser:Parser tokens:List[Token] -> List[Op] {
 # ============================================================================
 
 fn gather_captures parser:Parser lambda_function:Function function:Function {
-    0 = index
-    while index lambda_function Function::ops.length > do
-        index lambda_function Function::ops.get = op
+    for op in lambda_function Function::ops.iter do
         if OpKind::OpIdentifier op Op::kind != then
-            1 += index
             continue
         fi
         op op_str_value = name
         false = captured
 
         # Check enclosing function variables
-        0 = var_index
-        while var_index function Function::variables.length > do
-            if name var_index function Function::variables.get Variable::name == then
-                var_index function Function::variables.get lambda_function Function::captures.push
+        for variable in function Function::variables.iter do
+            if name variable Variable::name == then
+                variable lambda_function Function::captures.push
                 true = captured
                 break
             fi
-            1 += var_index
         done
 
         if captured ! then
@@ -2223,14 +2186,11 @@ fn gather_captures parser:Parser lambda_function:Function function:Function {
                 global_var_opt.unwrap lambda_function Function::captures.push
             fi
         fi
-        1 += index
     done
 }
 
 fn resolve_array_identifiers parser:Parser items:List[Op] function:Function errors:List[CasaError] {
-    0 = rai_i
-    while rai_i items.length > do
-        rai_i items.get = rai_item
+    for rai_item in items.iter do
         if OpKind::OpPushArray rai_item Op::kind == then
             errors function rai_item Op::value(List[Op]) parser resolve_array_identifiers
         elif OpKind::OpIdentifier rai_item Op::kind == then
@@ -2245,7 +2205,6 @@ fn resolve_array_identifiers parser:Parser items:List[Op] function:Function erro
                 rai_item Op::location f"Identifier `{rai_name}` is not defined" ErrorKind::UndefinedName make_error errors.push
             fi
         fi
-        1 += rai_i
     done
 }
 
@@ -2273,9 +2232,7 @@ fn resolve_enum_variant
     fi
     # Register bindings as variables
     if 0 variant EnumVariant::bindings.length != then
-        0 = rev_bi
-        while rev_bi variant EnumVariant::bindings.length > do
-            rev_bi variant EnumVariant::bindings.get = rev_var_name
+        for rev_var_name in variant EnumVariant::bindings.iter do
             rev_var_name make_variable = rev_var
             if GLOBAL_SCOPE_LABEL function Function::name == then
                 rev_var_name rev_var parser.store.variables.set drop
@@ -2284,7 +2241,6 @@ fn resolve_enum_variant
                     rev_var function Function::variables.push
                 fi
             fi
-            1 += rev_bi
         done
     fi
 }
@@ -2319,11 +2275,9 @@ fn resolve_match_op parser:Parser function:Function op:Op errors:List[CasaError]
         PatternKind::PatStruct => {
             op pattern_value_of (StructPattern) = struct_pattern
             struct_pattern StructPattern::bindings.keys = pattern_keys
-            0 = field_index
-            while field_index pattern_keys.length > do
-                field_index pattern_keys.get struct_pattern StructPattern::bindings.get.unwrap = binding_name
+            for pattern_key in pattern_keys.iter do
+                pattern_key struct_pattern StructPattern::bindings.get.unwrap = binding_name
                 binding_name function parser register_struct_pattern_binding
-                1 += field_index
             done
         }
         PatternKind::PatEnumVariant => {
@@ -2563,10 +2517,8 @@ fn resolve_identifiers_fn parser:Parser ops:List[Op] function:Function -> List[O
                     1 += name_index
                 done
                 # Insert imported ops
-                0 = inner_index
-                while inner_index import_ops.length > do
-                    inner_index import_ops.get new_ops.push
-                    1 += inner_index
+                for inner_op in import_ops.iter do
+                    inner_op new_ops.push
                 done
                 # Copy remaining ops
                 op_index = name_index
@@ -2586,10 +2538,8 @@ fn resolve_identifiers_fn parser:Parser ops:List[Op] function:Function -> List[O
             resolve_errors report_errors
             1 exit
         else
-            0 = error_index
-            while error_index resolve_errors.length > do
-                error_index resolve_errors.get ERRORS.push
-                1 += error_index
+            for resolve_error in resolve_errors.iter do
+                resolve_error ERRORS.push
             done
         fi
     fi

--- a/compiler/typechecker.casa
+++ b/compiler/typechecker.casa
@@ -423,10 +423,8 @@ fn resolve_return_type bindings:Map[str str] ret:str -> str {
         if params_opt.is_some then
             params_opt.unwrap = params
             List::new(List[str]) = resolved
-            0 = index
             false = changed
-            while index params.length > do
-                index params.get = param
+            for param in params.iter do
                 param bindings.get = param_bound_opt
                 if param_bound_opt.is_some then
                     param_bound_opt.unwrap resolved.push
@@ -434,7 +432,6 @@ fn resolve_return_type bindings:Map[str str] ret:str -> str {
                 else
                     param resolved.push
                 fi
-                1 += index
             done
             if changed then
                 resolved base build_parameterized_type return
@@ -523,13 +520,10 @@ fn bind_generic_param
         fi
     fi
     if base actual == ANY_TYPE actual == || then
-        0 = bind_index
-        while bind_index expected_params.length > do
-            bind_index expected_params.get = expected_param
+        for expected_param in expected_params.iter do
             if expected_param sig Signature::type_vars.has then
                 ANY_TYPE expected_param bindings tc bind_type_var = bindings
             fi
-            1 += bind_index
         done
         true return
     fi
@@ -606,10 +600,8 @@ fn apply_signature tc:TypeChecker sig:Signature name:str {
             1 += index
         done
         "" tc TypeChecker::set_current_expect_ctx
-        0 = index
-        while index sig Signature::return_types.length > do
-            index sig Signature::return_types.get tc stack_push
-            1 += index
+        for return_type in sig Signature::return_types.iter do
+            return_type tc stack_push
         done
         return
     fi
@@ -651,10 +643,8 @@ fn apply_signature tc:TypeChecker sig:Signature name:str {
     "" tc TypeChecker::set_current_expect_ctx
 
     # Push resolved return types
-    0 = index
-    while index sig Signature::return_types.length > do
-        index sig Signature::return_types.get bindings resolve_return_type tc stack_push
-        1 += index
+    for return_type in sig Signature::return_types.iter do
+        return_type bindings resolve_return_type tc stack_push
     done
 }
 
@@ -894,16 +884,13 @@ fn simulate_trait_exec tc:TypeChecker function:Function var_name:str {
     trait_bound_opt.unwrap TraitBound::name tc.store.traits.get = trait_def_opt
     if trait_def_opt.is_none then return fi
     trait_def_opt.unwrap = trait_def
-    0 = trait_lookup_index
-    while trait_lookup_index trait_def CasaTrait::methods.length > do
-        trait_lookup_index trait_def CasaTrait::methods.get = trait_method_entry
+    for trait_method_entry in trait_def CasaTrait::methods.iter do
         if trait_method_name trait_method_entry TraitMethod::name == then
             tc stack_pop drop
             trait_type_var trait_method_entry TraitMethod::signature resolve_trait_sig = resolved_exec_sig
             f"{trait_type_var}::{trait_method_name}" resolved_exec_sig tc apply_signature
             return
         fi
-        1 += trait_lookup_index
     done
 }
 
@@ -1138,9 +1125,7 @@ fn type_satisfies_trait type_name:str trait_name:str function_opt:Option[Functio
             if trait_name bound_opt.unwrap trait_bound_to_str == then true return fi
         fi
     fi
-    0 = index
-    while index trait_def CasaTrait::methods.length > do
-        index trait_def CasaTrait::methods.get = method
+    for method in trait_def CasaTrait::methods.iter do
         f"{type_name}::{method TraitMethod::name}" = fn_name
         fn_name DEFAULT_PARSER.store.functions.get = fn_opt
         false = via_generic_base
@@ -1156,7 +1141,6 @@ fn type_satisfies_trait type_name:str trait_name:str function_opt:Option[Functio
         if fn_opt.is_none then
             # Default methods (with a body) don't require a concrete implementation
             if 0 method TraitMethod::default_ops.length != then
-                1 += index
                 continue
             fi
             false return
@@ -1167,7 +1151,6 @@ fn type_satisfies_trait type_name:str trait_name:str function_opt:Option[Functio
         # When satisfying via the generic base, skip strict signature comparison —
         # the concrete trait bounds are verified at the actual call site.
         if via_generic_base then
-            1 += index
             continue
         fi
         trait_subs type_name method TraitMethod::signature resolve_trait_sig apply_type_subs_to_sig = resolved
@@ -1203,7 +1186,6 @@ fn type_satisfies_trait type_name:str trait_name:str function_opt:Option[Functio
             fi
             1 += return_index
         done
-        1 += index
     done
     true
 }
@@ -1319,15 +1301,12 @@ fn method_diff_bind_for_bound
     trait_def CasaTrait::type_params = trait_params
     bound TraitBound::type_args = bound_args
     if bound_args.length trait_params.length != then bindings return fi
-    0 = method_index
-    while method_index trait_def CasaTrait::methods.length > do
-        method_index trait_def CasaTrait::methods.get = trait_method
+    for trait_method in trait_def CasaTrait::methods.iter do
         f"{concrete}::{trait_method TraitMethod::name}" DEFAULT_PARSER.store.functions.get = concrete_fn_opt
         if concrete_fn_opt.is_some then
             concrete trait_method TraitMethod::signature resolve_trait_sig = trait_resolved
             concrete_fn_opt.unwrap Function::signature trait_resolved bound_args trait_params sig bindings diff_method_sig = bindings
         fi
-        1 += method_index
     done
     bindings
 }
@@ -1338,15 +1317,12 @@ fn method_diff_bind_all
     bindings:Map[str str]
 -> Map[str str] {
     sig Signature::trait_bounds.keys = bound_keys
-    0 = bound_index
-    while bound_index bound_keys.length > do
-        bound_index bound_keys.get = bound_type_var
+    for bound_type_var in bound_keys.iter do
         bound_type_var sig Signature::trait_bounds.get.unwrap = bound_constraint
         bound_type_var bindings.get = concrete_opt
         if concrete_opt.is_some then
             concrete_opt.unwrap bound_constraint sig bindings method_diff_bind_for_bound = bindings
         fi
-        1 += bound_index
     done
     bindings
 }
@@ -1364,13 +1340,10 @@ fn inject_trait_fn_ptrs
 
     # Collect non-hidden parameters
     List::new(List[Parameter]) = non_hidden
-    0 = index
-    while index sig Signature::parameters.length > do
-        index sig Signature::parameters.get = param
+    for param in sig Signature::parameters.iter do
         if param Parameter::name "__trait_" str::starts_with ! then
             param non_hidden.push
         fi
-        1 += index
     done
 
     # Peek at stack to bind type variables
@@ -1408,10 +1381,8 @@ fn inject_trait_fn_ptrs
         op_index ops.get Op::kind = next_kind
         if OpKind::OpTypeCast next_kind == then
             op_index ops.get op_str_value = cast_type
-            0 = return_index
-            while return_index sig Signature::return_types.length > do
-                sig Signature::type_vars cast_type return_index sig Signature::return_types.get bindings bind_generic_params_standalone = bindings
-                1 += return_index
+            for return_type in sig Signature::return_types.iter do
+                sig Signature::type_vars cast_type return_type bindings bind_generic_params_standalone = bindings
             done
         fi
     fi
@@ -1690,25 +1661,20 @@ fn check_enum_variant tc:TypeChecker op:Op {
         for type_var in casa_enum CasaEnum::type_vars.iter do
             type_var type_vars.add = type_vars
         done
-        0 = index
-        while index inner_types.length > do
-            index inner_types.get = expected
+        for expected in inner_types.iter do
             if expected type_vars.has then
                 tc stack_pop = actual
                 actual expected bindings tc bind_type_var = bindings
             else
                 expected tc expect_type drop
             fi
-            1 += index
         done
         # Build resolved type name
         bindings casa_enum CasaEnum::type_vars enum_name build_resolved_type tc stack_push
     else
         # Non-generic variant: pop inner values directly
-        0 = index
-        while index inner_types.length > do
-            index inner_types.get tc expect_type drop
-            1 += index
+        for inner_type in inner_types.iter do
+            inner_type tc expect_type drop
         done
         enum_name tc stack_push
     fi
@@ -1766,14 +1732,11 @@ fn resolve_match_type typ:str -> str {
 fn set_binding_type var_name:str field_type:str function_opt:Option[Function] {
     if function_opt.is_some then
         function_opt.unwrap = function
-        0 = index
-        while index function Function::variables.length > do
-            index function Function::variables.get = variable
+        for variable in function Function::variables.iter do
             if var_name variable Variable::name == then
                 field_type variable Variable::set_typ
                 return
             fi
-            1 += index
         done
     fi
     var_name DEFAULT_PARSER.store.variables.get = global_opt
@@ -1840,13 +1803,10 @@ fn check_match tc:TypeChecker op:Op function_opt:Option[Function] {
 
             # Build covered set
             Set::new(Set[str]) = covered_set
-            0 = covered_index
-            while covered_index match_ctx MatchContext::branch_records.length > do
-                covered_index match_ctx MatchContext::branch_records.get = record
+            for record in match_ctx MatchContext::branch_records.iter do
                 if record "__covered:" str::starts_with then
                     record 10 record.length 10 - str::substring covered_set.add = covered_set
                 fi
-                1 += covered_index
             done
             MATCH_WILDCARD covered_set.has = has_wildcard
 
@@ -1929,20 +1889,15 @@ fn check_struct_new tc:TypeChecker op:Op {
     casa_struct CasaStruct::name = name
     # Build type variable bindings from actual stack values
     Map::new(Map[str str]) = bindings
-    0 = index
-    while index casa_struct CasaStruct::members.length > do
-        index casa_struct CasaStruct::members.get = member
+    for member in casa_struct CasaStruct::members.iter do
         tc stack_pop = actual
         member Member::typ = expected
         # If expected is a type variable, bind it to the actual type
-        0 = type_var_index
-        while type_var_index casa_struct CasaStruct::type_vars.length > do
-            if expected type_var_index casa_struct CasaStruct::type_vars.get == then
+        for type_var in casa_struct CasaStruct::type_vars.iter do
+            if expected type_var == then
                 expected actual bindings.set = bindings
             fi
-            1 += type_var_index
         done
-        1 += index
     done
     # Construct the result type
     if 0 casa_struct CasaStruct::type_vars.length == then
@@ -1970,14 +1925,11 @@ fn check_struct_literal tc:TypeChecker op:Op {
     while 0 index >= do
         index literal StructLiteral::field_order.get = field_name
         # Find member type
-        0 = member_index
-        while member_index casa_struct CasaStruct::members.length > do
-            member_index casa_struct CasaStruct::members.get = member
+        for member in casa_struct CasaStruct::members.iter do
             if field_name member Member::name == then
                 member Member::typ tc expect_type drop
-                casa_struct CasaStruct::members.length = member_index
+                break
             fi
-            1 += member_index
         done
         index 1 - = index
     done
@@ -2025,46 +1977,32 @@ fn find_method_by_name method_name:str -> Option[str] {
 
 fn find_default_trait_method method_name:str -> Option[TraitMethod] {
     DEFAULT_PARSER.store.traits.keys = find_trait_keys
-    0 = find_trait_index
-    while find_trait_index find_trait_keys.length > do
-        find_trait_index find_trait_keys.get = find_trait_key
+    for find_trait_key in find_trait_keys.iter do
         find_trait_key DEFAULT_PARSER.store.traits.get.unwrap = find_trait_def
-        0 = find_method_index
-        while find_method_index find_trait_def CasaTrait::methods.length > do
-            find_method_index find_trait_def CasaTrait::methods.get = find_method
+        for find_method in find_trait_def CasaTrait::methods.iter do
             if method_name find_method TraitMethod::name == 0 find_method TraitMethod::default_ops.length != && then
                 find_method Option::Some return
             fi
-            1 += find_method_index
         done
-        1 += find_trait_index
     done
     Option::None(Option[TraitMethod])
 }
 
 fn find_trait_for_method method_name:str -> Option[CasaTrait] {
     DEFAULT_PARSER.store.traits.keys = ftm_trait_keys
-    0 = ftm_trait_index
-    while ftm_trait_index ftm_trait_keys.length > do
-        ftm_trait_index ftm_trait_keys.get = ftm_trait_key
+    for ftm_trait_key in ftm_trait_keys.iter do
         ftm_trait_key DEFAULT_PARSER.store.traits.get.unwrap = ftm_trait_def
-        0 = ftm_method_index
-        while ftm_method_index ftm_trait_def CasaTrait::methods.length > do
-            ftm_method_index ftm_trait_def CasaTrait::methods.get = ftm_method
+        for ftm_method in ftm_trait_def CasaTrait::methods.iter do
             if method_name ftm_method TraitMethod::name == 0 ftm_method TraitMethod::default_ops.length != && then
                 ftm_trait_def Option::Some return
             fi
-            1 += ftm_method_index
         done
-        1 += ftm_trait_index
     done
     Option::None(Option[CasaTrait])
 }
 
 fn check_abstract_methods_present receiver:str trait_def:CasaTrait -> bool {
-    0 = cam_index
-    while cam_index trait_def CasaTrait::methods.length > do
-        cam_index trait_def CasaTrait::methods.get = cam_method
+    for cam_method in trait_def CasaTrait::methods.iter do
         if 0 cam_method TraitMethod::default_ops.length == then
             f"{receiver}::{cam_method TraitMethod::name}" DEFAULT_PARSER.store.functions.get = cam_fn_opt
             if cam_fn_opt.is_none then
@@ -2077,7 +2015,6 @@ fn check_abstract_methods_present receiver:str trait_def:CasaTrait -> bool {
                 false return
             fi
         fi
-        1 += cam_index
     done
     true
 }
@@ -2158,9 +2095,7 @@ fn instantiate_default_trait_method
         for type_param in type_params.iter do
             type_param type_param_set.add = type_param_set
         done
-        0 = infer_index
-        while infer_index trait_def CasaTrait::methods.length > do
-            infer_index trait_def CasaTrait::methods.get = infer_method
+        for infer_method in trait_def CasaTrait::methods.iter do
             if 0 infer_method TraitMethod::default_ops.length == then
                 f"{receiver}::{infer_method TraitMethod::name}" DEFAULT_PARSER.store.functions.get = infer_fn_opt
                 if infer_fn_opt.is_some then
@@ -2174,7 +2109,6 @@ fn instantiate_default_trait_method
                     done
                 fi
             fi
-            1 += infer_index
         done
         trait_subs receiver default_method TraitMethod::signature resolve_trait_sig apply_type_subs_to_sig = resolved_sig
     fi
@@ -2196,24 +2130,19 @@ fn instantiate_default_trait_method
     # Build function ops: parameter assignments + cloned body
     List::new(List[Op]) = synth_ops
     List::new(List[Variable]) = synth_vars
-    0 = param_iter
-    while param_iter resolved_sig Signature::parameters.length > do
-        param_iter resolved_sig Signature::parameters.get = synth_param
+    for synth_param in resolved_sig Signature::parameters.iter do
         if "" synth_param Parameter::name != then
             synth_param Parameter::typ synth_param Parameter::name Variable synth_vars.push
             empty_location OpKind::OpAssignVar synth_param Parameter::name make_op_str synth_ops.push
         fi
-        1 += param_iter
     done
 
     default_method TraitMethod::default_ops clone_ops = cloned_body
     if 0 trait_subs.length != then
         trait_subs cloned_body substitute_ops_types
     fi
-    0 = body_index
-    while body_index cloned_body.length > do
-        body_index cloned_body.get synth_ops.push
-        1 += body_index
+    for body_op in cloned_body.iter do
+        body_op synth_ops.push
     done
 
     # Create, register, and typecheck the function
@@ -2265,9 +2194,7 @@ fn check_method_call
                         1 += constraint_index
                     done
                 fi
-                0 = trait_method_index
-                while trait_method_index trait_def CasaTrait::methods.length > do
-                    trait_method_index trait_def CasaTrait::methods.get = trait_method
+                for trait_method in trait_def CasaTrait::methods.iter do
                     if method_name trait_method TraitMethod::name == then
                         f"__trait_{receiver}_{method_name}" = hidden_var
                         tc stack_pop drop
@@ -2281,7 +2208,6 @@ fn check_method_call
                         op_index exec_op ops.insert
                         op_index 1 + return
                     fi
-                    1 += trait_method_index
                 done
             fi
         fi
@@ -2684,16 +2610,12 @@ fn type_check_ops ops:List[Op] function_opt:Option[Function] -> Signature {
 
 fn type_check_functions {
     DEFAULT_PARSER.store.functions.keys = function_keys
-    0 = func_index
-    while func_index function_keys.length > do
-        func_index function_keys.get = func_name
+    for func_name in function_keys.iter do
         func_name DEFAULT_PARSER.store.functions.get.unwrap = current_fn
         if current_fn Function::is_typechecked then
-            1 += func_index
             continue
         fi
         if func_name "lambda__" str::starts_with then
-            1 += func_index
             continue
         fi
         true current_fn Function::set_is_typechecked
@@ -2701,20 +2623,17 @@ fn type_check_functions {
         resolved_ops current_fn Function::set_ops
         # Skip type checking for functions with trait bounds (checked on demand)
         if 0 current_fn Function::signature Signature::trait_bounds.keys.length != then
-            1 += func_index
             continue
         fi
         ERRORS.length = errors_before
         current_fn Option::Some current_fn Function::ops type_check_ops = inferred_sig
         ERRORS.length errors_before < = had_errors
         if had_errors then
-            1 += func_index
             continue
         fi
         if current_fn Function::signature signature_to_str "None -> None" == then
             inferred_sig current_fn Function::set_signature
         fi
-        1 += func_index
     done
     flush_errors
 }

--- a/formatter/format.casa
+++ b/formatter/format.casa
@@ -694,12 +694,10 @@ fn format_tokens tokens:List[Token] source:str -> str {
             if "fn" first_value == then
                 # Check if this line contains { (complete signature)
                 false = has_open_brace
-                0 = brace_check
-                while brace_check line_tokens.length > do
-                    if "{" brace_check line_tokens.get Token::value == then
+                for brace_token in line_tokens.iter do
+                    if "{" brace_token Token::value == then
                         true = has_open_brace
                     fi
-                    1 += brace_check
                 done
                 if has_open_brace ! then
                     # Incomplete fn signature — collect continuation lines
@@ -769,16 +767,13 @@ fn format_tokens tokens:List[Token] source:str -> str {
             fi
 
             # Check if line contains match keyword
-            0 = mi
-            while mi line_tokens.length > do
-                mi line_tokens.get = mt
+            for mt in line_tokens.iter do
                 if TokenKind::Keyword mt Token::kind == then
                     if "match" mt Token::value == then
                         1 += depth
                         true = prev_was_open
                     fi
                 fi
-                1 += mi
             done
 
             # Track if this line was a comment

--- a/lib/argparse.casa
+++ b/lib/argparse.casa
@@ -95,15 +95,12 @@ impl ArgParser {
         Map::new(Map[str List[str]]) = multi_values
 
         # Initialize flag defaults and multi-option lists
-        0 = init_index
-        while init_index self.definitions.length > do
-            init_index self.definitions.get = init_def
+        for init_def in self.definitions.iter do
             if init_def.kind ArgKind::Flag == then
                 init_def.name "0" values.set = values
             elif init_def.kind ArgKind::MultiOption == then
                 init_def.name List::new(List[str]) multi_values.set = multi_values
             fi
-            1 += init_index
         done
 
         0 = pos_index
@@ -160,9 +157,7 @@ impl ArgParser {
     }
 
     fn find_def self:ArgParser arg_value:str -> Option[ArgDef] {
-        0 = find_index
-        while find_index self.definitions.length > do
-            find_index self.definitions.get = find_def
+        for find_def in self.definitions.iter do
             if
             arg_value find_def.short_flag ==
             arg_value find_def.long_flag == ||
@@ -170,7 +165,6 @@ impl ArgParser {
                 find_def Option::Some
                 return
             fi
-            1 += find_index
         done
         Option::None(Option[ArgDef])
     }
@@ -191,29 +185,23 @@ impl ArgParser {
 
     fn count_positionals self:ArgParser -> int {
         0 = count
-        0 = count_index
-        while count_index self.definitions.length > do
-            count_index self.definitions.get = count_def
+        for count_def in self.definitions.iter do
             if count_def.kind ArgKind::Positional == then
                 1 += count
             fi
-            1 += count_index
         done
         count
     }
 
     fn nth_positional_name self:ArgParser target:int -> str {
         0 = nth_count
-        0 = nth_index
-        while nth_index self.definitions.length > do
-            nth_index self.definitions.get = nth_def
+        for nth_def in self.definitions.iter do
             if nth_def.kind ArgKind::Positional == then
                 if nth_count target == then
                     nth_def.name return
                 fi
                 1 += nth_count
             fi
-            1 += nth_index
         done
         ""
     }
@@ -231,46 +219,34 @@ impl ArgParser {
         f"usage: {self.program_name}" usage_sb.append
         " [-h]" usage_sb.append
         # Optional arguments
-        0 = usage_index
-        while usage_index self.definitions.length > do
-            usage_index self.definitions.get = usage_def
+        for usage_def in self.definitions.iter do
             if usage_def.kind ArgKind::Positional != then
                 usage_def usage_sb append_usage_optional
             fi
-            1 += usage_index
         done
         # Positional arguments
-        0 = usage_index
-        while usage_index self.definitions.length > do
-            usage_index self.definitions.get = usage_def
+        for usage_def in self.definitions.iter do
             if usage_def.kind ArgKind::Positional == then
                 f" {usage_def.name}" usage_sb.append
             fi
-            1 += usage_index
         done
         usage_sb.build
     }
 
     fn print_help_positionals self:ArgParser {
-        0 = help_index
-        while help_index self.definitions.length > do
-            help_index self.definitions.get = help_def
+        for help_def in self.definitions.iter do
             if help_def.kind ArgKind::Positional == then
                 help_def.help_text help_def.name print_help_line
             fi
-            1 += help_index
         done
     }
 
     fn print_help_options self:ArgParser {
         "show this help message and exit" "-h, --help" print_help_line
-        0 = help_index
-        while help_index self.definitions.length > do
-            help_index self.definitions.get = help_def
+        for help_def in self.definitions.iter do
             if help_def.kind ArgKind::Positional != then
                 help_def.help_text help_def build_flag_column print_help_line
             fi
-            1 += help_index
         done
     }
 
@@ -334,9 +310,7 @@ fn append_usage_optional usage_sb:StringBuilder definition:ArgDef {
 
 fn metavar name:str -> str {
     StringBuilder::new = meta_sb
-    0 = meta_index
-    while meta_index name.length > do
-        meta_index name.at = meta_char
+    for meta_char in name.iter do
         if meta_char '-' == then
             '_' meta_sb.append_char
         elif meta_char.is_lower then
@@ -344,7 +318,6 @@ fn metavar name:str -> str {
         else
             meta_char meta_sb.append_char
         fi
-        1 += meta_index
     done
     meta_sb.build
 }

--- a/lib/json.casa
+++ b/lib/json.casa
@@ -288,9 +288,7 @@ fn json_parse cursor:Cursor -> Result[JsonValue ParseError] {
 
 fn json_escape_string text:str -> str {
     StringBuilder::new = builder
-    0 = index
-    while index text.length > do
-        index text.at = character
+    for character in text.iter do
         character match
             '"' => "\\\"" builder.append
             '\\' => "\\\\" builder.append
@@ -299,7 +297,6 @@ fn json_escape_string text:str -> str {
             '\r' => "\\r" builder.append
             _ => character builder.append_char
         end
-        1 += index
     done
     builder.build
 }

--- a/lib/std.casa
+++ b/lib/std.casa
@@ -714,10 +714,8 @@ impl str {
 
 fn str_hash s:str -> int {
     5381 = hash
-    0 = index
-    while index s.length > do
-        hash 5 << hash + index s.at (int) + = hash
-        1 += index
+    for sh_char in s.iter do
+        hash 5 << hash + sh_char (int) + = hash
     done
     if 0 hash < then
         0 hash - = hash
@@ -982,10 +980,8 @@ impl StringBuilder {
     }
 
     fn append self:StringBuilder s:str {
-        0 = append_index
-        while append_index s.length > do
-            append_index s.at self.chars.push
-            1 += append_index
+        for sb_char in s.iter do
+            sb_char self.chars.push
         done
     }
 

--- a/lib/test.casa
+++ b/lib/test.casa
@@ -103,26 +103,22 @@ fn assert_error_count expected:int message:str {
 
 fn assert_error_contains needle:str message:str {
     false = error_found
-    0 = error_index
-    while error_index ERRORS.length > do
-        error_index ERRORS.get CasaError::message = error_message
+    for error in ERRORS.iter do
+        error CasaError::message = error_message
         error_message needle str::find = match_pos
         if 0 match_pos >= then
             true = error_found
         fi
-        1 += error_index
     done
     message error_found assert_true
 }
 
 fn assert_error_kind expected_kind:ErrorKind message:str {
     false = kind_found
-    0 = error_index
-    while error_index ERRORS.length > do
-        if expected_kind error_index ERRORS.get CasaError::kind == then
+    for error in ERRORS.iter do
+        if expected_kind error CasaError::kind == then
             true = kind_found
         fi
-        1 += error_index
     done
     message kind_found assert_true
 }
@@ -133,14 +129,12 @@ fn assert_warning_count expected:int message:str {
 
 fn assert_warning_contains needle:str message:str {
     false = warning_found
-    0 = warning_index
-    while warning_index WARNINGS.length > do
-        warning_index WARNINGS.get CasaWarning::message = warning_message
+    for warning in WARNINGS.iter do
+        warning CasaWarning::message = warning_message
         warning_message needle str::find = match_pos
         if 0 match_pos >= then
             true = warning_found
         fi
-        1 += warning_index
     done
     message warning_found assert_true
 }

--- a/lsp.casa
+++ b/lsp.casa
@@ -302,14 +302,11 @@ fn compile_document file_path:str source:str open_docs:Map[str DocumentState] ->
 
     # Seed SOURCE_CACHE from peer open documents
     open_docs.keys = uris
-    0 = uri_index
-    while uri_index uris.length > do
-        uri_index uris.get = uri
+    for uri in uris.iter do
         uri open_docs.get.unwrap = cached_state
         if cached_state DocumentState::file_path file_path != then
             cached_state DocumentState::file_path cached_state DocumentState::source SOURCE_CACHE.set = SOURCE_CACHE
         fi
-        1 += uri_index
     done
 
     # Lex
@@ -340,45 +337,33 @@ fn compile_document file_path:str source:str open_docs:Map[str DocumentState] ->
     final_source
     Map::new(Map[str Variable]) = vars_copy
     DEFAULT_PARSER.store.variables.keys = var_keys
-    0 = var_index
-    while var_index var_keys.length > do
-        var_index var_keys.get = var_name
+    for var_name in var_keys.iter do
         var_name DEFAULT_PARSER.store.variables.get.unwrap = var_value
         var_name var_value vars_copy.set = vars_copy
-        1 += var_index
     done
     vars_copy
 
     Map::new(Map[str CasaEnum]) = enums_copy
     DEFAULT_PARSER.store.enums.keys = enum_keys
-    0 = enum_index
-    while enum_index enum_keys.length > do
-        enum_index enum_keys.get = enum_name
+    for enum_name in enum_keys.iter do
         enum_name DEFAULT_PARSER.store.enums.get.unwrap = enum_value
         enum_name enum_value enums_copy.set = enums_copy
-        1 += enum_index
     done
     enums_copy
 
     Map::new(Map[str CasaStruct]) = structs_copy
     DEFAULT_PARSER.store.structs.keys = struct_keys
-    0 = struct_index
-    while struct_index struct_keys.length > do
-        struct_index struct_keys.get = struct_name
+    for struct_name in struct_keys.iter do
         struct_name DEFAULT_PARSER.store.structs.get.unwrap = struct_value
         struct_name struct_value structs_copy.set = structs_copy
-        1 += struct_index
     done
     structs_copy
 
     Map::new(Map[str Function]) = fns_copy
     DEFAULT_PARSER.store.functions.keys = fn_keys
-    0 = fn_index
-    while fn_index fn_keys.length > do
-        fn_index fn_keys.get = fn_name
+    for fn_name in fn_keys.iter do
         fn_name DEFAULT_PARSER.store.functions.get.unwrap = fn_value
         fn_name fn_value fns_copy.set = fns_copy
-        1 += fn_index
     done
     fns_copy
 
@@ -410,14 +395,11 @@ fn diagnostics_from result:CompileResult path:str -> List[LspDiagnostic] {
     List::new(List[LspDiagnostic]) = diagnostics
 
     # Convert errors
-    0 = error_index
-    while error_index errors.length > do
-        error_index errors.get = error
+    for error in errors.iter do
         if
         "" error CasaError::location Location::file !=
         error CasaError::location Location::file path != &&
         then
-            1 += error_index
             continue
         fi
         error CasaError::location Location::file source_cache.get = source_opt
@@ -447,18 +429,14 @@ fn diagnostics_from result:CompileResult path:str -> List[LspDiagnostic] {
         error CasaError::location Location::span Span::offset
         error_source offset_to_lsp_range
         LspDiagnostic diagnostics.push
-        1 += error_index
     done
 
     # Convert warnings
-    0 = warn_index
-    while warn_index warnings.length > do
-        warn_index warnings.get = warning
+    for warning in warnings.iter do
         if
         "" warning CasaWarning::location Location::file !=
         warning CasaWarning::location Location::file path != &&
         then
-            1 += warn_index
             continue
         fi
         warning CasaWarning::location Location::file source_cache.get = warn_source_opt
@@ -473,7 +451,6 @@ fn diagnostics_from result:CompileResult path:str -> List[LspDiagnostic] {
         warning CasaWarning::location Location::span Span::offset
         warn_source offset_to_lsp_range
         LspDiagnostic diagnostics.push
-        1 += warn_index
     done
 
     diagnostics
@@ -481,10 +458,8 @@ fn diagnostics_from result:CompileResult path:str -> List[LspDiagnostic] {
 
 fn publish_diagnostics uri:str diagnostics:List[LspDiagnostic] {
     List::new(List[JsonValue]) = json_array
-    0 = diag_index
-    while diag_index diagnostics.length > do
-        diag_index diagnostics.get lsp_diagnostic_to_json json_array.push
-        1 += diag_index
+    for diagnostic in diagnostics.iter do
+        diagnostic lsp_diagnostic_to_json json_array.push
     done
     json_object
     "uri" uri JsonValue::JsonString json_set
@@ -504,11 +479,8 @@ fn find_best_spanning_op
     func:Option[Function]
     find_state:FindOpState
 -> FindOpState {
-    0 = index
-    while index ops.length > do
-        index ops.get = op
+    for op in ops.iter do
         if op Op::location Location::file file_path != then
-            1 += index
             continue
         fi
         op Op::location Location::span Span::offset = span_offset
@@ -521,7 +493,6 @@ fn find_best_spanning_op
         then
             span_length func op FindResult Option::Some FindOpState = find_state
         fi
-        1 += index
     done
     find_state
 }
@@ -535,18 +506,15 @@ fn find_op_at_position state:DocumentState line:int col:int -> Option[FindResult
 
     # Search function ops
     state DocumentState::functions.keys = func_keys
-    0 = func_index
-    while func_index func_keys.length > do
-        func_index func_keys.get state DocumentState::functions.get.unwrap = func
+    for func_name in func_keys.iter do
+        func_name state DocumentState::functions.get.unwrap = func
         if
         "" func Function::location Location::file ==
         func Function::location Location::file state DocumentState::file_path != ||
         then
-            1 += func_index
             continue
         fi
         find_state func Option::Some target_offset state DocumentState::file_path func Function::ops find_best_spanning_op = find_state
-        1 += func_index
     done
 
     find_state FindOpState::best
@@ -555,21 +523,18 @@ fn find_op_at_position state:DocumentState line:int col:int -> Option[FindResult
 fn find_function_at_position state:DocumentState line:int col:int -> Option[Function] {
     col line state DocumentState::source position_to_offset = target_offset
     state DocumentState::functions.keys = func_keys
-    0 = func_index
-    while func_index func_keys.length > do
-        func_index func_keys.get state DocumentState::functions.get.unwrap = func
+    for func_name in func_keys.iter do
+        func_name state DocumentState::functions.get.unwrap = func
         if
         "" func Function::location Location::file ==
         func Function::location Location::file state DocumentState::file_path != ||
         then
-            1 += func_index
             continue
         fi
         if
         func Function::name "lambda__" str::starts_with
         func Function::name "__" str::starts_with ||
         then
-            1 += func_index
             continue
         fi
         func Function::location Location::span Span::offset = fn_offset
@@ -580,7 +545,6 @@ fn find_function_at_position state:DocumentState line:int col:int -> Option[Func
         then
             func Option::Some return
         fi
-        1 += func_index
     done
     Option::None(Option[Function])
 }
@@ -596,19 +560,15 @@ fn function_short_name name:str -> str {
 
 fn find_containing_function state:DocumentState offset:int -> Option[Function] {
     state DocumentState::functions.keys = func_keys
-    0 = index
-    while index func_keys.length > do
-        index func_keys.get state DocumentState::functions.get.unwrap = func
+    for func_name in func_keys.iter do
+        func_name state DocumentState::functions.get.unwrap = func
         if "" func Function::location Location::file == then
-            1 += index
             continue
         fi
         if func Function::location Location::file state DocumentState::file_path != then
-            1 += index
             continue
         fi
         if 0 func Function::ops.length == then
-            1 += index
             continue
         fi
         0 func Function::ops.get Op::location Location::span Span::offset = start_offset
@@ -618,7 +578,6 @@ fn find_containing_function state:DocumentState offset:int -> Option[Function] {
             func Option::Some
             return
         fi
-        1 += index
     done
     Option::None(Option[Function])
 }
@@ -737,15 +696,11 @@ fn handle_did_save message:JsonValue {
 # ============================================================================
 
 fn find_best_assignment name:str ops:List[Op] usage_offset:int best:Option[Op] -> Option[Op] {
-    0 = index
-    while index ops.length > do
-        index ops.get = op
+    for op in ops.iter do
         if OpKind::OpAssignVar op Op::kind != then
-            1 += index
             continue
         fi
         if op op_str_value name != then
-            1 += index
             continue
         fi
         if op Op::location Location::span Span::offset usage_offset > then
@@ -753,7 +708,6 @@ fn find_best_assignment name:str ops:List[Op] usage_offset:int best:Option[Op] -
         elif best.is_none then
             op Option::Some = best
         fi
-        1 += index
     done
     best
 }
@@ -900,27 +854,21 @@ fn handle_definition message:JsonValue {
 fn resolve_variable_type name:str func:Option[Function] state:DocumentState -> Option[str] {
     if func.is_some then
         func.unwrap = resolved_func
-        0 = index
-        while index resolved_func Function::variables.length > do
-            index resolved_func Function::variables.get = variable
+        for variable in resolved_func Function::variables.iter do
             if variable Variable::name name == then
                 if "" variable Variable::typ != then
                     variable Variable::typ Option::Some
                     return
                 fi
             fi
-            1 += index
         done
-        0 = capture_index
-        while capture_index resolved_func Function::captures.length > do
-            capture_index resolved_func Function::captures.get = capture
+        for capture in resolved_func Function::captures.iter do
             if capture Variable::name name == then
                 if "" capture Variable::typ != then
                     capture Variable::typ Option::Some
                     return
                 fi
             fi
-            1 += capture_index
         done
     fi
     name state DocumentState::variables.get = global_var_opt
@@ -1244,14 +1192,11 @@ fn methods_for_type receiver_type:str state:DocumentState -> List[CompletionItem
     f"{base_type}::" = method_prefix
     List::new(List[CompletionItem]) = items
     state DocumentState::functions.keys = fn_keys
-    0 = index
-    while index fn_keys.length > do
-        index fn_keys.get = fn_name
+    for fn_name in fn_keys.iter do
         if fn_name method_prefix str::starts_with then
             fn_name method_prefix.length fn_name.length method_prefix.length - str::substring = method_name
             "" COMPLETION_METHOD method_name CompletionItem items.push
         fi
-        1 += index
     done
     items
 }
@@ -1262,19 +1207,14 @@ fn members_for_qualified type_name:str state:DocumentState -> List[CompletionIte
     type_name state DocumentState::enums.get = enum_opt
     if enum_opt.is_some then
         enum_opt.unwrap = casa_enum
-        0 = variant_index
-        while variant_index casa_enum CasaEnum::variants.length > do
-            variant_index casa_enum CasaEnum::variants.get = variant_name
+        for variant_name in casa_enum CasaEnum::variants.iter do
             "" COMPLETION_ENUM_MEMBER variant_name CompletionItem items.push
-            1 += variant_index
         done
     fi
     # Methods
     state type_name methods_for_type = methods
-    0 = method_index
-    while method_index methods.length > do
-        method_index methods.get items.push
-        1 += method_index
+    for method in methods.iter do
+        method items.push
     done
     items
 }
@@ -1324,13 +1264,11 @@ fn infer_literal_type text:str -> Option[str] {
         return
     fi
     true = all_digits
-    0 = digit_index
-    while digit_index text.length > do
-        if digit_index text.at.is_digit ! then
+    for digit_char in text.iter do
+        if digit_char.is_digit ! then
             false = all_digits
             break
         fi
-        1 += digit_index
     done
     if all_digits then
         "int" Option::Some
@@ -1425,27 +1363,20 @@ fn compute_completion state:DocumentState line:int col:int trigger:str -> List[C
 
     # Functions (skip lambda, internal, qualified)
     state DocumentState::functions.keys = fn_keys
-    0 = fn_index
-    while fn_index fn_keys.length > do
-        fn_index fn_keys.get = fn_name
+    for fn_name in fn_keys.iter do
         if fn_name "lambda__" str::starts_with fn_name "__" str::starts_with || then
-            1 += fn_index
             continue
         fi
         if fn_name "::" str::contains then
-            1 += fn_index
             continue
         fi
         "" COMPLETION_FUNCTION fn_name CompletionItem items.push
-        1 += fn_index
     done
 
     # Structs
     state DocumentState::structs.keys = struct_keys
-    0 = struct_index
-    while struct_index struct_keys.length > do
-        struct_index struct_keys.get = struct_name
-        struct_index struct_keys.get state DocumentState::structs.get.unwrap = struct_val
+    for struct_name in struct_keys.iter do
+        struct_name state DocumentState::structs.get.unwrap = struct_val
         StringBuilder::new = member_builder
         0 = member_index
         while member_index struct_val CasaStruct::members.length > do
@@ -1457,37 +1388,27 @@ fn compute_completion state:DocumentState line:int col:int trigger:str -> List[C
             1 += member_index
         done
         member_builder.build COMPLETION_STRUCT struct_name CompletionItem items.push
-        1 += struct_index
     done
 
     # Enums
     state DocumentState::enums.keys = enum_keys
-    0 = enum_index
-    while enum_index enum_keys.length > do
-        enum_index enum_keys.get = enum_name_val
+    for enum_name_val in enum_keys.iter do
         "" COMPLETION_ENUM enum_name_val CompletionItem items.push
-        1 += enum_index
     done
 
     # Local variables
     cursor_offset state find_containing_function = containing_func_opt
     if containing_func_opt.is_some then
         containing_func_opt.unwrap = containing_func
-        0 = local_index
-        while local_index containing_func Function::variables.length > do
-            local_index containing_func Function::variables.get = local_var
+        for local_var in containing_func Function::variables.iter do
             local_var Variable::typ COMPLETION_VARIABLE local_var Variable::name CompletionItem items.push
-            1 += local_index
         done
     fi
 
     # Global variables
     state DocumentState::variables.keys = global_var_keys
-    0 = global_var_index
-    while global_var_index global_var_keys.length > do
-        global_var_index global_var_keys.get = global_var_name
+    for global_var_name in global_var_keys.iter do
         global_var_name state DocumentState::variables.get.unwrap Variable::typ COMPLETION_VARIABLE global_var_name CompletionItem items.push
-        1 += global_var_index
     done
 
     # Keywords
@@ -1541,10 +1462,8 @@ fn handle_completion message:JsonValue {
 
     # Build response
     List::new(List[JsonValue]) = json_items
-    0 = json_index
-    while json_index items.length > do
-        json_index items.get completion_item_to_json json_items.push
-        1 += json_index
+    for completion_item in items.iter do
+        completion_item completion_item_to_json json_items.push
     done
     json_object
     "isIncomplete" false JsonValue::JsonBool json_set
@@ -1557,19 +1476,14 @@ fn handle_completion message:JsonValue {
 # ============================================================================
 
 fn collect_fn_refs ops:List[Op] name:str results:List[LspLocation] {
-    0 = index
-    while index ops.length > do
-        index ops.get = op
+    for op in ops.iter do
         if OpKind::OpFnCall op Op::kind != OpKind::OpFnPush op Op::kind != && then
-            1 += index
             continue
         fi
         if op op_str_value name != then
-            1 += index
             continue
         fi
         op Op::location casa_location_to_lsp results.push
-        1 += index
     done
 }
 
@@ -1583,26 +1497,19 @@ fn is_var_op op:Op -> bool {
 }
 
 fn collect_var_refs ops:List[Op] name:str results:List[LspLocation] {
-    0 = index
-    while index ops.length > do
-        index ops.get = op
+    for op in ops.iter do
         if op is_var_op ! then
-            1 += index
             continue
         fi
         if op op_str_value name != then
-            1 += index
             continue
         fi
         op Op::location casa_location_to_lsp results.push
-        1 += index
     done
 }
 
 fn collect_struct_refs ops:List[Op] name:str results:List[LspLocation] {
-    0 = index
-    while index ops.length > do
-        index ops.get = op
+    for op in ops.iter do
         if OpKind::OpStructNew op Op::kind == then
             if op Op::value(CasaStruct) CasaStruct::name name == then
                 op Op::location casa_location_to_lsp results.push
@@ -1612,24 +1519,18 @@ fn collect_struct_refs ops:List[Op] name:str results:List[LspLocation] {
                 op Op::location casa_location_to_lsp results.push
             fi
         fi
-        1 += index
     done
 }
 
 fn collect_enum_refs ops:List[Op] enum_name:str results:List[LspLocation] {
-    0 = index
-    while index ops.length > do
-        index ops.get = op
+    for op in ops.iter do
         if OpKind::OpPushEnumVariant op Op::kind != then
-            1 += index
             continue
         fi
         if op Op::value(EnumVariant) EnumVariant::enum_name enum_name != then
-            1 += index
             continue
         fi
         op Op::location casa_location_to_lsp results.push
-        1 += index
     done
 }
 
@@ -1639,10 +1540,9 @@ fn collect_refs_in_all_functions
     name:str
     results:List[LspLocation]
 {
-    state DocumentState::functions.keys = keys
-    0 = index
-    while index keys.length > do
-        index keys.get state DocumentState::functions.get.unwrap = func
+    state DocumentState::functions.keys = fn_keys
+    for fn_name in fn_keys.iter do
+        fn_name state DocumentState::functions.get.unwrap = func
         if COLLECTOR_FN collector_kind == then
             results name func Function::ops collect_fn_refs
         elif COLLECTOR_VAR collector_kind == then
@@ -1652,19 +1552,16 @@ fn collect_refs_in_all_functions
         elif COLLECTOR_ENUM collector_kind == then
             results name func Function::ops collect_enum_refs
         fi
-        1 += index
     done
 }
 
 fn is_local_variable name:str func:Option[Function] -> bool {
     if func.is_none then false return fi
     func.unwrap = resolved_func
-    0 = index
-    while index resolved_func Function::variables.length > do
-        if index resolved_func Function::variables.get Variable::name name == then
+    for variable in resolved_func Function::variables.iter do
+        if variable Variable::name name == then
             true return
         fi
-        1 += index
     done
     false
 }
@@ -1798,10 +1695,8 @@ fn handle_references message:JsonValue {
     fi
     refs_opt.unwrap = refs
     List::new(List[JsonValue]) = json_refs
-    0 = ref_index
-    while ref_index refs.length > do
-        ref_index refs.get lsp_location_to_json json_refs.push
-        1 += ref_index
+    for ref_loc in refs.iter do
+        ref_loc lsp_location_to_json json_refs.push
     done
     json_refs JsonValue::JsonArray request_id send_response
 }
@@ -1842,9 +1737,7 @@ fn compute_rename
 
     # Build workspace edit: group edits by URI
     Map::new(Map[str List[TextEdit]]) = edits_map
-    0 = ref_index
-    while ref_index refs.length > do
-        ref_index refs.get = ref_loc
+    for ref_loc in refs.iter do
         ref_loc LspLocation::uri = ref_uri
         ref_loc LspLocation::range = edit_range
 
@@ -1868,7 +1761,6 @@ fn compute_rename
             edit_item new_list.push
             ref_uri new_list edits_map.set = edits_map
         fi
-        1 += ref_index
     done
 
     edits_map Option::Some
@@ -1898,19 +1790,13 @@ fn handle_rename message:JsonValue {
     # Convert to JSON changes object
     json_object = changes
     edits_map.keys = change_uris
-    0 = uri_index
-    while uri_index change_uris.length > do
-        uri_index change_uris.get = change_uri
+    for change_uri in change_uris.iter do
         change_uri edits_map.get.unwrap = edit_list
         List::new(List[JsonValue]) = edit_json_list
-        0 = edit_index
-        while edit_index edit_list.length > do
-            edit_index edit_list.get = edit_item
+        for edit_item in edit_list.iter do
             edit_item TextEdit::new_text edit_item TextEdit::range text_edit_to_json edit_json_list.push
-            1 += edit_index
         done
         changes change_uri edit_json_list JsonValue::JsonArray json_set = changes
-        1 += uri_index
     done
 
     json_object
@@ -2011,22 +1897,17 @@ TOKEN_ENUM_MEMBER = QUALIFIED_MEMBER_ENUM_VARIANT
 
 fn collect_semantic_tokens ops:List[Op] state:DocumentState tokens:List[SemanticToken] {
     state DocumentState::source = token_source
-    0 = index
-    while index ops.length > do
-        index ops.get = op
+    for op in ops.iter do
         if op Op::location Location::file state DocumentState::file_path != then
-            1 += index
             continue
         fi
         op Op::location Location::span Span::offset = start
         op Op::location Location::span Span::length = length
         if 0 length <= then
-            1 += index
             continue
         fi
         op Op::kind TOKEN_TYPE_MAP.get = token_type_opt
         if token_type_opt.is_none then
-            1 += index
             continue
         fi
         token_type_opt.unwrap = token_type
@@ -2053,7 +1934,6 @@ fn collect_semantic_tokens ops:List[Op] state:DocumentState tokens:List[Semantic
                     if OpKind::OpPushEnumVariant op Op::kind == then QUALIFIED_MEMBER_ENUM_VARIANT else QUALIFIED_MEMBER_FN fi = member_token_type
                     0 member_token_type member_length member_col member_line SemanticToken tokens.push
                 fi
-                1 += index
                 continue
             fi
         fi
@@ -2061,7 +1941,6 @@ fn collect_semantic_tokens ops:List[Op] state:DocumentState tokens:List[Semantic
         start token_source offset_to_line_col 1 - = token_line
         start token_source offset_to_col 1 - = token_col
         0 token_type length token_col token_line SemanticToken tokens.push
-        1 += index
     done
 }
 
@@ -2095,27 +1974,21 @@ fn compute_semantic_tokens state:DocumentState -> List[SemanticToken] {
 
     # Collect from function ops
     state DocumentState::functions.keys = fn_keys
-    0 = fn_index
-    while fn_index fn_keys.length > do
-        fn_index fn_keys.get state DocumentState::functions.get.unwrap = func
+    for fn_name in fn_keys.iter do
+        fn_name state DocumentState::functions.get.unwrap = func
         tokens state func Function::ops collect_semantic_tokens
-        1 += fn_index
     done
 
     # Add function definition names + fn keyword
-    0 = fn_def_index
-    while fn_def_index fn_keys.length > do
-        fn_def_index fn_keys.get state DocumentState::functions.get.unwrap = fn_def
+    for fn_def_name in fn_keys.iter do
+        fn_def_name state DocumentState::functions.get.unwrap = fn_def
         if "" fn_def Function::location Location::file == then
-            1 += fn_def_index
             continue
         fi
         if fn_def Function::location Location::file state DocumentState::file_path != then
-            1 += fn_def_index
             continue
         fi
         if fn_def Function::name "lambda__" str::starts_with fn_def Function::name "__" str::starts_with || then
-            1 += fn_def_index
             continue
         fi
         fn_def Function::location Location::span Span::offset = fn_offset
@@ -2126,16 +1999,13 @@ fn compute_semantic_tokens state:DocumentState -> List[SemanticToken] {
             0 TOKEN_FUNCTION fn_length fn_col fn_line SemanticToken tokens.push
         fi
         tokens "fn" fn_offset source scan_keyword_before
-        1 += fn_def_index
     done
 
     # Add enum definition names + enum keyword
     state DocumentState::enums.keys = enum_keys
-    0 = enum_def_index
-    while enum_def_index enum_keys.length > do
-        enum_def_index enum_keys.get state DocumentState::enums.get.unwrap = enum_def
+    for enum_def_name in enum_keys.iter do
+        enum_def_name state DocumentState::enums.get.unwrap = enum_def
         if enum_def CasaEnum::location Location::file state DocumentState::file_path != then
-            1 += enum_def_index
             continue
         fi
         enum_def CasaEnum::location Location::span Span::offset = enum_offset
@@ -2146,16 +2016,13 @@ fn compute_semantic_tokens state:DocumentState -> List[SemanticToken] {
             0 TOKEN_TYPE enum_length enum_col enum_line SemanticToken tokens.push
         fi
         tokens "enum" enum_offset source scan_keyword_before
-        1 += enum_def_index
     done
 
     # Add struct definition names + struct keyword
     state DocumentState::structs.keys = struct_keys
-    0 = struct_def_index
-    while struct_def_index struct_keys.length > do
-        struct_def_index struct_keys.get state DocumentState::structs.get.unwrap = struct_def
+    for struct_def_name in struct_keys.iter do
+        struct_def_name state DocumentState::structs.get.unwrap = struct_def
         if struct_def CasaStruct::location Location::file state DocumentState::file_path != then
-            1 += struct_def_index
             continue
         fi
         struct_def CasaStruct::location Location::span Span::offset = struct_offset
@@ -2166,7 +2033,6 @@ fn compute_semantic_tokens state:DocumentState -> List[SemanticToken] {
             0 TOKEN_STRUCT struct_length struct_col struct_line SemanticToken tokens.push
         fi
         tokens "struct" struct_offset source scan_keyword_before
-        1 += struct_def_index
     done
 
     # Sort tokens by (line, col)
@@ -2212,9 +2078,7 @@ fn handle_semantic_tokens message:JsonValue {
     List::new(List[JsonValue]) = encoded_data
     0 = prev_line
     0 = prev_col
-    0 = encode_index
-    while encode_index tokens.length > do
-        encode_index tokens.get = token
+    for token in tokens.iter do
         token SemanticToken::line prev_line - = delta_line
         if 0 delta_line == then
             token SemanticToken::col prev_col -
@@ -2229,7 +2093,6 @@ fn handle_semantic_tokens message:JsonValue {
         token SemanticToken::modifiers JsonValue::JsonInt encoded_data.push
         token SemanticToken::line = prev_line
         token SemanticToken::col = prev_col
-        1 += encode_index
     done
 
     json_object
@@ -2370,13 +2233,10 @@ fn extract_library_paths message:JsonValue -> List[str] {
     "libraryPaths" init_options_option.unwrap json_get_array = library_paths_option
     if library_paths_option.is_none then paths return fi
     library_paths_option.unwrap = library_paths_array
-    0 = path_index
-    while path_index library_paths_array.length > do
-        path_index library_paths_array.get = path_value
+    for path_value in library_paths_array.iter do
         if path_value JsonValue::JsonString(path_string) is then
             path_string paths.push
         fi
-        1 += path_index
     done
     paths
 }


### PR DESCRIPTION
## Summary

Finishes the work started in #122. PR #122 deferred conversions in files where the first `Iter[T]` instantiation crashed stage1 (issue #125 — closure-capture aliasing, fixed by #127). With #127 merged, the remaining eligible `while INDEX xs.length > do ... 1 += INDEX done` index-counter loops now convert cleanly to `for x in xs.iter do ... done`.

Per-module commits cover: error, pattern, common, bytecode, emitter, typechecker, syntax, test, argparse, json, std, format, lsp.

Lexer and parser had no eligible candidates (all whiles either cursor-driven or starting from a non-zero index).

Eligibility rule (from the plan):
- Convert: forward iteration where the index is used only in `xs.get` / `xs.nth` / `xs.at`, with a single `1 += index` at end of body.
- Skip: cursor-driven (`while cursor.is_finished !`), `while true`, reverse iteration, compound conditions, builder loops with `if 0 X != then` first-iteration checks, and integer-range counters.

## Test plan

- [x] `tests/test_compiler.sh < /dev/null` — 24/24 pass (incl. self_compilation, fixed_point)
- [x] `tests/test_examples.sh` — 39/39 pass
- [x] Two-stage self-host: stage1.s == stage2.s == stage3.s (binary diff is intrinsic ELF metadata only)