### PR TITLE
Migrate BytecodeCompiler::function to Option[Function] (#128 Track A)

### DIFF
--- a/compiler/bytecode.casa
+++ b/compiler/bytecode.casa
@@ -105,11 +105,11 @@ fn intern_table table:List[str] value:str -> int {
 }
 
 fn intern_string compiler:BytecodeCompiler value:str -> int {
-    value compiler BytecodeCompiler::string_table intern_table
+    value compiler.string_table intern_table
 }
 
 fn intern_constant compiler:BytecodeCompiler name:str -> int {
-    name compiler BytecodeCompiler::constants_table intern_table
+    name compiler.constants_table intern_table
 }
 
 # ============================================================================
@@ -117,7 +117,7 @@ fn intern_constant compiler:BytecodeCompiler name:str -> int {
 # ============================================================================
 
 fn resolve_variable compiler:BytecodeCompiler variable_name:str -> ResolvedVariable {
-    if compiler BytecodeCompiler::function Option::Some(function) is then
+    if compiler.function Option::Some(function) is then
         variable_name function Function::variables variable_list_contains = is_local
         if is_local then
             variable_name function Function::variables variable_list_index = local_index
@@ -253,7 +253,7 @@ fn compile_assignment compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
 # ============================================================================
 
 fn compile_if_block compiler:BytecodeCompiler op:Op op_index:int bytecode:List[Inst] {
-    compiler BytecodeCompiler::ops = ops
+    compiler.ops = ops
     op Op::location = loc
 
     List::new(List[OpKind]) = start_targets
@@ -278,21 +278,21 @@ fn compile_if_block compiler:BytecodeCompiler op:Op op_index:int bytecode:List[I
         }
         OpKind::OpIfElif => {
             true "`elif` without parent `if`" loc start_targets OpKind::OpIfStart op_index ops require_matching drop
-            op_index compiler BytecodeCompiler::ops op_ptr_to_label = elif_label
+            op_index compiler.ops op_ptr_to_label = elif_label
             false "`elif` without matching `fi`" loc end_targets OpKind::OpIfEnd op_index ops require_matching = end_label_2
             end_label_2 InstKind::InstJump make_inst_int bytecode.push
             elif_label InstKind::InstLabel make_inst_int bytecode.push
         }
         OpKind::OpIfElse => {
             true "`else` without parent `if`" loc start_targets OpKind::OpIfStart op_index ops require_matching drop
-            op_index compiler BytecodeCompiler::ops op_ptr_to_label = else_label
+            op_index compiler.ops op_ptr_to_label = else_label
             false "`else` without matching `fi`" loc end_targets OpKind::OpIfEnd op_index ops require_matching = end_label_3
             end_label_3 InstKind::InstJump make_inst_int bytecode.push
             else_label InstKind::InstLabel make_inst_int bytecode.push
         }
         OpKind::OpIfEnd => {
             true "`fi` without parent `if`" loc start_targets OpKind::OpIfStart op_index ops require_matching drop
-            op_index compiler BytecodeCompiler::ops op_ptr_to_label = fi_label
+            op_index compiler.ops op_ptr_to_label = fi_label
             fi_label InstKind::InstLabel make_inst_int bytecode.push
         }
         OpKind::OpIfStart => false "`if` without matching `fi`" loc end_targets OpKind::OpIfEnd op_index ops require_matching drop
@@ -308,7 +308,7 @@ fn compile_if_block compiler:BytecodeCompiler op:Op op_index:int bytecode:List[I
 # ============================================================================
 
 fn compile_while_block compiler:BytecodeCompiler op:Op op_index:int bytecode:List[Inst] {
-    compiler BytecodeCompiler::ops = ops
+    compiler.ops = ops
     op Op::location = loc
 
     List::new(List[OpKind]) = start_targets
@@ -333,13 +333,13 @@ fn compile_while_block compiler:BytecodeCompiler op:Op op_index:int bytecode:Lis
             continue_target InstKind::InstJump make_inst_int bytecode.push
         }
         OpKind::OpWhileEnd => {
-            op_index compiler BytecodeCompiler::ops op_ptr_to_label = while_label
+            op_index compiler.ops op_ptr_to_label = while_label
             true "`done` without parent `while`" loc start_targets OpKind::OpWhileStart op_index ops require_matching = loop_start
             loop_start InstKind::InstJump make_inst_int bytecode.push
             while_label InstKind::InstLabel make_inst_int bytecode.push
         }
         OpKind::OpWhileStart => {
-            op_index compiler BytecodeCompiler::ops op_ptr_to_label = start_label
+            op_index compiler.ops op_ptr_to_label = start_label
             start_label InstKind::InstLabel make_inst_int bytecode.push
         }
         _ => {
@@ -489,7 +489,7 @@ fn compile_match_op
 }
 
 fn compile_match_block compiler:BytecodeCompiler op:Op op_index:int bytecode:List[Inst] {
-    compiler BytecodeCompiler::ops = ops
+    compiler.ops = ops
 
     if OpKind::OpMatchStart op Op::kind == then
         # Nothing to emit
@@ -516,7 +516,7 @@ fn compile_match_block compiler:BytecodeCompiler op:Op op_index:int bytecode:Lis
 
         bytecode next_arm is_last op compiler compile_match_op
     elif OpKind::OpMatchEnd op Op::kind == then
-        op_index compiler BytecodeCompiler::ops op_ptr_to_label = end_match_label
+        op_index compiler.ops op_ptr_to_label = end_match_label
         end_match_label InstKind::InstLabel make_inst_int bytecode.push
     fi
 }
@@ -565,16 +565,16 @@ fn compile_enum_variant
     List::new(List[int]) = temps
     0 = index
     while index inner_count > do
-        compiler BytecodeCompiler::locals_count = local_index
-        compiler BytecodeCompiler::locals_count 1 + compiler->locals_count
+        compiler.locals_count = local_index
+        compiler.locals_count 1 + compiler->locals_count
         local_index temps.push
         local_index InstKind::InstLocalSet make_inst_int bytecode.push
         1 += index
     done
 
     # Allocate heap
-    compiler BytecodeCompiler::locals_count = ptr_local
-    compiler BytecodeCompiler::locals_count 1 + compiler->locals_count
+    compiler.locals_count = ptr_local
+    compiler.locals_count 1 + compiler->locals_count
     slot_count WORD_SIZE * InstKind::InstPush make_inst_int bytecode.push
     InstKind::InstHeapAlloc make_inst bytecode.push
     ptr_local InstKind::InstLocalSet make_inst_int bytecode.push
@@ -629,8 +629,8 @@ fn compile_is_check compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
     fi
 
     # Data-carrying enum with bindings
-    compiler BytecodeCompiler::locals_count = temp_ptr
-    compiler BytecodeCompiler::locals_count 1 + compiler->locals_count
+    compiler.locals_count = temp_ptr
+    compiler.locals_count 1 + compiler->locals_count
 
     new_label = skip_bindings
 
@@ -678,8 +678,8 @@ fn compile_struct_literal compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
     literal StructLiteral::field_order.length 1 - = field_index
     Map::new(Map[str int]) = temp_locals
     while 0 field_index >= do
-        compiler BytecodeCompiler::locals_count = local_index
-        compiler BytecodeCompiler::locals_count 1 + compiler->locals_count
+        compiler.locals_count = local_index
+        compiler.locals_count 1 + compiler->locals_count
         field_index literal StructLiteral::field_order.get = field_name
         field_name local_index temp_locals.set = temp_locals
         local_index InstKind::InstLocalSet make_inst_int bytecode.push
@@ -724,8 +724,8 @@ fn compile_push_array compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
     done
 
     # Allocate memory: header (data_ptr + length) + elements
-    compiler BytecodeCompiler::locals_count = list_local
-    compiler BytecodeCompiler::locals_count 1 + compiler->locals_count
+    compiler.locals_count = list_local
+    compiler.locals_count 1 + compiler->locals_count
     length 2 + WORD_SIZE * InstKind::InstPush make_inst_int bytecode.push
     InstKind::InstHeapAlloc make_inst bytecode.push
     list_local InstKind::InstLocalSet make_inst_int bytecode.push
@@ -745,8 +745,8 @@ fn compile_push_array compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
     InstKind::InstStore64 make_inst bytecode.push
 
     # Store elements starting at offset 16
-    compiler BytecodeCompiler::locals_count = index_local
-    compiler BytecodeCompiler::locals_count 1 + compiler->locals_count
+    compiler.locals_count = index_local
+    compiler.locals_count 1 + compiler->locals_count
     16 InstKind::InstPush make_inst_int bytecode.push
     index_local InstKind::InstLocalSet make_inst_int bytecode.push
 
@@ -795,11 +795,11 @@ fn compile_function compiler:BytecodeCompiler function:Function op:Op {
     function Function::name COMPILED_FUNCTIONS.add = COMPILED_FUNCTIONS
 
     List::new(List[Inst]) = function_bytecode
-    compiler BytecodeCompiler::constants_table compiler BytecodeCompiler::string_table function Option::Some ops compiler.store make_compiler_with_tables = function_compiler
+    compiler.constants_table compiler.string_table function Option::Some ops compiler.store make_compiler_with_tables = function_compiler
     function_bytecode function_compiler compile_ops
 
     # Handle locals
-    function_compiler BytecodeCompiler::locals_count = locals_count
+    function_compiler.locals_count = locals_count
     if locals_count 0 < then
         # Build new list with LOCALS_INIT at front
         List::new(List[Inst]) = final_bytecode
@@ -869,8 +869,8 @@ fn compile_function_ops compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
 # ============================================================================
 
 fn compile_enum_comparison compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
-    compiler BytecodeCompiler::locals_count = local_a
-    compiler BytecodeCompiler::locals_count 1 + compiler->locals_count
+    compiler.locals_count = local_a
+    compiler.locals_count 1 + compiler->locals_count
     local_a InstKind::InstLocalSet make_inst_int bytecode.push
     InstKind::InstLoad64 make_inst bytecode.push
     local_a InstKind::InstLocalGet make_inst_int bytecode.push
@@ -996,7 +996,7 @@ fn compile_op compiler:BytecodeCompiler op:Op op_index:int bytecode:List[Inst] {
         op op_int_value InstKind::InstPushChar make_inst_int bytecode.push
     elif OpKind::OpPushCapture kind == then
         op op_str_value = capture_name
-        if compiler BytecodeCompiler::function Option::Some(function) is then
+        if compiler.function Option::Some(function) is then
             capture_name function Function::captures variable_list_index = capture_index
             capture_index InstKind::InstCaptureLoad make_inst_int bytecode.push
         fi
@@ -1034,7 +1034,7 @@ fn compile_op compiler:BytecodeCompiler op:Op op_index:int bytecode:List[Inst] {
 
 fn compile_ops compiler:BytecodeCompiler bytecode:List[Inst] {
     # Set locals_count from function variables
-    if compiler BytecodeCompiler::function Option::Some(function) is then
+    if compiler.function Option::Some(function) is then
         function Function::variables.length = var_count
         var_count compiler->locals_count
     fi
@@ -1044,8 +1044,8 @@ fn compile_ops compiler:BytecodeCompiler bytecode:List[Inst] {
     function_label InstKind::InstLabel make_inst_int bytecode.push
 
     0 = index
-    while index compiler BytecodeCompiler::ops.length > do
-        index compiler BytecodeCompiler::ops.get = op
+    while index compiler.ops.length > do
+        index compiler.ops.get = op
         bytecode index op compiler compile_op
         1 += index
     done
@@ -1069,7 +1069,7 @@ fn compile_bytecode store:SymbolStore ops:List[Op] -> Program {
     bytecode compiler compile_ops
 
     # Handle locals for global scope
-    compiler BytecodeCompiler::locals_count = locals_count
+    compiler.locals_count = locals_count
     if locals_count 0 < then
         List::new(List[Inst]) = final_bytecode
         locals_count InstKind::InstLocalsInit make_inst_int final_bytecode.push
@@ -1090,9 +1090,9 @@ fn compile_bytecode store:SymbolStore ops:List[Op] -> Program {
         fi
     done
 
-    compiler BytecodeCompiler::constants_table.length
+    compiler.constants_table.length
     compiler.store.variables.length
-    compiler BytecodeCompiler::string_table
+    compiler.string_table
     functions
     bytecode
     Program

--- a/compiler/bytecode.casa
+++ b/compiler/bytecode.casa
@@ -56,7 +56,7 @@ fn op_ptr_to_label ops:List[Op] op_index:int -> int {
 
 struct BytecodeCompiler {
     ops:             List[Op]
-    function:        int
+    function:        Option[Function]
     locals_count:    int
     string_table:    List[str]
     constants_table: List[str]
@@ -68,7 +68,7 @@ fn make_compiler store:SymbolStore ops:List[Op] -> BytecodeCompiler {
     List::new(List[str])
     List::new(List[str])
     0
-    0
+    Option::None(Option[Function])
     ops
     BytecodeCompiler
 }
@@ -76,7 +76,7 @@ fn make_compiler store:SymbolStore ops:List[Op] -> BytecodeCompiler {
 fn make_compiler_with_tables
     store:SymbolStore
     ops:List[Op]
-    function:int
+    function:Option[Function]
     string_table:List[str]
     constants_table:List[str]
 -> BytecodeCompiler {
@@ -117,9 +117,7 @@ fn intern_constant compiler:BytecodeCompiler name:str -> int {
 # ============================================================================
 
 fn resolve_variable compiler:BytecodeCompiler variable_name:str -> ResolvedVariable {
-    compiler BytecodeCompiler::function = function_ptr
-    if 0 function_ptr != then
-        function_ptr (Function) = function
+    if compiler BytecodeCompiler::function Option::Some(function) is then
         variable_name function Function::variables variable_list_contains = is_local
         if is_local then
             variable_name function Function::variables variable_list_index = local_index
@@ -797,7 +795,7 @@ fn compile_function compiler:BytecodeCompiler function:Function op:Op {
     function Function::name COMPILED_FUNCTIONS.add = COMPILED_FUNCTIONS
 
     List::new(List[Inst]) = function_bytecode
-    compiler BytecodeCompiler::constants_table compiler BytecodeCompiler::string_table function (int) ops compiler.store make_compiler_with_tables = function_compiler
+    compiler BytecodeCompiler::constants_table compiler BytecodeCompiler::string_table function Option::Some ops compiler.store make_compiler_with_tables = function_compiler
     function_bytecode function_compiler compile_ops
 
     # Handle locals
@@ -998,9 +996,10 @@ fn compile_op compiler:BytecodeCompiler op:Op op_index:int bytecode:List[Inst] {
         op op_int_value InstKind::InstPushChar make_inst_int bytecode.push
     elif OpKind::OpPushCapture kind == then
         op op_str_value = capture_name
-        compiler BytecodeCompiler::function(Function) = function
-        capture_name function Function::captures variable_list_index = capture_index
-        capture_index InstKind::InstCaptureLoad make_inst_int bytecode.push
+        if compiler BytecodeCompiler::function Option::Some(function) is then
+            capture_name function Function::captures variable_list_index = capture_index
+            capture_index InstKind::InstCaptureLoad make_inst_int bytecode.push
+        fi
     elif OpKind::OpPushInt kind == then
         op op_int_value InstKind::InstPush make_inst_int bytecode.push
     elif OpKind::OpPushStr kind == then
@@ -1035,9 +1034,8 @@ fn compile_op compiler:BytecodeCompiler op:Op op_index:int bytecode:List[Inst] {
 
 fn compile_ops compiler:BytecodeCompiler bytecode:List[Inst] {
     # Set locals_count from function variables
-    compiler BytecodeCompiler::function = function_ptr
-    if 0 function_ptr != then
-        function_ptr (Function) Function::variables.length = var_count
+    if compiler BytecodeCompiler::function Option::Some(function) is then
+        function Function::variables.length = var_count
         var_count compiler->locals_count
     fi
 

--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -148,7 +148,7 @@ When the signature would exceed 100 characters, wrap as follows:
 fn make_compiler_with_tables
     store:SymbolStore
     ops:List[Op]
-    function:int
+    function:Option[Function]
     string_table:List[str]
     constants_table:List[str]
 -> BytecodeCompiler {

--- a/docs/structs-and-methods.md
+++ b/docs/structs-and-methods.md
@@ -97,6 +97,34 @@ person.name print                  # John Doe (dot on variable)
 "Jane Doe" person->name    # same as: "Jane Doe" person Person::set_name
 ```
 
+## Struct-Typed Fields
+
+A struct field can be declared with another struct type. Reads and writes are type-checked — no manual cast at the use site.
+
+```casa
+struct Node {
+    value: int
+    next:  Node
+}
+
+0 (Node) 42 Node = first      # next=null, value=42
+0 (Node) 99 Node = second
+second first->next            # first.next now points at second
+```
+
+Self-referential and mutually recursive struct types are supported. The null sentinel for "no value" is `0 (StructName)`. For optional references, prefer `Option[StructName]`, which makes absence explicit:
+
+```casa
+struct BytecodeCompiler {
+    ops:      List[Op]
+    function: Option[Function]
+}
+
+if compiler BytecodeCompiler::function Option::Some(function) is then
+    function Function::variables.length print
+fi
+```
+
 ## Generic Structs
 
 Structs can have type parameters. These are declared in square brackets after the struct name.

--- a/tests/compiler/test_bytecode.casa
+++ b/tests/compiler/test_bytecode.casa
@@ -197,12 +197,7 @@ fn test_compile_local_variable {
     "y" make_variable func Function::variables.push
 
     List::new(List[Inst]) = bytecode
-    # make_compiler_with_tables ops:List[Op] function:int string_table:List[str] constants_table:List[str]
-    # param1=ops, param2=function, param3=string_table, param4=constants_table
-    # make_compiler_with_tables ops:List[Op] function:int string_table:List[str] constants_table:List[str]
-    # param1=ops, param2=function, param3=string_table, param4=constants_table
-    # push order: constants_table, string_table, function, ops
-    List::new(List[str]) List::new(List[str]) func (int) fn_ops TEST_STORE make_compiler_with_tables = compiler
+    List::new(List[str]) List::new(List[str]) func Option::Some fn_ops TEST_STORE make_compiler_with_tables = compiler
     bytecode compiler compile_ops
 
     # Index 0 is label, 1 is LOCAL_SET, 2 is LOCAL_GET

--- a/tests/compiler/test_typed_struct_fields.casa
+++ b/tests/compiler/test_typed_struct_fields.casa
@@ -1,0 +1,74 @@
+import "../../compiler/common.casa"
+import "../../compiler/error.casa"
+import "../../compiler/lexer.casa"
+import "../../compiler/syntax.casa"
+import "../../lib/test.casa"
+
+# Regression test for issue #128: structs as direct fields of other structs.
+
+struct Node {
+    value: int
+    next:  Node
+}
+
+struct Owner {
+    name: str
+    node: Node
+}
+
+struct Pair {
+    label: str
+    other: Pair
+}
+
+fn make_node value:int -> Node {
+    0 (Node) value Node
+}
+
+fn make_owner name:str node:Node -> Owner {
+    node name Owner
+}
+
+fn make_pair label:str -> Pair {
+    0 (Pair) label Pair
+}
+
+fn test_self_ref_construct_with_null_sentinel {
+    "self_ref_construct_with_null_sentinel" test_start
+    42 make_node = node
+    "value reads back" 42 node Node::value assert_eq
+    "next is null" 0 node Node::next(int) == assert_true
+}
+
+fn test_self_ref_setter_and_chained_read {
+    "self_ref_setter_and_chained_read" test_start
+    1 make_node = first
+    2 make_node = second
+    second first->next
+    "first.value" 1 first Node::value assert_eq
+    "first.next.value" 2 first Node::next Node::value assert_eq
+    "first.next.next is null" 0 first Node::next Node::next(int) == assert_true
+}
+
+fn test_cross_struct_field_read {
+    "cross_struct_field_read" test_start
+    99 make_node = inner
+    inner "owner" make_owner = owner
+    "name" "owner" owner Owner::name assert_str_eq
+    "inner.value via owner" 99 owner Owner::node Node::value assert_eq
+}
+
+fn test_mutual_back_reference {
+    "mutual_back_reference" test_start
+    "first" make_pair = first
+    "second" make_pair = second
+    second first->other
+    first second->other
+    "first.other.label" "second" first Pair::other Pair::label assert_str_eq
+    "first.other.other.label loops back" "first" first Pair::other Pair::other Pair::label assert_str_eq
+}
+test_self_ref_construct_with_null_sentinel
+test_self_ref_setter_and_chained_read
+test_cross_struct_field_read
+test_mutual_back_reference
+test_summary

--- a/tests/formatter/fn_wrap.expected.casa
+++ b/tests/formatter/fn_wrap.expected.casa
@@ -3,7 +3,7 @@ fn short a:int b:int -> int { a b + }
 fn make_compiler_with_tables
     store:SymbolStore
     ops:List[Op]
-    function:int
+    function:Option[Function]
     string_table:List[str]
     constants_table:List[str]
 -> BytecodeCompiler {

--- a/tests/formatter/fn_wrap.input.casa
+++ b/tests/formatter/fn_wrap.input.casa
@@ -1,5 +1,5 @@
 fn short a:int b:int -> int { a b + }
 
-fn make_compiler_with_tables store:SymbolStore ops:List[Op] function:int string_table:List[str] constants_table:List[str] -> BytecodeCompiler {
+fn make_compiler_with_tables store:SymbolStore ops:List[Op] function:Option[Function] string_table:List[str] constants_table:List[str] -> BytecodeCompiler {
     "body" print
 }


### PR DESCRIPTION
Closes part of #128 (Track A).

## Summary
- Replaces the `int`-as-pointer null-sentinel pattern in `BytecodeCompiler::function` with `Option[Function]`, removing manual `(Function)` casts at the three read sites and the `(int)` cast at the construction site.
- Adds a regression test (`tests/compiler/test_typed_struct_fields.casa`) pinning the typed-struct-field contract: self-referential, cross-struct, and mutually recursive struct fields read/write/null-compare without explicit casts.
- Sweeps verbose `compiler BytecodeCompiler::field` reads to the `compiler.field` shorthand throughout `bytecode.casa`.
- Updates docs (`docs/structs-and-methods.md` adds a "Struct-Typed Fields" section; `docs/FORMAT.md` example) and fixtures (`tests/formatter/fn_wrap.{input,expected}.casa`, `tests/compiler/test_bytecode.casa`) that referenced the old `function:int` signature.

Triage Track B (polymorphic `Op::value` sum type) is left for a follow-up.

## Test plan
- [x] `tests/test_compiler.sh < /dev/null` — 25 passed
- [x] `tests/test_examples.sh` — 39 passed
- [x] `tests/test_formatter.sh` — 63 passed
- [x] stage2/stage3 fixed-point holds