### PR TITLE
refactor(common): replace polymorphic Op::value:int with OpValue tagged enum (#133)

### DIFF
--- a/compiler/bytecode.casa
+++ b/compiler/bytecode.casa
@@ -352,7 +352,7 @@ fn compile_while_block compiler:BytecodeCompiler op:Op op_index:int bytecode:Lis
 # ============================================================================
 # Compile match block
 # ============================================================================
-# compile_match_op — per-arm bytecode entry point dispatching on PatternKind.
+# compile_match_op — per-arm bytecode entry point dispatching on PatternValue.
 # Replaces the three former compile_match_arm_* helpers and consolidates
 # literal / enum / struct emission behind a single pattern-driven function.
 
@@ -451,21 +451,17 @@ fn compile_match_op
     next_arm:Option[int]
     bytecode:List[Inst]
 {
-    op pattern_kind match
-        PatternKind::PatStruct => {
-            op pattern_value_of (StructPattern) = struct_pattern
+    op pattern_value_of match
+        PatternValue::Struct(struct_pattern) => {
             bytecode struct_pattern compiler emit_struct_arm
         }
-        PatternKind::PatLiteral => {
-            op pattern_value_of (LiteralPattern) = literal_pattern
+        PatternValue::Literal(literal_pattern) => {
             bytecode next_arm is_last literal_pattern compiler emit_literal_arm
         }
-        PatternKind::PatEnumVariant => {
-            op pattern_value_of (EnumVariant) = variant
+        PatternValue::EnumVariant(variant) => {
             op pattern_is_wildcard = is_wildcard
             bytecode next_arm is_last is_wildcard variant compiler emit_enum_arm
         }
-        PatternKind::PatWildcard => { }
     end
     op pattern_guard_ops = guard_ops
     if guard_ops.length 0 != then

--- a/compiler/bytecode.casa
+++ b/compiler/bytecode.casa
@@ -611,7 +611,7 @@ fn compile_enum_variant
 # ============================================================================
 
 fn compile_is_check compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
-    op Op::value(EnumVariant) = variant
+    op enum_variant_of = variant
     variant EnumVariant::enum_name = enum_name
     enum_name compiler.store.enums.get.unwrap = casa_enum
 
@@ -963,7 +963,7 @@ fn compile_op compiler:BytecodeCompiler op:Op op_index:int bytecode:List[Inst] {
     elif OpKind::OpImportFile kind == OpKind::OpTypeCast kind == || then
         # No instruction emitted
     elif OpKind::OpPushEnumVariant kind == then
-        op Op::value(EnumVariant) = variant
+        op enum_variant_of = variant
         variant EnumVariant::enum_name compiler.store.enums.get.unwrap = casa_enum
         if casa_enum has_inner_values then
             bytecode casa_enum variant compiler compile_enum_variant

--- a/compiler/bytecode.casa
+++ b/compiler/bytecode.casa
@@ -671,7 +671,7 @@ fn compile_is_check compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
 # ============================================================================
 
 fn compile_struct_literal compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
-    op Op::value(StructLiteral) = literal
+    op struct_literal_of = literal
     literal StructLiteral::struct_name compiler.store.structs.get.unwrap = casa_struct
     casa_struct CasaStruct::members.length = count
 

--- a/compiler/bytecode.casa
+++ b/compiler/bytecode.casa
@@ -714,7 +714,7 @@ fn compile_struct_literal compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
 # ============================================================================
 
 fn compile_push_array compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
-    op Op::value(List[Op]) = items
+    op op_list_of = items
     items.length = length
 
     # Compile items in reverse order

--- a/compiler/bytecode.casa
+++ b/compiler/bytecode.casa
@@ -376,6 +376,11 @@ fn emit_struct_arm compiler:BytecodeCompiler struct_pattern:StructPattern byteco
     done
 }
 
+fn emit_int_eq value:int bytecode:List[Inst] {
+    value InstKind::InstPush make_inst_int bytecode.push
+    InstKind::InstEq make_inst bytecode.push
+}
+
 fn emit_literal_arm
     compiler:BytecodeCompiler
     literal_pattern:LiteralPattern
@@ -385,15 +390,16 @@ fn emit_literal_arm
 {
     if is_last then return fi
     InstKind::InstDup make_inst bytecode.push
-    if "str" literal_pattern LiteralPattern::typ == then
-        literal_pattern LiteralPattern::value(str) = str_value
-        str_value compiler intern_string = str_index
-        str_index InstKind::InstPushStr make_inst_int bytecode.push
-        InstKind::InstStrEq make_inst bytecode.push
-    else
-        literal_pattern LiteralPattern::value InstKind::InstPush make_inst_int bytecode.push
-        InstKind::InstEq make_inst bytecode.push
-    fi
+    literal_pattern.value match
+        LiteralValue::Str(str_value) => {
+            str_value compiler intern_string = str_index
+            str_index InstKind::InstPushStr make_inst_int bytecode.push
+            InstKind::InstStrEq make_inst bytecode.push
+        }
+        LiteralValue::Int(int_value) => { bytecode int_value emit_int_eq }
+        LiteralValue::Char(char_value) => { bytecode char_value emit_int_eq }
+        LiteralValue::Bool(bool_value) => { bytecode bool_value (int) emit_int_eq }
+    end
     next_arm.unwrap InstKind::InstJumpNe make_inst_int bytecode.push
 }
 

--- a/compiler/bytecode.casa
+++ b/compiler/bytecode.casa
@@ -528,7 +528,7 @@ fn compile_match_block compiler:BytecodeCompiler op:Op op_index:int bytecode:Lis
 # ============================================================================
 
 fn compile_struct_new compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
-    op Op::value(CasaStruct) = casa_struct
+    op casa_struct_of = casa_struct
     casa_struct CasaStruct::members.length = count
     count WORD_SIZE * InstKind::InstPush make_inst_int bytecode.push
     InstKind::InstHeapAlloc make_inst bytecode.push

--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -458,12 +458,12 @@ fn make_token value:str kind:TokenKind location:Location -> Token {
 #   - PUSH_BOOL: value is 0 or 1
 #   - PUSH_STR, FN_CALL, FN_PUSH, etc.: value is a ptr to a str
 #   - MATCH_ARM: value is a ptr to MatchArm
-#   - STRUCT_LITERAL: value is a ptr to StructLiteral
 #   - Control flow / intrinsics: value unused (0)
 # Migrated:
 #   - PUSH_ENUM_VARIANT, IS_CHECK: value_v = OpValue::EnumVariant(EnumVariant)
 #   - PUSH_ARRAY: value_v = OpValue::OpList(List[Op])
 #   - STRUCT_NEW: value_v = OpValue::Struct(CasaStruct)
+#   - STRUCT_LITERAL: value_v = OpValue::StructLit(StructLiteral)
 # ============================================================================
 
 struct Op {
@@ -671,6 +671,7 @@ enum OpValue {
     EnumVariant (EnumVariant)
     OpList (List[Op])
     Struct (CasaStruct)
+    StructLit (StructLiteral)
 }
 
 fn enum_variant_of op:Op -> EnumVariant {
@@ -698,6 +699,15 @@ fn casa_struct_of op:Op -> CasaStruct {
     "Internal error: casa_struct_of called on non-Struct op\n" eprint
     1 exit
     List::new(List[str]) empty_location List::new(List[Member]) "" CasaStruct
+}
+
+fn struct_literal_of op:Op -> StructLiteral {
+    if op.value_v OpValue::StructLit(literal) is then
+        literal return
+    fi
+    "Internal error: struct_literal_of called on non-StructLit op\n" eprint
+    1 exit
+    List::new(List[str]) "" StructLiteral
 }
 
 # MatchArm — wrapper stored on OpMatchArm.value. Carries the pattern payload

--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -457,13 +457,13 @@ fn make_token value:str kind:TokenKind location:Location -> Token {
 #   - PUSH_INT, PUSH_CHAR, FSTRING_CONCAT: value is the integer directly
 #   - PUSH_BOOL: value is 0 or 1
 #   - PUSH_STR, FN_CALL, FN_PUSH, etc.: value is a ptr to a str
-#   - MATCH_ARM: value is a ptr to MatchArm
 #   - Control flow / intrinsics: value unused (0)
 # Migrated:
 #   - PUSH_ENUM_VARIANT, IS_CHECK: value_v = OpValue::EnumVariant(EnumVariant)
 #   - PUSH_ARRAY: value_v = OpValue::OpList(List[Op])
 #   - STRUCT_NEW: value_v = OpValue::Struct(CasaStruct)
 #   - STRUCT_LITERAL: value_v = OpValue::StructLit(StructLiteral)
+#   - MATCH_ARM: value_v = OpValue::Match(MatchArm)
 # ============================================================================
 
 struct Op {
@@ -672,6 +672,7 @@ enum OpValue {
     OpList (List[Op])
     Struct (CasaStruct)
     StructLit (StructLiteral)
+    Match (MatchArm)
 }
 
 fn enum_variant_of op:Op -> EnumVariant {
@@ -709,7 +710,6 @@ fn struct_literal_of op:Op -> StructLiteral {
     1 exit
     List::new(List[str]) "" StructLiteral
 }
-
 # MatchArm — wrapper stored on OpMatchArm.value. Carries the pattern payload
 # (typed via PatternValue) and an optional guard expression. `guard_ops` is
 # empty for unguarded arms; when non-empty it is compiled after pattern
@@ -726,7 +726,14 @@ fn make_match_arm pattern_value:PatternValue guard_ops:List[Op] -> MatchArm {
 }
 
 fn match_arm_of op:Op -> MatchArm {
-    op Op::value(MatchArm)
+    if op.value_v OpValue::Match(arm) is then
+        arm return
+    fi
+    "Internal error: match_arm_of called on non-Match op\n" eprint
+    1 exit
+    List::new(List[Op])
+    "" 0 LiteralValue::Int LiteralPattern PatternValue::Literal
+    make_match_arm
 }
 
 fn pattern_value_of op:Op -> PatternValue {

--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -456,7 +456,6 @@ fn make_token value:str kind:TokenKind location:Location -> Token {
 # still use `value:int` interpreted per OpKind:
 #   - PUSH_INT, PUSH_CHAR, FSTRING_CONCAT: value is the integer directly
 #   - PUSH_BOOL: value is 0 or 1
-#   - PUSH_STR, FN_CALL, FN_PUSH, etc.: value is a ptr to a str
 #   - Control flow / intrinsics: value unused (0)
 # Migrated:
 #   - PUSH_ENUM_VARIANT, IS_CHECK: value_v = OpValue::EnumVariant(EnumVariant)
@@ -464,6 +463,9 @@ fn make_token value:str kind:TokenKind location:Location -> Token {
 #   - STRUCT_NEW: value_v = OpValue::Struct(CasaStruct)
 #   - STRUCT_LITERAL: value_v = OpValue::StructLit(StructLiteral)
 #   - MATCH_ARM: value_v = OpValue::Match(MatchArm)
+#   - PUSH_STR, FN_CALL, FN_PUSH, IDENTIFIER, IMPORT_FILE, ASSIGN_VAR,
+#     PUSH_VAR, PUSH_CAPTURE, ASSIGN_DEC, ASSIGN_INC, TYPE_CAST:
+#     value_v = OpValue::Str(str)
 # ============================================================================
 
 struct Op {
@@ -480,7 +482,7 @@ fn make_op value:int kind:OpKind location:Location -> Op {
 }
 
 fn make_op_str value:str kind:OpKind location:Location -> Op {
-    OpValue::None "" "" location kind value (int) Op
+    value OpValue::Str "" "" location kind 0 Op
 }
 
 fn make_op_annotated value:int kind:OpKind location:Location annotation:str -> Op {
@@ -503,7 +505,7 @@ fn substitute_ops_types ops:List[Op] subs:Map[str str] {
     for sub_op in ops.iter do
         if OpKind::OpTypeCast sub_op Op::kind == then
             subs sub_op op_str_value substitute_type_params = new_cast_type
-            new_cast_type (int) sub_op Op::set_value
+            new_cast_type OpValue::Str sub_op Op::set_value_v
         fi
         if "" sub_op Op::type_annotation != then
             subs sub_op Op::type_annotation substitute_type_params = new_annot
@@ -517,7 +519,12 @@ fn substitute_ops_types ops:List[Op] subs:Map[str str] {
 }
 
 fn op_str_value op:Op -> str {
-    op Op::value(str)
+    if op.value_v OpValue::Str(value) is then
+        value return
+    fi
+    "Internal error: op_str_value called on non-Str op\n" eprint
+    1 exit
+    ""
 }
 
 fn op_int_value op:Op -> int {
@@ -673,6 +680,7 @@ enum OpValue {
     Struct (CasaStruct)
     StructLit (StructLiteral)
     Match (MatchArm)
+    Str (str)
 }
 
 fn enum_variant_of op:Op -> EnumVariant {

--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -458,12 +458,12 @@ fn make_token value:str kind:TokenKind location:Location -> Token {
 #   - PUSH_BOOL: value is 0 or 1
 #   - PUSH_STR, FN_CALL, FN_PUSH, etc.: value is a ptr to a str
 #   - MATCH_ARM: value is a ptr to MatchArm
-#   - STRUCT_NEW: value is a ptr to CasaStruct
 #   - STRUCT_LITERAL: value is a ptr to StructLiteral
 #   - Control flow / intrinsics: value unused (0)
 # Migrated:
 #   - PUSH_ENUM_VARIANT, IS_CHECK: value_v = OpValue::EnumVariant(EnumVariant)
 #   - PUSH_ARRAY: value_v = OpValue::OpList(List[Op])
+#   - STRUCT_NEW: value_v = OpValue::Struct(CasaStruct)
 # ============================================================================
 
 struct Op {
@@ -670,6 +670,7 @@ enum OpValue {
     None
     EnumVariant (EnumVariant)
     OpList (List[Op])
+    Struct (CasaStruct)
 }
 
 fn enum_variant_of op:Op -> EnumVariant {
@@ -688,6 +689,15 @@ fn op_list_of op:Op -> List[Op] {
     "Internal error: op_list_of called on non-OpList op\n" eprint
     1 exit
     List::new(List[Op])
+}
+
+fn casa_struct_of op:Op -> CasaStruct {
+    if op.value_v OpValue::Struct(casa_struct) is then
+        casa_struct return
+    fi
+    "Internal error: casa_struct_of called on non-Struct op\n" eprint
+    1 exit
+    List::new(List[str]) empty_location List::new(List[Member]) "" CasaStruct
 }
 
 # MatchArm — wrapper stored on OpMatchArm.value. Carries the pattern payload

--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -460,10 +460,10 @@ fn make_token value:str kind:TokenKind location:Location -> Token {
 #   - MATCH_ARM: value is a ptr to MatchArm
 #   - STRUCT_NEW: value is a ptr to CasaStruct
 #   - STRUCT_LITERAL: value is a ptr to StructLiteral
-#   - PUSH_ARRAY: value is a ptr to List[Op]
 #   - Control flow / intrinsics: value unused (0)
 # Migrated:
 #   - PUSH_ENUM_VARIANT, IS_CHECK: value_v = OpValue::EnumVariant(EnumVariant)
+#   - PUSH_ARRAY: value_v = OpValue::OpList(List[Op])
 # ============================================================================
 
 struct Op {
@@ -669,6 +669,7 @@ enum PatternValue {
 enum OpValue {
     None
     EnumVariant (EnumVariant)
+    OpList (List[Op])
 }
 
 fn enum_variant_of op:Op -> EnumVariant {
@@ -678,6 +679,15 @@ fn enum_variant_of op:Op -> EnumVariant {
     "Internal error: enum_variant_of called on non-EnumVariant op\n" eprint
     1 exit
     Option::None(Option[int]) "" "" make_enum_variant
+}
+
+fn op_list_of op:Op -> List[Op] {
+    if op.value_v OpValue::OpList(items) is then
+        items return
+    fi
+    "Internal error: op_list_of called on non-OpList op\n" eprint
+    1 exit
+    List::new(List[Op])
 }
 
 # MatchArm — wrapper stored on OpMatchArm.value. Carries the pattern payload

--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -630,9 +630,15 @@ struct StructPattern {
     bindings:    Map[str str]
 }
 
+enum LiteralValue {
+    Int (int)
+    Str (str)
+    Bool (bool)
+    Char (int)
+}
+
 struct LiteralPattern {
-    value: int
-    typ:   str
+    value: LiteralValue
     raw:   str
 }
 

--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -468,29 +468,24 @@ struct Op {
     location:             Location
     type_annotation:      str
     deferred_return_type: str
-    pattern_kind:         PatternKind
 }
 
 fn make_op value:int kind:OpKind location:Location -> Op {
-    PatternKind::PatWildcard "" "" location kind value Op
+    "" "" location kind value Op
 }
 
 fn make_op_str value:str kind:OpKind location:Location -> Op {
-    PatternKind::PatWildcard "" "" location kind value (int) Op
+    "" "" location kind value (int) Op
 }
 
 fn make_op_annotated value:int kind:OpKind location:Location annotation:str -> Op {
-    PatternKind::PatWildcard "" annotation location kind value Op
-}
-
-fn make_op_pattern value:int kind:OpKind location:Location pattern_kind:PatternKind -> Op {
-    pattern_kind "" "" location kind value Op
+    "" annotation location kind value Op
 }
 
 fn clone_ops ops:List[Op] -> List[Op] {
     List::new(List[Op]) = result
     for source_op in ops.iter do
-        source_op Op::pattern_kind source_op Op::deferred_return_type source_op Op::type_annotation source_op Op::location source_op Op::kind source_op Op::value Op result.push
+        source_op.deferred_return_type source_op.type_annotation source_op.location source_op.kind source_op.value Op result.push
     done
     result
 }
@@ -641,51 +636,37 @@ struct LiteralPattern {
     raw:   str
 }
 
+# PatternValue — tagged-union payload carried by OpMatchArm. Each match arm
+# stores one of these in MatchArm::pattern_value; the variant tag both
+# discriminates pattern shape and provides a typed payload.
+
+enum PatternValue {
+    Struct (StructPattern)
+    EnumVariant (EnumVariant)
+    Literal (LiteralPattern)
+}
+
 # MatchArm — wrapper stored on OpMatchArm.value. Carries the pattern payload
-# pointer (StructPattern / EnumVariant / LiteralPattern, interpreted per
-# Op.pattern_kind) and an optional guard expression. `guard_ops` is empty for
-# unguarded arms; when non-empty it is compiled after pattern bindings and
-# produces a bool that diverts execution to the next arm when false.
+# (typed via PatternValue) and an optional guard expression. `guard_ops` is
+# empty for unguarded arms; when non-empty it is compiled after pattern
+# bindings and produces a bool that diverts execution to the next arm when
+# false.
 
 struct MatchArm {
-    pattern_value: int
+    pattern_value: PatternValue
     guard_ops:     List[Op]
 }
 
-fn make_match_arm pattern_value:int guard_ops:List[Op] -> MatchArm {
+fn make_match_arm pattern_value:PatternValue guard_ops:List[Op] -> MatchArm {
     guard_ops pattern_value MatchArm
-}
-
-# ============================================================================
-# PatternKind — discriminator for OpMatchArm pattern shape.
-#
-# Every match-arm Op carries its PatternKind directly in Op.pattern_kind.
-# Ops of other kinds keep a default of PatternKind::PatWildcard; the field
-# is only meaningful when Op.kind == OpKind::OpMatchArm.
-# ============================================================================
-
-enum PatternKind {
-    PatStruct
-    PatEnumVariant
-    PatLiteral
-    PatWildcard
-}
-
-impl PatternKind {
-    fn hash self:PatternKind -> int { self (int) int_hash }
-    fn eq self:PatternKind other:PatternKind -> bool { self other == }
-}
-
-fn pattern_kind op:Op -> PatternKind {
-    op Op::pattern_kind
 }
 
 fn match_arm_of op:Op -> MatchArm {
     op Op::value(MatchArm)
 }
 
-fn pattern_value_of op:Op -> int {
-    op match_arm_of MatchArm::pattern_value
+fn pattern_value_of op:Op -> PatternValue {
+    op match_arm_of.pattern_value
 }
 
 fn pattern_guard_ops op:Op -> List[Op] {

--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -452,12 +452,9 @@ fn make_token value:str kind:TokenKind location:Location -> Token {
 # Migration in progress (#133): Op::value:int + Op::kind:OpKind are being
 # replaced by `value_v: OpValue`, a tagged enum with typed payloads. During
 # transition both fields exist on every Op. Migrated kinds carry their
-# payload in `value_v` and leave `value:int = 0`; not-yet-migrated kinds
-# still use `value:int` interpreted per OpKind:
-#   - PUSH_INT, PUSH_CHAR, FSTRING_CONCAT: value is the integer directly
-#   - PUSH_BOOL: value is 0 or 1
-#   - Control flow / intrinsics: value unused (0)
-# Migrated:
+# payload in `value_v` and leave `value:int = 0`. The remaining ops are
+# control-flow / intrinsics that do not carry a payload.
+# Migrated payloads:
 #   - PUSH_ENUM_VARIANT, IS_CHECK: value_v = OpValue::EnumVariant(EnumVariant)
 #   - PUSH_ARRAY: value_v = OpValue::OpList(List[Op])
 #   - STRUCT_NEW: value_v = OpValue::Struct(CasaStruct)
@@ -466,6 +463,8 @@ fn make_token value:str kind:TokenKind location:Location -> Token {
 #   - PUSH_STR, FN_CALL, FN_PUSH, IDENTIFIER, IMPORT_FILE, ASSIGN_VAR,
 #     PUSH_VAR, PUSH_CAPTURE, ASSIGN_DEC, ASSIGN_INC, TYPE_CAST:
 #     value_v = OpValue::Str(str)
+#   - PUSH_INT, PUSH_CHAR, PUSH_BOOL, FSTRING_CONCAT:
+#     value_v = OpValue::Int(int)
 # ============================================================================
 
 struct Op {
@@ -483,6 +482,10 @@ fn make_op value:int kind:OpKind location:Location -> Op {
 
 fn make_op_str value:str kind:OpKind location:Location -> Op {
     value OpValue::Str "" "" location kind 0 Op
+}
+
+fn make_op_int value:int kind:OpKind location:Location -> Op {
+    value OpValue::Int "" "" location kind 0 Op
 }
 
 fn make_op_annotated value:int kind:OpKind location:Location annotation:str -> Op {
@@ -528,7 +531,12 @@ fn op_str_value op:Op -> str {
 }
 
 fn op_int_value op:Op -> int {
-    op Op::value
+    if op.value_v OpValue::Int(value) is then
+        value return
+    fi
+    "Internal error: op_int_value called on non-Int op\n" eprint
+    1 exit
+    0
 }
 
 # ============================================================================
@@ -681,6 +689,7 @@ enum OpValue {
     StructLit (StructLiteral)
     Match (MatchArm)
     Str (str)
+    Int (int)
 }
 
 fn enum_variant_of op:Op -> EnumVariant {

--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -449,57 +449,53 @@ fn make_token value:str kind:TokenKind location:Location -> Token {
 # ============================================================================
 # Op value types
 #
-# Migration in progress (#133): Op::value:int + Op::kind:OpKind are being
-# replaced by `value_v: OpValue`, a tagged enum with typed payloads. During
-# transition both fields exist on every Op. Migrated kinds carry their
-# payload in `value_v` and leave `value:int = 0`. The remaining ops are
-# control-flow / intrinsics that do not carry a payload.
-# Migrated payloads:
-#   - PUSH_ENUM_VARIANT, IS_CHECK: value_v = OpValue::EnumVariant(EnumVariant)
-#   - PUSH_ARRAY: value_v = OpValue::OpList(List[Op])
-#   - STRUCT_NEW: value_v = OpValue::Struct(CasaStruct)
-#   - STRUCT_LITERAL: value_v = OpValue::StructLit(StructLiteral)
-#   - MATCH_ARM: value_v = OpValue::Match(MatchArm)
+# Op carries its payload in `value: OpValue`, a tagged enum where the
+# variant tag identifies the payload type and `kind: OpKind` discriminates
+# among Ops that share a payload type. Mapping from OpKind to payload:
+#   - PUSH_ENUM_VARIANT, IS_CHECK: OpValue::EnumVariant(EnumVariant)
+#   - PUSH_ARRAY: OpValue::OpList(List[Op])
+#   - STRUCT_NEW: OpValue::Struct(CasaStruct)
+#   - STRUCT_LITERAL: OpValue::StructLit(StructLiteral)
+#   - MATCH_ARM: OpValue::Match(MatchArm)
 #   - PUSH_STR, FN_CALL, FN_PUSH, IDENTIFIER, IMPORT_FILE, ASSIGN_VAR,
 #     PUSH_VAR, PUSH_CAPTURE, ASSIGN_DEC, ASSIGN_INC, TYPE_CAST:
-#     value_v = OpValue::Str(str)
-#   - PUSH_INT, PUSH_CHAR, PUSH_BOOL, FSTRING_CONCAT:
-#     value_v = OpValue::Int(int)
+#     OpValue::Str(str)
+#   - PUSH_INT, PUSH_CHAR, PUSH_BOOL, FSTRING_CONCAT: OpValue::Int(int)
+#   - Control flow / intrinsics: OpValue::None
 # ============================================================================
 
 struct Op {
-    value:                int
     kind:                 OpKind
     location:             Location
     type_annotation:      str
     deferred_return_type: str
-    value_v:              OpValue
+    value:                OpValue
 }
 
-fn make_op value:int kind:OpKind location:Location -> Op {
-    OpValue::None "" "" location kind value Op
+fn make_op kind:OpKind location:Location -> Op {
+    OpValue::None "" "" location kind Op
 }
 
 fn make_op_str value:str kind:OpKind location:Location -> Op {
-    value OpValue::Str "" "" location kind 0 Op
+    value OpValue::Str "" "" location kind Op
 }
 
 fn make_op_int value:int kind:OpKind location:Location -> Op {
-    value OpValue::Int "" "" location kind 0 Op
+    value OpValue::Int "" "" location kind Op
 }
 
-fn make_op_annotated value:int kind:OpKind location:Location annotation:str -> Op {
-    OpValue::None "" annotation location kind value Op
+fn make_op_annotated kind:OpKind location:Location annotation:str -> Op {
+    OpValue::None "" annotation location kind Op
 }
 
 fn make_op_v value:OpValue kind:OpKind location:Location -> Op {
-    value "" "" location kind 0 Op
+    value "" "" location kind Op
 }
 
 fn clone_ops ops:List[Op] -> List[Op] {
     List::new(List[Op]) = result
     for source_op in ops.iter do
-        source_op.value_v source_op.deferred_return_type source_op.type_annotation source_op.location source_op.kind source_op.value Op result.push
+        source_op.value source_op.deferred_return_type source_op.type_annotation source_op.location source_op.kind Op result.push
     done
     result
 }
@@ -508,7 +504,7 @@ fn substitute_ops_types ops:List[Op] subs:Map[str str] {
     for sub_op in ops.iter do
         if OpKind::OpTypeCast sub_op Op::kind == then
             subs sub_op op_str_value substitute_type_params = new_cast_type
-            new_cast_type OpValue::Str sub_op Op::set_value_v
+            new_cast_type OpValue::Str sub_op Op::set_value
         fi
         if "" sub_op Op::type_annotation != then
             subs sub_op Op::type_annotation substitute_type_params = new_annot
@@ -522,7 +518,7 @@ fn substitute_ops_types ops:List[Op] subs:Map[str str] {
 }
 
 fn op_str_value op:Op -> str {
-    if op.value_v OpValue::Str(value) is then
+    if op.value OpValue::Str(value) is then
         value return
     fi
     "Internal error: op_str_value called on non-Str op\n" eprint
@@ -531,7 +527,7 @@ fn op_str_value op:Op -> str {
 }
 
 fn op_int_value op:Op -> int {
-    if op.value_v OpValue::Int(value) is then
+    if op.value OpValue::Int(value) is then
         value return
     fi
     "Internal error: op_int_value called on non-Int op\n" eprint
@@ -676,10 +672,10 @@ enum PatternValue {
     Literal (LiteralPattern)
 }
 
-# OpValue — tagged-union payload carried by Op, replacing the polymorphic
-# Op::value:int + Op::kind discriminator pair (#133). Migrated incrementally:
-# each commit adds one variant for the matching OpKind(s). `None` is the
-# default for ops whose value still lives in `value:int` during transition.
+# OpValue — tagged-union payload carried by every Op (#133). The variant
+# tag identifies the payload type; `kind: OpKind` discriminates among Ops
+# that share a payload type. `None` is used by ops without a payload
+# (control flow, intrinsics, arithmetic).
 
 enum OpValue {
     None
@@ -693,7 +689,7 @@ enum OpValue {
 }
 
 fn enum_variant_of op:Op -> EnumVariant {
-    if op.value_v OpValue::EnumVariant(variant) is then
+    if op.value OpValue::EnumVariant(variant) is then
         variant return
     fi
     "Internal error: enum_variant_of called on non-EnumVariant op\n" eprint
@@ -702,7 +698,7 @@ fn enum_variant_of op:Op -> EnumVariant {
 }
 
 fn op_list_of op:Op -> List[Op] {
-    if op.value_v OpValue::OpList(items) is then
+    if op.value OpValue::OpList(items) is then
         items return
     fi
     "Internal error: op_list_of called on non-OpList op\n" eprint
@@ -711,7 +707,7 @@ fn op_list_of op:Op -> List[Op] {
 }
 
 fn casa_struct_of op:Op -> CasaStruct {
-    if op.value_v OpValue::Struct(casa_struct) is then
+    if op.value OpValue::Struct(casa_struct) is then
         casa_struct return
     fi
     "Internal error: casa_struct_of called on non-Struct op\n" eprint
@@ -720,7 +716,7 @@ fn casa_struct_of op:Op -> CasaStruct {
 }
 
 fn struct_literal_of op:Op -> StructLiteral {
-    if op.value_v OpValue::StructLit(literal) is then
+    if op.value OpValue::StructLit(literal) is then
         literal return
     fi
     "Internal error: struct_literal_of called on non-StructLit op\n" eprint
@@ -743,7 +739,7 @@ fn make_match_arm pattern_value:PatternValue guard_ops:List[Op] -> MatchArm {
 }
 
 fn match_arm_of op:Op -> MatchArm {
-    if op.value_v OpValue::Match(arm) is then
+    if op.value OpValue::Match(arm) is then
         arm return
     fi
     "Internal error: match_arm_of called on non-Match op\n" eprint

--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -449,17 +449,21 @@ fn make_token value:str kind:TokenKind location:Location -> Token {
 # ============================================================================
 # Op value types
 #
-# Since Casa does not have union types, Op values are stored as int (ptr).
-# The OpKind determines how to interpret the value:
+# Migration in progress (#133): Op::value:int + Op::kind:OpKind are being
+# replaced by `value_v: OpValue`, a tagged enum with typed payloads. During
+# transition both fields exist on every Op. Migrated kinds carry their
+# payload in `value_v` and leave `value:int = 0`; not-yet-migrated kinds
+# still use `value:int` interpreted per OpKind:
 #   - PUSH_INT, PUSH_CHAR, FSTRING_CONCAT: value is the integer directly
 #   - PUSH_BOOL: value is 0 or 1
 #   - PUSH_STR, FN_CALL, FN_PUSH, etc.: value is a ptr to a str
-#   - PUSH_ENUM_VARIANT, IS_CHECK: value is a ptr to EnumVariant
-#   - MATCH_ARM: value is a ptr to EnumVariant, StructPattern, or LiteralPattern
+#   - MATCH_ARM: value is a ptr to MatchArm
 #   - STRUCT_NEW: value is a ptr to CasaStruct
 #   - STRUCT_LITERAL: value is a ptr to StructLiteral
 #   - PUSH_ARRAY: value is a ptr to List[Op]
 #   - Control flow / intrinsics: value unused (0)
+# Migrated:
+#   - PUSH_ENUM_VARIANT, IS_CHECK: value_v = OpValue::EnumVariant(EnumVariant)
 # ============================================================================
 
 struct Op {
@@ -468,24 +472,29 @@ struct Op {
     location:             Location
     type_annotation:      str
     deferred_return_type: str
+    value_v:              OpValue
 }
 
 fn make_op value:int kind:OpKind location:Location -> Op {
-    "" "" location kind value Op
+    OpValue::None "" "" location kind value Op
 }
 
 fn make_op_str value:str kind:OpKind location:Location -> Op {
-    "" "" location kind value (int) Op
+    OpValue::None "" "" location kind value (int) Op
 }
 
 fn make_op_annotated value:int kind:OpKind location:Location annotation:str -> Op {
-    "" annotation location kind value Op
+    OpValue::None "" annotation location kind value Op
+}
+
+fn make_op_v value:OpValue kind:OpKind location:Location -> Op {
+    value "" "" location kind 0 Op
 }
 
 fn clone_ops ops:List[Op] -> List[Op] {
     List::new(List[Op]) = result
     for source_op in ops.iter do
-        source_op.deferred_return_type source_op.type_annotation source_op.location source_op.kind source_op.value Op result.push
+        source_op.value_v source_op.deferred_return_type source_op.type_annotation source_op.location source_op.kind source_op.value Op result.push
     done
     result
 }
@@ -650,6 +659,25 @@ enum PatternValue {
     Struct (StructPattern)
     EnumVariant (EnumVariant)
     Literal (LiteralPattern)
+}
+
+# OpValue — tagged-union payload carried by Op, replacing the polymorphic
+# Op::value:int + Op::kind discriminator pair (#133). Migrated incrementally:
+# each commit adds one variant for the matching OpKind(s). `None` is the
+# default for ops whose value still lives in `value:int` during transition.
+
+enum OpValue {
+    None
+    EnumVariant (EnumVariant)
+}
+
+fn enum_variant_of op:Op -> EnumVariant {
+    if op.value_v OpValue::EnumVariant(variant) is then
+        variant return
+    fi
+    "Internal error: enum_variant_of called on non-EnumVariant op\n" eprint
+    1 exit
+    Option::None(Option[int]) "" "" make_enum_variant
 }
 
 # MatchArm — wrapper stored on OpMatchArm.value. Carries the pattern payload

--- a/compiler/pattern.casa
+++ b/compiler/pattern.casa
@@ -13,14 +13,12 @@ import "typechecker"
 # Currently stored as an EnumVariant whose variant_name is "_".
 
 fn pattern_is_wildcard op:Op -> bool {
-    op pattern_kind match
-        PatternKind::PatEnumVariant => {
-            op pattern_value_of (EnumVariant) = variant
-            MATCH_WILDCARD variant EnumVariant::variant_name ==
+    op pattern_value_of match
+        PatternValue::EnumVariant(variant) => {
+            MATCH_WILDCARD variant.variant_name ==
         }
-        PatternKind::PatStruct => false
-        PatternKind::PatLiteral => false
-        PatternKind::PatWildcard => true
+        PatternValue::Struct => false
+        PatternValue::Literal => false
     end
 }
 # pattern_is_guarded — true when the arm carries a guard expression.
@@ -38,20 +36,16 @@ fn pattern_is_guarded op:Op -> bool {
 
 fn pattern_covered_key op:Op -> str {
     if op pattern_is_guarded then "" return fi
-    op pattern_kind match
-        PatternKind::PatStruct => {
-            op pattern_value_of (StructPattern) = struct_pat
-            f"__covered:{struct_pat StructPattern::struct_name}"
+    op pattern_value_of match
+        PatternValue::Struct(struct_pat) => {
+            f"__covered:{struct_pat.struct_name}"
         }
-        PatternKind::PatLiteral => {
-            op pattern_value_of (LiteralPattern) = literal_pat
-            f"__covered:{literal_pat LiteralPattern::raw}"
+        PatternValue::Literal(literal_pat) => {
+            f"__covered:{literal_pat.raw}"
         }
-        PatternKind::PatEnumVariant => {
-            op pattern_value_of (EnumVariant) = variant
-            f"__covered:{variant EnumVariant::variant_name}"
+        PatternValue::EnumVariant(variant) => {
+            f"__covered:{variant.variant_name}"
         }
-        PatternKind::PatWildcard => ""
     end
 }
 
@@ -62,24 +56,21 @@ fn pattern_covered_key op:Op -> str {
 
 fn pattern_bindings op:Op -> List[str] {
     List::new(List[str]) = out
-    op pattern_kind match
-        PatternKind::PatStruct => {
-            op pattern_value_of (StructPattern) = struct_pat
-            struct_pat StructPattern::bindings.keys = field_names
+    op pattern_value_of match
+        PatternValue::Struct(struct_pat) => {
+            struct_pat.bindings.keys = field_names
             for field_name in field_names.iter do
-                field_name struct_pat StructPattern::bindings.get.unwrap = bound_name
+                field_name struct_pat.bindings.get.unwrap = bound_name
                 bound_name out.push
             done
         }
-        PatternKind::PatEnumVariant => {
-            op pattern_value_of (EnumVariant) = variant
-            variant EnumVariant::bindings = names
+        PatternValue::EnumVariant(variant) => {
+            variant.bindings = names
             for name in names.iter do
                 name out.push
             done
         }
-        PatternKind::PatLiteral => { }
-        PatternKind::PatWildcard => { }
+        PatternValue::Literal => { }
     end
     out
 }
@@ -242,18 +233,15 @@ fn register_pattern_bindings
     op:Op
     match_subject_type:str
 {
-    op pattern_kind match
-        PatternKind::PatStruct => {
-            op pattern_value_of (StructPattern) = struct_pattern
+    op pattern_value_of match
+        PatternValue::Struct(struct_pattern) => {
             struct_pattern function_opt tc register_struct_pattern_bindings
         }
-        PatternKind::PatEnumVariant => {
+        PatternValue::EnumVariant(variant) => {
             if op pattern_is_wildcard then return fi
-            op pattern_value_of (EnumVariant) = variant
             match_subject_type variant function_opt tc register_enum_pattern_bindings
         }
-        PatternKind::PatLiteral => { }
-        PatternKind::PatWildcard => { }
+        PatternValue::Literal => { }
     end
 }
 
@@ -270,18 +258,13 @@ fn typecheck_match_op tc:TypeChecker function_opt:Option[Function] op:Op {
     tc TypeChecker::branched_stacks.length 1 - tc TypeChecker::branched_stacks.get = top_frame
     if top_frame BranchFrame::BranchMatch(match_ctx) is then
         match_ctx MatchContext::match_type = match_subject_type
-        op pattern_kind = kind
         op pattern_covered_key = covered_key
         match_subject_type resolve_match_type = arm_base
-        op pattern_is_wildcard = is_wildcard
-        PatternKind::PatEnumVariant kind == = is_enum_pattern
 
-        if
-        is_enum_pattern
-        is_wildcard ! &&
-        then
-            op pattern_value_of (EnumVariant) = variant
-            arm_base variant op tc diagnose_bare_enum_pattern
+        if op pattern_value_of PatternValue::EnumVariant(variant) is then
+            if op pattern_is_wildcard ! then
+                arm_base variant op tc diagnose_bare_enum_pattern
+            fi
         fi
 
         covered_key op match_ctx detect_duplicate_arm

--- a/compiler/syntax.casa
+++ b/compiler/syntax.casa
@@ -1530,24 +1530,24 @@ fn parse_match_arm_pattern
         function_name cursor parser parse_pattern_terminator = wildcard_guard_ops
         Option::None MATCH_WILDCARD "" make_enum_variant = wildcard
         wildcard_guard_ops wildcard PatternValue::EnumVariant make_match_arm = wildcard_arm
-        arm_token Token::location OpKind::OpMatchArm wildcard_arm (int) make_op ops.push
+        arm_token Token::location OpKind::OpMatchArm wildcard_arm OpValue::Match make_op_v ops.push
     elif TokenKind::Literal arm_token Token::kind == then
         function_name cursor parser parse_pattern_terminator = literal_guard_ops
         arm_token parse_literal_match_pattern = literal_pattern
         literal_guard_ops literal_pattern PatternValue::Literal make_match_arm = literal_arm
-        arm_token Token::location OpKind::OpMatchArm literal_arm (int) make_op ops.push
+        arm_token Token::location OpKind::OpMatchArm literal_arm OpValue::Match make_op_v ops.push
     elif TokenKind::Identifier arm_token Token::kind != then
         arm_token Token::location "Expected match pattern or `_`" ErrorKind::UnexpectedToken raise_error
     elif cursor.peek.is_some "{" cursor.peek.unwrap Token::value == && then
         cursor arm_token parser parse_struct_match_pattern = struct_pattern
         function_name cursor parser parse_pattern_terminator = struct_guard_ops
         struct_guard_ops struct_pattern PatternValue::Struct make_match_arm = struct_arm
-        arm_token Token::location OpKind::OpMatchArm struct_arm (int) make_op ops.push
+        arm_token Token::location OpKind::OpMatchArm struct_arm OpValue::Match make_op_v ops.push
     elif arm_token Token::value "::" str::find 0 > then
         function_name cursor parser parse_pattern_terminator = bare_guard_ops
         Option::None arm_token Token::value "" make_enum_variant = bare_variant
         bare_guard_ops bare_variant PatternValue::EnumVariant make_match_arm = bare_arm
-        arm_token Token::location OpKind::OpMatchArm bare_arm (int) make_op ops.push
+        arm_token Token::location OpKind::OpMatchArm bare_arm OpValue::Match make_op_v ops.push
     else
         arm_token Token::value "::" str::find = separator
         arm_token Token::value 0 separator str::substring = enum_name
@@ -1575,7 +1575,7 @@ fn parse_match_arm_pattern
         Option::None variant_name enum_name make_enum_variant = variant
         bindings variant EnumVariant::set_bindings
         enum_guard_ops variant PatternValue::EnumVariant make_match_arm = variant_arm
-        arm_token Token::location OpKind::OpMatchArm variant_arm (int) make_op ops.push
+        arm_token Token::location OpKind::OpMatchArm variant_arm OpValue::Match make_op_v ops.push
     fi
 }
 # Parse a match-arm body (either a `{...}` block or a single-line expression

--- a/compiler/syntax.casa
+++ b/compiler/syntax.casa
@@ -1495,26 +1495,26 @@ fn parse_pattern_terminator parser:Parser cursor:TokenCursor function_name:str -
 fn parse_literal_match_pattern token:Token -> LiteralPattern {
     token Token::value = value
     if "true" value == then
-        "true" "bool" 1 LiteralPattern return
+        "true" true LiteralValue::Bool LiteralPattern return
     fi
     if "false" value == then
-        "false" "bool" 0 LiteralPattern return
+        "false" false LiteralValue::Bool LiteralPattern return
     fi
     if 0 value.at.is_digit value is_negative_integer_literal || then
-        value "int" value str_to_int LiteralPattern return
+        value value str_to_int LiteralValue::Int LiteralPattern return
     fi
     if
     '\'' 0 value.at ==
     3 value.length == &&
     then
-        value "char" 1 value.at (int) LiteralPattern return
+        value 1 value.at (int) LiteralValue::Char LiteralPattern return
     fi
     if '"' 0 value.at == '"' value.length 1 - value.at == && then
-        value "str" value 1 value.length 2 - str::substring(int) LiteralPattern return
+        value value 1 value.length 2 - str::substring LiteralValue::Str LiteralPattern return
     fi
     token Token::location f"Unsupported literal in match arm: `{value}`" ErrorKind::UnexpectedToken raise_error
     # Unreachable
-    "" "int" 0 LiteralPattern
+    "" 0 LiteralValue::Int LiteralPattern
 }
 # Parse one match-arm pattern (wildcard, literal, struct, bare ident, or
 # Enum::Variant) plus its optional guard, append the OpMatchArm to `ops`.

--- a/compiler/syntax.casa
+++ b/compiler/syntax.casa
@@ -617,7 +617,7 @@ fn try_parse_is_check token:Token cursor:TokenCursor -> Option[Op] {
 
     Option::None variant_name enum_name make_enum_variant = variant
     bindings variant EnumVariant::set_bindings
-    token Token::location OpKind::OpIsCheck variant (int) make_op Option::Some
+    token Token::location OpKind::OpIsCheck variant OpValue::EnumVariant make_op_v Option::Some
 }
 
 # ============================================================================
@@ -2352,7 +2352,7 @@ fn try_resolve_enum_variant_ident
     else
         OpKind::OpPushEnumVariant op Op::set_kind
         ordinal Option::Some binding_name enum_name make_enum_variant = enum_variant
-        enum_variant (int) op Op::set_value
+        enum_variant OpValue::EnumVariant op Op::set_value_v
     fi
     true
 }
@@ -2487,7 +2487,7 @@ fn resolve_identifiers_fn parser:Parser ops:List[Op] function:Function -> List[O
 
         # IS_CHECK: resolve enum variant
         if OpKind::OpIsCheck op_kind == then
-            current_op Op::value(EnumVariant) = is_enum_variant
+            current_op enum_variant_of = is_enum_variant
             resolve_errors function current_op is_enum_variant parser resolve_enum_variant
             continue
         fi

--- a/compiler/syntax.casa
+++ b/compiler/syntax.casa
@@ -2409,7 +2409,7 @@ fn resolve_plain_identifier
     ident parser.store.structs.get = struct_opt
     if struct_opt.is_some then
         OpKind::OpStructNew op Op::set_kind
-        struct_opt.unwrap (int) op Op::set_value
+        struct_opt.unwrap OpValue::Struct op Op::set_value_v
         return
     fi
 

--- a/compiler/syntax.casa
+++ b/compiler/syntax.casa
@@ -2055,7 +2055,7 @@ fn parse_struct_literal
     done
 
     field_order name_token Token::value StructLiteral = literal
-    name_token Token::location OpKind::OpStructLiteral literal (int) make_op all_ops.push
+    name_token Token::location OpKind::OpStructLiteral literal OpValue::StructLit make_op_v all_ops.push
     all_ops
 }
 

--- a/compiler/syntax.casa
+++ b/compiler/syntax.casa
@@ -328,7 +328,7 @@ fn get_op_intrinsic token:Token -> Op {
     if opkind_opt.is_none then
         token Token::location f"No OpKind for intrinsic `{token Token::value}`" ErrorKind::Syntax raise_error
     fi
-    token Token::location opkind_opt.unwrap 0 make_op
+    token Token::location opkind_opt.unwrap make_op
 }
 
 # ============================================================================
@@ -381,7 +381,7 @@ fn get_op_operator token:Token cursor:TokenCursor function_name:str -> Op {
     if opkind_opt.is_none then
         token Token::location f"No OpKind for operator `{token Token::value}`" ErrorKind::Syntax raise_error
     fi
-    token Token::location opkind_opt.unwrap 0 make_op
+    token Token::location opkind_opt.unwrap make_op
 }
 
 # ============================================================================
@@ -492,7 +492,7 @@ fn handle_fstring
             token Token::location expr_ops lambda_name make_function = lambda_function
             lambda_name lambda_function parser.store.functions.set drop
             token Token::location OpKind::OpFnPush lambda_name make_op_str ops.push
-            token Token::location OpKind::OpFnExec 0 make_op ops.push
+            token Token::location OpKind::OpFnExec make_op ops.push
             token Token::location OpKind::OpFstringToStr "" make_op_str ops.push
             1 += part_count
         elif TokenKind::FstringEnd token Token::kind == then
@@ -1060,8 +1060,8 @@ fn create_member_accessor
     List::new(List[Op]) = getter_ops
     location OpKind::OpTypeCast "ptr" make_op_str getter_ops.push
     location OpKind::OpPushInt offset make_op_int getter_ops.push
-    location OpKind::OpAdd 0 make_op getter_ops.push
-    location OpKind::OpLoad64 0 make_op getter_ops.push
+    location OpKind::OpAdd make_op getter_ops.push
+    location OpKind::OpLoad64 make_op getter_ops.push
     location OpKind::OpTypeCast member_type make_op_str getter_ops.push
 
     List::new(List[Parameter]) = getter_params
@@ -1082,8 +1082,8 @@ fn create_member_accessor
     List::new(List[Op]) = setter_ops
     location OpKind::OpTypeCast "ptr" make_op_str setter_ops.push
     location OpKind::OpPushInt offset make_op_int setter_ops.push
-    location OpKind::OpAdd 0 make_op setter_ops.push
-    location OpKind::OpStore64 0 make_op setter_ops.push
+    location OpKind::OpAdd make_op setter_ops.push
+    location OpKind::OpStore64 make_op setter_ops.push
 
     List::new(List[Parameter]) = setter_params
     param_type make_param setter_params.push
@@ -1609,12 +1609,12 @@ fn parse_match_arm_body parser:Parser cursor:TokenCursor function_name:str ops:L
 
 fn parse_match_block parser:Parser token:Token cursor:TokenCursor function_name:str -> List[Op] {
     List::new(List[Op]) = ops
-    token Token::location OpKind::OpMatchStart 0 make_op ops.push
+    token Token::location OpKind::OpMatchStart make_op ops.push
 
     while true do
         cursor expect_token = arm_token
         if "end" arm_token Token::value == then
-            arm_token Token::location OpKind::OpMatchEnd 0 make_op ops.push
+            arm_token Token::location OpKind::OpMatchEnd make_op ops.push
             break
         fi
         ops function_name cursor arm_token parser parse_match_arm_pattern
@@ -1822,13 +1822,13 @@ fn handle_keyword_for parser:Parser token:Token cursor:TokenCursor function_name
     # Loop preamble: store iterator into hidden local, then open the while
     # loop with the `next`/`is_some` condition.
     for_loc OpKind::OpAssignVar hidden_iter_name make_op_str ops.push
-    for_loc OpKind::OpWhileStart 0 make_op ops.push
+    for_loc OpKind::OpWhileStart make_op ops.push
     for_loc OpKind::OpPushVar hidden_iter_name make_op_str ops.push
     for_loc OpKind::OpMethodCall "next" make_op_str ops.push
     for_loc OpKind::OpAssignVar hidden_opt_name make_op_str ops.push
     for_loc OpKind::OpPushVar hidden_opt_name make_op_str ops.push
     for_loc OpKind::OpMethodCall "is_some" make_op_str ops.push
-    for_loc OpKind::OpWhileCondition 0 make_op ops.push
+    for_loc OpKind::OpWhileCondition make_op ops.push
     for_loc OpKind::OpPushVar hidden_opt_name make_op_str ops.push
     for_loc OpKind::OpMethodCall "unwrap" make_op_str ops.push
     for_loc OpKind::OpAssignVar loop_var_name make_op_str ops.push
@@ -1844,7 +1844,7 @@ fn handle_keyword_for parser:Parser token:Token cursor:TokenCursor function_name
         body_peek_opt.unwrap = body_token
         if "done" body_token Token::value == 0 body_nesting_depth == && then
             cursor.pop drop
-            body_token Token::location OpKind::OpWhileEnd 0 make_op ops.push
+            body_token Token::location OpKind::OpWhileEnd make_op ops.push
             return
         fi
         if "while" body_token Token::value == then
@@ -1876,7 +1876,7 @@ fn get_op_keyword parser:Parser token:Token cursor:TokenCursor function_name:str
     # Simple keyword -> opkind mapping
     keyword SIMPLE_KEYWORD_OPS.get = simple_opt
     if simple_opt.is_some then
-        token Token::location simple_opt.unwrap 0 make_op ops.push
+        token Token::location simple_opt.unwrap make_op ops.push
         return
     fi
 
@@ -2317,14 +2317,14 @@ fn try_resolve_fn_ref
             ref_name ref_name "::" str::find 2 + ref_name.length ref_name "::" str::find - 2 - str::substring = ref_trait_method
             f"__trait_{ref_type_var}_{ref_trait_method}" = ref_hidden
             OpKind::OpPushVar op Op::set_kind
-            ref_hidden OpValue::Str op Op::set_value_v
+            ref_hidden OpValue::Str op Op::set_value
             true return
         fi
     fi
     ref_name parser.store.functions.get = ref_fn_opt
     if ref_fn_opt.is_some then
         OpKind::OpFnPush op Op::set_kind
-        ref_name OpValue::Str op Op::set_value_v
+        ref_name OpValue::Str op Op::set_value
         true ref_fn_opt.unwrap Function::set_is_used
     else
         op Op::location f"Function `{ref_name}` is not defined" ErrorKind::UndefinedName make_error resolve_errors.push
@@ -2352,7 +2352,7 @@ fn try_resolve_enum_variant_ident
     else
         OpKind::OpPushEnumVariant op Op::set_kind
         ordinal Option::Some binding_name enum_name make_enum_variant = enum_variant
-        enum_variant OpValue::EnumVariant op Op::set_value_v
+        enum_variant OpValue::EnumVariant op Op::set_value
     fi
     true
 }
@@ -2369,7 +2369,7 @@ fn try_resolve_trait_method_call parser:Parser function:Function op:Op ident:str
         hidden_var make_variable function Function::variables.push
     fi
     OpKind::OpPushVar op Op::set_kind
-    hidden_var OpValue::Str op Op::set_value_v
+    hidden_var OpValue::Str op Op::set_value
     "trait_exec" op Op::set_type_annotation
     true
 }
@@ -2409,14 +2409,14 @@ fn resolve_plain_identifier
     ident parser.store.structs.get = struct_opt
     if struct_opt.is_some then
         OpKind::OpStructNew op Op::set_kind
-        struct_opt.unwrap OpValue::Struct op Op::set_value_v
+        struct_opt.unwrap OpValue::Struct op Op::set_value
         return
     fi
 
     ident parser.store.enums.get = resolved_enum_opt
     if resolved_enum_opt.is_some then
         OpKind::OpPushInt op Op::set_kind
-        resolved_enum_opt.unwrap CasaEnum::variants.length OpValue::Int op Op::set_value_v
+        resolved_enum_opt.unwrap CasaEnum::variants.length OpValue::Int op Op::set_value
         return
     fi
 

--- a/compiler/syntax.casa
+++ b/compiler/syntax.casa
@@ -285,15 +285,15 @@ fn get_op_type_cast cursor:TokenCursor -> Op {
 fn get_op_literal token:Token -> Op {
     token Token::value = value
     if "true" value == then
-        token Token::location OpKind::OpPushBool 1 make_op return
+        token Token::location OpKind::OpPushBool 1 make_op_int return
     fi
     if "false" value == then
-        token Token::location OpKind::OpPushBool 0 make_op return
+        token Token::location OpKind::OpPushBool 0 make_op_int return
     fi
     # Integer literal (positive or negative)
     if 0 value.at.is_digit value is_negative_integer_literal || then
         value str_to_int = int_value
-        token Token::location OpKind::OpPushInt int_value make_op return
+        token Token::location OpKind::OpPushInt int_value make_op_int return
     fi
     # Char literal: 'X'
     if
@@ -302,7 +302,7 @@ fn get_op_literal token:Token -> Op {
     3 value.length == &&
     then
         1 value.at (int) = char_value
-        token Token::location OpKind::OpPushChar char_value make_op return
+        token Token::location OpKind::OpPushChar char_value make_op_int return
     fi
     # String literal: "..."
     if '"' 0 value.at == '"' value.length 1 - value.at == && then
@@ -311,7 +311,7 @@ fn get_op_literal token:Token -> Op {
     fi
     token Token::location f"Token `{value}` is not a literal" ErrorKind::Syntax raise_error
     # Unreachable - raise_error exits
-    token Token::location OpKind::OpPushInt 0 make_op
+    token Token::location OpKind::OpPushInt 0 make_op_int
 }
 
 # ============================================================================
@@ -504,7 +504,7 @@ fn handle_fstring
         1 = part_count
     fi
     if 1 part_count > then
-        start_token Token::location OpKind::OpFstringConcat part_count make_op ops.push
+        start_token Token::location OpKind::OpFstringConcat part_count make_op_int ops.push
     fi
 }
 
@@ -1059,7 +1059,7 @@ fn create_member_accessor
     f"{struct_name}::{member_name}" = getter_name
     List::new(List[Op]) = getter_ops
     location OpKind::OpTypeCast "ptr" make_op_str getter_ops.push
-    location OpKind::OpPushInt offset make_op getter_ops.push
+    location OpKind::OpPushInt offset make_op_int getter_ops.push
     location OpKind::OpAdd 0 make_op getter_ops.push
     location OpKind::OpLoad64 0 make_op getter_ops.push
     location OpKind::OpTypeCast member_type make_op_str getter_ops.push
@@ -1081,7 +1081,7 @@ fn create_member_accessor
     f"{struct_name}::set_{member_name}" = setter_name
     List::new(List[Op]) = setter_ops
     location OpKind::OpTypeCast "ptr" make_op_str setter_ops.push
-    location OpKind::OpPushInt offset make_op setter_ops.push
+    location OpKind::OpPushInt offset make_op_int setter_ops.push
     location OpKind::OpAdd 0 make_op setter_ops.push
     location OpKind::OpStore64 0 make_op setter_ops.push
 
@@ -2416,7 +2416,7 @@ fn resolve_plain_identifier
     ident parser.store.enums.get = resolved_enum_opt
     if resolved_enum_opt.is_some then
         OpKind::OpPushInt op Op::set_kind
-        resolved_enum_opt.unwrap CasaEnum::variants.length op Op::set_value
+        resolved_enum_opt.unwrap CasaEnum::variants.length OpValue::Int op Op::set_value_v
         return
     fi
 

--- a/compiler/syntax.casa
+++ b/compiler/syntax.casa
@@ -1529,25 +1529,25 @@ fn parse_match_arm_pattern
     if MATCH_WILDCARD arm_token Token::value == then
         function_name cursor parser parse_pattern_terminator = wildcard_guard_ops
         Option::None MATCH_WILDCARD "" make_enum_variant = wildcard
-        wildcard_guard_ops wildcard (int) make_match_arm = wildcard_arm
-        PatternKind::PatEnumVariant arm_token Token::location OpKind::OpMatchArm wildcard_arm (int) make_op_pattern ops.push
+        wildcard_guard_ops wildcard PatternValue::EnumVariant make_match_arm = wildcard_arm
+        arm_token Token::location OpKind::OpMatchArm wildcard_arm (int) make_op ops.push
     elif TokenKind::Literal arm_token Token::kind == then
         function_name cursor parser parse_pattern_terminator = literal_guard_ops
         arm_token parse_literal_match_pattern = literal_pattern
-        literal_guard_ops literal_pattern (int) make_match_arm = literal_arm
-        PatternKind::PatLiteral arm_token Token::location OpKind::OpMatchArm literal_arm (int) make_op_pattern ops.push
+        literal_guard_ops literal_pattern PatternValue::Literal make_match_arm = literal_arm
+        arm_token Token::location OpKind::OpMatchArm literal_arm (int) make_op ops.push
     elif TokenKind::Identifier arm_token Token::kind != then
         arm_token Token::location "Expected match pattern or `_`" ErrorKind::UnexpectedToken raise_error
     elif cursor.peek.is_some "{" cursor.peek.unwrap Token::value == && then
         cursor arm_token parser parse_struct_match_pattern = struct_pattern
         function_name cursor parser parse_pattern_terminator = struct_guard_ops
-        struct_guard_ops struct_pattern (int) make_match_arm = struct_arm
-        PatternKind::PatStruct arm_token Token::location OpKind::OpMatchArm struct_arm (int) make_op_pattern ops.push
+        struct_guard_ops struct_pattern PatternValue::Struct make_match_arm = struct_arm
+        arm_token Token::location OpKind::OpMatchArm struct_arm (int) make_op ops.push
     elif arm_token Token::value "::" str::find 0 > then
         function_name cursor parser parse_pattern_terminator = bare_guard_ops
         Option::None arm_token Token::value "" make_enum_variant = bare_variant
-        bare_guard_ops bare_variant (int) make_match_arm = bare_arm
-        PatternKind::PatEnumVariant arm_token Token::location OpKind::OpMatchArm bare_arm (int) make_op_pattern ops.push
+        bare_guard_ops bare_variant PatternValue::EnumVariant make_match_arm = bare_arm
+        arm_token Token::location OpKind::OpMatchArm bare_arm (int) make_op ops.push
     else
         arm_token Token::value "::" str::find = separator
         arm_token Token::value 0 separator str::substring = enum_name
@@ -1574,8 +1574,8 @@ fn parse_match_arm_pattern
         function_name cursor parser parse_pattern_terminator = enum_guard_ops
         Option::None variant_name enum_name make_enum_variant = variant
         bindings variant EnumVariant::set_bindings
-        enum_guard_ops variant (int) make_match_arm = variant_arm
-        PatternKind::PatEnumVariant arm_token Token::location OpKind::OpMatchArm variant_arm (int) make_op_pattern ops.push
+        enum_guard_ops variant PatternValue::EnumVariant make_match_arm = variant_arm
+        arm_token Token::location OpKind::OpMatchArm variant_arm (int) make_op ops.push
     fi
 }
 # Parse a match-arm body (either a `{...}` block or a single-line expression
@@ -2271,21 +2271,18 @@ fn register_struct_pattern_binding parser:Parser function:Function binding_name:
 }
 
 fn resolve_match_op parser:Parser function:Function op:Op errors:List[CasaError] {
-    op pattern_kind match
-        PatternKind::PatStruct => {
-            op pattern_value_of (StructPattern) = struct_pattern
-            struct_pattern StructPattern::bindings.keys = pattern_keys
+    op pattern_value_of match
+        PatternValue::Struct(struct_pattern) => {
+            struct_pattern.bindings.keys = pattern_keys
             for pattern_key in pattern_keys.iter do
-                pattern_key struct_pattern StructPattern::bindings.get.unwrap = binding_name
+                pattern_key struct_pattern.bindings.get.unwrap = binding_name
                 binding_name function parser register_struct_pattern_binding
             done
         }
-        PatternKind::PatEnumVariant => {
-            op pattern_value_of (EnumVariant) = variant
+        PatternValue::EnumVariant(variant) => {
             errors function op variant parser resolve_enum_variant
         }
-        PatternKind::PatLiteral => { }
-        PatternKind::PatWildcard => { }
+        PatternValue::Literal => { }
     end
     # Resolve identifiers inside the guard expression (bindings registered
     # by the pattern above are now in scope).

--- a/compiler/syntax.casa
+++ b/compiler/syntax.casa
@@ -356,11 +356,11 @@ fn get_op_operator token:Token cursor:TokenCursor function_name:str -> Op {
                 cursor parse_type = type_annotation
             fi
         fi
-        if "" type_annotation == then
-            name_token Token::location OpKind::OpAssignVar var_name make_op_str
-        else
-            type_annotation name_token Token::location OpKind::OpAssignVar var_name (int) make_op_annotated
+        name_token Token::location OpKind::OpAssignVar var_name make_op_str = assign_op
+        if "" type_annotation != then
+            type_annotation assign_op->type_annotation
         fi
+        assign_op
         return
     fi
 
@@ -2317,14 +2317,14 @@ fn try_resolve_fn_ref
             ref_name ref_name "::" str::find 2 + ref_name.length ref_name "::" str::find - 2 - str::substring = ref_trait_method
             f"__trait_{ref_type_var}_{ref_trait_method}" = ref_hidden
             OpKind::OpPushVar op Op::set_kind
-            ref_hidden (int) op Op::set_value
+            ref_hidden OpValue::Str op Op::set_value_v
             true return
         fi
     fi
     ref_name parser.store.functions.get = ref_fn_opt
     if ref_fn_opt.is_some then
         OpKind::OpFnPush op Op::set_kind
-        ref_name (int) op Op::set_value
+        ref_name OpValue::Str op Op::set_value_v
         true ref_fn_opt.unwrap Function::set_is_used
     else
         op Op::location f"Function `{ref_name}` is not defined" ErrorKind::UndefinedName make_error resolve_errors.push
@@ -2369,7 +2369,7 @@ fn try_resolve_trait_method_call parser:Parser function:Function op:Op ident:str
         hidden_var make_variable function Function::variables.push
     fi
     OpKind::OpPushVar op Op::set_kind
-    hidden_var (int) op Op::set_value
+    hidden_var OpValue::Str op Op::set_value_v
     "trait_exec" op Op::set_type_annotation
     true
 }

--- a/compiler/syntax.casa
+++ b/compiler/syntax.casa
@@ -419,7 +419,7 @@ fn get_op_array cursor:TokenCursor -> Op {
         fi
         "," cursor expect_delimiter drop
     done
-    open_token Token::location OpKind::OpPushArray items (int) make_op
+    open_token Token::location OpKind::OpPushArray items OpValue::OpList make_op_v
 }
 
 # ============================================================================
@@ -2192,7 +2192,7 @@ fn gather_captures parser:Parser lambda_function:Function function:Function {
 fn resolve_array_identifiers parser:Parser items:List[Op] function:Function errors:List[CasaError] {
     for rai_item in items.iter do
         if OpKind::OpPushArray rai_item Op::kind == then
-            errors function rai_item Op::value(List[Op]) parser resolve_array_identifiers
+            errors function rai_item op_list_of parser resolve_array_identifiers
         elif OpKind::OpIdentifier rai_item Op::kind == then
             rai_item op_str_value = rai_name
             if rai_name function Function::variables variable_list_contains then
@@ -2465,7 +2465,7 @@ fn resolve_identifiers_fn parser:Parser ops:List[Op] function:Function -> List[O
 
         # PUSH_ARRAY: resolve identifiers inside array literals
         if OpKind::OpPushArray op_kind == then
-            resolve_errors function current_op Op::value(List[Op]) parser resolve_array_identifiers
+            resolve_errors function current_op op_list_of parser resolve_array_identifiers
             continue
         fi
 

--- a/compiler/typechecker.casa
+++ b/compiler/typechecker.casa
@@ -1885,7 +1885,7 @@ fn check_match tc:TypeChecker op:Op function_opt:Option[Function] {
 # ============================================================================
 
 fn check_struct_new tc:TypeChecker op:Op {
-    op Op::value(CasaStruct) = casa_struct
+    op casa_struct_of = casa_struct
     casa_struct CasaStruct::name = name
     # Build type variable bindings from actual stack values
     Map::new(Map[str str]) = bindings

--- a/compiler/typechecker.casa
+++ b/compiler/typechecker.casa
@@ -1912,7 +1912,7 @@ fn check_struct_new tc:TypeChecker op:Op {
 # ============================================================================
 
 fn check_struct_literal tc:TypeChecker op:Op {
-    op Op::value(StructLiteral) = literal
+    op struct_literal_of = literal
     literal StructLiteral::struct_name = name
     name tc.store.structs.get = struct_opt
     if struct_opt.is_none then

--- a/compiler/typechecker.casa
+++ b/compiler/typechecker.casa
@@ -2202,7 +2202,7 @@ fn check_method_call
                         receiver tc stack_push
                         f"{receiver}::{method_name}" resolved_sig tc apply_signature
                         OpKind::OpPushVar op Op::set_kind
-                        hidden_var (int) op Op::set_value
+                        hidden_var OpValue::Str op Op::set_value_v
                         # Insert FN_EXEC op after the PUSH_VARIABLE
                         op Op::location OpKind::OpFnExec 0 make_op = exec_op
                         op_index exec_op ops.insert
@@ -2258,7 +2258,7 @@ fn check_method_call
             function_opt op Op::location op_index ops sig tc inject_trait_fn_ptrs += op_index
         fi
         fn_name sig tc apply_signature
-        fn_name (int) op Op::set_value
+        fn_name OpValue::Str op Op::set_value_v
         OpKind::OpFnCall op Op::set_kind
     else
         op Op::location f"Method `{fn_name}` does not exist" ErrorKind::UndefinedName raise_error
@@ -2288,7 +2288,7 @@ fn check_fstring_to_str
         op_index return
     fi
     OpKind::OpMethodCall op Op::set_kind
-    "to_str" (int) op Op::set_value
+    "to_str" OpValue::Str op Op::set_value_v
     function_opt op_index ops op tc check_method_call
 }
 

--- a/compiler/typechecker.casa
+++ b/compiler/typechecker.casa
@@ -1624,7 +1624,7 @@ fn check_syscalls tc:TypeChecker op:Op {
 # ============================================================================
 
 fn check_enum_variant tc:TypeChecker op:Op {
-    op Op::value(EnumVariant) = variant
+    op enum_variant_of = variant
     variant EnumVariant::enum_name = enum_name
     enum_name tc.store.enums.get = enum_opt
     if enum_opt.is_none then
@@ -1693,7 +1693,7 @@ fn check_is tc:TypeChecker op:Op {
         return
     fi
     base tc.store.enums.get.unwrap = casa_enum
-    op Op::value(EnumVariant) = variant
+    op enum_variant_of = variant
     # Validate the variant belongs to the correct enum
     if "" variant EnumVariant::enum_name != then
         if variant EnumVariant::enum_name casa_enum CasaEnum::name != then

--- a/compiler/typechecker.casa
+++ b/compiler/typechecker.casa
@@ -2202,9 +2202,9 @@ fn check_method_call
                         receiver tc stack_push
                         f"{receiver}::{method_name}" resolved_sig tc apply_signature
                         OpKind::OpPushVar op Op::set_kind
-                        hidden_var OpValue::Str op Op::set_value_v
+                        hidden_var OpValue::Str op Op::set_value
                         # Insert FN_EXEC op after the PUSH_VARIABLE
-                        op Op::location OpKind::OpFnExec 0 make_op = exec_op
+                        op Op::location OpKind::OpFnExec make_op = exec_op
                         op_index exec_op ops.insert
                         op_index 1 + return
                     fi
@@ -2258,7 +2258,7 @@ fn check_method_call
             function_opt op Op::location op_index ops sig tc inject_trait_fn_ptrs += op_index
         fi
         fn_name sig tc apply_signature
-        fn_name OpValue::Str op Op::set_value_v
+        fn_name OpValue::Str op Op::set_value
         OpKind::OpFnCall op Op::set_kind
     else
         op Op::location f"Method `{fn_name}` does not exist" ErrorKind::UndefinedName raise_error
@@ -2288,7 +2288,7 @@ fn check_fstring_to_str
         op_index return
     fi
     OpKind::OpMethodCall op Op::set_kind
-    "to_str" OpValue::Str op Op::set_value_v
+    "to_str" OpValue::Str op Op::set_value
     function_opt op_index ops op tc check_method_call
 }
 

--- a/lsp.casa
+++ b/lsp.casa
@@ -790,7 +790,7 @@ fn compute_definition state:DocumentState line:int col:int -> Option[LspLocation
 
     # STRUCT_NEW
     if OpKind::OpStructNew kind == then
-        op Op::value(CasaStruct) CasaStruct::location casa_location_to_lsp Option::Some
+        op casa_struct_of CasaStruct::location casa_location_to_lsp Option::Some
         return
     fi
 
@@ -941,7 +941,7 @@ fn format_hover op:Op state:DocumentState func:Option[Function] -> Option[str] {
 
     # Struct new
     if OpKind::OpStructNew kind == then
-        op Op::value(CasaStruct) = struct_val
+        op casa_struct_of = struct_val
         StringBuilder::new = struct_builder
         "struct " struct_builder.append
         struct_val CasaStruct::name struct_builder.append
@@ -1512,7 +1512,7 @@ fn collect_var_refs ops:List[Op] name:str results:List[LspLocation] {
 fn collect_struct_refs ops:List[Op] name:str results:List[LspLocation] {
     for op in ops.iter do
         if OpKind::OpStructNew op Op::kind == then
-            if op Op::value(CasaStruct) CasaStruct::name name == then
+            if op casa_struct_of CasaStruct::name name == then
                 op Op::location casa_location_to_lsp results.push
             fi
         elif OpKind::OpTypeCast op Op::kind == then
@@ -1612,9 +1612,10 @@ fn find_all_references
 
     # Struct
     if OpKind::OpStructNew kind == then
-        op Op::value(CasaStruct) CasaStruct::name = struct_name
+        op casa_struct_of = casa_struct
+        casa_struct CasaStruct::name = struct_name
         if include_declaration then
-            op Op::value(CasaStruct) CasaStruct::location casa_location_to_lsp results.push
+            casa_struct CasaStruct::location casa_location_to_lsp results.push
         fi
         results struct_name state DocumentState::ops collect_struct_refs
         results struct_name COLLECTOR_STRUCT state collect_refs_in_all_functions

--- a/lsp.casa
+++ b/lsp.casa
@@ -796,13 +796,14 @@ fn compute_definition state:DocumentState line:int col:int -> Option[LspLocation
 
     # PUSH_ENUM_VARIANT
     if OpKind::OpPushEnumVariant kind == then
-        op Op::value(EnumVariant) EnumVariant::enum_name = enum_name
+        op enum_variant_of = enum_variant
+        enum_variant EnumVariant::enum_name = enum_name
         if enum_name state DocumentState::enums.has ! then
             Option::None(Option[LspLocation])
             return
         fi
         enum_name state DocumentState::enums.get.unwrap = casa_enum
-        op Op::value(EnumVariant) EnumVariant::variant_name casa_enum CasaEnum::variant_locations.get = variant_loc_opt
+        enum_variant EnumVariant::variant_name casa_enum CasaEnum::variant_locations.get = variant_loc_opt
         if QPART_MEMBER qpart == variant_loc_opt.is_some && then
             variant_loc_opt.unwrap casa_location_to_lsp Option::Some
             return
@@ -961,7 +962,7 @@ fn format_hover op:Op state:DocumentState func:Option[Function] -> Option[str] {
 
     # Enum variant
     if OpKind::OpPushEnumVariant kind == then
-        op Op::value(EnumVariant) = variant
+        op enum_variant_of = variant
         f"{variant EnumVariant::enum_name}::{variant EnumVariant::variant_name}" Option::Some
         return
     fi
@@ -1122,7 +1123,7 @@ fn compute_hover state:DocumentState line:int col:int -> Option[HoverContent] {
     QPART_NONE qpart !=
     OpKind::OpPushEnumVariant op Op::kind == &&
     then
-        op Op::value(EnumVariant) = enum_variant
+        op enum_variant_of = enum_variant
         if QPART_TYPE qpart == then
             op state DocumentState::source qualified_type_range = enum_range
             if enum_variant EnumVariant::enum_name state DocumentState::enums.has then
@@ -1527,7 +1528,7 @@ fn collect_enum_refs ops:List[Op] enum_name:str results:List[LspLocation] {
         if OpKind::OpPushEnumVariant op Op::kind != then
             continue
         fi
-        if op Op::value(EnumVariant) EnumVariant::enum_name enum_name != then
+        if op enum_variant_of EnumVariant::enum_name enum_name != then
             continue
         fi
         op Op::location casa_location_to_lsp results.push
@@ -1623,7 +1624,7 @@ fn find_all_references
 
     # Enum variant
     if OpKind::OpPushEnumVariant kind == then
-        op Op::value(EnumVariant) EnumVariant::enum_name = enum_name
+        op enum_variant_of EnumVariant::enum_name = enum_name
         if include_declaration enum_name state DocumentState::enums.has && then
             enum_name state DocumentState::enums.get.unwrap CasaEnum::location casa_location_to_lsp results.push
         fi

--- a/tests/compiler/test_bytecode.casa
+++ b/tests/compiler/test_bytecode.casa
@@ -17,12 +17,11 @@ fn make_test_location -> Location {
     # param1=file, param2=offset, param3=length -> length offset file make_location
     1 0 "test.casa" make_location
 }
-# Helper to create an op with int value
-# make_op value:int kind:int location:Location
-# param1=value, param2=kind, param3=location
+# Helper to create a payloadless op
+# make_op kind:OpKind location:Location -> param1=kind, param2=location
 
-fn test_make_op value:int kind:OpKind -> Op {
-    make_test_location kind value make_op
+fn test_make_op kind:OpKind -> Op {
+    make_test_location kind make_op
 }
 
 fn test_make_op_int value:int kind:OpKind -> Op {
@@ -30,17 +29,15 @@ fn test_make_op_int value:int kind:OpKind -> Op {
 }
 # Helper to create an op with str value
 # make_op_str value:str kind:OpKind location:Location
-# param1=value, param2=kind, param3=location
 
 fn test_make_op_str value:str kind:OpKind -> Op {
     make_test_location kind value make_op_str
 }
 # Helper to create an annotated op
-# make_op_annotated value:int kind:OpKind location:Location annotation:str
-# param1=value, param2=kind, param3=location, param4=annotation
+# make_op_annotated kind:OpKind location:Location annotation:str
 
-fn test_make_op_annotated value:int kind:OpKind annotation:str -> Op {
-    annotation make_test_location kind value make_op_annotated
+fn test_make_op_annotated kind:OpKind annotation:str -> Op {
+    annotation make_test_location kind make_op_annotated
 }
 
 # ============================================================================
@@ -145,10 +142,10 @@ fn test_compile_direct_ops {
     "compile_direct_ops" test_start
     reset_labels
     List::new(List[Op]) = ops
-    OpKind::OpAdd 0 test_make_op ops.push
-    OpKind::OpSub 0 test_make_op ops.push
-    OpKind::OpDup 0 test_make_op ops.push
-    OpKind::OpDrop 0 test_make_op ops.push
+    OpKind::OpAdd test_make_op ops.push
+    OpKind::OpSub test_make_op ops.push
+    OpKind::OpDup test_make_op ops.push
+    OpKind::OpDrop test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
     List::new(List[Inst]) = bytecode
@@ -229,7 +226,7 @@ fn test_compile_type_cast_no_output {
     "compile_type_cast_no_output" test_start
     reset_labels
     List::new(List[Op]) = ops
-    OpKind::OpTypeCast 0 test_make_op ops.push
+    OpKind::OpTypeCast test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
     List::new(List[Inst]) = bytecode
@@ -243,7 +240,7 @@ fn test_compile_import_no_output {
     "compile_import_no_output" test_start
     reset_labels
     List::new(List[Op]) = ops
-    OpKind::OpImportFile 0 test_make_op ops.push
+    OpKind::OpImportFile test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
     List::new(List[Inst]) = bytecode
@@ -266,9 +263,9 @@ fn test_compile_if_block {
     "compile_if_block" test_start
     reset_labels
     List::new(List[Op]) = ops
-    OpKind::OpIfStart 0 test_make_op ops.push
-    OpKind::OpIfCondition 0 test_make_op ops.push
-    OpKind::OpIfEnd 0 test_make_op ops.push
+    OpKind::OpIfStart test_make_op ops.push
+    OpKind::OpIfCondition test_make_op ops.push
+    OpKind::OpIfEnd test_make_op ops.push
 
     "ops has 3 elements" 3 ops.length assert_eq
     "op 0 is if_start" OpKind::OpIfStart 0 ops.get Op::kind == assert_true
@@ -289,9 +286,9 @@ fn test_compile_while_block {
     "compile_while_block" test_start
     reset_labels
     List::new(List[Op]) = ops
-    OpKind::OpWhileStart 0 test_make_op ops.push
-    OpKind::OpWhileCondition 0 test_make_op ops.push
-    OpKind::OpWhileEnd 0 test_make_op ops.push
+    OpKind::OpWhileStart test_make_op ops.push
+    OpKind::OpWhileCondition test_make_op ops.push
+    OpKind::OpWhileEnd test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
     List::new(List[Inst]) = bytecode
@@ -310,8 +307,7 @@ fn test_compile_string_eq {
     "compile_string_eq" test_start
     reset_labels
     List::new(List[Op]) = ops
-    # make_op_annotated value:int kind:int location:Location annotation:str
-    "str" OpKind::OpEq 0 test_make_op_annotated ops.push
+    "str" OpKind::OpEq test_make_op_annotated ops.push
 
     ops TEST_STORE make_compiler = compiler
     List::new(List[Inst]) = bytecode
@@ -324,7 +320,7 @@ fn test_compile_string_ne {
     "compile_string_ne" test_start
     reset_labels
     List::new(List[Op]) = ops
-    "str" OpKind::OpNe 0 test_make_op_annotated ops.push
+    "str" OpKind::OpNe test_make_op_annotated ops.push
 
     ops TEST_STORE make_compiler = compiler
     List::new(List[Inst]) = bytecode
@@ -396,23 +392,23 @@ fn test_compile_more_direct_ops {
     "compile_more_direct_ops" test_start
     reset_labels
     List::new(List[Op]) = ops
-    OpKind::OpMul 0 test_make_op ops.push
-    OpKind::OpDiv 0 test_make_op ops.push
-    OpKind::OpMod 0 test_make_op ops.push
-    OpKind::OpShl 0 test_make_op ops.push
-    OpKind::OpShr 0 test_make_op ops.push
-    OpKind::OpAnd 0 test_make_op ops.push
-    OpKind::OpOr 0 test_make_op ops.push
-    OpKind::OpNot 0 test_make_op ops.push
-    OpKind::OpEq 0 test_make_op ops.push
-    OpKind::OpNe 0 test_make_op ops.push
-    OpKind::OpGt 0 test_make_op ops.push
-    OpKind::OpGe 0 test_make_op ops.push
-    OpKind::OpLt 0 test_make_op ops.push
-    OpKind::OpLe 0 test_make_op ops.push
-    OpKind::OpSwap 0 test_make_op ops.push
-    OpKind::OpOver 0 test_make_op ops.push
-    OpKind::OpRot 0 test_make_op ops.push
+    OpKind::OpMul test_make_op ops.push
+    OpKind::OpDiv test_make_op ops.push
+    OpKind::OpMod test_make_op ops.push
+    OpKind::OpShl test_make_op ops.push
+    OpKind::OpShr test_make_op ops.push
+    OpKind::OpAnd test_make_op ops.push
+    OpKind::OpOr test_make_op ops.push
+    OpKind::OpNot test_make_op ops.push
+    OpKind::OpEq test_make_op ops.push
+    OpKind::OpNe test_make_op ops.push
+    OpKind::OpGt test_make_op ops.push
+    OpKind::OpGe test_make_op ops.push
+    OpKind::OpLt test_make_op ops.push
+    OpKind::OpLe test_make_op ops.push
+    OpKind::OpSwap test_make_op ops.push
+    OpKind::OpOver test_make_op ops.push
+    OpKind::OpRot test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
     List::new(List[Inst]) = bytecode
@@ -442,10 +438,10 @@ fn test_compile_direct_ops_bitwise {
     "compile_direct_ops_bitwise" test_start
     reset_labels
     List::new(List[Op]) = ops
-    OpKind::OpBitAnd 0 test_make_op ops.push
-    OpKind::OpBitOr 0 test_make_op ops.push
-    OpKind::OpBitXor 0 test_make_op ops.push
-    OpKind::OpBitNot 0 test_make_op ops.push
+    OpKind::OpBitAnd test_make_op ops.push
+    OpKind::OpBitOr test_make_op ops.push
+    OpKind::OpBitXor test_make_op ops.push
+    OpKind::OpBitNot test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
     List::new(List[Inst]) = bytecode
@@ -461,15 +457,15 @@ fn test_compile_direct_ops_memory {
     "compile_direct_ops_memory" test_start
     reset_labels
     List::new(List[Op]) = ops
-    OpKind::OpHeapAlloc 0 test_make_op ops.push
-    OpKind::OpLoad8 0 test_make_op ops.push
-    OpKind::OpLoad16 0 test_make_op ops.push
-    OpKind::OpLoad32 0 test_make_op ops.push
-    OpKind::OpLoad64 0 test_make_op ops.push
-    OpKind::OpStore8 0 test_make_op ops.push
-    OpKind::OpStore16 0 test_make_op ops.push
-    OpKind::OpStore32 0 test_make_op ops.push
-    OpKind::OpStore64 0 test_make_op ops.push
+    OpKind::OpHeapAlloc test_make_op ops.push
+    OpKind::OpLoad8 test_make_op ops.push
+    OpKind::OpLoad16 test_make_op ops.push
+    OpKind::OpLoad32 test_make_op ops.push
+    OpKind::OpLoad64 test_make_op ops.push
+    OpKind::OpStore8 test_make_op ops.push
+    OpKind::OpStore16 test_make_op ops.push
+    OpKind::OpStore32 test_make_op ops.push
+    OpKind::OpStore64 test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
     List::new(List[Inst]) = bytecode
@@ -490,13 +486,13 @@ fn test_compile_direct_ops_syscall {
     "compile_direct_ops_syscall" test_start
     reset_labels
     List::new(List[Op]) = ops
-    OpKind::OpSyscall0 0 test_make_op ops.push
-    OpKind::OpSyscall1 0 test_make_op ops.push
-    OpKind::OpSyscall2 0 test_make_op ops.push
-    OpKind::OpSyscall3 0 test_make_op ops.push
-    OpKind::OpSyscall4 0 test_make_op ops.push
-    OpKind::OpSyscall5 0 test_make_op ops.push
-    OpKind::OpSyscall6 0 test_make_op ops.push
+    OpKind::OpSyscall0 test_make_op ops.push
+    OpKind::OpSyscall1 test_make_op ops.push
+    OpKind::OpSyscall2 test_make_op ops.push
+    OpKind::OpSyscall3 test_make_op ops.push
+    OpKind::OpSyscall4 test_make_op ops.push
+    OpKind::OpSyscall5 test_make_op ops.push
+    OpKind::OpSyscall6 test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
     List::new(List[Inst]) = bytecode
@@ -515,11 +511,11 @@ fn test_compile_direct_ops_print {
     "compile_direct_ops_print" test_start
     reset_labels
     List::new(List[Op]) = ops
-    OpKind::OpPrintInt 0 test_make_op ops.push
-    OpKind::OpPrintStr 0 test_make_op ops.push
-    OpKind::OpPrintChar 0 test_make_op ops.push
-    OpKind::OpPrintCstr 0 test_make_op ops.push
-    OpKind::OpPrintBool 0 test_make_op ops.push
+    OpKind::OpPrintInt test_make_op ops.push
+    OpKind::OpPrintStr test_make_op ops.push
+    OpKind::OpPrintChar test_make_op ops.push
+    OpKind::OpPrintCstr test_make_op ops.push
+    OpKind::OpPrintBool test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
     List::new(List[Inst]) = bytecode
@@ -536,8 +532,8 @@ fn test_compile_direct_ops_fn {
     "compile_direct_ops_fn" test_start
     reset_labels
     List::new(List[Op]) = ops
-    OpKind::OpFnExec 0 test_make_op ops.push
-    OpKind::OpFnReturn 0 test_make_op ops.push
+    OpKind::OpFnExec test_make_op ops.push
+    OpKind::OpFnReturn test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
     List::new(List[Inst]) = bytecode
@@ -600,12 +596,12 @@ fn test_compile_if_elif_else {
     reset_labels
     List::new(List[Op]) = ops
     # if ... then ... elif ... then ... else ... fi
-    OpKind::OpIfStart 0 test_make_op ops.push
-    OpKind::OpIfCondition 0 test_make_op ops.push
-    OpKind::OpIfElif 0 test_make_op ops.push
-    OpKind::OpIfCondition 0 test_make_op ops.push
-    OpKind::OpIfElse 0 test_make_op ops.push
-    OpKind::OpIfEnd 0 test_make_op ops.push
+    OpKind::OpIfStart test_make_op ops.push
+    OpKind::OpIfCondition test_make_op ops.push
+    OpKind::OpIfElif test_make_op ops.push
+    OpKind::OpIfCondition test_make_op ops.push
+    OpKind::OpIfElse test_make_op ops.push
+    OpKind::OpIfEnd test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
     List::new(List[Inst]) = bytecode

--- a/tests/compiler/test_bytecode.casa
+++ b/tests/compiler/test_bytecode.casa
@@ -555,7 +555,7 @@ fn test_compile_push_array {
 
     # Create a PushArray op with the items list as value
     List::new(List[Op]) = ops
-    make_test_location OpKind::OpPushArray items (int) make_op ops.push
+    make_test_location OpKind::OpPushArray items OpValue::OpList make_op_v ops.push
 
     ops TEST_STORE make_compiler = compiler
     List::new(List[Inst]) = bytecode

--- a/tests/compiler/test_bytecode.casa
+++ b/tests/compiler/test_bytecode.casa
@@ -24,6 +24,10 @@ fn make_test_location -> Location {
 fn test_make_op value:int kind:OpKind -> Op {
     make_test_location kind value make_op
 }
+
+fn test_make_op_int value:int kind:OpKind -> Op {
+    make_test_location kind value make_op_int
+}
 # Helper to create an op with str value
 # make_op_str value:str kind:OpKind location:Location
 # param1=value, param2=kind, param3=location
@@ -79,7 +83,7 @@ fn test_compile_push_int {
     "compile_push_int" test_start
     reset_labels
     List::new(List[Op]) = ops
-    OpKind::OpPushInt 42 test_make_op ops.push
+    OpKind::OpPushInt 42 test_make_op_int ops.push
 
     ops TEST_STORE make_compiler = compiler
     List::new(List[Inst]) = bytecode
@@ -98,7 +102,7 @@ fn test_compile_push_bool {
     "compile_push_bool" test_start
     reset_labels
     List::new(List[Op]) = ops
-    OpKind::OpPushBool 1 test_make_op ops.push
+    OpKind::OpPushBool 1 test_make_op_int ops.push
 
     ops TEST_STORE make_compiler = compiler
     List::new(List[Inst]) = bytecode
@@ -127,7 +131,7 @@ fn test_compile_push_char {
     "compile_push_char" test_start
     reset_labels
     List::new(List[Op]) = ops
-    OpKind::OpPushChar 'A' (int) test_make_op ops.push
+    OpKind::OpPushChar 'A' (int) test_make_op_int ops.push
 
     ops TEST_STORE make_compiler = compiler
     List::new(List[Inst]) = bytecode
@@ -211,7 +215,7 @@ fn test_compile_fstring_concat {
     "compile_fstring_concat" test_start
     reset_labels
     List::new(List[Op]) = ops
-    OpKind::OpFstringConcat 3 test_make_op ops.push
+    OpKind::OpFstringConcat 3 test_make_op_int ops.push
 
     ops TEST_STORE make_compiler = compiler
     List::new(List[Inst]) = bytecode
@@ -378,7 +382,7 @@ fn test_compile_push_bool_false {
     "compile_push_bool_false" test_start
     reset_labels
     List::new(List[Op]) = ops
-    OpKind::OpPushBool 0 test_make_op ops.push
+    OpKind::OpPushBool 0 test_make_op_int ops.push
 
     ops TEST_STORE make_compiler = compiler
     List::new(List[Inst]) = bytecode
@@ -549,9 +553,9 @@ fn test_compile_push_array {
 
     # Create array items: [1, 2, 3]
     List::new(List[Op]) = items
-    OpKind::OpPushInt 1 test_make_op items.push
-    OpKind::OpPushInt 2 test_make_op items.push
-    OpKind::OpPushInt 3 test_make_op items.push
+    OpKind::OpPushInt 1 test_make_op_int items.push
+    OpKind::OpPushInt 2 test_make_op_int items.push
+    OpKind::OpPushInt 3 test_make_op_int items.push
 
     # Create a PushArray op with the items list as value
     List::new(List[Op]) = ops
@@ -657,7 +661,7 @@ fn test_compile_fn_push {
 
     # Register a function in TEST_STORE.functions with has_deferred_methods = 0
     List::new(List[Op]) = fn_ops
-    OpKind::OpPushInt 1 test_make_op fn_ops.push
+    OpKind::OpPushInt 1 test_make_op_int fn_ops.push
     make_test_location fn_ops "adder" make_function = func
     "adder" func TEST_STORE.functions.set drop
 

--- a/tests/compiler/test_enum.casa
+++ b/tests/compiler/test_enum.casa
@@ -260,7 +260,7 @@ fn test_resolve_enum_variant_ordinal_first {
     0 = index
     while index ops.length > do
         if OpKind::OpPushEnumVariant index ops.get Op::kind == then
-            index ops.get Op::value(EnumVariant) = variant
+            index ops.get enum_variant_of = variant
             "ordinal 0" 0 variant EnumVariant::ordinal.unwrap assert_eq
             "enum name" "Color" variant EnumVariant::enum_name assert_str_eq
             "variant name" "Red" variant EnumVariant::variant_name assert_str_eq
@@ -275,7 +275,7 @@ fn test_resolve_enum_variant_ordinal_second {
     0 = index
     while index ops.length > do
         if OpKind::OpPushEnumVariant index ops.get Op::kind == then
-            index ops.get Op::value(EnumVariant) = variant
+            index ops.get enum_variant_of = variant
             "ordinal 1" 1 variant EnumVariant::ordinal.unwrap assert_eq
             "variant name" "Green" variant EnumVariant::variant_name assert_str_eq
         fi
@@ -289,7 +289,7 @@ fn test_resolve_enum_variant_ordinal_third {
     0 = index
     while index ops.length > do
         if OpKind::OpPushEnumVariant index ops.get Op::kind == then
-            index ops.get Op::value(EnumVariant) = variant
+            index ops.get enum_variant_of = variant
             "ordinal 2" 2 variant EnumVariant::ordinal.unwrap assert_eq
             "variant name" "Blue" variant EnumVariant::variant_name assert_str_eq
         fi
@@ -903,7 +903,7 @@ fn test_is_check_resolves_ordinal {
     0 = index
     while index ops.length > do
         if OpKind::OpIsCheck index ops.get Op::kind == then
-            index ops.get Op::value(EnumVariant) = variant
+            index ops.get enum_variant_of = variant
             "ordinal 2" 2 variant EnumVariant::ordinal.unwrap assert_eq
         fi
         1 += index
@@ -916,7 +916,7 @@ fn test_is_check_with_bindings_parsed {
     0 = index
     while index ops.length > do
         if OpKind::OpIsCheck index ops.get Op::kind == then
-            index ops.get Op::value(EnumVariant) = variant
+            index ops.get enum_variant_of = variant
             "has binding" 1 variant EnumVariant::bindings.length assert_eq
             "binding name" "r" 0 variant EnumVariant::bindings.get assert_str_eq
         fi
@@ -930,7 +930,7 @@ fn test_is_check_multiple_bindings_parsed {
     0 = index
     while index ops.length > do
         if OpKind::OpIsCheck index ops.get Op::kind == then
-            index ops.get Op::value(EnumVariant) = variant
+            index ops.get enum_variant_of = variant
             "has bindings" 2 variant EnumVariant::bindings.length assert_eq
             "binding w" "w" 0 variant EnumVariant::bindings.get assert_str_eq
             "binding h" "h" 1 variant EnumVariant::bindings.get assert_str_eq

--- a/tests/compiler/test_parser.casa
+++ b/tests/compiler/test_parser.casa
@@ -14,7 +14,7 @@ fn test_parse_integer {
     tokens DEFAULT_PARSER parse_ops = ops
     "count" 1 ops.length assert_eq
     "kind" OpKind::OpPushInt 0 ops.get Op::kind == assert_true
-    "value" 42 0 ops.get Op::value assert_eq
+    "value" 42 0 ops.get op_int_value assert_eq
 }
 
 fn test_parse_negative_integer {
@@ -23,7 +23,7 @@ fn test_parse_negative_integer {
     tokens DEFAULT_PARSER parse_ops = ops
     "count" 1 ops.length assert_eq
     "kind" OpKind::OpPushInt 0 ops.get Op::kind == assert_true
-    "value" 0 7 - 0 ops.get Op::value assert_eq
+    "value" 0 7 - 0 ops.get op_int_value assert_eq
 }
 
 fn test_parse_bool_true {
@@ -32,7 +32,7 @@ fn test_parse_bool_true {
     tokens DEFAULT_PARSER parse_ops = ops
     "count" 1 ops.length assert_eq
     "kind" OpKind::OpPushBool 0 ops.get Op::kind == assert_true
-    "value" 1 0 ops.get Op::value assert_eq
+    "value" 1 0 ops.get op_int_value assert_eq
 }
 
 fn test_parse_bool_false {
@@ -41,7 +41,7 @@ fn test_parse_bool_false {
     tokens DEFAULT_PARSER parse_ops = ops
     "count" 1 ops.length assert_eq
     "kind" OpKind::OpPushBool 0 ops.get Op::kind == assert_true
-    "value" 0 0 ops.get Op::value assert_eq
+    "value" 0 0 ops.get op_int_value assert_eq
 }
 
 fn test_parse_string {
@@ -59,7 +59,7 @@ fn test_parse_char {
     tokens DEFAULT_PARSER parse_ops = ops
     "count" 1 ops.length assert_eq
     "kind" OpKind::OpPushChar 0 ops.get Op::kind == assert_true
-    "value" 65 0 ops.get Op::value assert_eq
+    "value" 65 0 ops.get op_int_value assert_eq
 }
 
 # ============================================================================

--- a/tests/compiler/test_pattern.casa
+++ b/tests/compiler/test_pattern.casa
@@ -189,7 +189,7 @@ fn test_guard_excluded_from_covered_key {
     "covered when unguarded" "__covered:42" unguarded pattern_covered_key assert_str_eq
     "42" 0 LiteralValue::Int LiteralPattern = literal_pat
     List::new(List[Op]) = guard_ops
-    empty_location OpKind::OpPushBool 1 make_op guard_ops.push
+    empty_location OpKind::OpPushBool 1 make_op_int guard_ops.push
     guard_ops literal_pat PatternValue::Literal make_match_arm = arm
     empty_location OpKind::OpMatchArm arm OpValue::Match make_op_v = guarded
     "is guarded" guarded pattern_is_guarded assert_true

--- a/tests/compiler/test_pattern.casa
+++ b/tests/compiler/test_pattern.casa
@@ -11,50 +11,23 @@ import "../../lib/test.casa"
 # Helpers for building match-arm ops for tests
 # ============================================================================
 
-fn arm_of_kind kind:PatternKind -> Op {
-    List::new(List[Op]) 0 make_match_arm = empty_arm
-    kind empty_location OpKind::OpMatchArm empty_arm (int) make_op_pattern
-}
-
 fn make_enum_arm enum_name:str variant_name:str -> Op {
     Option::None variant_name enum_name make_enum_variant = variant
-    List::new(List[Op]) variant (int) make_match_arm = arm
-    PatternKind::PatEnumVariant empty_location OpKind::OpMatchArm arm (int) make_op_pattern
+    List::new(List[Op]) variant PatternValue::EnumVariant make_match_arm = arm
+    empty_location OpKind::OpMatchArm arm (int) make_op
 }
 
 fn make_struct_arm struct_name:str -> Op {
     Map::new(Map[str str]) = bindings
     bindings struct_name StructPattern = struct_pat
-    List::new(List[Op]) struct_pat (int) make_match_arm = arm
-    PatternKind::PatStruct empty_location OpKind::OpMatchArm arm (int) make_op_pattern
+    List::new(List[Op]) struct_pat PatternValue::Struct make_match_arm = arm
+    empty_location OpKind::OpMatchArm arm (int) make_op
 }
 
 fn make_literal_arm raw:str -> Op {
     raw "int" 0 LiteralPattern = literal_pat
-    List::new(List[Op]) literal_pat (int) make_match_arm = arm
-    PatternKind::PatLiteral empty_location OpKind::OpMatchArm arm (int) make_op_pattern
-}
-
-# ============================================================================
-# pattern_kind primitive
-# ============================================================================
-
-fn test_pattern_kind_struct {
-    "pattern_kind_struct" test_start
-    "Point" make_struct_arm = op
-    "struct" PatternKind::PatStruct op pattern_kind == assert_true
-}
-
-fn test_pattern_kind_enum_variant {
-    "pattern_kind_enum_variant" test_start
-    "Up" "Dir" make_enum_arm = op
-    "enum" PatternKind::PatEnumVariant op pattern_kind == assert_true
-}
-
-fn test_pattern_kind_literal {
-    "pattern_kind_literal" test_start
-    "42" make_literal_arm = op
-    "literal" PatternKind::PatLiteral op pattern_kind == assert_true
+    List::new(List[Op]) literal_pat PatternValue::Literal make_match_arm = arm
+    empty_location OpKind::OpMatchArm arm (int) make_op
 }
 
 # ============================================================================
@@ -129,8 +102,8 @@ fn test_pattern_bindings_enum_with_payload {
     List::new(List[str]) = binds
     "x" binds.push
     binds variant EnumVariant::set_bindings
-    List::new(List[Op]) variant (int) make_match_arm = arm
-    PatternKind::PatEnumVariant empty_location OpKind::OpMatchArm arm (int) make_op_pattern = op
+    List::new(List[Op]) variant PatternValue::EnumVariant make_match_arm = arm
+    empty_location OpKind::OpMatchArm arm (int) make_op = op
     op pattern_bindings = out
     "count" 1 out.length assert_eq
     "name" "x" 0 out.get assert_str_eq
@@ -142,8 +115,8 @@ fn test_pattern_bindings_struct_fields {
     "row" "y" bindings.set drop
     "col" "x" bindings.set drop
     bindings "Point" StructPattern = struct_pat
-    List::new(List[Op]) struct_pat (int) make_match_arm = arm
-    PatternKind::PatStruct empty_location OpKind::OpMatchArm arm (int) make_op_pattern = op
+    List::new(List[Op]) struct_pat PatternValue::Struct make_match_arm = arm
+    empty_location OpKind::OpMatchArm arm (int) make_op = op
     op pattern_bindings = out
     "count" 2 out.length assert_eq
 }
@@ -217,8 +190,8 @@ fn test_guard_excluded_from_covered_key {
     "42" "int" 0 LiteralPattern = literal_pat
     List::new(List[Op]) = guard_ops
     empty_location OpKind::OpPushBool 1 make_op guard_ops.push
-    guard_ops literal_pat (int) make_match_arm = arm
-    PatternKind::PatLiteral empty_location OpKind::OpMatchArm arm (int) make_op_pattern = guarded
+    guard_ops literal_pat PatternValue::Literal make_match_arm = arm
+    empty_location OpKind::OpMatchArm arm (int) make_op = guarded
     "is guarded" guarded pattern_is_guarded assert_true
     "empty key when guarded" "" guarded pattern_covered_key assert_str_eq
 }
@@ -261,9 +234,6 @@ fn test_guard_non_exhaustive_without_fallback {
     "guard alone non-exhaustive" "Non-exhaustive match" assert_error_contains
     disable_test_mode
 }
-test_pattern_kind_struct
-test_pattern_kind_enum_variant
-test_pattern_kind_literal
 test_pattern_is_wildcard_underscore_variant
 test_pattern_is_wildcard_named_variant
 test_pattern_is_wildcard_literal

--- a/tests/compiler/test_pattern.casa
+++ b/tests/compiler/test_pattern.casa
@@ -25,7 +25,7 @@ fn make_struct_arm struct_name:str -> Op {
 }
 
 fn make_literal_arm raw:str -> Op {
-    raw "int" 0 LiteralPattern = literal_pat
+    raw 0 LiteralValue::Int LiteralPattern = literal_pat
     List::new(List[Op]) literal_pat PatternValue::Literal make_match_arm = arm
     empty_location OpKind::OpMatchArm arm (int) make_op
 }
@@ -187,7 +187,7 @@ fn test_guard_excluded_from_covered_key {
     "guard_excluded_from_covered_key" test_start
     "42" make_literal_arm = unguarded
     "covered when unguarded" "__covered:42" unguarded pattern_covered_key assert_str_eq
-    "42" "int" 0 LiteralPattern = literal_pat
+    "42" 0 LiteralValue::Int LiteralPattern = literal_pat
     List::new(List[Op]) = guard_ops
     empty_location OpKind::OpPushBool 1 make_op guard_ops.push
     guard_ops literal_pat PatternValue::Literal make_match_arm = arm

--- a/tests/compiler/test_pattern.casa
+++ b/tests/compiler/test_pattern.casa
@@ -14,20 +14,20 @@ import "../../lib/test.casa"
 fn make_enum_arm enum_name:str variant_name:str -> Op {
     Option::None variant_name enum_name make_enum_variant = variant
     List::new(List[Op]) variant PatternValue::EnumVariant make_match_arm = arm
-    empty_location OpKind::OpMatchArm arm (int) make_op
+    empty_location OpKind::OpMatchArm arm OpValue::Match make_op_v
 }
 
 fn make_struct_arm struct_name:str -> Op {
     Map::new(Map[str str]) = bindings
     bindings struct_name StructPattern = struct_pat
     List::new(List[Op]) struct_pat PatternValue::Struct make_match_arm = arm
-    empty_location OpKind::OpMatchArm arm (int) make_op
+    empty_location OpKind::OpMatchArm arm OpValue::Match make_op_v
 }
 
 fn make_literal_arm raw:str -> Op {
     raw 0 LiteralValue::Int LiteralPattern = literal_pat
     List::new(List[Op]) literal_pat PatternValue::Literal make_match_arm = arm
-    empty_location OpKind::OpMatchArm arm (int) make_op
+    empty_location OpKind::OpMatchArm arm OpValue::Match make_op_v
 }
 
 # ============================================================================
@@ -103,7 +103,7 @@ fn test_pattern_bindings_enum_with_payload {
     "x" binds.push
     binds variant EnumVariant::set_bindings
     List::new(List[Op]) variant PatternValue::EnumVariant make_match_arm = arm
-    empty_location OpKind::OpMatchArm arm (int) make_op = op
+    empty_location OpKind::OpMatchArm arm OpValue::Match make_op_v = op
     op pattern_bindings = out
     "count" 1 out.length assert_eq
     "name" "x" 0 out.get assert_str_eq
@@ -116,7 +116,7 @@ fn test_pattern_bindings_struct_fields {
     "col" "x" bindings.set drop
     bindings "Point" StructPattern = struct_pat
     List::new(List[Op]) struct_pat PatternValue::Struct make_match_arm = arm
-    empty_location OpKind::OpMatchArm arm (int) make_op = op
+    empty_location OpKind::OpMatchArm arm OpValue::Match make_op_v = op
     op pattern_bindings = out
     "count" 2 out.length assert_eq
 }
@@ -191,7 +191,7 @@ fn test_guard_excluded_from_covered_key {
     List::new(List[Op]) = guard_ops
     empty_location OpKind::OpPushBool 1 make_op guard_ops.push
     guard_ops literal_pat PatternValue::Literal make_match_arm = arm
-    empty_location OpKind::OpMatchArm arm (int) make_op = guarded
+    empty_location OpKind::OpMatchArm arm OpValue::Match make_op_v = guarded
     "is guarded" guarded pattern_is_guarded assert_true
     "empty key when guarded" "" guarded pattern_covered_key assert_str_eq
 }

--- a/tests/compiler/test_struct_literal.casa
+++ b/tests/compiler/test_struct_literal.casa
@@ -80,7 +80,7 @@ fn test_basic_struct_literal {
     0 = index
     while index ops.length > do
         if OpKind::OpStructLiteral index ops.get Op::kind == then
-            index ops.get Op::value(StructLiteral) = literal
+            index ops.get struct_literal_of = literal
             "struct name" "Point" literal StructLiteral::struct_name assert_str_eq
             "field count" 2 literal StructLiteral::field_order.length assert_eq
             "field 0" "x" 0 literal StructLiteral::field_order.get assert_str_eq
@@ -96,7 +96,7 @@ fn test_reverse_field_order {
     0 = index
     while index ops.length > do
         if OpKind::OpStructLiteral index ops.get Op::kind == then
-            index ops.get Op::value(StructLiteral) = literal
+            index ops.get struct_literal_of = literal
             "field 0" "y" 0 literal StructLiteral::field_order.get assert_str_eq
             "field 1" "x" 1 literal StructLiteral::field_order.get assert_str_eq
         fi

--- a/tests/compiler/test_struct_literal.casa
+++ b/tests/compiler/test_struct_literal.casa
@@ -111,10 +111,11 @@ fn test_struct_match_pattern {
     0 = index
     while index ops.length > do
         if OpKind::OpMatchArm index ops.get Op::kind == then
-            index ops.get pattern_value_of (StructPattern) = pattern
-            "struct name" "Point" pattern StructPattern::struct_name assert_str_eq
-            "binding x" "px" "x" pattern StructPattern::bindings.get.unwrap assert_str_eq
-            "binding y" "py" "y" pattern StructPattern::bindings.get.unwrap assert_str_eq
+            if index ops.get pattern_value_of PatternValue::Struct(pattern) is then
+                "struct name" "Point" pattern.struct_name assert_str_eq
+                "binding x" "px" "x" pattern.bindings.get.unwrap assert_str_eq
+                "binding y" "py" "y" pattern.bindings.get.unwrap assert_str_eq
+            fi
         fi
         1 += index
     done
@@ -126,9 +127,10 @@ fn test_partial_binding {
     0 = index
     while index ops.length > do
         if OpKind::OpMatchArm index ops.get Op::kind == then
-            index ops.get pattern_value_of (StructPattern) = pattern
-            "binding x" "px" "x" pattern StructPattern::bindings.get.unwrap assert_str_eq
-            "no y binding" "y" pattern StructPattern::bindings.get.is_none assert_true
+            if index ops.get pattern_value_of PatternValue::Struct(pattern) is then
+                "binding x" "px" "x" pattern.bindings.get.unwrap assert_str_eq
+                "no y binding" "y" pattern.bindings.get.is_none assert_true
+            fi
         fi
         1 += index
     done

--- a/tests/compiler/test_traits.casa
+++ b/tests/compiler/test_traits.casa
@@ -342,7 +342,7 @@ fn test_trait_hidden_params_creates_assign_ops {
         index func Function::ops.get = current_op
         if
         OpKind::OpAssignVar current_op Op::kind ==
-        "__trait_K_hash" current_op Op::value(str) == &&
+        "__trait_K_hash" current_op op_str_value == &&
         then
             true = found
         fi
@@ -640,7 +640,7 @@ fn test_k_coloncolon_method_resolved_as_push_variable_exec {
         index func Function::ops.get = current_op
         if
         OpKind::OpPushVar current_op Op::kind ==
-        "__trait_K_hash" current_op Op::value(str) == &&
+        "__trait_K_hash" current_op op_str_value == &&
         then
             true = found_push_var
             if "trait_exec" current_op Op::type_annotation == then
@@ -668,7 +668,7 @@ fn test_ampersand_k_coloncolon_method_resolved_as_push_variable {
         index func Function::ops.get = current_op
         if
         OpKind::OpPushVar current_op Op::kind ==
-        "__trait_K_hash" current_op Op::value(str) == &&
+        "__trait_K_hash" current_op op_str_value == &&
         then
             true = found_push_var
         fi

--- a/tests/compiler/test_typechecker.casa
+++ b/tests/compiler/test_typechecker.casa
@@ -141,7 +141,7 @@ fn tc_check ops:List[Op] -> TypeChecker {
 fn test_push_int_stack {
     "push_int_stack" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushInt 42 make_op ops.push
+    empty_location OpKind::OpPushInt 42 make_op_int ops.push
     ops tc_check = result_tc
     "stack has one item" 1 result_tc TypeChecker::live TypedStack::types.length assert_eq
     "type is int" "int" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
@@ -154,8 +154,8 @@ fn test_push_int_stack {
 fn test_add_stack_effect {
     "add_stack_effect" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushInt 10 make_op ops.push
-    empty_location OpKind::OpPushInt 20 make_op ops.push
+    empty_location OpKind::OpPushInt 10 make_op_int ops.push
+    empty_location OpKind::OpPushInt 20 make_op_int ops.push
     empty_location OpKind::OpAdd 0 make_op ops.push
     ops tc_check = result_tc
     "stack has one item after add" 1 result_tc TypeChecker::live TypedStack::types.length assert_eq
@@ -171,8 +171,8 @@ fn test_arithmetic_ops {
 
     # Sub
     List::new(List[Op]) = ops_sub
-    empty_location OpKind::OpPushInt 5 make_op ops_sub.push
-    empty_location OpKind::OpPushInt 3 make_op ops_sub.push
+    empty_location OpKind::OpPushInt 5 make_op_int ops_sub.push
+    empty_location OpKind::OpPushInt 3 make_op_int ops_sub.push
     empty_location OpKind::OpSub 0 make_op ops_sub.push
     ops_sub tc_check = tc_sub
     "sub result" 1 tc_sub TypeChecker::live TypedStack::types.length assert_eq
@@ -180,24 +180,24 @@ fn test_arithmetic_ops {
 
     # Mul
     List::new(List[Op]) = ops_mul
-    empty_location OpKind::OpPushInt 2 make_op ops_mul.push
-    empty_location OpKind::OpPushInt 3 make_op ops_mul.push
+    empty_location OpKind::OpPushInt 2 make_op_int ops_mul.push
+    empty_location OpKind::OpPushInt 3 make_op_int ops_mul.push
     empty_location OpKind::OpMul 0 make_op ops_mul.push
     ops_mul tc_check = tc_mul
     "mul type" "int" 0 tc_mul TypeChecker::live TypedStack::types.get assert_str_eq
 
     # Div
     List::new(List[Op]) = ops_div
-    empty_location OpKind::OpPushInt 10 make_op ops_div.push
-    empty_location OpKind::OpPushInt 2 make_op ops_div.push
+    empty_location OpKind::OpPushInt 10 make_op_int ops_div.push
+    empty_location OpKind::OpPushInt 2 make_op_int ops_div.push
     empty_location OpKind::OpDiv 0 make_op ops_div.push
     ops_div tc_check = tc_div
     "div type" "int" 0 tc_div TypeChecker::live TypedStack::types.get assert_str_eq
 
     # Mod
     List::new(List[Op]) = ops_mod
-    empty_location OpKind::OpPushInt 10 make_op ops_mod.push
-    empty_location OpKind::OpPushInt 3 make_op ops_mod.push
+    empty_location OpKind::OpPushInt 10 make_op_int ops_mod.push
+    empty_location OpKind::OpPushInt 3 make_op_int ops_mod.push
     empty_location OpKind::OpMod 0 make_op ops_mod.push
     ops_mod tc_check = tc_mod
     "mod type" "int" 0 tc_mod TypeChecker::live TypedStack::types.get assert_str_eq
@@ -210,8 +210,8 @@ fn test_arithmetic_ops {
 fn test_comparison_produces_bool {
     "comparison_produces_bool" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushInt 1 make_op ops.push
-    empty_location OpKind::OpPushInt 2 make_op ops.push
+    empty_location OpKind::OpPushInt 1 make_op_int ops.push
+    empty_location OpKind::OpPushInt 2 make_op_int ops.push
     empty_location OpKind::OpLt 0 make_op ops.push
     ops tc_check = result_tc
     "stack after lt" 1 result_tc TypeChecker::live TypedStack::types.length assert_eq
@@ -226,23 +226,23 @@ fn test_boolean_ops {
     "boolean_ops" test_start
     # AND
     List::new(List[Op]) = ops_and
-    empty_location OpKind::OpPushBool 1 make_op ops_and.push
-    empty_location OpKind::OpPushBool 0 make_op ops_and.push
+    empty_location OpKind::OpPushBool 1 make_op_int ops_and.push
+    empty_location OpKind::OpPushBool 0 make_op_int ops_and.push
     empty_location OpKind::OpAnd 0 make_op ops_and.push
     ops_and tc_check = tc_and
     "and result" "bool" 0 tc_and TypeChecker::live TypedStack::types.get assert_str_eq
 
     # OR
     List::new(List[Op]) = ops_or
-    empty_location OpKind::OpPushBool 1 make_op ops_or.push
-    empty_location OpKind::OpPushBool 0 make_op ops_or.push
+    empty_location OpKind::OpPushBool 1 make_op_int ops_or.push
+    empty_location OpKind::OpPushBool 0 make_op_int ops_or.push
     empty_location OpKind::OpOr 0 make_op ops_or.push
     ops_or tc_check = tc_or
     "or result" "bool" 0 tc_or TypeChecker::live TypedStack::types.get assert_str_eq
 
     # NOT
     List::new(List[Op]) = ops_not
-    empty_location OpKind::OpPushBool 1 make_op ops_not.push
+    empty_location OpKind::OpPushBool 1 make_op_int ops_not.push
     empty_location OpKind::OpNot 0 make_op ops_not.push
     ops_not tc_check = tc_not
     "not result" "bool" 0 tc_not TypeChecker::live TypedStack::types.get assert_str_eq
@@ -255,7 +255,7 @@ fn test_boolean_ops {
 fn test_dup_stack_effect {
     "dup_stack_effect" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushInt 42 make_op ops.push
+    empty_location OpKind::OpPushInt 42 make_op_int ops.push
     empty_location OpKind::OpDup 0 make_op ops.push
     ops tc_check = result_tc
     "stack after dup" 2 result_tc TypeChecker::live TypedStack::types.length assert_eq
@@ -270,7 +270,7 @@ fn test_dup_stack_effect {
 fn test_swap_stack_effect {
     "swap_stack_effect" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushInt 42 make_op ops.push
+    empty_location OpKind::OpPushInt 42 make_op_int ops.push
     empty_location OpKind::OpPushStr "hello" make_op_str ops.push
     empty_location OpKind::OpSwap 0 make_op ops.push
     ops tc_check = result_tc
@@ -286,7 +286,7 @@ fn test_swap_stack_effect {
 fn test_over_stack_effect {
     "over_stack_effect" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushInt 42 make_op ops.push
+    empty_location OpKind::OpPushInt 42 make_op_int ops.push
     empty_location OpKind::OpPushStr "hello" make_op_str ops.push
     empty_location OpKind::OpOver 0 make_op ops.push
     ops tc_check = result_tc
@@ -303,7 +303,7 @@ fn test_over_stack_effect {
 fn test_drop_stack_effect {
     "drop_stack_effect" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushInt 42 make_op ops.push
+    empty_location OpKind::OpPushInt 42 make_op_int ops.push
     empty_location OpKind::OpPushStr "hello" make_op_str ops.push
     empty_location OpKind::OpDrop 0 make_op ops.push
     ops tc_check = result_tc
@@ -318,9 +318,9 @@ fn test_drop_stack_effect {
 fn test_rot_stack_effect {
     "rot_stack_effect" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushInt 42 make_op ops.push
+    empty_location OpKind::OpPushInt 42 make_op_int ops.push
     empty_location OpKind::OpPushStr "hello" make_op_str ops.push
-    empty_location OpKind::OpPushBool 1 make_op ops.push
+    empty_location OpKind::OpPushBool 1 make_op_int ops.push
     empty_location OpKind::OpRot 0 make_op ops.push
     ops tc_check = result_tc
     "stack after rot" 3 result_tc TypeChecker::live TypedStack::types.length assert_eq
@@ -337,7 +337,7 @@ fn test_rot_stack_effect {
 fn test_type_cast {
     "type_cast" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushInt 42 make_op ops.push
+    empty_location OpKind::OpPushInt 42 make_op_int ops.push
     empty_location OpKind::OpTypeCast "str" make_op_str ops.push
     ops tc_check = result_tc
     "stack after cast" 1 result_tc TypeChecker::live TypedStack::types.length assert_eq
@@ -351,10 +351,10 @@ fn test_type_cast {
 fn test_push_literals {
     "push_literals" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushInt 42 make_op ops.push
+    empty_location OpKind::OpPushInt 42 make_op_int ops.push
     empty_location OpKind::OpPushStr "hi" make_op_str ops.push
-    empty_location OpKind::OpPushBool 1 make_op ops.push
-    empty_location OpKind::OpPushChar 65 make_op ops.push
+    empty_location OpKind::OpPushBool 1 make_op_int ops.push
+    empty_location OpKind::OpPushChar 65 make_op_int ops.push
     ops tc_check = result_tc
     "four items on stack" 4 result_tc TypeChecker::live TypedStack::types.length assert_eq
     "int" "int" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
@@ -379,14 +379,14 @@ fn test_print_dispatch {
 
     # print int -> OpPrintInt
     List::new(List[Op]) = ops_int
-    empty_location OpKind::OpPushInt 42 make_op ops_int.push
+    empty_location OpKind::OpPushInt 42 make_op_int ops_int.push
     empty_location OpKind::OpPrint 0 make_op ops_int.push
     ops_int tc_check drop
     "print int resolved" OpKind::OpPrintInt 1 ops_int.get Op::kind == assert_true
 
     # print bool -> OpPrintBool
     List::new(List[Op]) = ops_bool
-    empty_location OpKind::OpPushBool 1 make_op ops_bool.push
+    empty_location OpKind::OpPushBool 1 make_op_int ops_bool.push
     empty_location OpKind::OpPrint 0 make_op ops_bool.push
     ops_bool tc_check drop
     "print bool resolved" OpKind::OpPrintBool 1 ops_bool.get Op::kind == assert_true
@@ -399,7 +399,7 @@ fn test_print_dispatch {
 fn test_typeof_effect {
     "typeof_effect" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushInt 42 make_op ops.push
+    empty_location OpKind::OpPushInt 42 make_op_int ops.push
     empty_location OpKind::OpTypeof 0 make_op ops.push
     ops tc_check = result_tc
     "stack after typeof" 1 result_tc TypeChecker::live TypedStack::types.length assert_eq
@@ -415,23 +415,23 @@ fn test_bitwise_ops {
 
     # BIT_NOT
     List::new(List[Op]) = ops_bnot
-    empty_location OpKind::OpPushInt 42 make_op ops_bnot.push
+    empty_location OpKind::OpPushInt 42 make_op_int ops_bnot.push
     empty_location OpKind::OpBitNot 0 make_op ops_bnot.push
     ops_bnot tc_check = tc_bnot
     "bitnot result" "int" 0 tc_bnot TypeChecker::live TypedStack::types.get assert_str_eq
 
     # SHL
     List::new(List[Op]) = ops_shl
-    empty_location OpKind::OpPushInt 1 make_op ops_shl.push
-    empty_location OpKind::OpPushInt 3 make_op ops_shl.push
+    empty_location OpKind::OpPushInt 1 make_op_int ops_shl.push
+    empty_location OpKind::OpPushInt 3 make_op_int ops_shl.push
     empty_location OpKind::OpShl 0 make_op ops_shl.push
     ops_shl tc_check = tc_shl
     "shl result" "int" 0 tc_shl TypeChecker::live TypedStack::types.get assert_str_eq
 
     # BIT_AND
     List::new(List[Op]) = ops_band
-    empty_location OpKind::OpPushInt 0 make_op ops_band.push
-    empty_location OpKind::OpPushInt 1 make_op ops_band.push
+    empty_location OpKind::OpPushInt 0 make_op_int ops_band.push
+    empty_location OpKind::OpPushInt 1 make_op_int ops_band.push
     empty_location OpKind::OpBitAnd 0 make_op ops_band.push
     ops_band tc_check = tc_band
     "bitand result" "int" 0 tc_band TypeChecker::live TypedStack::types.get assert_str_eq
@@ -446,7 +446,7 @@ fn test_memory_ops {
 
     # heap_alloc: int -> ptr
     List::new(List[Op]) = ops_alloc
-    empty_location OpKind::OpPushInt 100 make_op ops_alloc.push
+    empty_location OpKind::OpPushInt 100 make_op_int ops_alloc.push
     empty_location OpKind::OpHeapAlloc 0 make_op ops_alloc.push
     ops_alloc tc_check = tc_alloc
     "alloc result is ptr" "ptr" 0 tc_alloc TypeChecker::live TypedStack::types.get assert_str_eq
@@ -618,7 +618,7 @@ fn test_tc_pipeline_memory {
 fn test_print_dispatch_char {
     "print_dispatch_char" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushChar 65 make_op ops.push
+    empty_location OpKind::OpPushChar 65 make_op_int ops.push
     empty_location OpKind::OpPrint 0 make_op ops.push
     ops tc_check drop
     "print char resolved" OpKind::OpPrintChar 1 ops.get Op::kind == assert_true
@@ -627,7 +627,7 @@ fn test_print_dispatch_char {
 fn test_print_dispatch_cstr {
     "print_dispatch_cstr" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushInt 42 make_op ops.push
+    empty_location OpKind::OpPushInt 42 make_op_int ops.push
     empty_location OpKind::OpTypeCast "cstr" make_op_str ops.push
     empty_location OpKind::OpPrint 0 make_op ops.push
     ops tc_check drop
@@ -641,7 +641,7 @@ fn test_print_dispatch_cstr {
 fn test_print_pops_stack {
     "print_pops_stack" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushInt 42 make_op ops.push
+    empty_location OpKind::OpPushInt 42 make_op_int ops.push
     empty_location OpKind::OpPrint 0 make_op ops.push
     ops tc_check = result_tc
     "stack empty after print" 0 result_tc TypeChecker::live TypedStack::types.length assert_eq
@@ -663,7 +663,7 @@ fn test_typeof_str {
 fn test_typeof_bool {
     "typeof_bool" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushBool 1 make_op ops.push
+    empty_location OpKind::OpPushBool 1 make_op_int ops.push
     empty_location OpKind::OpTypeof 0 make_op ops.push
     ops tc_check = result_tc
     "typeof bool result" "str" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
@@ -678,40 +678,40 @@ fn test_all_comparison_ops {
 
     # Eq
     List::new(List[Op]) = ops_eq
-    empty_location OpKind::OpPushInt 1 make_op ops_eq.push
-    empty_location OpKind::OpPushInt 1 make_op ops_eq.push
+    empty_location OpKind::OpPushInt 1 make_op_int ops_eq.push
+    empty_location OpKind::OpPushInt 1 make_op_int ops_eq.push
     empty_location OpKind::OpEq 0 make_op ops_eq.push
     ops_eq tc_check = tc_eq
     "eq is bool" "bool" 0 tc_eq TypeChecker::live TypedStack::types.get assert_str_eq
 
     # Ne
     List::new(List[Op]) = ops_ne
-    empty_location OpKind::OpPushInt 1 make_op ops_ne.push
-    empty_location OpKind::OpPushInt 2 make_op ops_ne.push
+    empty_location OpKind::OpPushInt 1 make_op_int ops_ne.push
+    empty_location OpKind::OpPushInt 2 make_op_int ops_ne.push
     empty_location OpKind::OpNe 0 make_op ops_ne.push
     ops_ne tc_check = tc_ne
     "ne is bool" "bool" 0 tc_ne TypeChecker::live TypedStack::types.get assert_str_eq
 
     # Le
     List::new(List[Op]) = ops_le
-    empty_location OpKind::OpPushInt 1 make_op ops_le.push
-    empty_location OpKind::OpPushInt 2 make_op ops_le.push
+    empty_location OpKind::OpPushInt 1 make_op_int ops_le.push
+    empty_location OpKind::OpPushInt 2 make_op_int ops_le.push
     empty_location OpKind::OpLe 0 make_op ops_le.push
     ops_le tc_check = tc_le
     "le is bool" "bool" 0 tc_le TypeChecker::live TypedStack::types.get assert_str_eq
 
     # Ge
     List::new(List[Op]) = ops_ge
-    empty_location OpKind::OpPushInt 1 make_op ops_ge.push
-    empty_location OpKind::OpPushInt 2 make_op ops_ge.push
+    empty_location OpKind::OpPushInt 1 make_op_int ops_ge.push
+    empty_location OpKind::OpPushInt 2 make_op_int ops_ge.push
     empty_location OpKind::OpGe 0 make_op ops_ge.push
     ops_ge tc_check = tc_ge
     "ge is bool" "bool" 0 tc_ge TypeChecker::live TypedStack::types.get assert_str_eq
 
     # Gt
     List::new(List[Op]) = ops_gt
-    empty_location OpKind::OpPushInt 5 make_op ops_gt.push
-    empty_location OpKind::OpPushInt 2 make_op ops_gt.push
+    empty_location OpKind::OpPushInt 5 make_op_int ops_gt.push
+    empty_location OpKind::OpPushInt 2 make_op_int ops_gt.push
     empty_location OpKind::OpGt 0 make_op ops_gt.push
     ops_gt tc_check = tc_gt
     "gt is bool" "bool" 0 tc_gt TypeChecker::live TypedStack::types.get assert_str_eq
@@ -739,8 +739,8 @@ fn test_string_comparison_annotation {
 fn test_bitwise_shr {
     "bitwise_shr" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushInt 8 make_op ops.push
-    empty_location OpKind::OpPushInt 2 make_op ops.push
+    empty_location OpKind::OpPushInt 8 make_op_int ops.push
+    empty_location OpKind::OpPushInt 2 make_op_int ops.push
     empty_location OpKind::OpShr 0 make_op ops.push
     ops tc_check = result_tc
     "shr result" "int" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
@@ -749,8 +749,8 @@ fn test_bitwise_shr {
 fn test_bitwise_or {
     "bitwise_or" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushInt 5 make_op ops.push
-    empty_location OpKind::OpPushInt 3 make_op ops.push
+    empty_location OpKind::OpPushInt 5 make_op_int ops.push
+    empty_location OpKind::OpPushInt 3 make_op_int ops.push
     empty_location OpKind::OpBitOr 0 make_op ops.push
     ops tc_check = result_tc
     "bitor result" "int" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
@@ -759,8 +759,8 @@ fn test_bitwise_or {
 fn test_bitwise_xor {
     "bitwise_xor" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushInt 5 make_op ops.push
-    empty_location OpKind::OpPushInt 3 make_op ops.push
+    empty_location OpKind::OpPushInt 5 make_op_int ops.push
+    empty_location OpKind::OpPushInt 3 make_op_int ops.push
     empty_location OpKind::OpBitXor 0 make_op ops.push
     ops tc_check = result_tc
     "bitxor result" "int" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
@@ -775,7 +775,7 @@ fn test_memory_load_sizes {
 
     # load8
     List::new(List[Op]) = ops8
-    empty_location OpKind::OpPushInt 8 make_op ops8.push
+    empty_location OpKind::OpPushInt 8 make_op_int ops8.push
     empty_location OpKind::OpHeapAlloc 0 make_op ops8.push
     empty_location OpKind::OpLoad8 0 make_op ops8.push
     ops8 tc_check = tc8
@@ -783,7 +783,7 @@ fn test_memory_load_sizes {
 
     # load16
     List::new(List[Op]) = ops16
-    empty_location OpKind::OpPushInt 8 make_op ops16.push
+    empty_location OpKind::OpPushInt 8 make_op_int ops16.push
     empty_location OpKind::OpHeapAlloc 0 make_op ops16.push
     empty_location OpKind::OpLoad16 0 make_op ops16.push
     ops16 tc_check = tc16
@@ -791,7 +791,7 @@ fn test_memory_load_sizes {
 
     # load32
     List::new(List[Op]) = ops32
-    empty_location OpKind::OpPushInt 8 make_op ops32.push
+    empty_location OpKind::OpPushInt 8 make_op_int ops32.push
     empty_location OpKind::OpHeapAlloc 0 make_op ops32.push
     empty_location OpKind::OpLoad32 0 make_op ops32.push
     ops32 tc_check = tc32
@@ -803,8 +803,8 @@ fn test_memory_store_sizes {
 
     # store8: value ptr -> (empty)
     List::new(List[Op]) = ops8
-    empty_location OpKind::OpPushInt 42 make_op ops8.push
-    empty_location OpKind::OpPushInt 8 make_op ops8.push
+    empty_location OpKind::OpPushInt 42 make_op_int ops8.push
+    empty_location OpKind::OpPushInt 8 make_op_int ops8.push
     empty_location OpKind::OpHeapAlloc 0 make_op ops8.push
     empty_location OpKind::OpStore8 0 make_op ops8.push
     ops8 tc_check = tc8
@@ -812,8 +812,8 @@ fn test_memory_store_sizes {
 
     # store16
     List::new(List[Op]) = ops16
-    empty_location OpKind::OpPushInt 42 make_op ops16.push
-    empty_location OpKind::OpPushInt 8 make_op ops16.push
+    empty_location OpKind::OpPushInt 42 make_op_int ops16.push
+    empty_location OpKind::OpPushInt 8 make_op_int ops16.push
     empty_location OpKind::OpHeapAlloc 0 make_op ops16.push
     empty_location OpKind::OpStore16 0 make_op ops16.push
     ops16 tc_check = tc16
@@ -821,8 +821,8 @@ fn test_memory_store_sizes {
 
     # store32
     List::new(List[Op]) = ops32
-    empty_location OpKind::OpPushInt 42 make_op ops32.push
-    empty_location OpKind::OpPushInt 8 make_op ops32.push
+    empty_location OpKind::OpPushInt 42 make_op_int ops32.push
+    empty_location OpKind::OpPushInt 8 make_op_int ops32.push
     empty_location OpKind::OpHeapAlloc 0 make_op ops32.push
     empty_location OpKind::OpStore32 0 make_op ops32.push
     ops32 tc_check = tc32
@@ -1155,8 +1155,8 @@ fn test_store_accepts_any_value_type {
 fn test_memory_store64 {
     "memory_store64" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushInt 42 make_op ops.push
-    empty_location OpKind::OpPushInt 8 make_op ops.push
+    empty_location OpKind::OpPushInt 42 make_op_int ops.push
+    empty_location OpKind::OpPushInt 8 make_op_int ops.push
     empty_location OpKind::OpHeapAlloc 0 make_op ops.push
     empty_location OpKind::OpStore64 0 make_op ops.push
     ops tc_check = result_tc
@@ -1213,7 +1213,7 @@ fn test_syscall_op_level {
 
     # syscall0: pops 1 (syscall number), pushes int
     List::new(List[Op]) = ops0
-    empty_location OpKind::OpPushInt 60 make_op ops0.push
+    empty_location OpKind::OpPushInt 60 make_op_int ops0.push
     empty_location OpKind::OpSyscall0 0 make_op ops0.push
     ops0 tc_check = tc0
     "syscall0 result" 1 tc0 TypeChecker::live TypedStack::types.length assert_eq
@@ -1221,8 +1221,8 @@ fn test_syscall_op_level {
 
     # syscall1: pops 2 (1 arg + syscall number), pushes int
     List::new(List[Op]) = ops1
-    empty_location OpKind::OpPushInt 0 make_op ops1.push
-    empty_location OpKind::OpPushInt 60 make_op ops1.push
+    empty_location OpKind::OpPushInt 0 make_op_int ops1.push
+    empty_location OpKind::OpPushInt 60 make_op_int ops1.push
     empty_location OpKind::OpSyscall1 0 make_op ops1.push
     ops1 tc_check = tc1
     "syscall1 result" 1 tc1 TypeChecker::live TypedStack::types.length assert_eq
@@ -1230,10 +1230,10 @@ fn test_syscall_op_level {
 
     # syscall3: pops 4 (3 args + syscall number), pushes int
     List::new(List[Op]) = ops3
-    empty_location OpKind::OpPushInt 0 make_op ops3.push
-    empty_location OpKind::OpPushInt 0 make_op ops3.push
-    empty_location OpKind::OpPushInt 0 make_op ops3.push
-    empty_location OpKind::OpPushInt 1 make_op ops3.push
+    empty_location OpKind::OpPushInt 0 make_op_int ops3.push
+    empty_location OpKind::OpPushInt 0 make_op_int ops3.push
+    empty_location OpKind::OpPushInt 0 make_op_int ops3.push
+    empty_location OpKind::OpPushInt 1 make_op_int ops3.push
     empty_location OpKind::OpSyscall3 0 make_op ops3.push
     ops3 tc_check = tc3
     "syscall3 result" 1 tc3 TypeChecker::live TypedStack::types.length assert_eq
@@ -1247,7 +1247,7 @@ fn test_syscall_op_level {
 fn test_typeof_char {
     "typeof_char" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushChar 65 make_op ops.push
+    empty_location OpKind::OpPushChar 65 make_op_int ops.push
     empty_location OpKind::OpTypeof 0 make_op ops.push
     ops tc_check = result_tc
     "typeof char result" "str" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
@@ -1256,7 +1256,7 @@ fn test_typeof_char {
 fn test_typeof_ptr {
     "typeof_ptr" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushInt 10 make_op ops.push
+    empty_location OpKind::OpPushInt 10 make_op_int ops.push
     empty_location OpKind::OpHeapAlloc 0 make_op ops.push
     empty_location OpKind::OpTypeof 0 make_op ops.push
     ops tc_check = result_tc
@@ -1281,7 +1281,7 @@ fn test_dup_preserves_str {
 fn test_dup_preserves_bool {
     "dup_preserves_bool" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushBool 1 make_op ops.push
+    empty_location OpKind::OpPushBool 1 make_op_int ops.push
     empty_location OpKind::OpDup 0 make_op ops.push
     ops tc_check = result_tc
     "dup bool count" 2 result_tc TypeChecker::live TypedStack::types.length assert_eq
@@ -1367,7 +1367,7 @@ fn test_error_fn_signature_mismatch {
     # Build a function with declared sig "int -> str" but body returns int
     "int -> str" signature_from_str = bad_sig
     List::new(List[Op]) = bad_ops
-    empty_location OpKind::OpPushInt 42 make_op bad_ops.push
+    empty_location OpKind::OpPushInt 42 make_op_int bad_ops.push
     # RPN: sig location ops name make_function_with_sig
     bad_sig empty_location bad_ops "bad_fn" make_function_with_sig = bad_fn
     bad_fn Option::Some bad_ops type_check_ops drop
@@ -1515,7 +1515,7 @@ fn test_types_match_array_types {
 fn test_print_dispatch_ptr {
     "print_dispatch_ptr" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushInt 10 make_op ops.push
+    empty_location OpKind::OpPushInt 10 make_op_int ops.push
     empty_location OpKind::OpHeapAlloc 0 make_op ops.push
     empty_location OpKind::OpPrint 0 make_op ops.push
     ops tc_check drop
@@ -1530,7 +1530,7 @@ fn test_print_dispatch_ptr {
 fn test_typeof_annotation {
     "typeof_annotation" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushInt 42 make_op ops.push
+    empty_location OpKind::OpPushInt 42 make_op_int ops.push
     empty_location OpKind::OpTypeof 0 make_op ops.push
     ops tc_check drop
     "typeof annotation" "int" 1 ops.get Op::type_annotation assert_str_eq
@@ -1553,7 +1553,7 @@ fn test_type_cast_str_to_int {
 fn test_type_cast_bool_to_int {
     "type_cast_bool_to_int" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushBool 1 make_op ops.push
+    empty_location OpKind::OpPushBool 1 make_op_int ops.push
     empty_location OpKind::OpTypeCast "int" make_op_str ops.push
     ops tc_check = result_tc
     "cast bool to int" "int" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
@@ -1604,7 +1604,7 @@ fn test_branch_if_empty_body {
     "branch_if_empty_body" test_start
     List::new(List[Op]) = ops
     empty_location OpKind::OpIfStart 0 make_op ops.push
-    empty_location OpKind::OpPushBool 1 make_op ops.push
+    empty_location OpKind::OpPushBool 1 make_op_int ops.push
     empty_location OpKind::OpIfCondition 0 make_op ops.push
     empty_location OpKind::OpIfEnd 0 make_op ops.push
     ops tc_check = result_tc
@@ -1617,11 +1617,11 @@ fn test_branch_if_else_agree_int {
     "branch_if_else_agree_int" test_start
     List::new(List[Op]) = ops
     empty_location OpKind::OpIfStart 0 make_op ops.push
-    empty_location OpKind::OpPushBool 1 make_op ops.push
+    empty_location OpKind::OpPushBool 1 make_op_int ops.push
     empty_location OpKind::OpIfCondition 0 make_op ops.push
-    empty_location OpKind::OpPushInt 10 make_op ops.push
+    empty_location OpKind::OpPushInt 10 make_op_int ops.push
     empty_location OpKind::OpIfElse 0 make_op ops.push
-    empty_location OpKind::OpPushInt 20 make_op ops.push
+    empty_location OpKind::OpPushInt 20 make_op_int ops.push
     empty_location OpKind::OpIfEnd 0 make_op ops.push
     ops tc_check = result_tc
     "live has one item" 1 result_tc TypeChecker::live TypedStack::types.length assert_eq
@@ -1634,7 +1634,7 @@ fn test_branch_if_end_pops_frame {
     "branch_if_end_pops_frame" test_start
     List::new(List[Op]) = ops
     empty_location OpKind::OpIfStart 0 make_op ops.push
-    empty_location OpKind::OpPushBool 1 make_op ops.push
+    empty_location OpKind::OpPushBool 1 make_op_int ops.push
     empty_location OpKind::OpIfCondition 0 make_op ops.push
     ops tc_check = result_tc
     "frame pushed on OpIfStart" 1 result_tc TypeChecker::branched_stacks.length assert_eq
@@ -1654,7 +1654,7 @@ fn test_branch_while_empty_body {
     "branch_while_empty_body" test_start
     List::new(List[Op]) = ops
     empty_location OpKind::OpWhileStart 0 make_op ops.push
-    empty_location OpKind::OpPushBool 0 make_op ops.push
+    empty_location OpKind::OpPushBool 0 make_op_int ops.push
     empty_location OpKind::OpWhileCondition 0 make_op ops.push
     empty_location OpKind::OpWhileEnd 0 make_op ops.push
     ops tc_check = result_tc
@@ -1712,7 +1712,7 @@ fn test_branch_return_inside_if_restores_live {
     # Begin an `if true then` block.
     List::new(List[Op]) = begin_ops
     empty_location OpKind::OpIfStart 0 make_op begin_ops.push
-    empty_location OpKind::OpPushBool 1 make_op begin_ops.push
+    empty_location OpKind::OpPushBool 1 make_op_int begin_ops.push
     empty_location OpKind::OpIfCondition 0 make_op begin_ops.push
     0 = br_i
     while br_i begin_ops.length > do

--- a/tests/compiler/test_typechecker.casa
+++ b/tests/compiler/test_typechecker.casa
@@ -156,7 +156,7 @@ fn test_add_stack_effect {
     List::new(List[Op]) = ops
     empty_location OpKind::OpPushInt 10 make_op_int ops.push
     empty_location OpKind::OpPushInt 20 make_op_int ops.push
-    empty_location OpKind::OpAdd 0 make_op ops.push
+    empty_location OpKind::OpAdd make_op ops.push
     ops tc_check = result_tc
     "stack has one item after add" 1 result_tc TypeChecker::live TypedStack::types.length assert_eq
     "result type is int" "int" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
@@ -173,7 +173,7 @@ fn test_arithmetic_ops {
     List::new(List[Op]) = ops_sub
     empty_location OpKind::OpPushInt 5 make_op_int ops_sub.push
     empty_location OpKind::OpPushInt 3 make_op_int ops_sub.push
-    empty_location OpKind::OpSub 0 make_op ops_sub.push
+    empty_location OpKind::OpSub make_op ops_sub.push
     ops_sub tc_check = tc_sub
     "sub result" 1 tc_sub TypeChecker::live TypedStack::types.length assert_eq
     "sub type" "int" 0 tc_sub TypeChecker::live TypedStack::types.get assert_str_eq
@@ -182,7 +182,7 @@ fn test_arithmetic_ops {
     List::new(List[Op]) = ops_mul
     empty_location OpKind::OpPushInt 2 make_op_int ops_mul.push
     empty_location OpKind::OpPushInt 3 make_op_int ops_mul.push
-    empty_location OpKind::OpMul 0 make_op ops_mul.push
+    empty_location OpKind::OpMul make_op ops_mul.push
     ops_mul tc_check = tc_mul
     "mul type" "int" 0 tc_mul TypeChecker::live TypedStack::types.get assert_str_eq
 
@@ -190,7 +190,7 @@ fn test_arithmetic_ops {
     List::new(List[Op]) = ops_div
     empty_location OpKind::OpPushInt 10 make_op_int ops_div.push
     empty_location OpKind::OpPushInt 2 make_op_int ops_div.push
-    empty_location OpKind::OpDiv 0 make_op ops_div.push
+    empty_location OpKind::OpDiv make_op ops_div.push
     ops_div tc_check = tc_div
     "div type" "int" 0 tc_div TypeChecker::live TypedStack::types.get assert_str_eq
 
@@ -198,7 +198,7 @@ fn test_arithmetic_ops {
     List::new(List[Op]) = ops_mod
     empty_location OpKind::OpPushInt 10 make_op_int ops_mod.push
     empty_location OpKind::OpPushInt 3 make_op_int ops_mod.push
-    empty_location OpKind::OpMod 0 make_op ops_mod.push
+    empty_location OpKind::OpMod make_op ops_mod.push
     ops_mod tc_check = tc_mod
     "mod type" "int" 0 tc_mod TypeChecker::live TypedStack::types.get assert_str_eq
 }
@@ -212,7 +212,7 @@ fn test_comparison_produces_bool {
     List::new(List[Op]) = ops
     empty_location OpKind::OpPushInt 1 make_op_int ops.push
     empty_location OpKind::OpPushInt 2 make_op_int ops.push
-    empty_location OpKind::OpLt 0 make_op ops.push
+    empty_location OpKind::OpLt make_op ops.push
     ops tc_check = result_tc
     "stack after lt" 1 result_tc TypeChecker::live TypedStack::types.length assert_eq
     "lt result is bool" "bool" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
@@ -228,7 +228,7 @@ fn test_boolean_ops {
     List::new(List[Op]) = ops_and
     empty_location OpKind::OpPushBool 1 make_op_int ops_and.push
     empty_location OpKind::OpPushBool 0 make_op_int ops_and.push
-    empty_location OpKind::OpAnd 0 make_op ops_and.push
+    empty_location OpKind::OpAnd make_op ops_and.push
     ops_and tc_check = tc_and
     "and result" "bool" 0 tc_and TypeChecker::live TypedStack::types.get assert_str_eq
 
@@ -236,14 +236,14 @@ fn test_boolean_ops {
     List::new(List[Op]) = ops_or
     empty_location OpKind::OpPushBool 1 make_op_int ops_or.push
     empty_location OpKind::OpPushBool 0 make_op_int ops_or.push
-    empty_location OpKind::OpOr 0 make_op ops_or.push
+    empty_location OpKind::OpOr make_op ops_or.push
     ops_or tc_check = tc_or
     "or result" "bool" 0 tc_or TypeChecker::live TypedStack::types.get assert_str_eq
 
     # NOT
     List::new(List[Op]) = ops_not
     empty_location OpKind::OpPushBool 1 make_op_int ops_not.push
-    empty_location OpKind::OpNot 0 make_op ops_not.push
+    empty_location OpKind::OpNot make_op ops_not.push
     ops_not tc_check = tc_not
     "not result" "bool" 0 tc_not TypeChecker::live TypedStack::types.get assert_str_eq
 }
@@ -256,7 +256,7 @@ fn test_dup_stack_effect {
     "dup_stack_effect" test_start
     List::new(List[Op]) = ops
     empty_location OpKind::OpPushInt 42 make_op_int ops.push
-    empty_location OpKind::OpDup 0 make_op ops.push
+    empty_location OpKind::OpDup make_op ops.push
     ops tc_check = result_tc
     "stack after dup" 2 result_tc TypeChecker::live TypedStack::types.length assert_eq
     "first is int" "int" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
@@ -272,7 +272,7 @@ fn test_swap_stack_effect {
     List::new(List[Op]) = ops
     empty_location OpKind::OpPushInt 42 make_op_int ops.push
     empty_location OpKind::OpPushStr "hello" make_op_str ops.push
-    empty_location OpKind::OpSwap 0 make_op ops.push
+    empty_location OpKind::OpSwap make_op ops.push
     ops tc_check = result_tc
     "stack after swap" 2 result_tc TypeChecker::live TypedStack::types.length assert_eq
     "bottom is str" "str" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
@@ -288,7 +288,7 @@ fn test_over_stack_effect {
     List::new(List[Op]) = ops
     empty_location OpKind::OpPushInt 42 make_op_int ops.push
     empty_location OpKind::OpPushStr "hello" make_op_str ops.push
-    empty_location OpKind::OpOver 0 make_op ops.push
+    empty_location OpKind::OpOver make_op ops.push
     ops tc_check = result_tc
     "stack after over" 3 result_tc TypeChecker::live TypedStack::types.length assert_eq
     "bottom is int" "int" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
@@ -305,7 +305,7 @@ fn test_drop_stack_effect {
     List::new(List[Op]) = ops
     empty_location OpKind::OpPushInt 42 make_op_int ops.push
     empty_location OpKind::OpPushStr "hello" make_op_str ops.push
-    empty_location OpKind::OpDrop 0 make_op ops.push
+    empty_location OpKind::OpDrop make_op ops.push
     ops tc_check = result_tc
     "stack after drop" 1 result_tc TypeChecker::live TypedStack::types.length assert_eq
     "remaining is int" "int" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
@@ -321,7 +321,7 @@ fn test_rot_stack_effect {
     empty_location OpKind::OpPushInt 42 make_op_int ops.push
     empty_location OpKind::OpPushStr "hello" make_op_str ops.push
     empty_location OpKind::OpPushBool 1 make_op_int ops.push
-    empty_location OpKind::OpRot 0 make_op ops.push
+    empty_location OpKind::OpRot make_op ops.push
     ops tc_check = result_tc
     "stack after rot" 3 result_tc TypeChecker::live TypedStack::types.length assert_eq
     # ROT: pop t1(bool), t2(str), t3(int) -> push t2(str), t1(bool), t3(int)
@@ -373,21 +373,21 @@ fn test_print_dispatch {
     # print str -> OpPrintStr
     List::new(List[Op]) = ops_str
     empty_location OpKind::OpPushStr "hello" make_op_str ops_str.push
-    empty_location OpKind::OpPrint 0 make_op ops_str.push
+    empty_location OpKind::OpPrint make_op ops_str.push
     ops_str tc_check drop
     "print str resolved" OpKind::OpPrintStr 1 ops_str.get Op::kind == assert_true
 
     # print int -> OpPrintInt
     List::new(List[Op]) = ops_int
     empty_location OpKind::OpPushInt 42 make_op_int ops_int.push
-    empty_location OpKind::OpPrint 0 make_op ops_int.push
+    empty_location OpKind::OpPrint make_op ops_int.push
     ops_int tc_check drop
     "print int resolved" OpKind::OpPrintInt 1 ops_int.get Op::kind == assert_true
 
     # print bool -> OpPrintBool
     List::new(List[Op]) = ops_bool
     empty_location OpKind::OpPushBool 1 make_op_int ops_bool.push
-    empty_location OpKind::OpPrint 0 make_op ops_bool.push
+    empty_location OpKind::OpPrint make_op ops_bool.push
     ops_bool tc_check drop
     "print bool resolved" OpKind::OpPrintBool 1 ops_bool.get Op::kind == assert_true
 }
@@ -400,7 +400,7 @@ fn test_typeof_effect {
     "typeof_effect" test_start
     List::new(List[Op]) = ops
     empty_location OpKind::OpPushInt 42 make_op_int ops.push
-    empty_location OpKind::OpTypeof 0 make_op ops.push
+    empty_location OpKind::OpTypeof make_op ops.push
     ops tc_check = result_tc
     "stack after typeof" 1 result_tc TypeChecker::live TypedStack::types.length assert_eq
     "typeof result is str" "str" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
@@ -416,7 +416,7 @@ fn test_bitwise_ops {
     # BIT_NOT
     List::new(List[Op]) = ops_bnot
     empty_location OpKind::OpPushInt 42 make_op_int ops_bnot.push
-    empty_location OpKind::OpBitNot 0 make_op ops_bnot.push
+    empty_location OpKind::OpBitNot make_op ops_bnot.push
     ops_bnot tc_check = tc_bnot
     "bitnot result" "int" 0 tc_bnot TypeChecker::live TypedStack::types.get assert_str_eq
 
@@ -424,7 +424,7 @@ fn test_bitwise_ops {
     List::new(List[Op]) = ops_shl
     empty_location OpKind::OpPushInt 1 make_op_int ops_shl.push
     empty_location OpKind::OpPushInt 3 make_op_int ops_shl.push
-    empty_location OpKind::OpShl 0 make_op ops_shl.push
+    empty_location OpKind::OpShl make_op ops_shl.push
     ops_shl tc_check = tc_shl
     "shl result" "int" 0 tc_shl TypeChecker::live TypedStack::types.get assert_str_eq
 
@@ -432,7 +432,7 @@ fn test_bitwise_ops {
     List::new(List[Op]) = ops_band
     empty_location OpKind::OpPushInt 0 make_op_int ops_band.push
     empty_location OpKind::OpPushInt 1 make_op_int ops_band.push
-    empty_location OpKind::OpBitAnd 0 make_op ops_band.push
+    empty_location OpKind::OpBitAnd make_op ops_band.push
     ops_band tc_check = tc_band
     "bitand result" "int" 0 tc_band TypeChecker::live TypedStack::types.get assert_str_eq
 }
@@ -447,7 +447,7 @@ fn test_memory_ops {
     # heap_alloc: int -> ptr
     List::new(List[Op]) = ops_alloc
     empty_location OpKind::OpPushInt 100 make_op_int ops_alloc.push
-    empty_location OpKind::OpHeapAlloc 0 make_op ops_alloc.push
+    empty_location OpKind::OpHeapAlloc make_op ops_alloc.push
     ops_alloc tc_check = tc_alloc
     "alloc result is ptr" "ptr" 0 tc_alloc TypeChecker::live TypedStack::types.get assert_str_eq
 }
@@ -459,8 +459,8 @@ fn test_memory_ops {
 fn test_argc_argv {
     "argc_argv" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpArgc 0 make_op ops.push
-    empty_location OpKind::OpArgv 0 make_op ops.push
+    empty_location OpKind::OpArgc make_op ops.push
+    empty_location OpKind::OpArgv make_op ops.push
     ops tc_check = result_tc
     "stack count" 2 result_tc TypeChecker::live TypedStack::types.length assert_eq
     "argc is int" "int" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
@@ -619,7 +619,7 @@ fn test_print_dispatch_char {
     "print_dispatch_char" test_start
     List::new(List[Op]) = ops
     empty_location OpKind::OpPushChar 65 make_op_int ops.push
-    empty_location OpKind::OpPrint 0 make_op ops.push
+    empty_location OpKind::OpPrint make_op ops.push
     ops tc_check drop
     "print char resolved" OpKind::OpPrintChar 1 ops.get Op::kind == assert_true
 }
@@ -629,7 +629,7 @@ fn test_print_dispatch_cstr {
     List::new(List[Op]) = ops
     empty_location OpKind::OpPushInt 42 make_op_int ops.push
     empty_location OpKind::OpTypeCast "cstr" make_op_str ops.push
-    empty_location OpKind::OpPrint 0 make_op ops.push
+    empty_location OpKind::OpPrint make_op ops.push
     ops tc_check drop
     "print cstr resolved" OpKind::OpPrintCstr 2 ops.get Op::kind == assert_true
 }
@@ -642,7 +642,7 @@ fn test_print_pops_stack {
     "print_pops_stack" test_start
     List::new(List[Op]) = ops
     empty_location OpKind::OpPushInt 42 make_op_int ops.push
-    empty_location OpKind::OpPrint 0 make_op ops.push
+    empty_location OpKind::OpPrint make_op ops.push
     ops tc_check = result_tc
     "stack empty after print" 0 result_tc TypeChecker::live TypedStack::types.length assert_eq
 }
@@ -655,7 +655,7 @@ fn test_typeof_str {
     "typeof_str" test_start
     List::new(List[Op]) = ops
     empty_location OpKind::OpPushStr "hi" make_op_str ops.push
-    empty_location OpKind::OpTypeof 0 make_op ops.push
+    empty_location OpKind::OpTypeof make_op ops.push
     ops tc_check = result_tc
     "typeof str result" "str" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
 }
@@ -664,7 +664,7 @@ fn test_typeof_bool {
     "typeof_bool" test_start
     List::new(List[Op]) = ops
     empty_location OpKind::OpPushBool 1 make_op_int ops.push
-    empty_location OpKind::OpTypeof 0 make_op ops.push
+    empty_location OpKind::OpTypeof make_op ops.push
     ops tc_check = result_tc
     "typeof bool result" "str" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
 }
@@ -680,7 +680,7 @@ fn test_all_comparison_ops {
     List::new(List[Op]) = ops_eq
     empty_location OpKind::OpPushInt 1 make_op_int ops_eq.push
     empty_location OpKind::OpPushInt 1 make_op_int ops_eq.push
-    empty_location OpKind::OpEq 0 make_op ops_eq.push
+    empty_location OpKind::OpEq make_op ops_eq.push
     ops_eq tc_check = tc_eq
     "eq is bool" "bool" 0 tc_eq TypeChecker::live TypedStack::types.get assert_str_eq
 
@@ -688,7 +688,7 @@ fn test_all_comparison_ops {
     List::new(List[Op]) = ops_ne
     empty_location OpKind::OpPushInt 1 make_op_int ops_ne.push
     empty_location OpKind::OpPushInt 2 make_op_int ops_ne.push
-    empty_location OpKind::OpNe 0 make_op ops_ne.push
+    empty_location OpKind::OpNe make_op ops_ne.push
     ops_ne tc_check = tc_ne
     "ne is bool" "bool" 0 tc_ne TypeChecker::live TypedStack::types.get assert_str_eq
 
@@ -696,7 +696,7 @@ fn test_all_comparison_ops {
     List::new(List[Op]) = ops_le
     empty_location OpKind::OpPushInt 1 make_op_int ops_le.push
     empty_location OpKind::OpPushInt 2 make_op_int ops_le.push
-    empty_location OpKind::OpLe 0 make_op ops_le.push
+    empty_location OpKind::OpLe make_op ops_le.push
     ops_le tc_check = tc_le
     "le is bool" "bool" 0 tc_le TypeChecker::live TypedStack::types.get assert_str_eq
 
@@ -704,7 +704,7 @@ fn test_all_comparison_ops {
     List::new(List[Op]) = ops_ge
     empty_location OpKind::OpPushInt 1 make_op_int ops_ge.push
     empty_location OpKind::OpPushInt 2 make_op_int ops_ge.push
-    empty_location OpKind::OpGe 0 make_op ops_ge.push
+    empty_location OpKind::OpGe make_op ops_ge.push
     ops_ge tc_check = tc_ge
     "ge is bool" "bool" 0 tc_ge TypeChecker::live TypedStack::types.get assert_str_eq
 
@@ -712,7 +712,7 @@ fn test_all_comparison_ops {
     List::new(List[Op]) = ops_gt
     empty_location OpKind::OpPushInt 5 make_op_int ops_gt.push
     empty_location OpKind::OpPushInt 2 make_op_int ops_gt.push
-    empty_location OpKind::OpGt 0 make_op ops_gt.push
+    empty_location OpKind::OpGt make_op ops_gt.push
     ops_gt tc_check = tc_gt
     "gt is bool" "bool" 0 tc_gt TypeChecker::live TypedStack::types.get assert_str_eq
 }
@@ -726,7 +726,7 @@ fn test_string_comparison_annotation {
     List::new(List[Op]) = ops
     empty_location OpKind::OpPushStr "a" make_op_str ops.push
     empty_location OpKind::OpPushStr "b" make_op_str ops.push
-    empty_location OpKind::OpEq 0 make_op ops.push
+    empty_location OpKind::OpEq make_op ops.push
     ops tc_check = result_tc
     "str cmp is bool" "bool" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
     "annotation is str" "str" 2 ops.get Op::type_annotation assert_str_eq
@@ -741,7 +741,7 @@ fn test_bitwise_shr {
     List::new(List[Op]) = ops
     empty_location OpKind::OpPushInt 8 make_op_int ops.push
     empty_location OpKind::OpPushInt 2 make_op_int ops.push
-    empty_location OpKind::OpShr 0 make_op ops.push
+    empty_location OpKind::OpShr make_op ops.push
     ops tc_check = result_tc
     "shr result" "int" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
 }
@@ -751,7 +751,7 @@ fn test_bitwise_or {
     List::new(List[Op]) = ops
     empty_location OpKind::OpPushInt 5 make_op_int ops.push
     empty_location OpKind::OpPushInt 3 make_op_int ops.push
-    empty_location OpKind::OpBitOr 0 make_op ops.push
+    empty_location OpKind::OpBitOr make_op ops.push
     ops tc_check = result_tc
     "bitor result" "int" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
 }
@@ -761,7 +761,7 @@ fn test_bitwise_xor {
     List::new(List[Op]) = ops
     empty_location OpKind::OpPushInt 5 make_op_int ops.push
     empty_location OpKind::OpPushInt 3 make_op_int ops.push
-    empty_location OpKind::OpBitXor 0 make_op ops.push
+    empty_location OpKind::OpBitXor make_op ops.push
     ops tc_check = result_tc
     "bitxor result" "int" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
 }
@@ -776,24 +776,24 @@ fn test_memory_load_sizes {
     # load8
     List::new(List[Op]) = ops8
     empty_location OpKind::OpPushInt 8 make_op_int ops8.push
-    empty_location OpKind::OpHeapAlloc 0 make_op ops8.push
-    empty_location OpKind::OpLoad8 0 make_op ops8.push
+    empty_location OpKind::OpHeapAlloc make_op ops8.push
+    empty_location OpKind::OpLoad8 make_op ops8.push
     ops8 tc_check = tc8
     "load8 result" "int" 0 tc8 TypeChecker::live TypedStack::types.get assert_str_eq
 
     # load16
     List::new(List[Op]) = ops16
     empty_location OpKind::OpPushInt 8 make_op_int ops16.push
-    empty_location OpKind::OpHeapAlloc 0 make_op ops16.push
-    empty_location OpKind::OpLoad16 0 make_op ops16.push
+    empty_location OpKind::OpHeapAlloc make_op ops16.push
+    empty_location OpKind::OpLoad16 make_op ops16.push
     ops16 tc_check = tc16
     "load16 result" "int" 0 tc16 TypeChecker::live TypedStack::types.get assert_str_eq
 
     # load32
     List::new(List[Op]) = ops32
     empty_location OpKind::OpPushInt 8 make_op_int ops32.push
-    empty_location OpKind::OpHeapAlloc 0 make_op ops32.push
-    empty_location OpKind::OpLoad32 0 make_op ops32.push
+    empty_location OpKind::OpHeapAlloc make_op ops32.push
+    empty_location OpKind::OpLoad32 make_op ops32.push
     ops32 tc_check = tc32
     "load32 result" "int" 0 tc32 TypeChecker::live TypedStack::types.get assert_str_eq
 }
@@ -805,8 +805,8 @@ fn test_memory_store_sizes {
     List::new(List[Op]) = ops8
     empty_location OpKind::OpPushInt 42 make_op_int ops8.push
     empty_location OpKind::OpPushInt 8 make_op_int ops8.push
-    empty_location OpKind::OpHeapAlloc 0 make_op ops8.push
-    empty_location OpKind::OpStore8 0 make_op ops8.push
+    empty_location OpKind::OpHeapAlloc make_op ops8.push
+    empty_location OpKind::OpStore8 make_op ops8.push
     ops8 tc_check = tc8
     "store8 empty" 0 tc8 TypeChecker::live TypedStack::types.length assert_eq
 
@@ -814,8 +814,8 @@ fn test_memory_store_sizes {
     List::new(List[Op]) = ops16
     empty_location OpKind::OpPushInt 42 make_op_int ops16.push
     empty_location OpKind::OpPushInt 8 make_op_int ops16.push
-    empty_location OpKind::OpHeapAlloc 0 make_op ops16.push
-    empty_location OpKind::OpStore16 0 make_op ops16.push
+    empty_location OpKind::OpHeapAlloc make_op ops16.push
+    empty_location OpKind::OpStore16 make_op ops16.push
     ops16 tc_check = tc16
     "store16 empty" 0 tc16 TypeChecker::live TypedStack::types.length assert_eq
 
@@ -823,8 +823,8 @@ fn test_memory_store_sizes {
     List::new(List[Op]) = ops32
     empty_location OpKind::OpPushInt 42 make_op_int ops32.push
     empty_location OpKind::OpPushInt 8 make_op_int ops32.push
-    empty_location OpKind::OpHeapAlloc 0 make_op ops32.push
-    empty_location OpKind::OpStore32 0 make_op ops32.push
+    empty_location OpKind::OpHeapAlloc make_op ops32.push
+    empty_location OpKind::OpStore32 make_op ops32.push
     ops32 tc_check = tc32
     "store32 empty" 0 tc32 TypeChecker::live TypedStack::types.length assert_eq
 }
@@ -1157,8 +1157,8 @@ fn test_memory_store64 {
     List::new(List[Op]) = ops
     empty_location OpKind::OpPushInt 42 make_op_int ops.push
     empty_location OpKind::OpPushInt 8 make_op_int ops.push
-    empty_location OpKind::OpHeapAlloc 0 make_op ops.push
-    empty_location OpKind::OpStore64 0 make_op ops.push
+    empty_location OpKind::OpHeapAlloc make_op ops.push
+    empty_location OpKind::OpStore64 make_op ops.push
     ops tc_check = result_tc
     "store64 empty" 0 result_tc TypeChecker::live TypedStack::types.length assert_eq
 }
@@ -1214,7 +1214,7 @@ fn test_syscall_op_level {
     # syscall0: pops 1 (syscall number), pushes int
     List::new(List[Op]) = ops0
     empty_location OpKind::OpPushInt 60 make_op_int ops0.push
-    empty_location OpKind::OpSyscall0 0 make_op ops0.push
+    empty_location OpKind::OpSyscall0 make_op ops0.push
     ops0 tc_check = tc0
     "syscall0 result" 1 tc0 TypeChecker::live TypedStack::types.length assert_eq
     "syscall0 type" "int" 0 tc0 TypeChecker::live TypedStack::types.get assert_str_eq
@@ -1223,7 +1223,7 @@ fn test_syscall_op_level {
     List::new(List[Op]) = ops1
     empty_location OpKind::OpPushInt 0 make_op_int ops1.push
     empty_location OpKind::OpPushInt 60 make_op_int ops1.push
-    empty_location OpKind::OpSyscall1 0 make_op ops1.push
+    empty_location OpKind::OpSyscall1 make_op ops1.push
     ops1 tc_check = tc1
     "syscall1 result" 1 tc1 TypeChecker::live TypedStack::types.length assert_eq
     "syscall1 type" "int" 0 tc1 TypeChecker::live TypedStack::types.get assert_str_eq
@@ -1234,7 +1234,7 @@ fn test_syscall_op_level {
     empty_location OpKind::OpPushInt 0 make_op_int ops3.push
     empty_location OpKind::OpPushInt 0 make_op_int ops3.push
     empty_location OpKind::OpPushInt 1 make_op_int ops3.push
-    empty_location OpKind::OpSyscall3 0 make_op ops3.push
+    empty_location OpKind::OpSyscall3 make_op ops3.push
     ops3 tc_check = tc3
     "syscall3 result" 1 tc3 TypeChecker::live TypedStack::types.length assert_eq
     "syscall3 type" "int" 0 tc3 TypeChecker::live TypedStack::types.get assert_str_eq
@@ -1248,7 +1248,7 @@ fn test_typeof_char {
     "typeof_char" test_start
     List::new(List[Op]) = ops
     empty_location OpKind::OpPushChar 65 make_op_int ops.push
-    empty_location OpKind::OpTypeof 0 make_op ops.push
+    empty_location OpKind::OpTypeof make_op ops.push
     ops tc_check = result_tc
     "typeof char result" "str" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
 }
@@ -1257,8 +1257,8 @@ fn test_typeof_ptr {
     "typeof_ptr" test_start
     List::new(List[Op]) = ops
     empty_location OpKind::OpPushInt 10 make_op_int ops.push
-    empty_location OpKind::OpHeapAlloc 0 make_op ops.push
-    empty_location OpKind::OpTypeof 0 make_op ops.push
+    empty_location OpKind::OpHeapAlloc make_op ops.push
+    empty_location OpKind::OpTypeof make_op ops.push
     ops tc_check = result_tc
     "typeof ptr result" "str" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
 }
@@ -1271,7 +1271,7 @@ fn test_dup_preserves_str {
     "dup_preserves_str" test_start
     List::new(List[Op]) = ops
     empty_location OpKind::OpPushStr "hello" make_op_str ops.push
-    empty_location OpKind::OpDup 0 make_op ops.push
+    empty_location OpKind::OpDup make_op ops.push
     ops tc_check = result_tc
     "dup str count" 2 result_tc TypeChecker::live TypedStack::types.length assert_eq
     "dup str first" "str" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
@@ -1282,7 +1282,7 @@ fn test_dup_preserves_bool {
     "dup_preserves_bool" test_start
     List::new(List[Op]) = ops
     empty_location OpKind::OpPushBool 1 make_op_int ops.push
-    empty_location OpKind::OpDup 0 make_op ops.push
+    empty_location OpKind::OpDup make_op ops.push
     ops tc_check = result_tc
     "dup bool count" 2 result_tc TypeChecker::live TypedStack::types.length assert_eq
     "dup bool first" "bool" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
@@ -1516,8 +1516,8 @@ fn test_print_dispatch_ptr {
     "print_dispatch_ptr" test_start
     List::new(List[Op]) = ops
     empty_location OpKind::OpPushInt 10 make_op_int ops.push
-    empty_location OpKind::OpHeapAlloc 0 make_op ops.push
-    empty_location OpKind::OpPrint 0 make_op ops.push
+    empty_location OpKind::OpHeapAlloc make_op ops.push
+    empty_location OpKind::OpPrint make_op ops.push
     ops tc_check drop
     # ptr falls through to print_int
     "print ptr resolved" OpKind::OpPrintInt 2 ops.get Op::kind == assert_true
@@ -1531,7 +1531,7 @@ fn test_typeof_annotation {
     "typeof_annotation" test_start
     List::new(List[Op]) = ops
     empty_location OpKind::OpPushInt 42 make_op_int ops.push
-    empty_location OpKind::OpTypeof 0 make_op ops.push
+    empty_location OpKind::OpTypeof make_op ops.push
     ops tc_check drop
     "typeof annotation" "int" 1 ops.get Op::type_annotation assert_str_eq
 }
@@ -1603,10 +1603,10 @@ fn test_error_str_lt_comparison {
 fn test_branch_if_empty_body {
     "branch_if_empty_body" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpIfStart 0 make_op ops.push
+    empty_location OpKind::OpIfStart make_op ops.push
     empty_location OpKind::OpPushBool 1 make_op_int ops.push
-    empty_location OpKind::OpIfCondition 0 make_op ops.push
-    empty_location OpKind::OpIfEnd 0 make_op ops.push
+    empty_location OpKind::OpIfCondition make_op ops.push
+    empty_location OpKind::OpIfEnd make_op ops.push
     ops tc_check = result_tc
     "live empty after empty if" 0 result_tc TypeChecker::live TypedStack::types.length assert_eq
     "frame stack empty" 0 result_tc TypeChecker::branched_stacks.length assert_eq
@@ -1616,13 +1616,13 @@ fn test_branch_if_empty_body {
 fn test_branch_if_else_agree_int {
     "branch_if_else_agree_int" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpIfStart 0 make_op ops.push
+    empty_location OpKind::OpIfStart make_op ops.push
     empty_location OpKind::OpPushBool 1 make_op_int ops.push
-    empty_location OpKind::OpIfCondition 0 make_op ops.push
+    empty_location OpKind::OpIfCondition make_op ops.push
     empty_location OpKind::OpPushInt 10 make_op_int ops.push
-    empty_location OpKind::OpIfElse 0 make_op ops.push
+    empty_location OpKind::OpIfElse make_op ops.push
     empty_location OpKind::OpPushInt 20 make_op_int ops.push
-    empty_location OpKind::OpIfEnd 0 make_op ops.push
+    empty_location OpKind::OpIfEnd make_op ops.push
     ops tc_check = result_tc
     "live has one item" 1 result_tc TypeChecker::live TypedStack::types.length assert_eq
     "unified type is int" "int" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
@@ -1633,14 +1633,14 @@ fn test_branch_if_else_agree_int {
 fn test_branch_if_end_pops_frame {
     "branch_if_end_pops_frame" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpIfStart 0 make_op ops.push
+    empty_location OpKind::OpIfStart make_op ops.push
     empty_location OpKind::OpPushBool 1 make_op_int ops.push
-    empty_location OpKind::OpIfCondition 0 make_op ops.push
+    empty_location OpKind::OpIfCondition make_op ops.push
     ops tc_check = result_tc
     "frame pushed on OpIfStart" 1 result_tc TypeChecker::branched_stacks.length assert_eq
     # Close the block
     List::new(List[Op]) = close_ops
-    empty_location OpKind::OpIfEnd 0 make_op close_ops.push
+    empty_location OpKind::OpIfEnd make_op close_ops.push
     0 = ci
     while ci close_ops.length > do
         ci close_ops.get result_tc check_if_block
@@ -1653,10 +1653,10 @@ fn test_branch_if_end_pops_frame {
 fn test_branch_while_empty_body {
     "branch_while_empty_body" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpWhileStart 0 make_op ops.push
+    empty_location OpKind::OpWhileStart make_op ops.push
     empty_location OpKind::OpPushBool 0 make_op_int ops.push
-    empty_location OpKind::OpWhileCondition 0 make_op ops.push
-    empty_location OpKind::OpWhileEnd 0 make_op ops.push
+    empty_location OpKind::OpWhileCondition make_op ops.push
+    empty_location OpKind::OpWhileEnd make_op ops.push
     ops tc_check = result_tc
     "live empty" 0 result_tc TypeChecker::live TypedStack::types.length assert_eq
     "frame stack empty" 0 result_tc TypeChecker::branched_stacks.length assert_eq
@@ -1669,7 +1669,7 @@ fn test_branch_frame_kind_dispatch {
     "branch_frame_kind_dispatch" test_start
     make_typechecker = tc
     List::new(List[Op]) = ops
-    empty_location OpKind::OpIfStart 0 make_op ops.push
+    empty_location OpKind::OpIfStart make_op ops.push
     0 = bd_i
     while bd_i ops.length > do
         bd_i ops.get tc check_if_block
@@ -1711,9 +1711,9 @@ fn test_branch_return_inside_if_restores_live {
     "int" tc stack_push
     # Begin an `if true then` block.
     List::new(List[Op]) = begin_ops
-    empty_location OpKind::OpIfStart 0 make_op begin_ops.push
+    empty_location OpKind::OpIfStart make_op begin_ops.push
     empty_location OpKind::OpPushBool 1 make_op_int begin_ops.push
-    empty_location OpKind::OpIfCondition 0 make_op begin_ops.push
+    empty_location OpKind::OpIfCondition make_op begin_ops.push
     0 = br_i
     while br_i begin_ops.length > do
         br_i begin_ops.get = br_op

--- a/tests/compiler/test_typechecker.casa
+++ b/tests/compiler/test_typechecker.casa
@@ -271,7 +271,7 @@ fn test_swap_stack_effect {
     "swap_stack_effect" test_start
     List::new(List[Op]) = ops
     empty_location OpKind::OpPushInt 42 make_op ops.push
-    empty_location OpKind::OpPushStr "hello" (int) make_op ops.push
+    empty_location OpKind::OpPushStr "hello" make_op_str ops.push
     empty_location OpKind::OpSwap 0 make_op ops.push
     ops tc_check = result_tc
     "stack after swap" 2 result_tc TypeChecker::live TypedStack::types.length assert_eq
@@ -287,7 +287,7 @@ fn test_over_stack_effect {
     "over_stack_effect" test_start
     List::new(List[Op]) = ops
     empty_location OpKind::OpPushInt 42 make_op ops.push
-    empty_location OpKind::OpPushStr "hello" (int) make_op ops.push
+    empty_location OpKind::OpPushStr "hello" make_op_str ops.push
     empty_location OpKind::OpOver 0 make_op ops.push
     ops tc_check = result_tc
     "stack after over" 3 result_tc TypeChecker::live TypedStack::types.length assert_eq
@@ -304,7 +304,7 @@ fn test_drop_stack_effect {
     "drop_stack_effect" test_start
     List::new(List[Op]) = ops
     empty_location OpKind::OpPushInt 42 make_op ops.push
-    empty_location OpKind::OpPushStr "hello" (int) make_op ops.push
+    empty_location OpKind::OpPushStr "hello" make_op_str ops.push
     empty_location OpKind::OpDrop 0 make_op ops.push
     ops tc_check = result_tc
     "stack after drop" 1 result_tc TypeChecker::live TypedStack::types.length assert_eq
@@ -319,7 +319,7 @@ fn test_rot_stack_effect {
     "rot_stack_effect" test_start
     List::new(List[Op]) = ops
     empty_location OpKind::OpPushInt 42 make_op ops.push
-    empty_location OpKind::OpPushStr "hello" (int) make_op ops.push
+    empty_location OpKind::OpPushStr "hello" make_op_str ops.push
     empty_location OpKind::OpPushBool 1 make_op ops.push
     empty_location OpKind::OpRot 0 make_op ops.push
     ops tc_check = result_tc
@@ -338,7 +338,7 @@ fn test_type_cast {
     "type_cast" test_start
     List::new(List[Op]) = ops
     empty_location OpKind::OpPushInt 42 make_op ops.push
-    empty_location OpKind::OpTypeCast "str" (int) make_op ops.push
+    empty_location OpKind::OpTypeCast "str" make_op_str ops.push
     ops tc_check = result_tc
     "stack after cast" 1 result_tc TypeChecker::live TypedStack::types.length assert_eq
     "cast to str" "str" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
@@ -352,7 +352,7 @@ fn test_push_literals {
     "push_literals" test_start
     List::new(List[Op]) = ops
     empty_location OpKind::OpPushInt 42 make_op ops.push
-    empty_location OpKind::OpPushStr "hi" (int) make_op ops.push
+    empty_location OpKind::OpPushStr "hi" make_op_str ops.push
     empty_location OpKind::OpPushBool 1 make_op ops.push
     empty_location OpKind::OpPushChar 65 make_op ops.push
     ops tc_check = result_tc
@@ -372,7 +372,7 @@ fn test_print_dispatch {
 
     # print str -> OpPrintStr
     List::new(List[Op]) = ops_str
-    empty_location OpKind::OpPushStr "hello" (int) make_op ops_str.push
+    empty_location OpKind::OpPushStr "hello" make_op_str ops_str.push
     empty_location OpKind::OpPrint 0 make_op ops_str.push
     ops_str tc_check drop
     "print str resolved" OpKind::OpPrintStr 1 ops_str.get Op::kind == assert_true
@@ -628,7 +628,7 @@ fn test_print_dispatch_cstr {
     "print_dispatch_cstr" test_start
     List::new(List[Op]) = ops
     empty_location OpKind::OpPushInt 42 make_op ops.push
-    empty_location OpKind::OpTypeCast "cstr" (int) make_op ops.push
+    empty_location OpKind::OpTypeCast "cstr" make_op_str ops.push
     empty_location OpKind::OpPrint 0 make_op ops.push
     ops tc_check drop
     "print cstr resolved" OpKind::OpPrintCstr 2 ops.get Op::kind == assert_true
@@ -654,7 +654,7 @@ fn test_print_pops_stack {
 fn test_typeof_str {
     "typeof_str" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushStr "hi" (int) make_op ops.push
+    empty_location OpKind::OpPushStr "hi" make_op_str ops.push
     empty_location OpKind::OpTypeof 0 make_op ops.push
     ops tc_check = result_tc
     "typeof str result" "str" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
@@ -724,8 +724,8 @@ fn test_all_comparison_ops {
 fn test_string_comparison_annotation {
     "string_comparison_annotation" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushStr "a" (int) make_op ops.push
-    empty_location OpKind::OpPushStr "b" (int) make_op ops.push
+    empty_location OpKind::OpPushStr "a" make_op_str ops.push
+    empty_location OpKind::OpPushStr "b" make_op_str ops.push
     empty_location OpKind::OpEq 0 make_op ops.push
     ops tc_check = result_tc
     "str cmp is bool" "bool" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
@@ -1270,7 +1270,7 @@ fn test_typeof_ptr {
 fn test_dup_preserves_str {
     "dup_preserves_str" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushStr "hello" (int) make_op ops.push
+    empty_location OpKind::OpPushStr "hello" make_op_str ops.push
     empty_location OpKind::OpDup 0 make_op ops.push
     ops tc_check = result_tc
     "dup str count" 2 result_tc TypeChecker::live TypedStack::types.length assert_eq
@@ -1543,8 +1543,8 @@ fn test_typeof_annotation {
 fn test_type_cast_str_to_int {
     "type_cast_str_to_int" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushStr "hello" (int) make_op ops.push
-    empty_location OpKind::OpTypeCast "int" (int) make_op ops.push
+    empty_location OpKind::OpPushStr "hello" make_op_str ops.push
+    empty_location OpKind::OpTypeCast "int" make_op_str ops.push
     ops tc_check = result_tc
     "cast str to int" 1 result_tc TypeChecker::live TypedStack::types.length assert_eq
     "cast result" "int" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
@@ -1554,7 +1554,7 @@ fn test_type_cast_bool_to_int {
     "type_cast_bool_to_int" test_start
     List::new(List[Op]) = ops
     empty_location OpKind::OpPushBool 1 make_op ops.push
-    empty_location OpKind::OpTypeCast "int" (int) make_op ops.push
+    empty_location OpKind::OpTypeCast "int" make_op_str ops.push
     ops tc_check = result_tc
     "cast bool to int" "int" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
 }


### PR DESCRIPTION
## Summary

Track B of #128 — replace `Op::value: int` (polymorphic over `str | EnumVariant | MatchArm | CasaStruct | StructLiteral | List[Op]`, discriminated by `Op::kind`) with `Op::value: OpValue`, a Rust-style tagged enum. Every read site previously did an unchecked `(StructName)` cast; the contract lived in comments only.

10 commits, one payload type per commit, bootstrap stable at every step.

## Changes

Pre-existing on branch:
- `MatchArm::pattern_value: int` → `PatternValue` tagged enum
- `LiteralPattern { value:int typ:str raw:str }` → `LiteralValue` tagged enum

This session:
1. Introduce `enum OpValue` + `Op::value_v: OpValue` parallel field, migrate `OpPushEnumVariant` / `OpIsCheck`
2. Migrate `OpPushArray` to `OpValue::OpList(List[Op])`
3. Migrate `OpStructNew` to `OpValue::Struct(CasaStruct)`
4. Migrate `OpStructLiteral` to `OpValue::StructLit(StructLiteral)`
5. Migrate `OpMatchArm` to `OpValue::Match(MatchArm)`
6. Migrate str-valued ops (`OpPushStr`, `OpFnCall`, `OpFnPush`, `OpIdentifier`, `OpImportFile`, `OpAssignVar`, `OpPushVar`, `OpPushCapture`, `OpAssignDec`, `OpAssignInc`, `OpTypeCast`) to `OpValue::Str(str)`
7. Migrate int-valued ops (`OpPushInt`, `OpPushChar`, `OpPushBool`, `OpFstringConcat`) to `OpValue::Int(int)`
8. Drop unused `Op::value:int` field. Rename `value_v` → `value`. Drop `value:int` param from `make_op` / `make_op_annotated`.

After: `Op::value: OpValue` carries every payload. Read sites use destructuring helpers (`enum_variant_of`, `op_list_of`, `casa_struct_of`, `struct_literal_of`, `match_arm_of`, `op_str_value`, `op_int_value`) instead of `(Type)Op::value` casts.

`Op::kind: OpKind` still exists alongside `OpValue` to discriminate among kinds that share a payload type. Collapsing `OpKind` into the `OpValue` variant tag (final step of the project plan) is intentionally deferred — large mechanical change, fits its own PR.

## Test plan

- [x] `tests/test_compiler.sh < /dev/null` — 25/25 pass after each commit
- [x] `tests/test_examples.sh` — 39/39 pass after each commit
- [x] Self-host stage1.s == stage2.s after each commit