### PR TITLE
refactor(common): collapse OpKind into OpValue tag (#133)

### DIFF
--- a/compiler/bytecode.casa
+++ b/compiler/bytecode.casa
@@ -198,11 +198,10 @@ fn op_value_list_contains items:List[OpValue] value:OpValue -> bool {
     done
     false
 }
-
-# Forward search for the next OpMatchArm or OpMatchEnd within the current
-# match block, respecting nested blocks. Returns the matching label or None
-# when the boundary is reached. Specialized to avoid constructing a
-# payload-carrying OpValue::MatchArm sentinel.
+# find_matching_label needs a sentinel value in target_values, but
+# OpValue::MatchArm carries a payload that cannot be constructed bare for
+# tag-only equality. This forward scan tracks depth and returns the label
+# of the next OpMatchArm or None on OpMatchEnd at depth 0.
 
 fn find_next_match_arm_or_end ops:List[Op] op_index:int -> Option[int] {
     1 = depth
@@ -259,21 +258,24 @@ fn compile_assignment compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
     resolved ResolvedVariable::set_kind = set_kind
     resolved ResolvedVariable::index = var_index
 
-    if op.value OpValue::AssignDec is then
-        var_index get_kind make_inst_int bytecode.push
-        InstKind::InstSwap make_inst bytecode.push
-        InstKind::InstSub make_inst bytecode.push
-        var_index set_kind make_inst_int bytecode.push
-    elif op.value OpValue::AssignInc is then
-        var_index get_kind make_inst_int bytecode.push
-        InstKind::InstAdd make_inst bytecode.push
-        var_index set_kind make_inst_int bytecode.push
-    elif op.value OpValue::AssignVar is then
-        var_index set_kind make_inst_int bytecode.push
-    else
-        "Internal error: compile_assignment called with non-assignment OpValue\n" eprint
-        1 exit
-    fi
+    op.value match
+        OpValue::AssignDec => {
+            var_index get_kind make_inst_int bytecode.push
+            InstKind::InstSwap make_inst bytecode.push
+            InstKind::InstSub make_inst bytecode.push
+            var_index set_kind make_inst_int bytecode.push
+        }
+        OpValue::AssignInc => {
+            var_index get_kind make_inst_int bytecode.push
+            InstKind::InstAdd make_inst bytecode.push
+            var_index set_kind make_inst_int bytecode.push
+        }
+        OpValue::AssignVar => var_index set_kind make_inst_int bytecode.push
+        _ => {
+            "Internal error: compile_assignment called with non-assignment OpValue\n" eprint
+            1 exit
+        }
+    end
 }
 
 # ============================================================================
@@ -854,51 +856,55 @@ fn compile_function compiler:BytecodeCompiler function:Function op:Op {
 fn compile_function_ops compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
     op op_str_value = name
 
-    if op.value OpValue::FnCall is then
-        name compiler.store.functions.get.unwrap = function
-        op function compiler compile_function
-        name InstKind::InstFnCall make_inst_str bytecode.push
-    elif op.value OpValue::FnPush is then
-        name compiler.store.functions.get = function_opt
-        if function_opt.is_none then
-            op Op::location f"Function `{name}` is not defined" ErrorKind::UndefinedName make_error ERRORS.push
-            return
-        fi
-        function_opt.unwrap = lambda
-        op lambda compiler compile_function
+    op.value match
+        OpValue::FnCall => {
+            name compiler.store.functions.get.unwrap = function
+            op function compiler compile_function
+            name InstKind::InstFnCall make_inst_str bytecode.push
+        }
+        OpValue::FnPush => {
+            name compiler.store.functions.get = function_opt
+            if function_opt.is_none then
+                op Op::location f"Function `{name}` is not defined" ErrorKind::UndefinedName make_error ERRORS.push
+                return
+            fi
+            function_opt.unwrap = lambda
+            op lambda compiler compile_function
 
-        # Zero-capture closures share a single static record so trait
-        # dispatch and named-function pushes do not allocate per call.
-        if 0 lambda Function::captures.length == then
-            name InstKind::InstFnPushStatic make_inst_str bytecode.push
-        else
-            # Captures are pushed before the function pointer so InstClosureRecord
-            # pops fn_ptr first into record[0] and then captures into record[1..].
-            for capture in lambda Function::captures.iter do
-                capture Variable::name compiler resolve_variable = capture_resolved
-                capture_resolved ResolvedVariable::index capture_resolved ResolvedVariable::get_kind make_inst_int bytecode.push
-            done
-            name InstKind::InstFnPush make_inst_str bytecode.push
-            lambda Function::captures.length InstKind::InstClosureRecord make_inst_int bytecode.push
-        fi
-    else
-        "Internal error: compile_function_ops called with non-function OpValue\n" eprint
-        1 exit
-    fi
+            # Zero-capture closures share a single static record so trait
+            # dispatch and named-function pushes do not allocate per call.
+            if 0 lambda Function::captures.length == then
+                name InstKind::InstFnPushStatic make_inst_str bytecode.push
+            else
+                # Captures are pushed before the function pointer so InstClosureRecord
+                # pops fn_ptr first into record[0] and then captures into record[1..].
+                for capture in lambda Function::captures.iter do
+                    capture Variable::name compiler resolve_variable = capture_resolved
+                    capture_resolved ResolvedVariable::index capture_resolved ResolvedVariable::get_kind make_inst_int bytecode.push
+                done
+                name InstKind::InstFnPush make_inst_str bytecode.push
+                lambda Function::captures.length InstKind::InstClosureRecord make_inst_int bytecode.push
+            fi
+        }
+        _ => {
+            "Internal error: compile_function_ops called with non-function OpValue\n" eprint
+            1 exit
+        }
+    end
 }
 
 # ============================================================================
 # Compile enum comparison (data-carrying enums)
 # ============================================================================
 
-fn compile_enum_comparison compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
+fn compile_enum_comparison compiler:BytecodeCompiler compare_kind:InstKind bytecode:List[Inst] {
     compiler.locals_count = local_a
     compiler.locals_count 1 + compiler->locals_count
     local_a InstKind::InstLocalSet make_inst_int bytecode.push
     InstKind::InstLoad64 make_inst bytecode.push
     local_a InstKind::InstLocalGet make_inst_int bytecode.push
     InstKind::InstLoad64 make_inst bytecode.push
-    op.value direct_op_to_inst.unwrap make_inst bytecode.push
+    compare_kind make_inst bytecode.push
 }
 
 # ============================================================================
@@ -922,7 +928,7 @@ fn compile_op compiler:BytecodeCompiler op:Op op_index:int bytecode:List[Inst] {
         "" op Op::type_annotation != &&
         op Op::type_annotation compiler.store.enums.has &&
         then
-            bytecode op compiler compile_enum_comparison
+            bytecode direct_inst_opt.unwrap compiler compile_enum_comparison
             return
         fi
         # String content comparison

--- a/compiler/bytecode.casa
+++ b/compiler/bytecode.casa
@@ -138,27 +138,27 @@ fn resolve_variable compiler:BytecodeCompiler variable_name:str -> ResolvedVaria
 # Block matching (find_matching_label)
 # ============================================================================
 
-fn is_block_start_kind kind:OpKind -> bool {
-    OpKind::OpIfStart kind ==
-    OpKind::OpWhileStart kind == ||
-    OpKind::OpMatchStart kind == ||
+fn is_block_start_value op_value:OpValue -> bool {
+    op_value OpValue::IfStart is
+    op_value OpValue::WhileStart is ||
+    op_value OpValue::MatchStart is ||
 }
 
-fn is_block_end_kind kind:OpKind -> bool {
-    OpKind::OpIfEnd kind ==
-    OpKind::OpWhileEnd kind == ||
-    OpKind::OpMatchEnd kind == ||
+fn is_block_end_value op_value:OpValue -> bool {
+    op_value OpValue::IfEnd is
+    op_value OpValue::WhileEnd is ||
+    op_value OpValue::MatchEnd is ||
 }
 # Search for matching block label respecting nesting. `backward` = true scans
-# toward index 0, false scans toward ops.length. `boundary_kind` is the
-# opening/closing kind at which to give up (end_kind going forward,
-# start_kind going backward).
+# toward index 0, false scans toward ops.length. `boundary_value` is the
+# opening/closing variant at which to give up (end variant going forward,
+# start variant going backward).
 
 fn find_matching_label
     ops:List[Op]
     op_index:int
-    boundary_kind:OpKind
-    target_kinds:List[OpKind]
+    boundary_value:OpValue
+    target_values:List[OpValue]
     backward:bool
 -> Option[int] {
     if backward then -1 else 1 fi = step
@@ -169,19 +169,19 @@ fn find_matching_label
     if backward then 0 index >= else index ops.length > fi
     do
         index ops.get = other_op
-        other_op Op::kind = kind
+        other_op.value = other_value
         if 1 depth <= then
-            if kind target_kinds opkind_list_contains then
+            if other_value target_values op_value_list_contains then
                 index ops op_ptr_to_label Option::Some return
             fi
         fi
-        if kind is_block_start_kind then
+        if other_value is_block_start_value then
             step += depth
-        elif kind is_block_end_kind then
+        elif other_value is_block_end_value then
             neg_step += depth
         fi
         if 1 depth < then
-            if boundary_kind kind == then
+            if boundary_value other_value == then
                 Option::None return
             fi
         fi
@@ -190,7 +190,7 @@ fn find_matching_label
     Option::None
 }
 
-fn opkind_list_contains items:List[OpKind] value:OpKind -> bool {
+fn op_value_list_contains items:List[OpValue] value:OpValue -> bool {
     for item in items.iter do
         if value item == then
             true return
@@ -199,16 +199,47 @@ fn opkind_list_contains items:List[OpKind] value:OpKind -> bool {
     false
 }
 
+# Forward search for the next OpMatchArm or OpMatchEnd within the current
+# match block, respecting nested blocks. Returns the matching label or None
+# when the boundary is reached. Specialized to avoid constructing a
+# payload-carrying OpValue::MatchArm sentinel.
+
+fn find_next_match_arm_or_end ops:List[Op] op_index:int -> Option[int] {
+    1 = depth
+    op_index 1 + = index
+    while index ops.length > do
+        index ops.get = other_op
+        other_op.value = other_value
+        if 1 depth <= then
+            if other_value OpValue::MatchArm is then
+                index ops op_ptr_to_label Option::Some return
+            fi
+        fi
+        if other_value is_block_start_value then
+            1 += depth
+        elif other_value is_block_end_value then
+            -1 += depth
+        fi
+        if 1 depth < then
+            if other_value OpValue::MatchEnd is then
+                Option::None return
+            fi
+        fi
+        1 += index
+    done
+    Option::None
+}
+
 fn require_matching
     ops:List[Op]
     op_index:int
-    boundary_kind:OpKind
-    target_kinds:List[OpKind]
+    boundary_value:OpValue
+    target_values:List[OpValue]
     location:Location
     message:str
     backward:bool
 -> int {
-    backward target_kinds boundary_kind op_index ops find_matching_label = result
+    backward target_values boundary_value op_index ops find_matching_label = result
     if result.is_none then
         location message ErrorKind::UnmatchedBlock make_error ERRORS.push
         0
@@ -228,24 +259,21 @@ fn compile_assignment compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
     resolved ResolvedVariable::set_kind = set_kind
     resolved ResolvedVariable::index = var_index
 
-    op Op::kind match
-        OpKind::OpAssignDec => {
-            var_index get_kind make_inst_int bytecode.push
-            InstKind::InstSwap make_inst bytecode.push
-            InstKind::InstSub make_inst bytecode.push
-            var_index set_kind make_inst_int bytecode.push
-        }
-        OpKind::OpAssignInc => {
-            var_index get_kind make_inst_int bytecode.push
-            InstKind::InstAdd make_inst bytecode.push
-            var_index set_kind make_inst_int bytecode.push
-        }
-        OpKind::OpAssignVar => var_index set_kind make_inst_int bytecode.push
-        _ => {
-            "Internal error: compile_assignment called with non-assignment OpKind\n" eprint
-            1 exit
-        }
-    end
+    if op.value OpValue::AssignDec is then
+        var_index get_kind make_inst_int bytecode.push
+        InstKind::InstSwap make_inst bytecode.push
+        InstKind::InstSub make_inst bytecode.push
+        var_index set_kind make_inst_int bytecode.push
+    elif op.value OpValue::AssignInc is then
+        var_index get_kind make_inst_int bytecode.push
+        InstKind::InstAdd make_inst bytecode.push
+        var_index set_kind make_inst_int bytecode.push
+    elif op.value OpValue::AssignVar is then
+        var_index set_kind make_inst_int bytecode.push
+    else
+        "Internal error: compile_assignment called with non-assignment OpValue\n" eprint
+        1 exit
+    fi
 }
 
 # ============================================================================
@@ -256,48 +284,48 @@ fn compile_if_block compiler:BytecodeCompiler op:Op op_index:int bytecode:List[I
     compiler.ops = ops
     op Op::location = loc
 
-    List::new(List[OpKind]) = start_targets
-    OpKind::OpIfStart start_targets.push
+    List::new(List[OpValue]) = start_targets
+    OpValue::IfStart start_targets.push
 
-    List::new(List[OpKind]) = elif_else_end
-    OpKind::OpIfElif elif_else_end.push
-    OpKind::OpIfElse elif_else_end.push
-    OpKind::OpIfEnd elif_else_end.push
+    List::new(List[OpValue]) = elif_else_end
+    OpValue::IfElif elif_else_end.push
+    OpValue::IfElse elif_else_end.push
+    OpValue::IfEnd elif_else_end.push
 
-    List::new(List[OpKind]) = end_targets
-    OpKind::OpIfEnd end_targets.push
+    List::new(List[OpValue]) = end_targets
+    OpValue::IfEnd end_targets.push
 
-    List::new(List[OpKind]) = else_targets
-    OpKind::OpIfElse else_targets.push
+    List::new(List[OpValue]) = else_targets
+    OpValue::IfElse else_targets.push
 
-    op Op::kind match
-        OpKind::OpIfCondition => {
-            true "`then` without matching `if`" loc start_targets OpKind::OpIfStart op_index ops require_matching drop
-            false "`then` without matching `fi`" loc elif_else_end OpKind::OpIfEnd op_index ops require_matching = end_label
+    op.value match
+        OpValue::IfCondition => {
+            true "`then` without matching `if`" loc start_targets OpValue::IfStart op_index ops require_matching drop
+            false "`then` without matching `fi`" loc elif_else_end OpValue::IfEnd op_index ops require_matching = end_label
             end_label InstKind::InstJumpNe make_inst_int bytecode.push
         }
-        OpKind::OpIfElif => {
-            true "`elif` without parent `if`" loc start_targets OpKind::OpIfStart op_index ops require_matching drop
+        OpValue::IfElif => {
+            true "`elif` without parent `if`" loc start_targets OpValue::IfStart op_index ops require_matching drop
             op_index compiler.ops op_ptr_to_label = elif_label
-            false "`elif` without matching `fi`" loc end_targets OpKind::OpIfEnd op_index ops require_matching = end_label_2
+            false "`elif` without matching `fi`" loc end_targets OpValue::IfEnd op_index ops require_matching = end_label_2
             end_label_2 InstKind::InstJump make_inst_int bytecode.push
             elif_label InstKind::InstLabel make_inst_int bytecode.push
         }
-        OpKind::OpIfElse => {
-            true "`else` without parent `if`" loc start_targets OpKind::OpIfStart op_index ops require_matching drop
+        OpValue::IfElse => {
+            true "`else` without parent `if`" loc start_targets OpValue::IfStart op_index ops require_matching drop
             op_index compiler.ops op_ptr_to_label = else_label
-            false "`else` without matching `fi`" loc end_targets OpKind::OpIfEnd op_index ops require_matching = end_label_3
+            false "`else` without matching `fi`" loc end_targets OpValue::IfEnd op_index ops require_matching = end_label_3
             end_label_3 InstKind::InstJump make_inst_int bytecode.push
             else_label InstKind::InstLabel make_inst_int bytecode.push
         }
-        OpKind::OpIfEnd => {
-            true "`fi` without parent `if`" loc start_targets OpKind::OpIfStart op_index ops require_matching drop
+        OpValue::IfEnd => {
+            true "`fi` without parent `if`" loc start_targets OpValue::IfStart op_index ops require_matching drop
             op_index compiler.ops op_ptr_to_label = fi_label
             fi_label InstKind::InstLabel make_inst_int bytecode.push
         }
-        OpKind::OpIfStart => false "`if` without matching `fi`" loc end_targets OpKind::OpIfEnd op_index ops require_matching drop
+        OpValue::IfStart => false "`if` without matching `fi`" loc end_targets OpValue::IfEnd op_index ops require_matching drop
         _ => {
-            "Internal error: compile_if_block called with non-if OpKind\n" eprint
+            "Internal error: compile_if_block called with non-if OpValue\n" eprint
             1 exit
         }
     end
@@ -311,39 +339,39 @@ fn compile_while_block compiler:BytecodeCompiler op:Op op_index:int bytecode:Lis
     compiler.ops = ops
     op Op::location = loc
 
-    List::new(List[OpKind]) = start_targets
-    OpKind::OpWhileStart start_targets.push
+    List::new(List[OpValue]) = start_targets
+    OpValue::WhileStart start_targets.push
 
-    List::new(List[OpKind]) = end_targets
-    OpKind::OpWhileEnd end_targets.push
+    List::new(List[OpValue]) = end_targets
+    OpValue::WhileEnd end_targets.push
 
-    op Op::kind match
-        OpKind::OpWhileBreak => {
-            true "`break` without parent `while`" loc start_targets OpKind::OpWhileStart op_index ops require_matching drop
-            false "`break` without matching `done`" loc end_targets OpKind::OpWhileEnd op_index ops require_matching = end_label
+    op.value match
+        OpValue::WhileBreak => {
+            true "`break` without parent `while`" loc start_targets OpValue::WhileStart op_index ops require_matching drop
+            false "`break` without matching `done`" loc end_targets OpValue::WhileEnd op_index ops require_matching = end_label
             end_label InstKind::InstJump make_inst_int bytecode.push
         }
-        OpKind::OpWhileCondition => {
-            true "`do` without parent `while`" loc start_targets OpKind::OpWhileStart op_index ops require_matching drop
-            false "`do` without matching `done`" loc end_targets OpKind::OpWhileEnd op_index ops require_matching = end_label_2
+        OpValue::WhileCondition => {
+            true "`do` without parent `while`" loc start_targets OpValue::WhileStart op_index ops require_matching drop
+            false "`do` without matching `done`" loc end_targets OpValue::WhileEnd op_index ops require_matching = end_label_2
             end_label_2 InstKind::InstJumpNe make_inst_int bytecode.push
         }
-        OpKind::OpWhileContinue => {
-            true "`continue` without parent `while`" loc start_targets OpKind::OpWhileStart op_index ops require_matching = continue_target
+        OpValue::WhileContinue => {
+            true "`continue` without parent `while`" loc start_targets OpValue::WhileStart op_index ops require_matching = continue_target
             continue_target InstKind::InstJump make_inst_int bytecode.push
         }
-        OpKind::OpWhileEnd => {
+        OpValue::WhileEnd => {
             op_index compiler.ops op_ptr_to_label = while_label
-            true "`done` without parent `while`" loc start_targets OpKind::OpWhileStart op_index ops require_matching = loop_start
+            true "`done` without parent `while`" loc start_targets OpValue::WhileStart op_index ops require_matching = loop_start
             loop_start InstKind::InstJump make_inst_int bytecode.push
             while_label InstKind::InstLabel make_inst_int bytecode.push
         }
-        OpKind::OpWhileStart => {
+        OpValue::WhileStart => {
             op_index compiler.ops op_ptr_to_label = start_label
             start_label InstKind::InstLabel make_inst_int bytecode.push
         }
         _ => {
-            "Internal error: compile_while_block called with non-while OpKind\n" eprint
+            "Internal error: compile_while_block called with non-while OpValue\n" eprint
             1 exit
         }
     end
@@ -492,16 +520,15 @@ fn compile_match_op
 
 fn compile_match_block compiler:BytecodeCompiler op:Op op_index:int bytecode:List[Inst] {
     compiler.ops = ops
+    op.value = match_value
 
-    if OpKind::OpMatchStart op Op::kind == then
-        # Nothing to emit
-    elif OpKind::OpMatchArm op Op::kind == then
+    if match_value OpValue::MatchArm is then
         op Op::location = loc
 
-        List::new(List[OpKind]) = end_targets
-        OpKind::OpMatchEnd end_targets.push
+        List::new(List[OpValue]) = end_targets
+        OpValue::MatchEnd end_targets.push
 
-        false "`match` arm without matching `end`" loc end_targets OpKind::OpMatchEnd op_index ops require_matching = end_label
+        false "`match` arm without matching `end`" loc end_targets OpValue::MatchEnd op_index ops require_matching = end_label
 
         op_index ops.get (int) OP_LABEL_MAP.get = existing
         existing.is_some ! = is_first
@@ -511,13 +538,11 @@ fn compile_match_block compiler:BytecodeCompiler op:Op op_index:int bytecode:Lis
             existing.unwrap InstKind::InstLabel make_inst_int bytecode.push
         fi
 
-        List::new(List[OpKind]) = arm_targets
-        OpKind::OpMatchArm arm_targets.push
-        false arm_targets OpKind::OpMatchEnd op_index ops find_matching_label = next_arm
+        op_index ops find_next_match_arm_or_end = next_arm
         next_arm.is_none = is_last
 
         bytecode next_arm is_last op compiler compile_match_op
-    elif OpKind::OpMatchEnd op Op::kind == then
+    elif match_value OpValue::MatchEnd is then
         op_index compiler.ops op_ptr_to_label = end_match_label
         end_match_label InstKind::InstLabel make_inst_int bytecode.push
     fi
@@ -829,41 +854,37 @@ fn compile_function compiler:BytecodeCompiler function:Function op:Op {
 fn compile_function_ops compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
     op op_str_value = name
 
-    op Op::kind match
-        OpKind::OpFnCall => {
-            name compiler.store.functions.get.unwrap = function
-            op function compiler compile_function
-            name InstKind::InstFnCall make_inst_str bytecode.push
-        }
-        OpKind::OpFnPush => {
-            name compiler.store.functions.get = function_opt
-            if function_opt.is_none then
-                op Op::location f"Function `{name}` is not defined" ErrorKind::UndefinedName make_error ERRORS.push
-                return
-            fi
-            function_opt.unwrap = lambda
-            op lambda compiler compile_function
+    if op.value OpValue::FnCall is then
+        name compiler.store.functions.get.unwrap = function
+        op function compiler compile_function
+        name InstKind::InstFnCall make_inst_str bytecode.push
+    elif op.value OpValue::FnPush is then
+        name compiler.store.functions.get = function_opt
+        if function_opt.is_none then
+            op Op::location f"Function `{name}` is not defined" ErrorKind::UndefinedName make_error ERRORS.push
+            return
+        fi
+        function_opt.unwrap = lambda
+        op lambda compiler compile_function
 
-            # Zero-capture closures share a single static record so trait
-            # dispatch and named-function pushes do not allocate per call.
-            if 0 lambda Function::captures.length == then
-                name InstKind::InstFnPushStatic make_inst_str bytecode.push
-            else
-                # Captures are pushed before the function pointer so InstClosureRecord
-                # pops fn_ptr first into record[0] and then captures into record[1..].
-                for capture in lambda Function::captures.iter do
-                    capture Variable::name compiler resolve_variable = capture_resolved
-                    capture_resolved ResolvedVariable::index capture_resolved ResolvedVariable::get_kind make_inst_int bytecode.push
-                done
-                name InstKind::InstFnPush make_inst_str bytecode.push
-                lambda Function::captures.length InstKind::InstClosureRecord make_inst_int bytecode.push
-            fi
-        }
-        _ => {
-            "Internal error: compile_function_ops called with non-function OpKind\n" eprint
-            1 exit
-        }
-    end
+        # Zero-capture closures share a single static record so trait
+        # dispatch and named-function pushes do not allocate per call.
+        if 0 lambda Function::captures.length == then
+            name InstKind::InstFnPushStatic make_inst_str bytecode.push
+        else
+            # Captures are pushed before the function pointer so InstClosureRecord
+            # pops fn_ptr first into record[0] and then captures into record[1..].
+            for capture in lambda Function::captures.iter do
+                capture Variable::name compiler resolve_variable = capture_resolved
+                capture_resolved ResolvedVariable::index capture_resolved ResolvedVariable::get_kind make_inst_int bytecode.push
+            done
+            name InstKind::InstFnPush make_inst_str bytecode.push
+            lambda Function::captures.length InstKind::InstClosureRecord make_inst_int bytecode.push
+        fi
+    else
+        "Internal error: compile_function_ops called with non-function OpValue\n" eprint
+        1 exit
+    fi
 }
 
 # ============================================================================
@@ -877,7 +898,7 @@ fn compile_enum_comparison compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
     InstKind::InstLoad64 make_inst bytecode.push
     local_a InstKind::InstLocalGet make_inst_int bytecode.push
     InstKind::InstLoad64 make_inst bytecode.push
-    op Op::kind DIRECT_OP_TO_INST.get.unwrap make_inst bytecode.push
+    op.value direct_op_to_inst.unwrap make_inst bytecode.push
 }
 
 # ============================================================================
@@ -885,18 +906,19 @@ fn compile_enum_comparison compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
 # ============================================================================
 
 fn compile_op compiler:BytecodeCompiler op:Op op_index:int bytecode:List[Inst] {
-    op Op::kind = kind
+    op.value = op_value
+    op_value direct_op_to_inst = direct_inst_opt
 
     # Check direct op-to-inst mapping first
-    if kind DIRECT_OP_TO_INST.has then
+    if direct_inst_opt.is_some then
         # Data-carrying enum comparison
         if
-        OpKind::OpEq kind ==
-        OpKind::OpNe kind == ||
-        OpKind::OpLt kind == ||
-        OpKind::OpLe kind == ||
-        OpKind::OpGt kind == ||
-        OpKind::OpGe kind == ||
+        op_value OpValue::Eq is
+        op_value OpValue::Ne is ||
+        op_value OpValue::Lt is ||
+        op_value OpValue::Le is ||
+        op_value OpValue::Gt is ||
+        op_value OpValue::Ge is ||
         "" op Op::type_annotation != &&
         op Op::type_annotation compiler.store.enums.has &&
         then
@@ -905,40 +927,40 @@ fn compile_op compiler:BytecodeCompiler op:Op op_index:int bytecode:List[Inst] {
         fi
         # String content comparison
         if
-        OpKind::OpEq kind ==
-        OpKind::OpNe kind == ||
+        op_value OpValue::Eq is
+        op_value OpValue::Ne is ||
         "str" op Op::type_annotation == &&
         then
             InstKind::InstStrEq make_inst bytecode.push
-            if OpKind::OpNe kind == then
+            if op_value OpValue::Ne is then
                 InstKind::InstNot make_inst bytecode.push
             fi
             return
         fi
         # Data-carrying enum print
-        if OpKind::OpPrintInt kind == "" op Op::type_annotation != && then
+        if op_value OpValue::PrintInt is "" op Op::type_annotation != && then
             InstKind::InstLoad64 make_inst bytecode.push
             InstKind::InstPrintInt make_inst bytecode.push
             return
         fi
-        kind DIRECT_OP_TO_INST.get.unwrap make_inst bytecode.push
+        direct_inst_opt.unwrap make_inst bytecode.push
         return
     fi
 
     # Non-direct ops
     if
-    OpKind::OpAssignDec kind ==
-    OpKind::OpAssignInc kind == ||
-    OpKind::OpAssignVar kind == ||
+    op_value OpValue::AssignDec is
+    op_value OpValue::AssignInc is ||
+    op_value OpValue::AssignVar is ||
     then
         bytecode op compiler compile_assignment
-    elif OpKind::OpFstringConcat kind == then
+    elif op_value OpValue::FstringConcat is then
         op op_int_value InstKind::InstFstringConcat make_inst_int bytecode.push
-    elif OpKind::OpFstringToStr kind == then
+    elif op_value OpValue::FstringToStr is then
         # Identity no-op: str expression already left on stack by the preceding lambda.
         # Non-str cases are rewritten to OpMethodCall during type checking.
-    elif OpKind::OpFnCall kind == OpKind::OpFnPush kind == || then
-        if OpKind::OpFnPush kind == then
+    elif op_value OpValue::FnCall is op_value OpValue::FnPush is || then
+        if op_value OpValue::FnPush is then
             op op_str_value compiler.store.functions.get = function_opt
             if function_opt.is_some then
                 function_opt.unwrap = function_check
@@ -949,20 +971,20 @@ fn compile_op compiler:BytecodeCompiler op:Op op_index:int bytecode:List[Inst] {
             fi
         fi
         bytecode op compiler compile_function_ops
-    elif OpKind::OpIdentifier kind == then
+    elif op_value OpValue::Identifier is then
         f"Identifier `{op op_str_value}` should be resolved by the parser\n" eprint
         1 exit
     elif
-    OpKind::OpIfCondition kind ==
-    OpKind::OpIfElif kind == ||
-    OpKind::OpIfElse kind == ||
-    OpKind::OpIfEnd kind == ||
-    OpKind::OpIfStart kind == ||
+    op_value OpValue::IfCondition is
+    op_value OpValue::IfElif is ||
+    op_value OpValue::IfElse is ||
+    op_value OpValue::IfEnd is ||
+    op_value OpValue::IfStart is ||
     then
         bytecode op_index op compiler compile_if_block
-    elif OpKind::OpImportFile kind == OpKind::OpTypeCast kind == || then
+    elif op_value OpValue::ImportFile is op_value OpValue::TypeCast is || then
         # No instruction emitted
-    elif OpKind::OpPushEnumVariant kind == then
+    elif op_value OpValue::PushEnumVariant is then
         op enum_variant_of = variant
         variant EnumVariant::enum_name compiler.store.enums.get.unwrap = casa_enum
         if casa_enum has_inner_values then
@@ -970,44 +992,44 @@ fn compile_op compiler:BytecodeCompiler op:Op op_index:int bytecode:List[Inst] {
         else
             variant EnumVariant::ordinal.unwrap InstKind::InstPush make_inst_int bytecode.push
         fi
-    elif OpKind::OpIsCheck kind == then
+    elif op_value OpValue::IsCheck is then
         bytecode op compiler compile_is_check
     elif
-    OpKind::OpMatchStart kind ==
-    OpKind::OpMatchArm kind == ||
-    OpKind::OpMatchEnd kind == ||
+    op_value OpValue::MatchStart is
+    op_value OpValue::MatchArm is ||
+    op_value OpValue::MatchEnd is ||
     then
         bytecode op_index op compiler compile_match_block
-    elif OpKind::OpMethodCall kind == then
+    elif op_value OpValue::MethodCall is then
         "Method call should be transpiled to function call during type checking\n" eprint
         1 exit
-    elif OpKind::OpPrint kind == then
+    elif op_value OpValue::Print is then
         "PRINT should be resolved by type checker\n" eprint
         1 exit
-    elif OpKind::OpTypeof kind == then
+    elif op_value OpValue::Typeof is then
         op Op::type_annotation = type_name
         type_name compiler intern_string = typeof_index
         InstKind::InstDrop make_inst bytecode.push
         typeof_index InstKind::InstPushStr make_inst_int bytecode.push
         InstKind::InstPrintStr make_inst bytecode.push
-    elif OpKind::OpPushArray kind == then
+    elif op_value OpValue::PushArray is then
         bytecode op compiler compile_push_array
-    elif OpKind::OpPushBool kind == then
+    elif op_value OpValue::PushBool is then
         op op_int_value InstKind::InstPush make_inst_int bytecode.push
-    elif OpKind::OpPushChar kind == then
+    elif op_value OpValue::PushChar is then
         op op_int_value InstKind::InstPushChar make_inst_int bytecode.push
-    elif OpKind::OpPushCapture kind == then
+    elif op_value OpValue::PushCapture is then
         op op_str_value = capture_name
         if compiler.function Option::Some(function) is then
             capture_name function Function::captures variable_list_index = capture_index
             capture_index InstKind::InstCaptureLoad make_inst_int bytecode.push
         fi
-    elif OpKind::OpPushInt kind == then
+    elif op_value OpValue::PushInt is then
         op op_int_value InstKind::InstPush make_inst_int bytecode.push
-    elif OpKind::OpPushStr kind == then
+    elif op_value OpValue::PushStr is then
         op op_str_value compiler intern_string = string_index
         string_index InstKind::InstPushStr make_inst_int bytecode.push
-    elif OpKind::OpPushVar kind == then
+    elif op_value OpValue::PushVar is then
         op op_str_value = var_name
         var_name compiler resolve_variable = var_resolved
         var_resolved ResolvedVariable::index var_resolved ResolvedVariable::get_kind make_inst_int bytecode.push
@@ -1015,16 +1037,16 @@ fn compile_op compiler:BytecodeCompiler op:Op op_index:int bytecode:List[Inst] {
         if "trait_exec" op Op::type_annotation == then
             InstKind::InstFnExec make_inst bytecode.push
         fi
-    elif OpKind::OpStructNew kind == then
+    elif op_value OpValue::StructNew is then
         bytecode op compiler compile_struct_new
-    elif OpKind::OpStructLiteral kind == then
+    elif op_value OpValue::StructLiteral is then
         bytecode op compiler compile_struct_literal
     elif
-    OpKind::OpWhileBreak kind ==
-    OpKind::OpWhileCondition kind == ||
-    OpKind::OpWhileContinue kind == ||
-    OpKind::OpWhileEnd kind == ||
-    OpKind::OpWhileStart kind == ||
+    op_value OpValue::WhileBreak is
+    op_value OpValue::WhileCondition is ||
+    op_value OpValue::WhileContinue is ||
+    op_value OpValue::WhileEnd is ||
+    op_value OpValue::WhileStart is ||
     then
         bytecode op_index op compiler compile_while_block
     fi

--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -631,8 +631,10 @@ enum OpValue {
 }
 
 # ============================================================================
-# OpValue accessors — exhaustively unwrap a payload-bearing variant. Each
-# helper aborts when the op carries a different payload type than expected.
+# OpValue accessors — extract a typed payload from any variant in a payload
+# family (str, int, etc.). Aborts when the op carries a different payload
+# type. Workaround for is-binding-type bug: direct destructure infers the
+# binding as `any`, so call sites pipe through these typed helpers instead.
 # ============================================================================
 
 fn op_str_value op:Op -> str {

--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -133,121 +133,9 @@ enum OperatorKind {
     AssignInc
 }
 
-# ============================================================================
-# OpKind enum (87 variants)
-# ============================================================================
-
-enum OpKind {
-    # Stack
-    OpDrop
-    OpDup
-    OpOver
-    OpRot
-    OpSwap
-    # IO
-    OpPrint
-    OpPrintBool
-    OpPrintChar
-    OpPrintCstr
-    OpPrintInt
-    OpPrintStr
-    OpTypeof
-    # Memory
-    OpHeapAlloc
-    OpLoad8
-    OpLoad16
-    OpLoad32
-    OpLoad64
-    OpStore8
-    OpStore16
-    OpStore32
-    OpStore64
-    # Syscalls
-    OpSyscall0
-    OpSyscall1
-    OpSyscall2
-    OpSyscall3
-    OpSyscall4
-    OpSyscall5
-    OpSyscall6
-    # Literals
-    OpPushArray
-    OpPushBool
-    OpPushChar
-    OpPushInt
-    OpPushStr
-    # Arithmetic
-    OpAdd
-    OpSub
-    OpMul
-    OpDiv
-    OpMod
-    # Bitshift
-    OpShl
-    OpShr
-    # Bitwise
-    OpBitAnd
-    OpBitOr
-    OpBitXor
-    OpBitNot
-    # Boolean
-    OpAnd
-    OpOr
-    OpNot
-    # Comparison
-    OpEq
-    OpGe
-    OpGt
-    OpLe
-    OpLt
-    OpNe
-    # Functions
-    OpFnCall
-    OpFnExec
-    OpFnPush
-    OpFnReturn
-    OpMethodCall
-    # Loops
-    OpWhileStart
-    OpWhileCondition
-    OpWhileBreak
-    OpWhileContinue
-    OpWhileEnd
-    # Conditionals
-    OpIfStart
-    OpIfCondition
-    OpIfElif
-    OpIfElse
-    OpIfEnd
-    # Variables
-    OpAssignDec
-    OpAssignInc
-    OpAssignVar
-    OpPushCapture
-    OpPushVar
-    # Enums
-    OpPushEnumVariant
-    OpIsCheck
-    # Match
-    OpMatchStart
-    OpMatchArm
-    OpMatchEnd
-    # Structs
-    OpStructNew
-    OpStructLiteral
-    # Types
-    OpTypeCast
-    # Import
-    OpImportFile
-    # F-strings
-    OpFstringConcat
-    OpFstringToStr
-    # Command-line arguments
-    OpArgc
-    OpArgv
-    # Identifier (should be resolved by parser)
-    OpIdentifier
-}
+# OpValue is defined later (after CasaStruct / EnumVariant / MatchArm / StructLiteral
+# are introduced) and discriminates every Op via 87 variants — payload-bearing
+# variants carry typed inner values, payloadless variants stand alone.
 
 # ============================================================================
 # InstKind enum (69 variants)
@@ -404,11 +292,6 @@ impl OperatorKind {
     fn eq self:OperatorKind other:OperatorKind -> bool { self other == }
 }
 
-impl OpKind {
-    fn hash self:OpKind -> int { self (int) int_hash }
-    fn eq self:OpKind other:OpKind -> bool { self other == }
-}
-
 impl InstKind {
     fn hash self:InstKind -> int { self (int) int_hash }
     fn eq self:InstKind other:InstKind -> bool { self other == }
@@ -449,62 +332,39 @@ fn make_token value:str kind:TokenKind location:Location -> Token {
 # ============================================================================
 # Op value types
 #
-# Op carries its payload in `value: OpValue`, a tagged enum where the
-# variant tag identifies the payload type and `kind: OpKind` discriminates
-# among Ops that share a payload type. Mapping from OpKind to payload:
-#   - PUSH_ENUM_VARIANT, IS_CHECK: OpValue::EnumVariant(EnumVariant)
-#   - PUSH_ARRAY: OpValue::OpList(List[Op])
-#   - STRUCT_NEW: OpValue::Struct(CasaStruct)
-#   - STRUCT_LITERAL: OpValue::StructLit(StructLiteral)
-#   - MATCH_ARM: OpValue::Match(MatchArm)
-#   - PUSH_STR, FN_CALL, FN_PUSH, IDENTIFIER, IMPORT_FILE, ASSIGN_VAR,
-#     PUSH_VAR, PUSH_CAPTURE, ASSIGN_DEC, ASSIGN_INC, TYPE_CAST:
-#     OpValue::Str(str)
-#   - PUSH_INT, PUSH_CHAR, PUSH_BOOL, FSTRING_CONCAT: OpValue::Int(int)
-#   - Control flow / intrinsics: OpValue::None
+# Op carries its discriminator and payload in `value: OpValue`, a tagged enum
+# whose 87 variants enumerate every opcode. Variants without inner values
+# stand alone (Add, Drop, IfStart, ...); payload-bearing variants pack the
+# inner value directly so call sites destructure with `is`/`match`.
 # ============================================================================
 
 struct Op {
-    kind:                 OpKind
     location:             Location
     type_annotation:      str
     deferred_return_type: str
     value:                OpValue
 }
 
-fn make_op kind:OpKind location:Location -> Op {
-    OpValue::None "" "" location kind Op
+fn make_op value:OpValue location:Location -> Op {
+    value "" "" location Op
 }
 
-fn make_op_str value:str kind:OpKind location:Location -> Op {
-    value OpValue::Str "" "" location kind Op
-}
-
-fn make_op_int value:int kind:OpKind location:Location -> Op {
-    value OpValue::Int "" "" location kind Op
-}
-
-fn make_op_annotated kind:OpKind location:Location annotation:str -> Op {
-    OpValue::None "" annotation location kind Op
-}
-
-fn make_op_v value:OpValue kind:OpKind location:Location -> Op {
-    value "" "" location kind Op
+fn make_op_annotated value:OpValue location:Location annotation:str -> Op {
+    value "" annotation location Op
 }
 
 fn clone_ops ops:List[Op] -> List[Op] {
     List::new(List[Op]) = result
     for source_op in ops.iter do
-        source_op.value source_op.deferred_return_type source_op.type_annotation source_op.location source_op.kind Op result.push
+        source_op.value source_op.deferred_return_type source_op.type_annotation source_op.location Op result.push
     done
     result
 }
 
 fn substitute_ops_types ops:List[Op] subs:Map[str str] {
     for sub_op in ops.iter do
-        if OpKind::OpTypeCast sub_op Op::kind == then
-            subs sub_op op_str_value substitute_type_params = new_cast_type
-            new_cast_type OpValue::Str sub_op Op::set_value
+        if sub_op.value OpValue::TypeCast(cast_type) is then
+            subs cast_type substitute_type_params OpValue::TypeCast sub_op Op::set_value
         fi
         if "" sub_op Op::type_annotation != then
             subs sub_op Op::type_annotation substitute_type_params = new_annot
@@ -515,24 +375,6 @@ fn substitute_ops_types ops:List[Op] subs:Map[str str] {
             new_deferred sub_op Op::set_deferred_return_type
         fi
     done
-}
-
-fn op_str_value op:Op -> str {
-    if op.value OpValue::Str(value) is then
-        value return
-    fi
-    "Internal error: op_str_value called on non-Str op\n" eprint
-    1 exit
-    ""
-}
-
-fn op_int_value op:Op -> int {
-    if op.value OpValue::Int(value) is then
-        value return
-    fi
-    "Internal error: op_int_value called on non-Int op\n" eprint
-    1 exit
-    0
 }
 
 # ============================================================================
@@ -672,58 +514,190 @@ enum PatternValue {
     Literal (LiteralPattern)
 }
 
-# OpValue — tagged-union payload carried by every Op (#133). The variant
-# tag identifies the payload type; `kind: OpKind` discriminates among Ops
-# that share a payload type. `None` is used by ops without a payload
-# (control flow, intrinsics, arithmetic).
+# OpValue — single tagged enum that classifies every Op. Each of the 87
+# variants represents a distinct opcode; payload-bearing variants carry the
+# typed inner value directly so call sites can destructure with `is`/`match`.
 
 enum OpValue {
-    None
-    EnumVariant (EnumVariant)
-    OpList (List[Op])
-    Struct (CasaStruct)
-    StructLit (StructLiteral)
-    Match (MatchArm)
-    Str (str)
-    Int (int)
+    # Stack
+    Drop
+    Dup
+    Over
+    Rot
+    Swap
+    # IO
+    Print
+    PrintBool
+    PrintChar
+    PrintCstr
+    PrintInt
+    PrintStr
+    Typeof
+    # Memory
+    HeapAlloc
+    Load8
+    Load16
+    Load32
+    Load64
+    Store8
+    Store16
+    Store32
+    Store64
+    # Syscalls
+    Syscall0
+    Syscall1
+    Syscall2
+    Syscall3
+    Syscall4
+    Syscall5
+    Syscall6
+    # Literals
+    PushArray (List[Op])
+    PushBool (int)
+    PushChar (int)
+    PushInt (int)
+    PushStr (str)
+    # Arithmetic
+    Add
+    Sub
+    Mul
+    Div
+    Mod
+    # Bitshift
+    Shl
+    Shr
+    # Bitwise
+    BitAnd
+    BitOr
+    BitXor
+    BitNot
+    # Boolean
+    And
+    Or
+    Not
+    # Comparison
+    Eq
+    Ge
+    Gt
+    Le
+    Lt
+    Ne
+    # Functions
+    FnCall (str)
+    FnExec
+    FnPush (str)
+    FnReturn
+    MethodCall (str)
+    # Loops
+    WhileStart
+    WhileCondition
+    WhileBreak
+    WhileContinue
+    WhileEnd
+    # Conditionals
+    IfStart
+    IfCondition
+    IfElif
+    IfElse
+    IfEnd
+    # Variables
+    AssignDec (str)
+    AssignInc (str)
+    AssignVar (str)
+    PushCapture (str)
+    PushVar (str)
+    # Enums
+    PushEnumVariant (EnumVariant)
+    IsCheck (EnumVariant)
+    # Match
+    MatchStart
+    MatchArm (MatchArm)
+    MatchEnd
+    # Structs
+    StructNew (CasaStruct)
+    StructLiteral (StructLiteral)
+    # Types
+    TypeCast (str)
+    # Import
+    ImportFile (str)
+    # F-strings
+    FstringConcat (int)
+    FstringToStr
+    # Command-line arguments
+    Argc
+    Argv
+    # Identifier (resolved by parser)
+    Identifier (str)
+}
+
+# ============================================================================
+# OpValue accessors — exhaustively unwrap a payload-bearing variant. Each
+# helper aborts when the op carries a different payload type than expected.
+# ============================================================================
+
+fn op_str_value op:Op -> str {
+    if op.value OpValue::FnCall(value) is then value return fi
+    if op.value OpValue::FnPush(value) is then value return fi
+    if op.value OpValue::MethodCall(value) is then value return fi
+    if op.value OpValue::PushStr(value) is then value return fi
+    if op.value OpValue::PushVar(value) is then value return fi
+    if op.value OpValue::PushCapture(value) is then value return fi
+    if op.value OpValue::AssignVar(value) is then value return fi
+    if op.value OpValue::AssignDec(value) is then value return fi
+    if op.value OpValue::AssignInc(value) is then value return fi
+    if op.value OpValue::TypeCast(value) is then value return fi
+    if op.value OpValue::ImportFile(value) is then value return fi
+    if op.value OpValue::Identifier(value) is then value return fi
+    "Internal error: op_str_value called on non-str op\n" eprint
+    1 exit
+    ""
+}
+
+fn op_int_value op:Op -> int {
+    if op.value OpValue::PushBool(value) is then value return fi
+    if op.value OpValue::PushChar(value) is then value return fi
+    if op.value OpValue::PushInt(value) is then value return fi
+    if op.value OpValue::FstringConcat(value) is then value return fi
+    "Internal error: op_int_value called on non-int op\n" eprint
+    1 exit
+    0
+}
+
+fn op_list_of op:Op -> List[Op] {
+    if op.value OpValue::PushArray(items) is then
+        items return
+    fi
+    "Internal error: op_list_of called on non-PushArray op\n" eprint
+    1 exit
+    List::new(List[Op])
 }
 
 fn enum_variant_of op:Op -> EnumVariant {
-    if op.value OpValue::EnumVariant(variant) is then
-        variant return
-    fi
+    if op.value OpValue::PushEnumVariant(variant) is then variant return fi
+    if op.value OpValue::IsCheck(variant) is then variant return fi
     "Internal error: enum_variant_of called on non-EnumVariant op\n" eprint
     1 exit
     Option::None(Option[int]) "" "" make_enum_variant
 }
 
-fn op_list_of op:Op -> List[Op] {
-    if op.value OpValue::OpList(items) is then
-        items return
-    fi
-    "Internal error: op_list_of called on non-OpList op\n" eprint
-    1 exit
-    List::new(List[Op])
-}
-
 fn casa_struct_of op:Op -> CasaStruct {
-    if op.value OpValue::Struct(casa_struct) is then
+    if op.value OpValue::StructNew(casa_struct) is then
         casa_struct return
     fi
-    "Internal error: casa_struct_of called on non-Struct op\n" eprint
+    "Internal error: casa_struct_of called on non-StructNew op\n" eprint
     1 exit
     List::new(List[str]) empty_location List::new(List[Member]) "" CasaStruct
 }
 
 fn struct_literal_of op:Op -> StructLiteral {
-    if op.value OpValue::StructLit(literal) is then
+    if op.value OpValue::StructLiteral(literal) is then
         literal return
     fi
-    "Internal error: struct_literal_of called on non-StructLit op\n" eprint
+    "Internal error: struct_literal_of called on non-StructLiteral op\n" eprint
     1 exit
     List::new(List[str]) "" StructLiteral
 }
-# MatchArm — wrapper stored on OpMatchArm.value. Carries the pattern payload
+# MatchArm — wrapper stored on OpValue::MatchArm. Carries the pattern payload
 # (typed via PatternValue) and an optional guard expression. `guard_ops` is
 # empty for unguarded arms; when non-empty it is compiled after pattern
 # bindings and produces a bool that diverts execution to the next arm when
@@ -739,10 +713,10 @@ fn make_match_arm pattern_value:PatternValue guard_ops:List[Op] -> MatchArm {
 }
 
 fn match_arm_of op:Op -> MatchArm {
-    if op.value OpValue::Match(arm) is then
+    if op.value OpValue::MatchArm(arm) is then
         arm return
     fi
-    "Internal error: match_arm_of called on non-Match op\n" eprint
+    "Internal error: match_arm_of called on non-MatchArm op\n" eprint
     1 exit
     List::new(List[Op])
     "" 0 LiteralValue::Int LiteralPattern PatternValue::Literal
@@ -1414,90 +1388,99 @@ fi
 }
 
 # ============================================================================
-# Intrinsic to OpKind mapping
+# IntrinsicKind -> OpValue lookup
 # ============================================================================
-Map::new(Map[IntrinsicKind OpKind]) = INTRINSIC_TO_OPKIND
-IntrinsicKind::Alloc OpKind::OpHeapAlloc INTRINSIC_TO_OPKIND.set = INTRINSIC_TO_OPKIND
-IntrinsicKind::Drop OpKind::OpDrop INTRINSIC_TO_OPKIND.set = INTRINSIC_TO_OPKIND
-IntrinsicKind::Dup OpKind::OpDup INTRINSIC_TO_OPKIND.set = INTRINSIC_TO_OPKIND
-IntrinsicKind::Exec OpKind::OpFnExec INTRINSIC_TO_OPKIND.set = INTRINSIC_TO_OPKIND
-IntrinsicKind::Load8 OpKind::OpLoad8 INTRINSIC_TO_OPKIND.set = INTRINSIC_TO_OPKIND
-IntrinsicKind::Load16 OpKind::OpLoad16 INTRINSIC_TO_OPKIND.set = INTRINSIC_TO_OPKIND
-IntrinsicKind::Load32 OpKind::OpLoad32 INTRINSIC_TO_OPKIND.set = INTRINSIC_TO_OPKIND
-IntrinsicKind::Load64 OpKind::OpLoad64 INTRINSIC_TO_OPKIND.set = INTRINSIC_TO_OPKIND
-IntrinsicKind::Over OpKind::OpOver INTRINSIC_TO_OPKIND.set = INTRINSIC_TO_OPKIND
-IntrinsicKind::Print OpKind::OpPrint INTRINSIC_TO_OPKIND.set = INTRINSIC_TO_OPKIND
-IntrinsicKind::Rot OpKind::OpRot INTRINSIC_TO_OPKIND.set = INTRINSIC_TO_OPKIND
-IntrinsicKind::Store8 OpKind::OpStore8 INTRINSIC_TO_OPKIND.set = INTRINSIC_TO_OPKIND
-IntrinsicKind::Store16 OpKind::OpStore16 INTRINSIC_TO_OPKIND.set = INTRINSIC_TO_OPKIND
-IntrinsicKind::Store32 OpKind::OpStore32 INTRINSIC_TO_OPKIND.set = INTRINSIC_TO_OPKIND
-IntrinsicKind::Store64 OpKind::OpStore64 INTRINSIC_TO_OPKIND.set = INTRINSIC_TO_OPKIND
-IntrinsicKind::Swap OpKind::OpSwap INTRINSIC_TO_OPKIND.set = INTRINSIC_TO_OPKIND
-IntrinsicKind::Typeof OpKind::OpTypeof INTRINSIC_TO_OPKIND.set = INTRINSIC_TO_OPKIND
-IntrinsicKind::Syscall0 OpKind::OpSyscall0 INTRINSIC_TO_OPKIND.set = INTRINSIC_TO_OPKIND
-IntrinsicKind::Syscall1 OpKind::OpSyscall1 INTRINSIC_TO_OPKIND.set = INTRINSIC_TO_OPKIND
-IntrinsicKind::Syscall2 OpKind::OpSyscall2 INTRINSIC_TO_OPKIND.set = INTRINSIC_TO_OPKIND
-IntrinsicKind::Syscall3 OpKind::OpSyscall3 INTRINSIC_TO_OPKIND.set = INTRINSIC_TO_OPKIND
-IntrinsicKind::Syscall4 OpKind::OpSyscall4 INTRINSIC_TO_OPKIND.set = INTRINSIC_TO_OPKIND
-IntrinsicKind::Syscall5 OpKind::OpSyscall5 INTRINSIC_TO_OPKIND.set = INTRINSIC_TO_OPKIND
-IntrinsicKind::Syscall6 OpKind::OpSyscall6 INTRINSIC_TO_OPKIND.set = INTRINSIC_TO_OPKIND
-IntrinsicKind::Argc OpKind::OpArgc INTRINSIC_TO_OPKIND.set = INTRINSIC_TO_OPKIND
-IntrinsicKind::Argv OpKind::OpArgv INTRINSIC_TO_OPKIND.set = INTRINSIC_TO_OPKIND
+
+fn intrinsic_to_op_value intrinsic_kind:IntrinsicKind -> Option[OpValue] {
+    intrinsic_kind match
+        IntrinsicKind::Alloc => OpValue::HeapAlloc Option::Some
+        IntrinsicKind::Drop => OpValue::Drop Option::Some
+        IntrinsicKind::Dup => OpValue::Dup Option::Some
+        IntrinsicKind::Exec => OpValue::FnExec Option::Some
+        IntrinsicKind::Load8 => OpValue::Load8 Option::Some
+        IntrinsicKind::Load16 => OpValue::Load16 Option::Some
+        IntrinsicKind::Load32 => OpValue::Load32 Option::Some
+        IntrinsicKind::Load64 => OpValue::Load64 Option::Some
+        IntrinsicKind::Over => OpValue::Over Option::Some
+        IntrinsicKind::Print => OpValue::Print Option::Some
+        IntrinsicKind::Rot => OpValue::Rot Option::Some
+        IntrinsicKind::Store8 => OpValue::Store8 Option::Some
+        IntrinsicKind::Store16 => OpValue::Store16 Option::Some
+        IntrinsicKind::Store32 => OpValue::Store32 Option::Some
+        IntrinsicKind::Store64 => OpValue::Store64 Option::Some
+        IntrinsicKind::Swap => OpValue::Swap Option::Some
+        IntrinsicKind::Typeof => OpValue::Typeof Option::Some
+        IntrinsicKind::Syscall0 => OpValue::Syscall0 Option::Some
+        IntrinsicKind::Syscall1 => OpValue::Syscall1 Option::Some
+        IntrinsicKind::Syscall2 => OpValue::Syscall2 Option::Some
+        IntrinsicKind::Syscall3 => OpValue::Syscall3 Option::Some
+        IntrinsicKind::Syscall4 => OpValue::Syscall4 Option::Some
+        IntrinsicKind::Syscall5 => OpValue::Syscall5 Option::Some
+        IntrinsicKind::Syscall6 => OpValue::Syscall6 Option::Some
+        IntrinsicKind::Argc => OpValue::Argc Option::Some
+        IntrinsicKind::Argv => OpValue::Argv Option::Some
+    end
+}
 
 # ============================================================================
-# OpKind to InstKind direct mapping
+# Direct OpValue -> InstKind lowering (for ops that translate 1:1)
 # ============================================================================
-Map::new(Map[OpKind InstKind]) = DIRECT_OP_TO_INST
-OpKind::OpAdd InstKind::InstAdd DIRECT_OP_TO_INST.set = DIRECT_OP_TO_INST
-OpKind::OpAnd InstKind::InstAnd DIRECT_OP_TO_INST.set = DIRECT_OP_TO_INST
-OpKind::OpBitAnd InstKind::InstBitAnd DIRECT_OP_TO_INST.set = DIRECT_OP_TO_INST
-OpKind::OpBitNot InstKind::InstBitNot DIRECT_OP_TO_INST.set = DIRECT_OP_TO_INST
-OpKind::OpBitOr InstKind::InstBitOr DIRECT_OP_TO_INST.set = DIRECT_OP_TO_INST
-OpKind::OpBitXor InstKind::InstBitXor DIRECT_OP_TO_INST.set = DIRECT_OP_TO_INST
-OpKind::OpDiv InstKind::InstDiv DIRECT_OP_TO_INST.set = DIRECT_OP_TO_INST
-OpKind::OpDrop InstKind::InstDrop DIRECT_OP_TO_INST.set = DIRECT_OP_TO_INST
-OpKind::OpDup InstKind::InstDup DIRECT_OP_TO_INST.set = DIRECT_OP_TO_INST
-OpKind::OpEq InstKind::InstEq DIRECT_OP_TO_INST.set = DIRECT_OP_TO_INST
-OpKind::OpFnExec InstKind::InstFnExec DIRECT_OP_TO_INST.set = DIRECT_OP_TO_INST
-OpKind::OpFnReturn InstKind::InstFnReturn DIRECT_OP_TO_INST.set = DIRECT_OP_TO_INST
-OpKind::OpGe InstKind::InstGe DIRECT_OP_TO_INST.set = DIRECT_OP_TO_INST
-OpKind::OpGt InstKind::InstGt DIRECT_OP_TO_INST.set = DIRECT_OP_TO_INST
-OpKind::OpHeapAlloc InstKind::InstHeapAlloc DIRECT_OP_TO_INST.set = DIRECT_OP_TO_INST
-OpKind::OpLe InstKind::InstLe DIRECT_OP_TO_INST.set = DIRECT_OP_TO_INST
-OpKind::OpLoad8 InstKind::InstLoad8 DIRECT_OP_TO_INST.set = DIRECT_OP_TO_INST
-OpKind::OpLoad16 InstKind::InstLoad16 DIRECT_OP_TO_INST.set = DIRECT_OP_TO_INST
-OpKind::OpLoad32 InstKind::InstLoad32 DIRECT_OP_TO_INST.set = DIRECT_OP_TO_INST
-OpKind::OpLoad64 InstKind::InstLoad64 DIRECT_OP_TO_INST.set = DIRECT_OP_TO_INST
-OpKind::OpLt InstKind::InstLt DIRECT_OP_TO_INST.set = DIRECT_OP_TO_INST
-OpKind::OpMod InstKind::InstMod DIRECT_OP_TO_INST.set = DIRECT_OP_TO_INST
-OpKind::OpMul InstKind::InstMul DIRECT_OP_TO_INST.set = DIRECT_OP_TO_INST
-OpKind::OpNe InstKind::InstNe DIRECT_OP_TO_INST.set = DIRECT_OP_TO_INST
-OpKind::OpNot InstKind::InstNot DIRECT_OP_TO_INST.set = DIRECT_OP_TO_INST
-OpKind::OpOr InstKind::InstOr DIRECT_OP_TO_INST.set = DIRECT_OP_TO_INST
-OpKind::OpOver InstKind::InstOver DIRECT_OP_TO_INST.set = DIRECT_OP_TO_INST
-OpKind::OpPrintBool InstKind::InstPrintBool DIRECT_OP_TO_INST.set = DIRECT_OP_TO_INST
-OpKind::OpPrintChar InstKind::InstPrintChar DIRECT_OP_TO_INST.set = DIRECT_OP_TO_INST
-OpKind::OpPrintCstr InstKind::InstPrintCstr DIRECT_OP_TO_INST.set = DIRECT_OP_TO_INST
-OpKind::OpPrintInt InstKind::InstPrintInt DIRECT_OP_TO_INST.set = DIRECT_OP_TO_INST
-OpKind::OpPrintStr InstKind::InstPrintStr DIRECT_OP_TO_INST.set = DIRECT_OP_TO_INST
-OpKind::OpRot InstKind::InstRot DIRECT_OP_TO_INST.set = DIRECT_OP_TO_INST
-OpKind::OpShl InstKind::InstShl DIRECT_OP_TO_INST.set = DIRECT_OP_TO_INST
-OpKind::OpShr InstKind::InstShr DIRECT_OP_TO_INST.set = DIRECT_OP_TO_INST
-OpKind::OpStore8 InstKind::InstStore8 DIRECT_OP_TO_INST.set = DIRECT_OP_TO_INST
-OpKind::OpStore16 InstKind::InstStore16 DIRECT_OP_TO_INST.set = DIRECT_OP_TO_INST
-OpKind::OpStore32 InstKind::InstStore32 DIRECT_OP_TO_INST.set = DIRECT_OP_TO_INST
-OpKind::OpStore64 InstKind::InstStore64 DIRECT_OP_TO_INST.set = DIRECT_OP_TO_INST
-OpKind::OpSub InstKind::InstSub DIRECT_OP_TO_INST.set = DIRECT_OP_TO_INST
-OpKind::OpSwap InstKind::InstSwap DIRECT_OP_TO_INST.set = DIRECT_OP_TO_INST
-OpKind::OpSyscall0 InstKind::InstSyscall0 DIRECT_OP_TO_INST.set = DIRECT_OP_TO_INST
-OpKind::OpSyscall1 InstKind::InstSyscall1 DIRECT_OP_TO_INST.set = DIRECT_OP_TO_INST
-OpKind::OpSyscall2 InstKind::InstSyscall2 DIRECT_OP_TO_INST.set = DIRECT_OP_TO_INST
-OpKind::OpSyscall3 InstKind::InstSyscall3 DIRECT_OP_TO_INST.set = DIRECT_OP_TO_INST
-OpKind::OpSyscall4 InstKind::InstSyscall4 DIRECT_OP_TO_INST.set = DIRECT_OP_TO_INST
-OpKind::OpSyscall5 InstKind::InstSyscall5 DIRECT_OP_TO_INST.set = DIRECT_OP_TO_INST
-OpKind::OpSyscall6 InstKind::InstSyscall6 DIRECT_OP_TO_INST.set = DIRECT_OP_TO_INST
-OpKind::OpArgc InstKind::InstArgc DIRECT_OP_TO_INST.set = DIRECT_OP_TO_INST
-OpKind::OpArgv InstKind::InstArgv DIRECT_OP_TO_INST.set = DIRECT_OP_TO_INST
+
+fn direct_op_to_inst value:OpValue -> Option[InstKind] {
+    value match
+        OpValue::Add => InstKind::InstAdd Option::Some
+        OpValue::And => InstKind::InstAnd Option::Some
+        OpValue::BitAnd => InstKind::InstBitAnd Option::Some
+        OpValue::BitNot => InstKind::InstBitNot Option::Some
+        OpValue::BitOr => InstKind::InstBitOr Option::Some
+        OpValue::BitXor => InstKind::InstBitXor Option::Some
+        OpValue::Div => InstKind::InstDiv Option::Some
+        OpValue::Drop => InstKind::InstDrop Option::Some
+        OpValue::Dup => InstKind::InstDup Option::Some
+        OpValue::Eq => InstKind::InstEq Option::Some
+        OpValue::FnExec => InstKind::InstFnExec Option::Some
+        OpValue::FnReturn => InstKind::InstFnReturn Option::Some
+        OpValue::Ge => InstKind::InstGe Option::Some
+        OpValue::Gt => InstKind::InstGt Option::Some
+        OpValue::HeapAlloc => InstKind::InstHeapAlloc Option::Some
+        OpValue::Le => InstKind::InstLe Option::Some
+        OpValue::Load8 => InstKind::InstLoad8 Option::Some
+        OpValue::Load16 => InstKind::InstLoad16 Option::Some
+        OpValue::Load32 => InstKind::InstLoad32 Option::Some
+        OpValue::Load64 => InstKind::InstLoad64 Option::Some
+        OpValue::Lt => InstKind::InstLt Option::Some
+        OpValue::Mod => InstKind::InstMod Option::Some
+        OpValue::Mul => InstKind::InstMul Option::Some
+        OpValue::Ne => InstKind::InstNe Option::Some
+        OpValue::Not => InstKind::InstNot Option::Some
+        OpValue::Or => InstKind::InstOr Option::Some
+        OpValue::Over => InstKind::InstOver Option::Some
+        OpValue::PrintBool => InstKind::InstPrintBool Option::Some
+        OpValue::PrintChar => InstKind::InstPrintChar Option::Some
+        OpValue::PrintCstr => InstKind::InstPrintCstr Option::Some
+        OpValue::PrintInt => InstKind::InstPrintInt Option::Some
+        OpValue::PrintStr => InstKind::InstPrintStr Option::Some
+        OpValue::Rot => InstKind::InstRot Option::Some
+        OpValue::Shl => InstKind::InstShl Option::Some
+        OpValue::Shr => InstKind::InstShr Option::Some
+        OpValue::Store8 => InstKind::InstStore8 Option::Some
+        OpValue::Store16 => InstKind::InstStore16 Option::Some
+        OpValue::Store32 => InstKind::InstStore32 Option::Some
+        OpValue::Store64 => InstKind::InstStore64 Option::Some
+        OpValue::Sub => InstKind::InstSub Option::Some
+        OpValue::Swap => InstKind::InstSwap Option::Some
+        OpValue::Syscall0 => InstKind::InstSyscall0 Option::Some
+        OpValue::Syscall1 => InstKind::InstSyscall1 Option::Some
+        OpValue::Syscall2 => InstKind::InstSyscall2 Option::Some
+        OpValue::Syscall3 => InstKind::InstSyscall3 Option::Some
+        OpValue::Syscall4 => InstKind::InstSyscall4 Option::Some
+        OpValue::Syscall5 => InstKind::InstSyscall5 Option::Some
+        OpValue::Syscall6 => InstKind::InstSyscall6 Option::Some
+        OpValue::Argc => InstKind::InstArgc Option::Some
+        OpValue::Argv => InstKind::InstArgv Option::Some
+        _ => Option::None(Option[InstKind])
+    end
+}
 
 # ============================================================================
 # List helpers for variables

--- a/compiler/syntax.casa
+++ b/compiler/syntax.casa
@@ -31,45 +31,55 @@ symbol_store_new = DEFAULT_STORE
 DEFAULT_STORE make_parser = DEFAULT_PARSER
 
 # ============================================================================
-# Simple keyword -> OpKind mapping
+# Simple keyword -> OpValue lookup (no-payload variants only)
 # ============================================================================
-Map::new(Map[KeywordKind OpKind]) = SIMPLE_KEYWORD_OPS
-KeywordKind::Break OpKind::OpWhileBreak SIMPLE_KEYWORD_OPS.set = SIMPLE_KEYWORD_OPS
-KeywordKind::Continue OpKind::OpWhileContinue SIMPLE_KEYWORD_OPS.set = SIMPLE_KEYWORD_OPS
-KeywordKind::Do OpKind::OpWhileCondition SIMPLE_KEYWORD_OPS.set = SIMPLE_KEYWORD_OPS
-KeywordKind::Done OpKind::OpWhileEnd SIMPLE_KEYWORD_OPS.set = SIMPLE_KEYWORD_OPS
-KeywordKind::Elif OpKind::OpIfElif SIMPLE_KEYWORD_OPS.set = SIMPLE_KEYWORD_OPS
-KeywordKind::Else OpKind::OpIfElse SIMPLE_KEYWORD_OPS.set = SIMPLE_KEYWORD_OPS
-KeywordKind::Fi OpKind::OpIfEnd SIMPLE_KEYWORD_OPS.set = SIMPLE_KEYWORD_OPS
-KeywordKind::If OpKind::OpIfStart SIMPLE_KEYWORD_OPS.set = SIMPLE_KEYWORD_OPS
-KeywordKind::Return OpKind::OpFnReturn SIMPLE_KEYWORD_OPS.set = SIMPLE_KEYWORD_OPS
-KeywordKind::Then OpKind::OpIfCondition SIMPLE_KEYWORD_OPS.set = SIMPLE_KEYWORD_OPS
-KeywordKind::While OpKind::OpWhileStart SIMPLE_KEYWORD_OPS.set = SIMPLE_KEYWORD_OPS
+
+fn keyword_to_op_value keyword_kind:KeywordKind -> Option[OpValue] {
+    keyword_kind match
+        KeywordKind::Break => OpValue::WhileBreak Option::Some
+        KeywordKind::Continue => OpValue::WhileContinue Option::Some
+        KeywordKind::Do => OpValue::WhileCondition Option::Some
+        KeywordKind::Done => OpValue::WhileEnd Option::Some
+        KeywordKind::Elif => OpValue::IfElif Option::Some
+        KeywordKind::Else => OpValue::IfElse Option::Some
+        KeywordKind::Fi => OpValue::IfEnd Option::Some
+        KeywordKind::If => OpValue::IfStart Option::Some
+        KeywordKind::Return => OpValue::FnReturn Option::Some
+        KeywordKind::Then => OpValue::IfCondition Option::Some
+        KeywordKind::While => OpValue::WhileStart Option::Some
+        _ => Option::None(Option[OpValue])
+    end
+}
 
 # ============================================================================
-# Operator -> OpKind mapping
+# Operator -> OpValue lookup
 # ============================================================================
-Map::new(Map[OperatorKind OpKind]) = OPERATOR_TO_OPKIND
-OperatorKind::Plus OpKind::OpAdd OPERATOR_TO_OPKIND.set = OPERATOR_TO_OPKIND
-OperatorKind::Minus OpKind::OpSub OPERATOR_TO_OPKIND.set = OPERATOR_TO_OPKIND
-OperatorKind::Mul OpKind::OpMul OPERATOR_TO_OPKIND.set = OPERATOR_TO_OPKIND
-OperatorKind::Div OpKind::OpDiv OPERATOR_TO_OPKIND.set = OPERATOR_TO_OPKIND
-OperatorKind::Mod OpKind::OpMod OPERATOR_TO_OPKIND.set = OPERATOR_TO_OPKIND
-OperatorKind::Shl OpKind::OpShl OPERATOR_TO_OPKIND.set = OPERATOR_TO_OPKIND
-OperatorKind::Shr OpKind::OpShr OPERATOR_TO_OPKIND.set = OPERATOR_TO_OPKIND
-OperatorKind::BitAnd OpKind::OpBitAnd OPERATOR_TO_OPKIND.set = OPERATOR_TO_OPKIND
-OperatorKind::BitOr OpKind::OpBitOr OPERATOR_TO_OPKIND.set = OPERATOR_TO_OPKIND
-OperatorKind::BitXor OpKind::OpBitXor OPERATOR_TO_OPKIND.set = OPERATOR_TO_OPKIND
-OperatorKind::BitNot OpKind::OpBitNot OPERATOR_TO_OPKIND.set = OPERATOR_TO_OPKIND
-OperatorKind::And OpKind::OpAnd OPERATOR_TO_OPKIND.set = OPERATOR_TO_OPKIND
-OperatorKind::Or OpKind::OpOr OPERATOR_TO_OPKIND.set = OPERATOR_TO_OPKIND
-OperatorKind::Not OpKind::OpNot OPERATOR_TO_OPKIND.set = OPERATOR_TO_OPKIND
-OperatorKind::Eq OpKind::OpEq OPERATOR_TO_OPKIND.set = OPERATOR_TO_OPKIND
-OperatorKind::Ge OpKind::OpGe OPERATOR_TO_OPKIND.set = OPERATOR_TO_OPKIND
-OperatorKind::Gt OpKind::OpGt OPERATOR_TO_OPKIND.set = OPERATOR_TO_OPKIND
-OperatorKind::Le OpKind::OpLe OPERATOR_TO_OPKIND.set = OPERATOR_TO_OPKIND
-OperatorKind::Lt OpKind::OpLt OPERATOR_TO_OPKIND.set = OPERATOR_TO_OPKIND
-OperatorKind::Ne OpKind::OpNe OPERATOR_TO_OPKIND.set = OPERATOR_TO_OPKIND
+
+fn operator_to_op_value operator_kind:OperatorKind -> Option[OpValue] {
+    operator_kind match
+        OperatorKind::Plus => OpValue::Add Option::Some
+        OperatorKind::Minus => OpValue::Sub Option::Some
+        OperatorKind::Mul => OpValue::Mul Option::Some
+        OperatorKind::Div => OpValue::Div Option::Some
+        OperatorKind::Mod => OpValue::Mod Option::Some
+        OperatorKind::Shl => OpValue::Shl Option::Some
+        OperatorKind::Shr => OpValue::Shr Option::Some
+        OperatorKind::BitAnd => OpValue::BitAnd Option::Some
+        OperatorKind::BitOr => OpValue::BitOr Option::Some
+        OperatorKind::BitXor => OpValue::BitXor Option::Some
+        OperatorKind::BitNot => OpValue::BitNot Option::Some
+        OperatorKind::And => OpValue::And Option::Some
+        OperatorKind::Or => OpValue::Or Option::Some
+        OperatorKind::Not => OpValue::Not Option::Some
+        OperatorKind::Eq => OpValue::Eq Option::Some
+        OperatorKind::Ge => OpValue::Ge Option::Some
+        OperatorKind::Gt => OpValue::Gt Option::Some
+        OperatorKind::Le => OpValue::Le Option::Some
+        OperatorKind::Lt => OpValue::Lt Option::Some
+        OperatorKind::Ne => OpValue::Ne Option::Some
+        _ => Option::None(Option[OpValue])
+    end
+}
 
 # ============================================================================
 # Token cursor
@@ -275,7 +285,7 @@ fn get_op_type_cast cursor:TokenCursor -> Op {
     close_token Token::location Location::span Span::offset = close_offset
     close_offset open_offset - 1 + = length
     length open_offset open_token Token::location Location::file make_location = loc
-    loc OpKind::OpTypeCast cast_type make_op_str
+    loc cast_type OpValue::TypeCast make_op
 }
 
 # ============================================================================
@@ -285,15 +295,15 @@ fn get_op_type_cast cursor:TokenCursor -> Op {
 fn get_op_literal token:Token -> Op {
     token Token::value = value
     if "true" value == then
-        token Token::location OpKind::OpPushBool 1 make_op_int return
+        token Token::location 1 OpValue::PushBool make_op return
     fi
     if "false" value == then
-        token Token::location OpKind::OpPushBool 0 make_op_int return
+        token Token::location 0 OpValue::PushBool make_op return
     fi
     # Integer literal (positive or negative)
     if 0 value.at.is_digit value is_negative_integer_literal || then
         value str_to_int = int_value
-        token Token::location OpKind::OpPushInt int_value make_op_int return
+        token Token::location int_value OpValue::PushInt make_op return
     fi
     # Char literal: 'X'
     if
@@ -302,16 +312,16 @@ fn get_op_literal token:Token -> Op {
     3 value.length == &&
     then
         1 value.at (int) = char_value
-        token Token::location OpKind::OpPushChar char_value make_op_int return
+        token Token::location char_value OpValue::PushChar make_op return
     fi
     # String literal: "..."
     if '"' 0 value.at == '"' value.length 1 - value.at == && then
         value 1 value.length 2 - str::substring = str_value
-        token Token::location OpKind::OpPushStr str_value make_op_str return
+        token Token::location str_value OpValue::PushStr make_op return
     fi
     token Token::location f"Token `{value}` is not a literal" ErrorKind::Syntax raise_error
     # Unreachable - raise_error exits
-    token Token::location OpKind::OpPushInt 0 make_op_int
+    token Token::location 0 OpValue::PushInt make_op
 }
 
 # ============================================================================
@@ -324,11 +334,11 @@ fn get_op_intrinsic token:Token -> Op {
         token Token::location f"Token `{token Token::value}` is not an intrinsic" ErrorKind::Syntax raise_error
     fi
     kind_opt.unwrap = intrinsic_kind
-    intrinsic_kind INTRINSIC_TO_OPKIND.get = opkind_opt
-    if opkind_opt.is_none then
-        token Token::location f"No OpKind for intrinsic `{token Token::value}`" ErrorKind::Syntax raise_error
+    intrinsic_kind intrinsic_to_op_value = op_value_opt
+    if op_value_opt.is_none then
+        token Token::location f"No OpValue for intrinsic `{token Token::value}`" ErrorKind::Syntax raise_error
     fi
-    token Token::location opkind_opt.unwrap make_op
+    token Token::location op_value_opt.unwrap make_op
 }
 
 # ============================================================================
@@ -356,7 +366,7 @@ fn get_op_operator token:Token cursor:TokenCursor function_name:str -> Op {
                 cursor parse_type = type_annotation
             fi
         fi
-        name_token Token::location OpKind::OpAssignVar var_name make_op_str = assign_op
+        name_token Token::location var_name OpValue::AssignVar make_op = assign_op
         if "" type_annotation != then
             type_annotation assign_op->type_annotation
         fi
@@ -367,21 +377,21 @@ fn get_op_operator token:Token cursor:TokenCursor function_name:str -> Op {
     # Compound assignment: += varname
     if OperatorKind::AssignInc operator_kind == then
         TokenKind::Identifier cursor expect_token_kind = inc_token
-        token Token::location OpKind::OpAssignInc inc_token Token::value make_op_str return
+        token Token::location inc_token Token::value OpValue::AssignInc make_op return
     fi
 
     # Compound assignment: -= varname
     if OperatorKind::AssignDec operator_kind == then
         TokenKind::Identifier cursor expect_token_kind = dec_token
-        token Token::location OpKind::OpAssignDec dec_token Token::value make_op_str return
+        token Token::location dec_token Token::value OpValue::AssignDec make_op return
     fi
 
-    # Simple operator -> opkind via map
-    operator_kind OPERATOR_TO_OPKIND.get = opkind_opt
-    if opkind_opt.is_none then
-        token Token::location f"No OpKind for operator `{token Token::value}`" ErrorKind::Syntax raise_error
+    # Simple operator -> OpValue lookup
+    operator_kind operator_to_op_value = op_value_opt
+    if op_value_opt.is_none then
+        token Token::location f"No OpValue for operator `{token Token::value}`" ErrorKind::Syntax raise_error
     fi
-    token Token::location opkind_opt.unwrap make_op
+    token Token::location op_value_opt.unwrap make_op
 }
 
 # ============================================================================
@@ -413,13 +423,13 @@ fn get_op_array cursor:TokenCursor -> Op {
         if TokenKind::Literal value_token Token::kind == then
             value_token get_op_literal items.push
         elif TokenKind::Identifier value_token Token::kind == then
-            value_token Token::location OpKind::OpIdentifier value_token Token::value make_op_str items.push
+            value_token Token::location value_token Token::value OpValue::Identifier make_op items.push
         else
             value_token Token::location "Unexpected token in array literal" ErrorKind::UnexpectedToken raise_error
         fi
         "," cursor expect_delimiter drop
     done
-    open_token Token::location OpKind::OpPushArray items OpValue::OpList make_op_v
+    open_token Token::location items OpValue::PushArray make_op
 }
 
 # ============================================================================
@@ -484,27 +494,27 @@ fn handle_fstring
         if token_opt.is_none then break fi
         token_opt.unwrap = token
         if TokenKind::FstringText token Token::kind == then
-            token Token::location OpKind::OpPushStr token Token::value make_op_str ops.push
+            token Token::location token Token::value OpValue::PushStr make_op ops.push
             1 += part_count
         elif TokenKind::FstringExprStart token Token::kind == then
             function_name cursor parser parse_fstring_expr = expr_ops
             f"lambda__{function_name}_o{token Token::location Location::span Span::offset}" = lambda_name
             token Token::location expr_ops lambda_name make_function = lambda_function
             lambda_name lambda_function parser.store.functions.set drop
-            token Token::location OpKind::OpFnPush lambda_name make_op_str ops.push
-            token Token::location OpKind::OpFnExec make_op ops.push
-            token Token::location OpKind::OpFstringToStr "" make_op_str ops.push
+            token Token::location lambda_name OpValue::FnPush make_op ops.push
+            token Token::location OpValue::FnExec make_op ops.push
+            token Token::location OpValue::FstringToStr make_op ops.push
             1 += part_count
         elif TokenKind::FstringEnd token Token::kind == then
             break
         fi
     done
     if 0 part_count == then
-        start_token Token::location OpKind::OpPushStr "" make_op_str ops.push
+        start_token Token::location "" OpValue::PushStr make_op ops.push
         1 = part_count
     fi
     if 1 part_count > then
-        start_token Token::location OpKind::OpFstringConcat part_count make_op_int ops.push
+        start_token Token::location part_count OpValue::FstringConcat make_op ops.push
     fi
 }
 
@@ -519,14 +529,14 @@ fn get_op_delimiter parser:Parser token:Token cursor:TokenCursor function_name:s
     if "->" value == then
         TokenKind::Identifier cursor expect_token_kind = member_token
         f"set_{member_token Token::value}" = god_setter_name
-        member_token Token::location OpKind::OpMethodCall god_setter_name make_op_str ops.push
+        member_token Token::location god_setter_name OpValue::MethodCall make_op ops.push
         return
     fi
 
     # Dot . method
     if "." value == then
         TokenKind::Identifier cursor expect_token_kind = method_token
-        method_token Token::location OpKind::OpMethodCall method_token Token::value make_op_str ops.push
+        method_token Token::location method_token Token::value OpValue::MethodCall make_op ops.push
         return
     fi
 
@@ -537,7 +547,7 @@ fn get_op_delimiter parser:Parser token:Token cursor:TokenCursor function_name:s
         f"lambda__{function_name}_o{token Token::location Location::span Span::offset}" = lambda_name
         token Token::location lambda_ops lambda_name make_function = lambda_function
         lambda_name lambda_function parser.store.functions.set drop
-        token Token::location OpKind::OpFnPush lambda_name make_op_str ops.push
+        token Token::location lambda_name OpValue::FnPush make_op ops.push
         return
     fi
 
@@ -617,7 +627,7 @@ fn try_parse_is_check token:Token cursor:TokenCursor -> Option[Op] {
 
     Option::None variant_name enum_name make_enum_variant = variant
     bindings variant EnumVariant::set_bindings
-    token Token::location OpKind::OpIsCheck variant OpValue::EnumVariant make_op_v Option::Some
+    token Token::location variant OpValue::IsCheck make_op Option::Some
 }
 
 # ============================================================================
@@ -935,7 +945,7 @@ fn parse_function parser:Parser cursor:TokenCursor -> Function {
             hidden HiddenTraitMethod::fn_type = hidden_type
             hidden_name hidden_type make_named_param hidden_params.push
             hidden_type hidden_name Variable variables.push
-            name_token Token::location OpKind::OpAssignVar hidden_name make_op_str ops.push
+            name_token Token::location hidden_name OpValue::AssignVar make_op ops.push
         done
         # Prepend hidden params to signature parameters
         for sig_parameter in sig Signature::parameters.iter do
@@ -949,7 +959,7 @@ fn parse_function parser:Parser cursor:TokenCursor -> Function {
         if "" param Parameter::name != then
             if param Parameter::name "__trait_" str::starts_with ! then
                 param Parameter::typ param Parameter::name Variable variables.push
-                name_token Token::location OpKind::OpAssignVar param Parameter::name make_op_str ops.push
+                name_token Token::location param Parameter::name OpValue::AssignVar make_op ops.push
             fi
         fi
     done
@@ -1058,11 +1068,11 @@ fn create_member_accessor
     # Getter
     f"{struct_name}::{member_name}" = getter_name
     List::new(List[Op]) = getter_ops
-    location OpKind::OpTypeCast "ptr" make_op_str getter_ops.push
-    location OpKind::OpPushInt offset make_op_int getter_ops.push
-    location OpKind::OpAdd make_op getter_ops.push
-    location OpKind::OpLoad64 make_op getter_ops.push
-    location OpKind::OpTypeCast member_type make_op_str getter_ops.push
+    location "ptr" OpValue::TypeCast make_op getter_ops.push
+    location offset OpValue::PushInt make_op getter_ops.push
+    location OpValue::Add make_op getter_ops.push
+    location OpValue::Load64 make_op getter_ops.push
+    location member_type OpValue::TypeCast make_op getter_ops.push
 
     List::new(List[Parameter]) = getter_params
     param_type make_param getter_params.push
@@ -1080,10 +1090,10 @@ fn create_member_accessor
     # Setter
     f"{struct_name}::set_{member_name}" = setter_name
     List::new(List[Op]) = setter_ops
-    location OpKind::OpTypeCast "ptr" make_op_str setter_ops.push
-    location OpKind::OpPushInt offset make_op_int setter_ops.push
-    location OpKind::OpAdd make_op setter_ops.push
-    location OpKind::OpStore64 make_op setter_ops.push
+    location "ptr" OpValue::TypeCast make_op setter_ops.push
+    location offset OpValue::PushInt make_op setter_ops.push
+    location OpValue::Add make_op setter_ops.push
+    location OpValue::Store64 make_op setter_ops.push
 
     List::new(List[Parameter]) = setter_params
     param_type make_param setter_params.push
@@ -1314,7 +1324,7 @@ fn inject_impl_trait_params
         hidden HiddenTraitMethod::fn_type = hidden_type
         hidden_name hidden_type make_named_param hidden_params.push
         hidden_name make_variable function Function::variables.push
-        function Function::location OpKind::OpAssignVar hidden_name make_op_str = assign_op
+        function Function::location hidden_name OpValue::AssignVar make_op = assign_op
         insert_pos assign_op function Function::ops.insert
         1 += insert_pos
     done
@@ -1530,24 +1540,24 @@ fn parse_match_arm_pattern
         function_name cursor parser parse_pattern_terminator = wildcard_guard_ops
         Option::None MATCH_WILDCARD "" make_enum_variant = wildcard
         wildcard_guard_ops wildcard PatternValue::EnumVariant make_match_arm = wildcard_arm
-        arm_token Token::location OpKind::OpMatchArm wildcard_arm OpValue::Match make_op_v ops.push
+        arm_token Token::location wildcard_arm OpValue::MatchArm make_op ops.push
     elif TokenKind::Literal arm_token Token::kind == then
         function_name cursor parser parse_pattern_terminator = literal_guard_ops
         arm_token parse_literal_match_pattern = literal_pattern
         literal_guard_ops literal_pattern PatternValue::Literal make_match_arm = literal_arm
-        arm_token Token::location OpKind::OpMatchArm literal_arm OpValue::Match make_op_v ops.push
+        arm_token Token::location literal_arm OpValue::MatchArm make_op ops.push
     elif TokenKind::Identifier arm_token Token::kind != then
         arm_token Token::location "Expected match pattern or `_`" ErrorKind::UnexpectedToken raise_error
     elif cursor.peek.is_some "{" cursor.peek.unwrap Token::value == && then
         cursor arm_token parser parse_struct_match_pattern = struct_pattern
         function_name cursor parser parse_pattern_terminator = struct_guard_ops
         struct_guard_ops struct_pattern PatternValue::Struct make_match_arm = struct_arm
-        arm_token Token::location OpKind::OpMatchArm struct_arm OpValue::Match make_op_v ops.push
+        arm_token Token::location struct_arm OpValue::MatchArm make_op ops.push
     elif arm_token Token::value "::" str::find 0 > then
         function_name cursor parser parse_pattern_terminator = bare_guard_ops
         Option::None arm_token Token::value "" make_enum_variant = bare_variant
         bare_guard_ops bare_variant PatternValue::EnumVariant make_match_arm = bare_arm
-        arm_token Token::location OpKind::OpMatchArm bare_arm OpValue::Match make_op_v ops.push
+        arm_token Token::location bare_arm OpValue::MatchArm make_op ops.push
     else
         arm_token Token::value "::" str::find = separator
         arm_token Token::value 0 separator str::substring = enum_name
@@ -1575,7 +1585,7 @@ fn parse_match_arm_pattern
         Option::None variant_name enum_name make_enum_variant = variant
         bindings variant EnumVariant::set_bindings
         enum_guard_ops variant PatternValue::EnumVariant make_match_arm = variant_arm
-        arm_token Token::location OpKind::OpMatchArm variant_arm OpValue::Match make_op_v ops.push
+        arm_token Token::location variant_arm OpValue::MatchArm make_op ops.push
     fi
 }
 # Parse a match-arm body (either a `{...}` block or a single-line expression
@@ -1609,12 +1619,12 @@ fn parse_match_arm_body parser:Parser cursor:TokenCursor function_name:str ops:L
 
 fn parse_match_block parser:Parser token:Token cursor:TokenCursor function_name:str -> List[Op] {
     List::new(List[Op]) = ops
-    token Token::location OpKind::OpMatchStart make_op ops.push
+    token Token::location OpValue::MatchStart make_op ops.push
 
     while true do
         cursor expect_token = arm_token
         if "end" arm_token Token::value == then
-            arm_token Token::location OpKind::OpMatchEnd make_op ops.push
+            arm_token Token::location OpValue::MatchEnd make_op ops.push
             break
         fi
         ops function_name cursor arm_token parser parse_match_arm_pattern
@@ -1741,16 +1751,16 @@ fn resolve_import parser:Parser importing_file:str spec:str location:Location ->
 fn handle_keyword_import parser:Parser cursor:TokenCursor -> Op {
     TokenKind::Literal cursor expect_token_kind = path_token
     path_token get_op_literal = literal_op
-    if OpKind::OpPushStr literal_op Op::kind != then
-        path_token Token::location "Expected string literal for import path" ErrorKind::UnexpectedToken raise_error
+    if literal_op.value OpValue::PushStr(spec) is then
+        path_token Token::location = path_location
+        path_location Location::file = importing_file
+        path_location spec importing_file parser resolve_import = resolved
+
+        path_location resolved OpValue::ImportFile make_op return
     fi
-    literal_op op_str_value = spec
-
-    path_token Token::location = path_location
-    path_location Location::file = importing_file
-    path_location spec importing_file parser resolve_import = resolved
-
-    path_location OpKind::OpImportFile resolved make_op_str
+    path_token Token::location "Expected string literal for import path" ErrorKind::UnexpectedToken raise_error
+    # Unreachable - raise_error exits
+    path_token Token::location "" OpValue::ImportFile make_op
 }
 
 # ============================================================================
@@ -1821,17 +1831,17 @@ fn handle_keyword_for parser:Parser token:Token cursor:TokenCursor function_name
 
     # Loop preamble: store iterator into hidden local, then open the while
     # loop with the `next`/`is_some` condition.
-    for_loc OpKind::OpAssignVar hidden_iter_name make_op_str ops.push
-    for_loc OpKind::OpWhileStart make_op ops.push
-    for_loc OpKind::OpPushVar hidden_iter_name make_op_str ops.push
-    for_loc OpKind::OpMethodCall "next" make_op_str ops.push
-    for_loc OpKind::OpAssignVar hidden_opt_name make_op_str ops.push
-    for_loc OpKind::OpPushVar hidden_opt_name make_op_str ops.push
-    for_loc OpKind::OpMethodCall "is_some" make_op_str ops.push
-    for_loc OpKind::OpWhileCondition make_op ops.push
-    for_loc OpKind::OpPushVar hidden_opt_name make_op_str ops.push
-    for_loc OpKind::OpMethodCall "unwrap" make_op_str ops.push
-    for_loc OpKind::OpAssignVar loop_var_name make_op_str ops.push
+    for_loc hidden_iter_name OpValue::AssignVar make_op ops.push
+    for_loc OpValue::WhileStart make_op ops.push
+    for_loc hidden_iter_name OpValue::PushVar make_op ops.push
+    for_loc "next" OpValue::MethodCall make_op ops.push
+    for_loc hidden_opt_name OpValue::AssignVar make_op ops.push
+    for_loc hidden_opt_name OpValue::PushVar make_op ops.push
+    for_loc "is_some" OpValue::MethodCall make_op ops.push
+    for_loc OpValue::WhileCondition make_op ops.push
+    for_loc hidden_opt_name OpValue::PushVar make_op ops.push
+    for_loc "unwrap" OpValue::MethodCall make_op ops.push
+    for_loc loop_var_name OpValue::AssignVar make_op ops.push
 
     # Body phase — emit ops until the matching `done`, then close the while.
     0 = body_nesting_depth
@@ -1844,7 +1854,7 @@ fn handle_keyword_for parser:Parser token:Token cursor:TokenCursor function_name
         body_peek_opt.unwrap = body_token
         if "done" body_token Token::value == 0 body_nesting_depth == && then
             cursor.pop drop
-            body_token Token::location OpKind::OpWhileEnd make_op ops.push
+            body_token Token::location OpValue::WhileEnd make_op ops.push
             return
         fi
         if "while" body_token Token::value == then
@@ -1873,8 +1883,8 @@ fn get_op_keyword parser:Parser token:Token cursor:TokenCursor function_name:str
     fi
     keyword_opt.unwrap = keyword
 
-    # Simple keyword -> opkind mapping
-    keyword SIMPLE_KEYWORD_OPS.get = simple_opt
+    # Simple keyword -> OpValue lookup
+    keyword keyword_to_op_value = simple_opt
     if simple_opt.is_some then
         token Token::location simple_opt.unwrap make_op ops.push
         return
@@ -2055,7 +2065,7 @@ fn parse_struct_literal
     done
 
     field_order name_token Token::value StructLiteral = literal
-    name_token Token::location OpKind::OpStructLiteral literal OpValue::StructLit make_op_v all_ops.push
+    name_token Token::location literal OpValue::StructLiteral make_op all_ops.push
     all_ops
 }
 
@@ -2120,7 +2130,7 @@ fn token_to_op parser:Parser token:Token cursor:TokenCursor function_name:str op
         fi
 
         # Plain identifier
-        token Token::location OpKind::OpIdentifier token Token::value make_op_str ops.push
+        token Token::location token Token::value OpValue::Identifier make_op ops.push
         return
     fi
 
@@ -2164,9 +2174,7 @@ fn parse_ops parser:Parser tokens:List[Token] -> List[Op] {
 
 fn gather_captures parser:Parser lambda_function:Function function:Function {
     for op in lambda_function Function::ops.iter do
-        if OpKind::OpIdentifier op Op::kind != then
-            continue
-        fi
+        if op.value OpValue::Identifier is ! then continue fi
         op op_str_value = name
         false = captured
 
@@ -2191,16 +2199,16 @@ fn gather_captures parser:Parser lambda_function:Function function:Function {
 
 fn resolve_array_identifiers parser:Parser items:List[Op] function:Function errors:List[CasaError] {
     for rai_item in items.iter do
-        if OpKind::OpPushArray rai_item Op::kind == then
+        if rai_item.value OpValue::PushArray is then
             errors function rai_item op_list_of parser resolve_array_identifiers
-        elif OpKind::OpIdentifier rai_item Op::kind == then
+        elif rai_item.value OpValue::Identifier is then
             rai_item op_str_value = rai_name
             if rai_name function Function::variables variable_list_contains then
-                OpKind::OpPushVar rai_item Op::set_kind
+                rai_name OpValue::PushVar rai_item Op::set_value
             elif rai_name function Function::captures variable_list_contains then
-                OpKind::OpPushCapture rai_item Op::set_kind
+                rai_name OpValue::PushCapture rai_item Op::set_value
             elif rai_name parser.store.variables.get.is_some then
-                OpKind::OpPushVar rai_item Op::set_kind
+                rai_name OpValue::PushVar rai_item Op::set_value
             else
                 rai_item Op::location f"Identifier `{rai_name}` is not defined" ErrorKind::UndefinedName make_error errors.push
             fi
@@ -2316,15 +2324,13 @@ fn try_resolve_fn_ref
         if ref_bound_opt.is_some then
             ref_name ref_name "::" str::find 2 + ref_name.length ref_name "::" str::find - 2 - str::substring = ref_trait_method
             f"__trait_{ref_type_var}_{ref_trait_method}" = ref_hidden
-            OpKind::OpPushVar op Op::set_kind
-            ref_hidden OpValue::Str op Op::set_value
+            ref_hidden OpValue::PushVar op Op::set_value
             true return
         fi
     fi
     ref_name parser.store.functions.get = ref_fn_opt
     if ref_fn_opt.is_some then
-        OpKind::OpFnPush op Op::set_kind
-        ref_name OpValue::Str op Op::set_value
+        ref_name OpValue::FnPush op Op::set_value
         true ref_fn_opt.unwrap Function::set_is_used
     else
         op Op::location f"Function `{ref_name}` is not defined" ErrorKind::UndefinedName make_error resolve_errors.push
@@ -2350,9 +2356,8 @@ fn try_resolve_enum_variant_ident
     if 0 ordinal < then
         op Op::location f"Variant `{binding_name}` is not defined in enum `{enum_name}`" ErrorKind::UndefinedName make_error resolve_errors.push
     else
-        OpKind::OpPushEnumVariant op Op::set_kind
         ordinal Option::Some binding_name enum_name make_enum_variant = enum_variant
-        enum_variant OpValue::EnumVariant op Op::set_value
+        enum_variant OpValue::PushEnumVariant op Op::set_value
     fi
     true
 }
@@ -2368,8 +2373,7 @@ fn try_resolve_trait_method_call parser:Parser function:Function op:Op ident:str
     if hidden_var function Function::variables variable_list_contains ! then
         hidden_var make_variable function Function::variables.push
     fi
-    OpKind::OpPushVar op Op::set_kind
-    hidden_var OpValue::Str op Op::set_value
+    hidden_var OpValue::PushVar op Op::set_value
     "trait_exec" op Op::set_type_annotation
     true
 }
@@ -2385,38 +2389,36 @@ fn resolve_plain_identifier
     resolve_errors:List[CasaError]
 {
     if ident function Function::variables variable_list_contains then
-        OpKind::OpPushVar op Op::set_kind
+        ident OpValue::PushVar op Op::set_value
         return
     fi
 
     ident parser.store.functions.get = generic_fn_opt
     if generic_fn_opt.is_some then
-        OpKind::OpFnCall op Op::set_kind
+        ident OpValue::FnCall op Op::set_value
         true generic_fn_opt.unwrap Function::set_is_used
         return
     fi
 
     if ident function Function::captures variable_list_contains then
-        OpKind::OpPushCapture op Op::set_kind
+        ident OpValue::PushCapture op Op::set_value
         return
     fi
 
     if ident parser.store.variables.get.is_some then
-        OpKind::OpPushVar op Op::set_kind
+        ident OpValue::PushVar op Op::set_value
         return
     fi
 
     ident parser.store.structs.get = struct_opt
     if struct_opt.is_some then
-        OpKind::OpStructNew op Op::set_kind
-        struct_opt.unwrap OpValue::Struct op Op::set_value
+        struct_opt.unwrap OpValue::StructNew op Op::set_value
         return
     fi
 
     ident parser.store.enums.get = resolved_enum_opt
     if resolved_enum_opt.is_some then
-        OpKind::OpPushInt op Op::set_kind
-        resolved_enum_opt.unwrap CasaEnum::variants.length OpValue::Int op Op::set_value
+        resolved_enum_opt.unwrap CasaEnum::variants.length OpValue::PushInt op Op::set_value
         return
     fi
 
@@ -2429,10 +2431,9 @@ fn resolve_identifiers_fn parser:Parser ops:List[Op] function:Function -> List[O
     while op_index ops.length > do
         op_index ops.get = current_op
         1 += op_index
-        current_op Op::kind = op_kind
 
         # ASSIGN_VARIABLE: register variable
-        if OpKind::OpAssignVar op_kind == then
+        if current_op.value OpValue::AssignVar is then
             current_op op_str_value = var_name
             var_name make_variable = variable
             # Global scope: store in parser.store.variables
@@ -2450,7 +2451,7 @@ fn resolve_identifiers_fn parser:Parser ops:List[Op] function:Function -> List[O
         fi
 
         # FN_PUSH: resolve lambda captures and identifiers
-        if OpKind::OpFnPush op_kind == then
+        if current_op.value OpValue::FnPush is then
             current_op op_str_value = fn_name
             fn_name parser.store.functions.get = lambda_opt
             if lambda_opt.is_some then
@@ -2464,13 +2465,14 @@ fn resolve_identifiers_fn parser:Parser ops:List[Op] function:Function -> List[O
         fi
 
         # PUSH_ARRAY: resolve identifiers inside array literals
-        if OpKind::OpPushArray op_kind == then
-            resolve_errors function current_op op_list_of parser resolve_array_identifiers
+        if current_op.value OpValue::PushArray is then
+            current_op op_list_of = items_inner
+            resolve_errors function items_inner parser resolve_array_identifiers
             continue
         fi
 
         # IDENTIFIER: resolve to specific op kinds
-        if OpKind::OpIdentifier op_kind == then
+        if current_op.value OpValue::Identifier is then
             current_op op_str_value = ident
             if resolve_errors ident current_op function parser try_resolve_fn_ref then continue fi
             if resolve_errors ident current_op parser try_resolve_enum_variant_ident then continue fi
@@ -2480,20 +2482,20 @@ fn resolve_identifiers_fn parser:Parser ops:List[Op] function:Function -> List[O
         fi
 
         # MATCH_ARM: delegate to the pattern module.
-        if OpKind::OpMatchArm op_kind == then
+        if current_op.value OpValue::MatchArm is then
             resolve_errors current_op function parser resolve_match_op
             continue
         fi
 
         # IS_CHECK: resolve enum variant
-        if OpKind::OpIsCheck op_kind == then
+        if current_op.value OpValue::IsCheck is then
             current_op enum_variant_of = is_enum_variant
             resolve_errors function current_op is_enum_variant parser resolve_enum_variant
             continue
         fi
 
         # IMPORT_FILE: process imported file
-        if OpKind::OpImportFile op_kind == then
+        if current_op.value OpValue::ImportFile is then
             current_op op_str_value = import_path
             # Resilient mode may produce an empty path when resolve_import
             # already reported a "module not found" error; skip the read.

--- a/compiler/typechecker.casa
+++ b/compiler/typechecker.casa
@@ -653,10 +653,10 @@ fn apply_signature tc:TypeChecker sig:Signature name:str {
 # ============================================================================
 
 fn check_arithmetic tc:TypeChecker op:Op {
-    op Op::kind = op_kind
+    op.value = op_value
     if
-    OpKind::OpAdd op_kind ==
-    OpKind::OpSub op_kind == ||
+    op_value OpValue::Add is
+    op_value OpValue::Sub is ||
     then
         "int" tc expect_type drop
         tc stack_pop = top_type
@@ -695,8 +695,8 @@ fn check_comparison tc:TypeChecker op:Op {
             f"Cannot compare `{type2}` with `{type1}`" tc raise_type_mismatch
         fi
         if
-        OpKind::OpEq op Op::kind !=
-        OpKind::OpNe op Op::kind != &&
+        op.value OpValue::Eq is !
+        op.value OpValue::Ne is ! &&
         then
             "Type `str` only supports `==` and `!=` comparison" tc raise_type_mismatch
         fi
@@ -710,7 +710,7 @@ fn check_comparison tc:TypeChecker op:Op {
 # ============================================================================
 
 fn check_boolean tc:TypeChecker op:Op {
-    if OpKind::OpNot op Op::kind == then
+    if op.value OpValue::Not is then
         tc stack_pop drop
     else
         tc stack_pop drop
@@ -724,13 +724,13 @@ fn check_boolean tc:TypeChecker op:Op {
 # ============================================================================
 
 fn check_bitwise tc:TypeChecker op:Op {
-    op Op::kind = bitwise_kind
-    if OpKind::OpBitNot bitwise_kind == then
+    op.value = bitwise_value
+    if bitwise_value OpValue::BitNot is then
         "int" tc expect_type drop
         "int" tc stack_push
     elif
-    OpKind::OpShl bitwise_kind ==
-    OpKind::OpShr bitwise_kind == ||
+    bitwise_value OpValue::Shl is
+    bitwise_value OpValue::Shr is ||
     then
         "int" tc expect_type drop
         tc stack_pop = shift_top
@@ -747,25 +747,25 @@ fn check_bitwise tc:TypeChecker op:Op {
 # ============================================================================
 
 fn check_stack_ops tc:TypeChecker op:Op {
-    op Op::kind = kind
-    if OpKind::OpDrop kind == then
+    op.value = stack_value
+    if stack_value OpValue::Drop is then
         tc stack_pop drop
-    elif OpKind::OpDup kind == then
+    elif stack_value OpValue::Dup is then
         tc stack_pop = typ
         typ tc stack_push
         typ tc stack_push
-    elif OpKind::OpSwap kind == then
+    elif stack_value OpValue::Swap is then
         tc stack_pop = type1
         tc stack_pop = type2
         type1 tc stack_push
         type2 tc stack_push
-    elif OpKind::OpOver kind == then
+    elif stack_value OpValue::Over is then
         tc stack_pop = type1
         tc stack_pop = type2
         type2 tc stack_push
         type1 tc stack_push
         type2 tc stack_push
-    elif OpKind::OpRot kind == then
+    elif stack_value OpValue::Rot is then
         tc stack_pop = type1
         tc stack_pop = type2
         tc stack_pop = type3
@@ -780,24 +780,24 @@ fn check_stack_ops tc:TypeChecker op:Op {
 # ============================================================================
 
 fn check_memory tc:TypeChecker op:Op {
-    op Op::kind = kind
+    op.value = mem_value
     if
-    OpKind::OpLoad8 kind ==
-    OpKind::OpLoad16 kind == ||
-    OpKind::OpLoad32 kind == ||
-    OpKind::OpLoad64 kind == ||
+    mem_value OpValue::Load8 is
+    mem_value OpValue::Load16 is ||
+    mem_value OpValue::Load32 is ||
+    mem_value OpValue::Load64 is ||
     then
         "ptr" tc expect_type drop
         "int" tc stack_push
     elif
-    OpKind::OpStore8 kind ==
-    OpKind::OpStore16 kind == ||
-    OpKind::OpStore32 kind == ||
-    OpKind::OpStore64 kind == ||
+    mem_value OpValue::Store8 is
+    mem_value OpValue::Store16 is ||
+    mem_value OpValue::Store32 is ||
+    mem_value OpValue::Store64 is ||
     then
         "ptr" tc expect_type drop
         tc stack_pop drop
-    elif OpKind::OpHeapAlloc kind == then
+    elif mem_value OpValue::HeapAlloc is then
         "int" tc expect_type drop
         "ptr" tc stack_push
     fi
@@ -827,8 +827,8 @@ fn unify_variable_assignment op:Op variable:Variable effective_type:str scope:st
 
 fn check_assignment tc:TypeChecker op:Op function_opt:Option[Function] {
     if
-    OpKind::OpAssignDec op Op::kind ==
-    OpKind::OpAssignInc op Op::kind == ||
+    op.value OpValue::AssignDec is
+    op.value OpValue::AssignInc is ||
     then
         "int" tc expect_type drop
         return
@@ -895,7 +895,7 @@ fn simulate_trait_exec tc:TypeChecker function:Function var_name:str {
 }
 
 fn check_push_var tc:TypeChecker op:Op function_opt:Option[Function] {
-    if OpKind::OpPushCapture op Op::kind == then
+    if op.value OpValue::PushCapture is then
         op op_str_value = capture_name
         if function_opt.is_some then
             function_opt.unwrap = function
@@ -954,14 +954,14 @@ fn check_push_var tc:TypeChecker op:Op function_opt:Option[Function] {
 # ============================================================================
 
 fn check_if_block tc:TypeChecker op:Op {
-    op Op::kind = kind
-    if OpKind::OpIfStart kind == then
+    op.value = if_value
+    if if_value OpValue::IfStart is then
         make_if_context = if_ctx
         op Op::location if_ctx IfContext::set_current_branch_location
         if_ctx BranchFrame::BranchIf = if_frame
         if_frame tc TypeChecker::branched_stacks.push
         true tc TypeChecker::set_in_branch_condition
-    elif OpKind::OpIfCondition kind == then
+    elif if_value OpValue::IfCondition is then
         false tc TypeChecker::set_in_branch_condition
         "bool" tc expect_type drop
         if 0 tc TypeChecker::branched_stacks.length == then return fi
@@ -975,13 +975,13 @@ fn check_if_block tc:TypeChecker op:Op {
             fi
         fi
     elif
-    OpKind::OpIfElif kind ==
-    OpKind::OpIfElse kind == ||
+    if_value OpValue::IfElif is
+    if_value OpValue::IfElse is ||
     then
         if 0 tc TypeChecker::branched_stacks.length == then return fi
         tc TypeChecker::branched_stacks.length 1 - tc TypeChecker::branched_stacks.get = top_frame
         if top_frame BranchFrame::BranchIf(if_ctx) is then
-            if OpKind::OpIfElse kind == then
+            if if_value OpValue::IfElse is then
                 true if_ctx IfContext::set_default_present
                 false tc TypeChecker::set_in_branch_condition
             else
@@ -1008,7 +1008,7 @@ fn check_if_block tc:TypeChecker op:Op {
             fi
             op Op::location "Branches have incompatible stack effects" ErrorKind::StackMismatch add_error
         fi
-    elif OpKind::OpIfEnd kind == then
+    elif if_value OpValue::IfEnd is then
         tc TypeChecker::branched_stacks.pop = top_frame
         if top_frame BranchFrame::BranchIf(if_ctx) is then
             if_ctx IfContext::before = if_before
@@ -1038,14 +1038,14 @@ fn check_if_block tc:TypeChecker op:Op {
 # ============================================================================
 
 fn check_while_block tc:TypeChecker op:Op {
-    op Op::kind = kind
-    if OpKind::OpWhileStart kind == then
+    op.value = while_value
+    if while_value OpValue::WhileStart is then
         make_while_context = while_ctx
         tc TypeChecker::live while_ctx WhileContext::before.restore
         op Op::location while_ctx WhileContext::set_current_branch_location
         while_ctx BranchFrame::BranchWhile = while_frame
         while_frame tc TypeChecker::branched_stacks.push
-    elif OpKind::OpWhileCondition kind == then
+    elif while_value OpValue::WhileCondition is then
         "bool" tc expect_type drop
         if 0 tc TypeChecker::branched_stacks.length == then return fi
         tc TypeChecker::branched_stacks.length 1 - tc TypeChecker::branched_stacks.get = top_frame
@@ -1053,11 +1053,11 @@ fn check_while_block tc:TypeChecker op:Op {
             true while_ctx WhileContext::set_condition_present
         fi
     elif
-    OpKind::OpWhileBreak kind ==
-    OpKind::OpWhileContinue kind == ||
+    while_value OpValue::WhileBreak is
+    while_value OpValue::WhileContinue is ||
     then
         if 0 tc TypeChecker::branched_stacks.length == then return fi
-    elif OpKind::OpWhileEnd kind == then
+    elif while_value OpValue::WhileEnd is then
         tc TypeChecker::branched_stacks.pop drop
     fi
 }
@@ -1378,9 +1378,9 @@ fn inject_trait_fn_ptrs
 
     # Check TYPE_CAST lookahead for return type binding
     if op_index ops.length > then
-        op_index ops.get Op::kind = next_kind
-        if OpKind::OpTypeCast next_kind == then
-            op_index ops.get op_str_value = cast_type
+        op_index ops.get = next_op
+        if next_op.value OpValue::TypeCast is then
+            next_op op_str_value = cast_type
             for return_type in sig Signature::return_types.iter do
                 sig Signature::type_vars cast_type return_type bindings bind_generic_params_standalone = bindings
             done
@@ -1429,7 +1429,7 @@ fn inject_trait_fn_ptrs
                 method_index trait_def CasaTrait::methods.get = method
                 if 0 method TraitMethod::default_ops.length == then
                     f"__trait_{concrete}_{method TraitMethod::name}" = hidden_var
-                    location OpKind::OpPushVar hidden_var make_op_str = push_op
+                    location hidden_var OpValue::PushVar make_op = push_op
                     insert_pos push_op ops.insert
                     1 += insert_pos
                     1 += inserted
@@ -1466,7 +1466,7 @@ fn inject_trait_fn_ptrs
                         global_fn global_fn Function::ops resolve_identifiers global_fn Function::set_ops
                     fi
                     global_fn ensure_typechecked
-                    location OpKind::OpFnPush fn_name make_op_str = push_op
+                    location fn_name OpValue::FnPush make_op = push_op
                     insert_pos push_op ops.insert
                     1 += insert_pos
                     1 += inserted
@@ -1491,8 +1491,8 @@ fn check_function_ops
     op_index:int
     function_opt:Option[Function]
 -> int {
-    op Op::kind = kind
-    if OpKind::OpFnCall kind == then
+    op.value = fn_value
+    if fn_value OpValue::FnCall is then
         op op_str_value = fn_name
         fn_name tc.store.functions.get = fn_opt
         if fn_opt.is_some then
@@ -1505,7 +1505,7 @@ fn check_function_ops
             fi
             fn_name sig tc apply_signature
         fi
-    elif OpKind::OpFnExec kind == then
+    elif fn_value OpValue::FnExec is then
         tc stack_peek = fn_ptr_type
         if ANY_TYPE fn_ptr_type == then "fn" = fn_ptr_type fi
         fn_ptr_type tc expect_type drop
@@ -1515,7 +1515,7 @@ fn check_function_ops
                 "exec" sig_str_opt.unwrap signature_from_str tc apply_signature
             fi
         fi
-    elif OpKind::OpFnPush kind == then
+    elif fn_value OpValue::FnPush is then
         op op_str_value = push_name
         push_name tc.store.functions.get = push_fn_opt
         if push_fn_opt.is_some then
@@ -1525,7 +1525,7 @@ fn check_function_ops
         else
             "fn" tc stack_push
         fi
-    elif OpKind::OpFnReturn kind == then
+    elif fn_value OpValue::FnReturn is then
         if tc TypeChecker::has_return_types ! then
             true tc TypeChecker::set_has_return_types
             tc TypeChecker::live tc TypeChecker::return_types.restore
@@ -1549,19 +1549,19 @@ fn check_function_ops
 # ============================================================================
 
 fn check_literals tc:TypeChecker op:Op {
-    op Op::kind = kind
-    if OpKind::OpPushInt kind == then
+    op.value = literal_value
+    if literal_value OpValue::PushInt is then
         "int" tc stack_push
-    elif OpKind::OpPushStr kind == then
+    elif literal_value OpValue::PushStr is then
         "str" tc stack_push
-    elif OpKind::OpPushBool kind == then
+    elif literal_value OpValue::PushBool is then
         "bool" tc stack_push
-    elif OpKind::OpPushChar kind == then
+    elif literal_value OpValue::PushChar is then
         "char" tc stack_push
-    elif OpKind::OpPushArray kind == then
+    elif literal_value OpValue::PushArray is then
         # Array literals: pop N items of same type
         "array[any]" tc stack_push
-    elif OpKind::OpFstringConcat kind == then
+    elif literal_value OpValue::FstringConcat is then
         op op_int_value = count
         0 = index
         while index count > do
@@ -1579,15 +1579,15 @@ fn check_literals tc:TypeChecker op:Op {
 fn check_io tc:TypeChecker op:Op {
     tc stack_pop = typ
     if "str" typ == then
-        OpKind::OpPrintStr op Op::set_kind
+        OpValue::PrintStr op Op::set_value
     elif "bool" typ == then
-        OpKind::OpPrintBool op Op::set_kind
+        OpValue::PrintBool op Op::set_value
     elif "char" typ == then
-        OpKind::OpPrintChar op Op::set_kind
+        OpValue::PrintChar op Op::set_value
     elif "cstr" typ == then
-        OpKind::OpPrintCstr op Op::set_kind
+        OpValue::PrintCstr op Op::set_value
     else
-        OpKind::OpPrintInt op Op::set_kind
+        OpValue::PrintInt op Op::set_value
     fi
 }
 
@@ -1606,10 +1606,16 @@ fn check_typeof tc:TypeChecker op:Op {
 # ============================================================================
 
 fn check_syscalls tc:TypeChecker op:Op {
-    op Op::kind = kind
-    # Calculate arg count from syscall variant
-    OpKind::OpSyscall0(int) = base
-    kind (int) base - = arg_count
+    op.value match
+        OpValue::Syscall0 => 0
+        OpValue::Syscall1 => 1
+        OpValue::Syscall2 => 2
+        OpValue::Syscall3 => 3
+        OpValue::Syscall4 => 4
+        OpValue::Syscall5 => 5
+        OpValue::Syscall6 => 6
+        _ => -1
+    end = arg_count
     "int" tc expect_type drop
     0 = index
     while index arg_count > do
@@ -1684,7 +1690,7 @@ fn check_enum_variant tc:TypeChecker op:Op {
 # Check is keyword
 # ============================================================================
 
-fn check_is tc:TypeChecker op:Op {
+fn check_is tc:TypeChecker op:Op function_opt:Option[Function] {
     tc stack_pop = typ
     typ resolve_match_type = base
     if base tc.store.enums.get.is_none then
@@ -1746,8 +1752,8 @@ fn set_binding_type var_name:str field_type:str function_opt:Option[Function] {
 }
 
 fn check_match tc:TypeChecker op:Op function_opt:Option[Function] {
-    op Op::kind = kind
-    if OpKind::OpMatchStart kind == then
+    op.value = match_value
+    if match_value OpValue::MatchStart is then
         if 0 tc TypeChecker::live TypedStack::types.length == then
             true = inferring_signature
             if function_opt.is_some then
@@ -1769,9 +1775,9 @@ fn check_match tc:TypeChecker op:Op function_opt:Option[Function] {
         op Op::location match_ctx MatchContext::set_current_branch_location
         match_ctx BranchFrame::BranchMatch = match_frame
         match_frame tc TypeChecker::branched_stacks.push
-    elif OpKind::OpMatchArm kind == then
+    elif match_value OpValue::MatchArm is then
         op function_opt tc typecheck_match_op
-    elif OpKind::OpMatchEnd kind == then
+    elif match_value OpValue::MatchEnd is then
         tc TypeChecker::branched_stacks.pop = top_frame
         if top_frame BranchFrame::BranchMatch(match_ctx) is then
             # Record last arm label
@@ -2133,7 +2139,7 @@ fn instantiate_default_trait_method
     for synth_param in resolved_sig Signature::parameters.iter do
         if "" synth_param Parameter::name != then
             synth_param Parameter::typ synth_param Parameter::name Variable synth_vars.push
-            empty_location OpKind::OpAssignVar synth_param Parameter::name make_op_str synth_ops.push
+            empty_location synth_param Parameter::name OpValue::AssignVar make_op synth_ops.push
         fi
     done
 
@@ -2201,10 +2207,9 @@ fn check_method_call
                         constraint_subs receiver trait_method TraitMethod::signature resolve_trait_sig apply_type_subs_to_sig = resolved_sig
                         receiver tc stack_push
                         f"{receiver}::{method_name}" resolved_sig tc apply_signature
-                        OpKind::OpPushVar op Op::set_kind
-                        hidden_var OpValue::Str op Op::set_value
+                        hidden_var OpValue::PushVar op Op::set_value
                         # Insert FN_EXEC op after the PUSH_VARIABLE
-                        op Op::location OpKind::OpFnExec make_op = exec_op
+                        op Op::location OpValue::FnExec make_op = exec_op
                         op_index exec_op ops.insert
                         op_index 1 + return
                     fi
@@ -2258,8 +2263,7 @@ fn check_method_call
             function_opt op Op::location op_index ops sig tc inject_trait_fn_ptrs += op_index
         fi
         fn_name sig tc apply_signature
-        fn_name OpValue::Str op Op::set_value
-        OpKind::OpFnCall op Op::set_kind
+        fn_name OpValue::FnCall op Op::set_value
     else
         op Op::location f"Method `{fn_name}` does not exist" ErrorKind::UndefinedName raise_error
     fi
@@ -2287,8 +2291,7 @@ fn check_fstring_to_str
         "str" tc stack_push
         op_index return
     fi
-    OpKind::OpMethodCall op Op::set_kind
-    "to_str" OpValue::Str op Op::set_value
+    "to_str" OpValue::MethodCall op Op::set_value
     function_opt op_index ops op tc check_method_call
 }
 
@@ -2318,14 +2321,14 @@ fn run_type_check_ops checker:TypeChecker ops:List[Op] function_opt:Option[Funct
         1 += op_index
         current_op Op::location checker TypeChecker::set_current_location
         "" checker TypeChecker::set_current_expect_ctx
-        current_op Op::kind = op_kind
+        current_op.value = op_value
         # Arithmetic
         if
-        OpKind::OpAdd op_kind ==
-        OpKind::OpSub op_kind == ||
-        OpKind::OpMul op_kind == ||
-        OpKind::OpDiv op_kind == ||
-        OpKind::OpMod op_kind == ||
+        op_value OpValue::Add is
+        op_value OpValue::Sub is ||
+        op_value OpValue::Mul is ||
+        op_value OpValue::Div is ||
+        op_value OpValue::Mod is ||
         then
             current_op checker check_arithmetic
             continue
@@ -2333,12 +2336,12 @@ fn run_type_check_ops checker:TypeChecker ops:List[Op] function_opt:Option[Funct
 
         # Comparison
         if
-        OpKind::OpEq op_kind ==
-        OpKind::OpNe op_kind == ||
-        OpKind::OpLt op_kind == ||
-        OpKind::OpLe op_kind == ||
-        OpKind::OpGt op_kind == ||
-        OpKind::OpGe op_kind == ||
+        op_value OpValue::Eq is
+        op_value OpValue::Ne is ||
+        op_value OpValue::Lt is ||
+        op_value OpValue::Le is ||
+        op_value OpValue::Gt is ||
+        op_value OpValue::Ge is ||
         then
             current_op checker check_comparison
             continue
@@ -2346,9 +2349,9 @@ fn run_type_check_ops checker:TypeChecker ops:List[Op] function_opt:Option[Funct
 
         # Boolean
         if
-        OpKind::OpAnd op_kind ==
-        OpKind::OpOr op_kind == ||
-        OpKind::OpNot op_kind == ||
+        op_value OpValue::And is
+        op_value OpValue::Or is ||
+        op_value OpValue::Not is ||
         then
             current_op checker check_boolean
             continue
@@ -2356,12 +2359,12 @@ fn run_type_check_ops checker:TypeChecker ops:List[Op] function_opt:Option[Funct
 
         # Bitwise
         if
-        OpKind::OpBitAnd op_kind ==
-        OpKind::OpBitOr op_kind == ||
-        OpKind::OpBitXor op_kind == ||
-        OpKind::OpBitNot op_kind == ||
-        OpKind::OpShl op_kind == ||
-        OpKind::OpShr op_kind == ||
+        op_value OpValue::BitAnd is
+        op_value OpValue::BitOr is ||
+        op_value OpValue::BitXor is ||
+        op_value OpValue::BitNot is ||
+        op_value OpValue::Shl is ||
+        op_value OpValue::Shr is ||
         then
             current_op checker check_bitwise
             continue
@@ -2369,11 +2372,11 @@ fn run_type_check_ops checker:TypeChecker ops:List[Op] function_opt:Option[Funct
 
         # Stack ops
         if
-        OpKind::OpDrop op_kind ==
-        OpKind::OpDup op_kind == ||
-        OpKind::OpSwap op_kind == ||
-        OpKind::OpOver op_kind == ||
-        OpKind::OpRot op_kind == ||
+        op_value OpValue::Drop is
+        op_value OpValue::Dup is ||
+        op_value OpValue::Swap is ||
+        op_value OpValue::Over is ||
+        op_value OpValue::Rot is ||
         then
             current_op checker check_stack_ops
             continue
@@ -2381,15 +2384,15 @@ fn run_type_check_ops checker:TypeChecker ops:List[Op] function_opt:Option[Funct
 
         # Memory
         if
-        OpKind::OpLoad8 op_kind ==
-        OpKind::OpLoad16 op_kind == ||
-        OpKind::OpLoad32 op_kind == ||
-        OpKind::OpLoad64 op_kind == ||
-        OpKind::OpStore8 op_kind == ||
-        OpKind::OpStore16 op_kind == ||
-        OpKind::OpStore32 op_kind == ||
-        OpKind::OpStore64 op_kind == ||
-        OpKind::OpHeapAlloc op_kind == ||
+        op_value OpValue::Load8 is
+        op_value OpValue::Load16 is ||
+        op_value OpValue::Load32 is ||
+        op_value OpValue::Load64 is ||
+        op_value OpValue::Store8 is ||
+        op_value OpValue::Store16 is ||
+        op_value OpValue::Store32 is ||
+        op_value OpValue::Store64 is ||
+        op_value OpValue::HeapAlloc is ||
         then
             current_op checker check_memory
             continue
@@ -2397,9 +2400,9 @@ fn run_type_check_ops checker:TypeChecker ops:List[Op] function_opt:Option[Funct
 
         # Assignment
         if
-        OpKind::OpAssignVar op_kind ==
-        OpKind::OpAssignDec op_kind == ||
-        OpKind::OpAssignInc op_kind == ||
+        op_value OpValue::AssignVar is
+        op_value OpValue::AssignDec is ||
+        op_value OpValue::AssignInc is ||
         then
             function_opt current_op checker check_assignment
             continue
@@ -2407,8 +2410,8 @@ fn run_type_check_ops checker:TypeChecker ops:List[Op] function_opt:Option[Funct
 
         # Push variable / capture
         if
-        OpKind::OpPushVar op_kind ==
-        OpKind::OpPushCapture op_kind == ||
+        op_value OpValue::PushVar is
+        op_value OpValue::PushCapture is ||
         then
             function_opt current_op checker check_push_var
             continue
@@ -2416,11 +2419,11 @@ fn run_type_check_ops checker:TypeChecker ops:List[Op] function_opt:Option[Funct
 
         # If block
         if
-        OpKind::OpIfStart op_kind ==
-        OpKind::OpIfCondition op_kind == ||
-        OpKind::OpIfElif op_kind == ||
-        OpKind::OpIfElse op_kind == ||
-        OpKind::OpIfEnd op_kind == ||
+        op_value OpValue::IfStart is
+        op_value OpValue::IfCondition is ||
+        op_value OpValue::IfElif is ||
+        op_value OpValue::IfElse is ||
+        op_value OpValue::IfEnd is ||
         then
             current_op checker check_if_block
             continue
@@ -2428,11 +2431,11 @@ fn run_type_check_ops checker:TypeChecker ops:List[Op] function_opt:Option[Funct
 
         # While block
         if
-        OpKind::OpWhileStart op_kind ==
-        OpKind::OpWhileCondition op_kind == ||
-        OpKind::OpWhileBreak op_kind == ||
-        OpKind::OpWhileContinue op_kind == ||
-        OpKind::OpWhileEnd op_kind == ||
+        op_value OpValue::WhileStart is
+        op_value OpValue::WhileCondition is ||
+        op_value OpValue::WhileBreak is ||
+        op_value OpValue::WhileContinue is ||
+        op_value OpValue::WhileEnd is ||
         then
             current_op checker check_while_block
             continue
@@ -2440,10 +2443,10 @@ fn run_type_check_ops checker:TypeChecker ops:List[Op] function_opt:Option[Funct
 
         # Function ops
         if
-        OpKind::OpFnCall op_kind ==
-        OpKind::OpFnExec op_kind == ||
-        OpKind::OpFnPush op_kind == ||
-        OpKind::OpFnReturn op_kind == ||
+        op_value OpValue::FnCall is
+        op_value OpValue::FnExec is ||
+        op_value OpValue::FnPush is ||
+        op_value OpValue::FnReturn is ||
         then
             function_opt op_index ops current_op checker check_function_ops = op_index
             continue
@@ -2451,124 +2454,124 @@ fn run_type_check_ops checker:TypeChecker ops:List[Op] function_opt:Option[Funct
 
         # Literals
         if
-        OpKind::OpPushInt op_kind ==
-        OpKind::OpPushStr op_kind == ||
-        OpKind::OpPushBool op_kind == ||
-        OpKind::OpPushChar op_kind == ||
-        OpKind::OpPushArray op_kind == ||
-        OpKind::OpFstringConcat op_kind == ||
+        op_value OpValue::PushInt is
+        op_value OpValue::PushStr is ||
+        op_value OpValue::PushBool is ||
+        op_value OpValue::PushChar is ||
+        op_value OpValue::PushArray is ||
+        op_value OpValue::FstringConcat is ||
         then
             current_op checker check_literals
             continue
         fi
 
         # IO
-        if OpKind::OpPrint op_kind == then
+        if op_value OpValue::Print is then
             current_op checker check_io
             continue
         fi
 
         # Typeof
-        if OpKind::OpTypeof op_kind == then
+        if op_value OpValue::Typeof is then
             current_op checker check_typeof
             continue
         fi
 
         # Syscalls
         if
-        OpKind::OpSyscall0 op_kind ==
-        OpKind::OpSyscall1 op_kind == ||
-        OpKind::OpSyscall2 op_kind == ||
-        OpKind::OpSyscall3 op_kind == ||
-        OpKind::OpSyscall4 op_kind == ||
-        OpKind::OpSyscall5 op_kind == ||
-        OpKind::OpSyscall6 op_kind == ||
+        op_value OpValue::Syscall0 is
+        op_value OpValue::Syscall1 is ||
+        op_value OpValue::Syscall2 is ||
+        op_value OpValue::Syscall3 is ||
+        op_value OpValue::Syscall4 is ||
+        op_value OpValue::Syscall5 is ||
+        op_value OpValue::Syscall6 is ||
         then
             current_op checker check_syscalls
             continue
         fi
 
         # Argc / Argv
-        if OpKind::OpArgc op_kind == then
+        if op_value OpValue::Argc is then
             "int" checker stack_push
             continue
         fi
-        if OpKind::OpArgv op_kind == then
+        if op_value OpValue::Argv is then
             "ptr" checker stack_push
             continue
         fi
 
         # Enum variant
-        if OpKind::OpPushEnumVariant op_kind == then
+        if op_value OpValue::PushEnumVariant is then
             current_op checker check_enum_variant
             continue
         fi
 
         # Is check
-        if OpKind::OpIsCheck op_kind == then
-            current_op checker check_is
+        if op_value OpValue::IsCheck is then
+            function_opt current_op checker check_is
             continue
         fi
 
         # Match block
         if
-        OpKind::OpMatchStart op_kind ==
-        OpKind::OpMatchArm op_kind == ||
-        OpKind::OpMatchEnd op_kind == ||
+        op_value OpValue::MatchStart is
+        op_value OpValue::MatchArm is ||
+        op_value OpValue::MatchEnd is ||
         then
             function_opt current_op checker check_match
             continue
         fi
 
         # Struct new
-        if OpKind::OpStructNew op_kind == then
+        if op_value OpValue::StructNew is then
             current_op checker check_struct_new
             continue
         fi
 
         # Struct literal
-        if OpKind::OpStructLiteral op_kind == then
+        if op_value OpValue::StructLiteral is then
             current_op checker check_struct_literal
             continue
         fi
 
         # Method call
-        if OpKind::OpMethodCall op_kind == then
+        if op_value OpValue::MethodCall is then
             function_opt op_index ops current_op checker check_method_call = op_index
             continue
         fi
 
         # F-string expression -> str conversion (Display trait)
-        if OpKind::OpFstringToStr op_kind == then
+        if op_value OpValue::FstringToStr is then
             function_opt op_index ops current_op checker check_fstring_to_str = op_index
             continue
         fi
 
         # Type cast
-        if OpKind::OpTypeCast op_kind == then
+        if op_value OpValue::TypeCast is then
             checker stack_pop drop
             current_op op_str_value checker stack_push
             continue
         fi
 
         # Import file (no-op in typechecker)
-        if OpKind::OpImportFile op_kind == then
+        if op_value OpValue::ImportFile is then
             continue
         fi
 
         # Print variants (already resolved, should not appear)
         if
-        OpKind::OpPrintBool op_kind ==
-        OpKind::OpPrintChar op_kind == ||
-        OpKind::OpPrintCstr op_kind == ||
-        OpKind::OpPrintInt op_kind == ||
-        OpKind::OpPrintStr op_kind == ||
+        op_value OpValue::PrintBool is
+        op_value OpValue::PrintChar is ||
+        op_value OpValue::PrintCstr is ||
+        op_value OpValue::PrintInt is ||
+        op_value OpValue::PrintStr is ||
         then
             continue
         fi
 
         # Identifier (should be resolved by parser)
-        if OpKind::OpIdentifier op_kind == then
+        if op_value OpValue::Identifier is then
             continue
         fi
     done

--- a/lsp.casa
+++ b/lsp.casa
@@ -125,8 +125,8 @@ struct CompileResult {
 # ============================================================================
 Map::new(Map[str DocumentState]) = DOCUMENT_STATES
 StdinReader::new = STDIN_READER
-Map::new(Map[OpKind str]) = STACK_EFFECTS
-Map::new(Map[OpKind int]) = TOKEN_TYPE_MAP
+# STACK_EFFECTS and TOKEN_TYPE_MAP collapsed into match-based fns
+# (see op_value_stack_effect / op_value_token_type below).
 
 # ============================================================================
 # Coordinate conversion utilities
@@ -697,16 +697,15 @@ fn handle_did_save message:JsonValue {
 
 fn find_best_assignment name:str ops:List[Op] usage_offset:int best:Option[Op] -> Option[Op] {
     for op in ops.iter do
-        if OpKind::OpAssignVar op Op::kind != then
-            continue
-        fi
-        if op op_str_value name != then
-            continue
-        fi
-        if op Op::location Location::span Span::offset usage_offset > then
-            op Option::Some = best
-        elif best.is_none then
-            op Option::Some = best
+        if op.value OpValue::AssignVar is then
+            op op_str_value = assign_name
+            if assign_name name == then
+                if op Op::location Location::span Span::offset usage_offset > then
+                    op Option::Some = best
+                elif best.is_none then
+                    op Option::Some = best
+                fi
+            fi
         fi
     done
     best
@@ -752,10 +751,10 @@ fn compute_definition state:DocumentState line:int col:int -> Option[LspLocation
         return
     fi
 
-    op Op::kind = kind
+    op.value = op_value
 
     # FN_CALL / FN_PUSH
-    if OpKind::OpFnCall kind == OpKind::OpFnPush kind == || then
+    if op_value OpValue::FnCall is op_value OpValue::FnPush is || then
         if QPART_TYPE qpart == then
             op op_str_value "::" str::split = parts
             0 parts.get = type_name
@@ -783,19 +782,19 @@ fn compute_definition state:DocumentState line:int col:int -> Option[LspLocation
     fi
 
     # PUSH_VARIABLE / PUSH_CAPTURE
-    if OpKind::OpPushVar kind == OpKind::OpPushCapture kind == || then
+    if op_value OpValue::PushVar is op_value OpValue::PushCapture is || then
         op Op::location Location::span Span::offset state func op op_str_value find_variable_definition
         return
     fi
 
     # STRUCT_NEW
-    if OpKind::OpStructNew kind == then
+    if op_value OpValue::StructNew is then
         op casa_struct_of CasaStruct::location casa_location_to_lsp Option::Some
         return
     fi
 
     # PUSH_ENUM_VARIANT
-    if OpKind::OpPushEnumVariant kind == then
+    if op_value OpValue::PushEnumVariant is then
         op enum_variant_of = enum_variant
         enum_variant EnumVariant::enum_name = enum_name
         if enum_name state DocumentState::enums.has ! then
@@ -813,7 +812,7 @@ fn compute_definition state:DocumentState line:int col:int -> Option[LspLocation
     fi
 
     # TYPE_CAST
-    if OpKind::OpTypeCast kind == then
+    if op_value OpValue::TypeCast is then
         op op_str_value = cast_type
         if cast_type state DocumentState::structs.has then
             cast_type state DocumentState::structs.get.unwrap CasaStruct::location casa_location_to_lsp Option::Some
@@ -884,10 +883,10 @@ fn resolve_variable_type name:str func:Option[Function] state:DocumentState -> O
 }
 
 fn format_hover op:Op state:DocumentState func:Option[Function] -> Option[str] {
-    op Op::kind = kind
+    op.value = op_value
 
     # Function call/push
-    if OpKind::OpFnCall kind == OpKind::OpFnPush kind == || then
+    if op_value OpValue::FnCall is op_value OpValue::FnPush is || then
         op op_str_value state DocumentState::functions.get = fn_opt
         if fn_opt.is_some then
             fn_opt.unwrap = hover_func
@@ -928,7 +927,7 @@ fn format_hover op:Op state:DocumentState func:Option[Function] -> Option[str] {
     fi
 
     # Variables
-    if OpKind::OpPushVar kind == OpKind::OpPushCapture kind == || then
+    if op_value OpValue::PushVar is op_value OpValue::PushCapture is || then
         op op_str_value = var_name
         state func var_name resolve_variable_type = var_type
         if var_type.is_some then
@@ -940,7 +939,7 @@ fn format_hover op:Op state:DocumentState func:Option[Function] -> Option[str] {
     fi
 
     # Struct new
-    if OpKind::OpStructNew kind == then
+    if op_value OpValue::StructNew is then
         op casa_struct_of = struct_val
         StringBuilder::new = struct_builder
         "struct " struct_builder.append
@@ -961,22 +960,22 @@ fn format_hover op:Op state:DocumentState func:Option[Function] -> Option[str] {
     fi
 
     # Enum variant
-    if OpKind::OpPushEnumVariant kind == then
+    if op_value OpValue::PushEnumVariant is then
         op enum_variant_of = variant
         f"{variant EnumVariant::enum_name}::{variant EnumVariant::variant_name}" Option::Some
         return
     fi
 
     # Literals
-    if OpKind::OpPushInt kind == then
+    if op_value OpValue::PushInt is then
         f"(int) {op op_int_value}" Option::Some
         return
     fi
-    if OpKind::OpPushStr kind == then
+    if op_value OpValue::PushStr is then
         f"(str) \"{op op_str_value}\"" Option::Some
         return
     fi
-    if OpKind::OpPushBool kind == then
+    if op_value OpValue::PushBool is then
         if op op_int_value 0 != then
             "(bool) true" Option::Some
         else
@@ -984,7 +983,7 @@ fn format_hover op:Op state:DocumentState func:Option[Function] -> Option[str] {
         fi
         return
     fi
-    if OpKind::OpPushChar kind == then
+    if op_value OpValue::PushChar is then
         # Build char string manually
         10 alloc (str) = char_buf
         1 char_buf (ptr) store64
@@ -995,7 +994,7 @@ fn format_hover op:Op state:DocumentState func:Option[Function] -> Option[str] {
     fi
 
     # Assignment
-    if OpKind::OpAssignVar kind == then
+    if op_value OpValue::AssignVar is then
         op op_str_value = assign_name
         state func assign_name resolve_variable_type = assign_type
         if assign_type.is_some then
@@ -1007,7 +1006,7 @@ fn format_hover op:Op state:DocumentState func:Option[Function] -> Option[str] {
     fi
 
     # Stack effects
-    kind STACK_EFFECTS.get = effect_opt
+    op_value op_value_stack_effect = effect_opt
     if effect_opt.is_some then
         effect_opt.unwrap Option::Some
         return
@@ -1088,7 +1087,7 @@ fn compute_hover state:DocumentState line:int col:int -> Option[HoverContent] {
     # Qualified function call
     if
     QPART_NONE qpart !=
-    OpKind::OpFnCall op Op::kind == OpKind::OpFnPush op Op::kind == || &&
+    op.value OpValue::FnCall is op.value OpValue::FnPush is || &&
     then
         op op_str_value "::" str::split = qualified_parts
         0 qualified_parts.get = qualified_type_name
@@ -1121,7 +1120,7 @@ fn compute_hover state:DocumentState line:int col:int -> Option[HoverContent] {
     # Qualified enum variant
     if
     QPART_NONE qpart !=
-    OpKind::OpPushEnumVariant op Op::kind == &&
+    op.value OpValue::PushEnumVariant is &&
     then
         op enum_variant_of = enum_variant
         if QPART_TYPE qpart == then
@@ -1478,7 +1477,7 @@ fn handle_completion message:JsonValue {
 
 fn collect_fn_refs ops:List[Op] name:str results:List[LspLocation] {
     for op in ops.iter do
-        if OpKind::OpFnCall op Op::kind != OpKind::OpFnPush op Op::kind != && then
+        if op.value OpValue::FnCall is ! op.value OpValue::FnPush is ! && then
             continue
         fi
         if op op_str_value name != then
@@ -1489,12 +1488,12 @@ fn collect_fn_refs ops:List[Op] name:str results:List[LspLocation] {
 }
 
 fn is_var_op op:Op -> bool {
-    op Op::kind = kind
-    OpKind::OpPushVar kind ==
-    OpKind::OpPushCapture kind == ||
-    OpKind::OpAssignVar kind == ||
-    OpKind::OpAssignInc kind == ||
-    OpKind::OpAssignDec kind == ||
+    op.value = op_value
+    op_value OpValue::PushVar is
+    op_value OpValue::PushCapture is ||
+    op_value OpValue::AssignVar is ||
+    op_value OpValue::AssignInc is ||
+    op_value OpValue::AssignDec is ||
 }
 
 fn collect_var_refs ops:List[Op] name:str results:List[LspLocation] {
@@ -1511,11 +1510,11 @@ fn collect_var_refs ops:List[Op] name:str results:List[LspLocation] {
 
 fn collect_struct_refs ops:List[Op] name:str results:List[LspLocation] {
     for op in ops.iter do
-        if OpKind::OpStructNew op Op::kind == then
+        if op.value OpValue::StructNew is then
             if op casa_struct_of CasaStruct::name name == then
                 op Op::location casa_location_to_lsp results.push
             fi
-        elif OpKind::OpTypeCast op Op::kind == then
+        elif op.value OpValue::TypeCast is then
             if op op_str_value name == then
                 op Op::location casa_location_to_lsp results.push
             fi
@@ -1525,13 +1524,11 @@ fn collect_struct_refs ops:List[Op] name:str results:List[LspLocation] {
 
 fn collect_enum_refs ops:List[Op] enum_name:str results:List[LspLocation] {
     for op in ops.iter do
-        if OpKind::OpPushEnumVariant op Op::kind != then
-            continue
+        if op.value OpValue::PushEnumVariant is then
+            if op enum_variant_of EnumVariant::enum_name enum_name == then
+                op Op::location casa_location_to_lsp results.push
+            fi
         fi
-        if op enum_variant_of EnumVariant::enum_name enum_name != then
-            continue
-        fi
-        op Op::location casa_location_to_lsp results.push
     done
 }
 
@@ -1578,10 +1575,10 @@ fn find_all_references
     include_declaration:bool
 -> List[LspLocation] {
     List::new(List[LspLocation]) = results
-    op Op::kind = kind
+    op.value = op_value
 
     # Function call/push
-    if OpKind::OpFnCall kind == OpKind::OpFnPush kind == || then
+    if op_value OpValue::FnCall is op_value OpValue::FnPush is || then
         op op_str_value = fn_name
         if include_declaration then
             fn_name state DocumentState::functions.get = fn_opt
@@ -1611,7 +1608,7 @@ fn find_all_references
     fi
 
     # Struct
-    if OpKind::OpStructNew kind == then
+    if op_value OpValue::StructNew is then
         op casa_struct_of = casa_struct
         casa_struct CasaStruct::name = struct_name
         if include_declaration then
@@ -1624,7 +1621,7 @@ fn find_all_references
     fi
 
     # Enum variant
-    if OpKind::OpPushEnumVariant kind == then
+    if op_value OpValue::PushEnumVariant is then
         op enum_variant_of EnumVariant::enum_name = enum_name
         if include_declaration enum_name state DocumentState::enums.has && then
             enum_name state DocumentState::enums.get.unwrap CasaEnum::location casa_location_to_lsp results.push
@@ -1647,7 +1644,7 @@ fn compute_references
     # Check function definition name first (parameter ops share the name token location)
     col line state find_function_at_position = fn_at_pos
     if fn_at_pos Option::Some(matched_function) is then
-        matched_function Function::location OpKind::OpFnCall matched_function Function::name make_op_str = op
+        matched_function Function::location matched_function Function::name OpValue::FnCall make_op = op
         Option::None(Option[Function]) = func
     else
         col line state find_op_at_position = result
@@ -1716,7 +1713,7 @@ fn compute_rename
     # Check function definition name first (parameter ops share the name token location)
     col line state find_function_at_position = fn_at_pos
     if fn_at_pos Option::Some(matched_function) is then
-        matched_function Function::location OpKind::OpFnCall matched_function Function::name make_op_str = op
+        matched_function Function::location matched_function Function::name OpValue::FnCall make_op = op
         Option::None(Option[Function]) = func
         matched_function Function::name function_short_name = old_name
     else
@@ -1810,85 +1807,88 @@ fn handle_rename message:JsonValue {
 # Semantic tokens handler
 # ============================================================================
 
-fn init_token_type_map {
-    OpKind::OpFnCall TOKEN_FUNCTION TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpFnPush TOKEN_FUNCTION TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpMethodCall TOKEN_FUNCTION TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpPushVar TOKEN_VARIABLE TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpPushCapture TOKEN_VARIABLE TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpAssignVar TOKEN_VARIABLE TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpAssignInc TOKEN_VARIABLE TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpAssignDec TOKEN_VARIABLE TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpPushStr TOKEN_STRING TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpPushInt TOKEN_NUMBER TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpPushChar TOKEN_NUMBER TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpPushBool TOKEN_KEYWORD TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpFnExec TOKEN_KEYWORD TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpIfStart TOKEN_KEYWORD TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpIfCondition TOKEN_KEYWORD TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpIfElif TOKEN_KEYWORD TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpIfElse TOKEN_KEYWORD TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpIfEnd TOKEN_KEYWORD TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpWhileStart TOKEN_KEYWORD TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpWhileCondition TOKEN_KEYWORD TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpWhileEnd TOKEN_KEYWORD TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpWhileBreak TOKEN_KEYWORD TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpWhileContinue TOKEN_KEYWORD TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpMatchStart TOKEN_KEYWORD TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpMatchArm TOKEN_KEYWORD TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpMatchEnd TOKEN_KEYWORD TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpFnReturn TOKEN_KEYWORD TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpAdd TOKEN_OPERATOR TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpSub TOKEN_OPERATOR TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpMul TOKEN_OPERATOR TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpDiv TOKEN_OPERATOR TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpMod TOKEN_OPERATOR TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpShl TOKEN_OPERATOR TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpShr TOKEN_OPERATOR TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpBitAnd TOKEN_OPERATOR TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpBitOr TOKEN_OPERATOR TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpBitXor TOKEN_OPERATOR TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpBitNot TOKEN_OPERATOR TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpAnd TOKEN_OPERATOR TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpOr TOKEN_OPERATOR TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpNot TOKEN_OPERATOR TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpEq TOKEN_OPERATOR TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpNe TOKEN_OPERATOR TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpLt TOKEN_OPERATOR TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpLe TOKEN_OPERATOR TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpGt TOKEN_OPERATOR TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpGe TOKEN_OPERATOR TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpTypeCast TOKEN_TYPE TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpPushEnumVariant TOKEN_ENUM_MEMBER TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpStructNew TOKEN_STRUCT TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpDrop TOKEN_MACRO TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpDup TOKEN_MACRO TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpSwap TOKEN_MACRO TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpOver TOKEN_MACRO TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpRot TOKEN_MACRO TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpPrint TOKEN_MACRO TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpPrintInt TOKEN_MACRO TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpPrintStr TOKEN_MACRO TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpPrintBool TOKEN_MACRO TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpPrintChar TOKEN_MACRO TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpPrintCstr TOKEN_MACRO TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpHeapAlloc TOKEN_MACRO TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpLoad8 TOKEN_MACRO TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpLoad16 TOKEN_MACRO TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpLoad32 TOKEN_MACRO TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpLoad64 TOKEN_MACRO TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpStore8 TOKEN_MACRO TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpStore16 TOKEN_MACRO TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpStore32 TOKEN_MACRO TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpStore64 TOKEN_MACRO TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpSyscall0 TOKEN_MACRO TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpSyscall1 TOKEN_MACRO TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpSyscall2 TOKEN_MACRO TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpSyscall3 TOKEN_MACRO TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpSyscall4 TOKEN_MACRO TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpSyscall5 TOKEN_MACRO TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpSyscall6 TOKEN_MACRO TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
-    OpKind::OpTypeof TOKEN_MACRO TOKEN_TYPE_MAP.set = TOKEN_TYPE_MAP
+fn op_value_token_type op_value:OpValue -> Option[int] {
+    op_value match
+        OpValue::FnCall(_) => TOKEN_FUNCTION Option::Some
+        OpValue::FnPush(_) => TOKEN_FUNCTION Option::Some
+        OpValue::MethodCall(_) => TOKEN_FUNCTION Option::Some
+        OpValue::PushVar(_) => TOKEN_VARIABLE Option::Some
+        OpValue::PushCapture(_) => TOKEN_VARIABLE Option::Some
+        OpValue::AssignVar(_) => TOKEN_VARIABLE Option::Some
+        OpValue::AssignInc(_) => TOKEN_VARIABLE Option::Some
+        OpValue::AssignDec(_) => TOKEN_VARIABLE Option::Some
+        OpValue::PushStr(_) => TOKEN_STRING Option::Some
+        OpValue::PushInt(_) => TOKEN_NUMBER Option::Some
+        OpValue::PushChar(_) => TOKEN_NUMBER Option::Some
+        OpValue::PushBool(_) => TOKEN_KEYWORD Option::Some
+        OpValue::FnExec => TOKEN_KEYWORD Option::Some
+        OpValue::IfStart => TOKEN_KEYWORD Option::Some
+        OpValue::IfCondition => TOKEN_KEYWORD Option::Some
+        OpValue::IfElif => TOKEN_KEYWORD Option::Some
+        OpValue::IfElse => TOKEN_KEYWORD Option::Some
+        OpValue::IfEnd => TOKEN_KEYWORD Option::Some
+        OpValue::WhileStart => TOKEN_KEYWORD Option::Some
+        OpValue::WhileCondition => TOKEN_KEYWORD Option::Some
+        OpValue::WhileEnd => TOKEN_KEYWORD Option::Some
+        OpValue::WhileBreak => TOKEN_KEYWORD Option::Some
+        OpValue::WhileContinue => TOKEN_KEYWORD Option::Some
+        OpValue::MatchStart => TOKEN_KEYWORD Option::Some
+        OpValue::MatchArm(_) => TOKEN_KEYWORD Option::Some
+        OpValue::MatchEnd => TOKEN_KEYWORD Option::Some
+        OpValue::FnReturn => TOKEN_KEYWORD Option::Some
+        OpValue::Add => TOKEN_OPERATOR Option::Some
+        OpValue::Sub => TOKEN_OPERATOR Option::Some
+        OpValue::Mul => TOKEN_OPERATOR Option::Some
+        OpValue::Div => TOKEN_OPERATOR Option::Some
+        OpValue::Mod => TOKEN_OPERATOR Option::Some
+        OpValue::Shl => TOKEN_OPERATOR Option::Some
+        OpValue::Shr => TOKEN_OPERATOR Option::Some
+        OpValue::BitAnd => TOKEN_OPERATOR Option::Some
+        OpValue::BitOr => TOKEN_OPERATOR Option::Some
+        OpValue::BitXor => TOKEN_OPERATOR Option::Some
+        OpValue::BitNot => TOKEN_OPERATOR Option::Some
+        OpValue::And => TOKEN_OPERATOR Option::Some
+        OpValue::Or => TOKEN_OPERATOR Option::Some
+        OpValue::Not => TOKEN_OPERATOR Option::Some
+        OpValue::Eq => TOKEN_OPERATOR Option::Some
+        OpValue::Ne => TOKEN_OPERATOR Option::Some
+        OpValue::Lt => TOKEN_OPERATOR Option::Some
+        OpValue::Le => TOKEN_OPERATOR Option::Some
+        OpValue::Gt => TOKEN_OPERATOR Option::Some
+        OpValue::Ge => TOKEN_OPERATOR Option::Some
+        OpValue::TypeCast(_) => TOKEN_TYPE Option::Some
+        OpValue::PushEnumVariant(_) => TOKEN_ENUM_MEMBER Option::Some
+        OpValue::StructNew(_) => TOKEN_STRUCT Option::Some
+        OpValue::Drop => TOKEN_MACRO Option::Some
+        OpValue::Dup => TOKEN_MACRO Option::Some
+        OpValue::Swap => TOKEN_MACRO Option::Some
+        OpValue::Over => TOKEN_MACRO Option::Some
+        OpValue::Rot => TOKEN_MACRO Option::Some
+        OpValue::Print => TOKEN_MACRO Option::Some
+        OpValue::PrintInt => TOKEN_MACRO Option::Some
+        OpValue::PrintStr => TOKEN_MACRO Option::Some
+        OpValue::PrintBool => TOKEN_MACRO Option::Some
+        OpValue::PrintChar => TOKEN_MACRO Option::Some
+        OpValue::PrintCstr => TOKEN_MACRO Option::Some
+        OpValue::HeapAlloc => TOKEN_MACRO Option::Some
+        OpValue::Load8 => TOKEN_MACRO Option::Some
+        OpValue::Load16 => TOKEN_MACRO Option::Some
+        OpValue::Load32 => TOKEN_MACRO Option::Some
+        OpValue::Load64 => TOKEN_MACRO Option::Some
+        OpValue::Store8 => TOKEN_MACRO Option::Some
+        OpValue::Store16 => TOKEN_MACRO Option::Some
+        OpValue::Store32 => TOKEN_MACRO Option::Some
+        OpValue::Store64 => TOKEN_MACRO Option::Some
+        OpValue::Syscall0 => TOKEN_MACRO Option::Some
+        OpValue::Syscall1 => TOKEN_MACRO Option::Some
+        OpValue::Syscall2 => TOKEN_MACRO Option::Some
+        OpValue::Syscall3 => TOKEN_MACRO Option::Some
+        OpValue::Syscall4 => TOKEN_MACRO Option::Some
+        OpValue::Syscall5 => TOKEN_MACRO Option::Some
+        OpValue::Syscall6 => TOKEN_MACRO Option::Some
+        OpValue::Typeof => TOKEN_MACRO Option::Some
+        _ => Option::None(Option[int])
+    end
 }
 # Qualified name token type maps
 # Type part is always TOKEN_TYPE for all qualified names
@@ -1908,7 +1908,7 @@ fn collect_semantic_tokens ops:List[Op] state:DocumentState tokens:List[Semantic
         if 0 length <= then
             continue
         fi
-        op Op::kind TOKEN_TYPE_MAP.get = token_type_opt
+        op.value op_value_token_type = token_type_opt
         if token_type_opt.is_none then
             continue
         fi
@@ -1916,9 +1916,9 @@ fn collect_semantic_tokens ops:List[Op] state:DocumentState tokens:List[Semantic
 
         # Check for qualified names
         if
-        OpKind::OpFnCall op Op::kind ==
-        OpKind::OpFnPush op Op::kind == ||
-        OpKind::OpPushEnumVariant op Op::kind == ||
+        op.value OpValue::FnCall is
+        op.value OpValue::FnPush is ||
+        op.value OpValue::PushEnumVariant is ||
         then
             state DocumentState::source start length str::substring = text
             text "::" str::find = separator
@@ -1933,7 +1933,7 @@ fn collect_semantic_tokens ops:List[Op] state:DocumentState tokens:List[Semantic
                 if 0 member_length > then
                     member_start token_source offset_to_line_col 1 - = member_line
                     member_start token_source offset_to_col 1 - = member_col
-                    if OpKind::OpPushEnumVariant op Op::kind == then QUALIFIED_MEMBER_ENUM_VARIANT else QUALIFIED_MEMBER_FN fi = member_token_type
+                    if op.value OpValue::PushEnumVariant is then QUALIFIED_MEMBER_ENUM_VARIANT else QUALIFIED_MEMBER_FN fi = member_token_type
                     0 member_token_type member_length member_col member_line SemanticToken tokens.push
                 fi
                 continue
@@ -2106,60 +2106,63 @@ fn handle_semantic_tokens message:JsonValue {
 # Stack effects map initialization
 # ============================================================================
 
-fn init_stack_effects {
-    OpKind::OpAdd "+: int int -> int" STACK_EFFECTS.set = STACK_EFFECTS
-    OpKind::OpSub "-: int int -> int" STACK_EFFECTS.set = STACK_EFFECTS
-    OpKind::OpMul "*: int int -> int" STACK_EFFECTS.set = STACK_EFFECTS
-    OpKind::OpDiv "/: int int -> int" STACK_EFFECTS.set = STACK_EFFECTS
-    OpKind::OpMod "%: int int -> int" STACK_EFFECTS.set = STACK_EFFECTS
-    OpKind::OpShl "<<: int int -> int" STACK_EFFECTS.set = STACK_EFFECTS
-    OpKind::OpShr ">>: int int -> int" STACK_EFFECTS.set = STACK_EFFECTS
-    OpKind::OpBitAnd "&: int int -> int" STACK_EFFECTS.set = STACK_EFFECTS
-    OpKind::OpBitOr "|: int int -> int" STACK_EFFECTS.set = STACK_EFFECTS
-    OpKind::OpBitXor "^: int int -> int" STACK_EFFECTS.set = STACK_EFFECTS
-    OpKind::OpBitNot "~: int -> int" STACK_EFFECTS.set = STACK_EFFECTS
-    OpKind::OpNot "!: bool -> bool" STACK_EFFECTS.set = STACK_EFFECTS
-    OpKind::OpEq "==: any any -> bool" STACK_EFFECTS.set = STACK_EFFECTS
-    OpKind::OpNe "!=: any any -> bool" STACK_EFFECTS.set = STACK_EFFECTS
-    OpKind::OpLt "<: any any -> bool" STACK_EFFECTS.set = STACK_EFFECTS
-    OpKind::OpLe "<=: any any -> bool" STACK_EFFECTS.set = STACK_EFFECTS
-    OpKind::OpGt ">: any any -> bool" STACK_EFFECTS.set = STACK_EFFECTS
-    OpKind::OpGe ">=: any any -> bool" STACK_EFFECTS.set = STACK_EFFECTS
-    OpKind::OpAnd "&&: bool bool -> bool" STACK_EFFECTS.set = STACK_EFFECTS
-    OpKind::OpOr "||: bool bool -> bool" STACK_EFFECTS.set = STACK_EFFECTS
-    OpKind::OpDrop "drop: any -> None" STACK_EFFECTS.set = STACK_EFFECTS
-    OpKind::OpDup "dup: any -> any any" STACK_EFFECTS.set = STACK_EFFECTS
-    OpKind::OpSwap "swap: any any -> any any" STACK_EFFECTS.set = STACK_EFFECTS
-    OpKind::OpOver "over: any any -> any any any" STACK_EFFECTS.set = STACK_EFFECTS
-    OpKind::OpRot "rot: any any any -> any any any" STACK_EFFECTS.set = STACK_EFFECTS
-    OpKind::OpPrint "print: any -> None" STACK_EFFECTS.set = STACK_EFFECTS
-    OpKind::OpPrintInt "print: any -> None" STACK_EFFECTS.set = STACK_EFFECTS
-    OpKind::OpPrintStr "print: any -> None" STACK_EFFECTS.set = STACK_EFFECTS
-    OpKind::OpPrintBool "print: any -> None" STACK_EFFECTS.set = STACK_EFFECTS
-    OpKind::OpPrintChar "print: any -> None" STACK_EFFECTS.set = STACK_EFFECTS
-    OpKind::OpPrintCstr "print: any -> None" STACK_EFFECTS.set = STACK_EFFECTS
-    OpKind::OpFnExec "exec: fn[sig] -> ..." STACK_EFFECTS.set = STACK_EFFECTS
-    OpKind::OpTypeof "typeof: any -> str" STACK_EFFECTS.set = STACK_EFFECTS
-    OpKind::OpAssignDec "-=: int -> None" STACK_EFFECTS.set = STACK_EFFECTS
-    OpKind::OpAssignInc "+=: int -> None" STACK_EFFECTS.set = STACK_EFFECTS
-    OpKind::OpHeapAlloc "alloc: int -> ptr" STACK_EFFECTS.set = STACK_EFFECTS
-    OpKind::OpLoad8 "load8: ptr -> int" STACK_EFFECTS.set = STACK_EFFECTS
-    OpKind::OpLoad16 "load16: ptr -> int" STACK_EFFECTS.set = STACK_EFFECTS
-    OpKind::OpLoad32 "load32: ptr -> int" STACK_EFFECTS.set = STACK_EFFECTS
-    OpKind::OpLoad64 "load64: ptr -> int" STACK_EFFECTS.set = STACK_EFFECTS
-    OpKind::OpStore8 "store8: any ptr -> None" STACK_EFFECTS.set = STACK_EFFECTS
-    OpKind::OpStore16 "store16: any ptr -> None" STACK_EFFECTS.set = STACK_EFFECTS
-    OpKind::OpStore32 "store32: any ptr -> None" STACK_EFFECTS.set = STACK_EFFECTS
-    OpKind::OpStore64 "store64: any ptr -> None" STACK_EFFECTS.set = STACK_EFFECTS
-    OpKind::OpSyscall0 "syscall0: int -> int" STACK_EFFECTS.set = STACK_EFFECTS
-    OpKind::OpSyscall1 "syscall1: any int -> int" STACK_EFFECTS.set = STACK_EFFECTS
-    OpKind::OpSyscall2 "syscall2: any any int -> int" STACK_EFFECTS.set = STACK_EFFECTS
-    OpKind::OpSyscall3 "syscall3: any any any int -> int" STACK_EFFECTS.set = STACK_EFFECTS
-    OpKind::OpSyscall4 "syscall4: any any any any int -> int" STACK_EFFECTS.set = STACK_EFFECTS
-    OpKind::OpSyscall5 "syscall5: any any any any any int -> int" STACK_EFFECTS.set = STACK_EFFECTS
-    OpKind::OpSyscall6 "syscall6: any any any any any any int -> int" STACK_EFFECTS.set = STACK_EFFECTS
-    OpKind::OpArgc "argc: None -> int" STACK_EFFECTS.set = STACK_EFFECTS
-    OpKind::OpArgv "argv: None -> ptr" STACK_EFFECTS.set = STACK_EFFECTS
+fn op_value_stack_effect op_value:OpValue -> Option[str] {
+    op_value match
+        OpValue::Add => "+: int int -> int" Option::Some
+        OpValue::Sub => "-: int int -> int" Option::Some
+        OpValue::Mul => "*: int int -> int" Option::Some
+        OpValue::Div => "/: int int -> int" Option::Some
+        OpValue::Mod => "%: int int -> int" Option::Some
+        OpValue::Shl => "<<: int int -> int" Option::Some
+        OpValue::Shr => ">>: int int -> int" Option::Some
+        OpValue::BitAnd => "&: int int -> int" Option::Some
+        OpValue::BitOr => "|: int int -> int" Option::Some
+        OpValue::BitXor => "^: int int -> int" Option::Some
+        OpValue::BitNot => "~: int -> int" Option::Some
+        OpValue::Not => "!: bool -> bool" Option::Some
+        OpValue::Eq => "==: any any -> bool" Option::Some
+        OpValue::Ne => "!=: any any -> bool" Option::Some
+        OpValue::Lt => "<: any any -> bool" Option::Some
+        OpValue::Le => "<=: any any -> bool" Option::Some
+        OpValue::Gt => ">: any any -> bool" Option::Some
+        OpValue::Ge => ">=: any any -> bool" Option::Some
+        OpValue::And => "&&: bool bool -> bool" Option::Some
+        OpValue::Or => "||: bool bool -> bool" Option::Some
+        OpValue::Drop => "drop: any -> None" Option::Some
+        OpValue::Dup => "dup: any -> any any" Option::Some
+        OpValue::Swap => "swap: any any -> any any" Option::Some
+        OpValue::Over => "over: any any -> any any any" Option::Some
+        OpValue::Rot => "rot: any any any -> any any any" Option::Some
+        OpValue::Print => "print: any -> None" Option::Some
+        OpValue::PrintInt => "print: any -> None" Option::Some
+        OpValue::PrintStr => "print: any -> None" Option::Some
+        OpValue::PrintBool => "print: any -> None" Option::Some
+        OpValue::PrintChar => "print: any -> None" Option::Some
+        OpValue::PrintCstr => "print: any -> None" Option::Some
+        OpValue::FnExec => "exec: fn[sig] -> ..." Option::Some
+        OpValue::Typeof => "typeof: any -> str" Option::Some
+        OpValue::AssignDec(_) => "-=: int -> None" Option::Some
+        OpValue::AssignInc(_) => "+=: int -> None" Option::Some
+        OpValue::HeapAlloc => "alloc: int -> ptr" Option::Some
+        OpValue::Load8 => "load8: ptr -> int" Option::Some
+        OpValue::Load16 => "load16: ptr -> int" Option::Some
+        OpValue::Load32 => "load32: ptr -> int" Option::Some
+        OpValue::Load64 => "load64: ptr -> int" Option::Some
+        OpValue::Store8 => "store8: any ptr -> None" Option::Some
+        OpValue::Store16 => "store16: any ptr -> None" Option::Some
+        OpValue::Store32 => "store32: any ptr -> None" Option::Some
+        OpValue::Store64 => "store64: any ptr -> None" Option::Some
+        OpValue::Syscall0 => "syscall0: int -> int" Option::Some
+        OpValue::Syscall1 => "syscall1: any int -> int" Option::Some
+        OpValue::Syscall2 => "syscall2: any any int -> int" Option::Some
+        OpValue::Syscall3 => "syscall3: any any any int -> int" Option::Some
+        OpValue::Syscall4 => "syscall4: any any any any int -> int" Option::Some
+        OpValue::Syscall5 => "syscall5: any any any any any int -> int" Option::Some
+        OpValue::Syscall6 => "syscall6: any any any any any any int -> int" Option::Some
+        OpValue::Argc => "argc: None -> int" Option::Some
+        OpValue::Argv => "argv: None -> ptr" Option::Some
+        _ => Option::None(Option[str])
+    end
 }
 
 # ============================================================================
@@ -2334,8 +2337,6 @@ fn dispatch_message message:JsonValue {
 
 fn main {
     true = RESILIENT_MODE
-    init_token_type_map
-    init_stack_effects
 
     while true do
         STDIN_READER read_message = msg_opt

--- a/tests/compiler/test_argv.casa
+++ b/tests/compiler/test_argv.casa
@@ -65,14 +65,14 @@ fn test_parse_argc {
     "parse_argc" test_start
     "test" "argc" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "argc kind" OpKind::OpArgc 0 ops.get Op::kind == assert_true
+    "argc kind" 0 ops.get.value OpValue::Argc is assert_true
 }
 
 fn test_parse_argv {
     "parse_argv" test_start
     "test" "argv" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "argv kind" OpKind::OpArgv 0 ops.get Op::kind == assert_true
+    "argv kind" 0 ops.get.value OpValue::Argv is assert_true
 }
 
 # ============================================================================

--- a/tests/compiler/test_bytecode.casa
+++ b/tests/compiler/test_bytecode.casa
@@ -17,27 +17,14 @@ fn make_test_location -> Location {
     # param1=file, param2=offset, param3=length -> length offset file make_location
     1 0 "test.casa" make_location
 }
-# Helper to create a payloadless op
-# make_op kind:OpKind location:Location -> param1=kind, param2=location
+# Helper to create an op with the unified OpValue payload.
 
-fn test_make_op kind:OpKind -> Op {
-    make_test_location kind make_op
+fn test_make_op value:OpValue -> Op {
+    make_test_location value make_op
 }
 
-fn test_make_op_int value:int kind:OpKind -> Op {
-    make_test_location kind value make_op_int
-}
-# Helper to create an op with str value
-# make_op_str value:str kind:OpKind location:Location
-
-fn test_make_op_str value:str kind:OpKind -> Op {
-    make_test_location kind value make_op_str
-}
-# Helper to create an annotated op
-# make_op_annotated kind:OpKind location:Location annotation:str
-
-fn test_make_op_annotated kind:OpKind annotation:str -> Op {
-    annotation make_test_location kind make_op_annotated
+fn test_make_op_annotated value:OpValue annotation:str -> Op {
+    annotation make_test_location value make_op_annotated
 }
 
 # ============================================================================
@@ -80,7 +67,7 @@ fn test_compile_push_int {
     "compile_push_int" test_start
     reset_labels
     List::new(List[Op]) = ops
-    OpKind::OpPushInt 42 test_make_op_int ops.push
+    42 OpValue::PushInt test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
     List::new(List[Inst]) = bytecode
@@ -99,7 +86,7 @@ fn test_compile_push_bool {
     "compile_push_bool" test_start
     reset_labels
     List::new(List[Op]) = ops
-    OpKind::OpPushBool 1 test_make_op_int ops.push
+    1 OpValue::PushBool test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
     List::new(List[Inst]) = bytecode
@@ -113,7 +100,7 @@ fn test_compile_push_str {
     "compile_push_str" test_start
     reset_labels
     List::new(List[Op]) = ops
-    OpKind::OpPushStr "hello" test_make_op_str ops.push
+    "hello" OpValue::PushStr test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
     List::new(List[Inst]) = bytecode
@@ -128,7 +115,7 @@ fn test_compile_push_char {
     "compile_push_char" test_start
     reset_labels
     List::new(List[Op]) = ops
-    OpKind::OpPushChar 'A' (int) test_make_op_int ops.push
+    'A' (int) OpValue::PushChar test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
     List::new(List[Inst]) = bytecode
@@ -142,10 +129,10 @@ fn test_compile_direct_ops {
     "compile_direct_ops" test_start
     reset_labels
     List::new(List[Op]) = ops
-    OpKind::OpAdd test_make_op ops.push
-    OpKind::OpSub test_make_op ops.push
-    OpKind::OpDup test_make_op ops.push
-    OpKind::OpDrop test_make_op ops.push
+    OpValue::Add test_make_op ops.push
+    OpValue::Sub test_make_op ops.push
+    OpValue::Dup test_make_op ops.push
+    OpValue::Drop test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
     List::new(List[Inst]) = bytecode
@@ -168,8 +155,8 @@ fn test_compile_variable_assign_and_push {
     "x" "" make_variable TEST_STORE.variables.set drop
 
     List::new(List[Op]) = ops
-    OpKind::OpAssignVar "x" test_make_op_str ops.push
-    OpKind::OpPushVar "x" test_make_op_str ops.push
+    "x" OpValue::AssignVar test_make_op ops.push
+    "x" OpValue::PushVar test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
     List::new(List[Inst]) = bytecode
@@ -189,8 +176,8 @@ fn test_compile_local_variable {
 
     # Create a function with a variable
     List::new(List[Op]) = fn_ops
-    OpKind::OpAssignVar "y" test_make_op_str fn_ops.push
-    OpKind::OpPushVar "y" test_make_op_str fn_ops.push
+    "y" OpValue::AssignVar test_make_op fn_ops.push
+    "y" OpValue::PushVar test_make_op fn_ops.push
 
     # make_function name:str ops:List[Op] location:Location
     # param1=name, param2=ops, param3=location
@@ -212,7 +199,7 @@ fn test_compile_fstring_concat {
     "compile_fstring_concat" test_start
     reset_labels
     List::new(List[Op]) = ops
-    OpKind::OpFstringConcat 3 test_make_op_int ops.push
+    3 OpValue::FstringConcat test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
     List::new(List[Inst]) = bytecode
@@ -226,7 +213,7 @@ fn test_compile_type_cast_no_output {
     "compile_type_cast_no_output" test_start
     reset_labels
     List::new(List[Op]) = ops
-    OpKind::OpTypeCast test_make_op ops.push
+    "" OpValue::TypeCast test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
     List::new(List[Inst]) = bytecode
@@ -240,7 +227,7 @@ fn test_compile_import_no_output {
     "compile_import_no_output" test_start
     reset_labels
     List::new(List[Op]) = ops
-    OpKind::OpImportFile test_make_op ops.push
+    "" OpValue::ImportFile test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
     List::new(List[Inst]) = bytecode
@@ -263,13 +250,13 @@ fn test_compile_if_block {
     "compile_if_block" test_start
     reset_labels
     List::new(List[Op]) = ops
-    OpKind::OpIfStart test_make_op ops.push
-    OpKind::OpIfCondition test_make_op ops.push
-    OpKind::OpIfEnd test_make_op ops.push
+    OpValue::IfStart test_make_op ops.push
+    OpValue::IfCondition test_make_op ops.push
+    OpValue::IfEnd test_make_op ops.push
 
     "ops has 3 elements" 3 ops.length assert_eq
-    "op 0 is if_start" OpKind::OpIfStart 0 ops.get Op::kind == assert_true
-    "op 2 is if_end" OpKind::OpIfEnd 2 ops.get Op::kind == assert_true
+    "op 0 is if_start" 0 ops.get.value OpValue::IfStart is assert_true
+    "op 2 is if_end" 2 ops.get.value OpValue::IfEnd is assert_true
 
     ops TEST_STORE make_compiler = compiler
     List::new(List[Inst]) = bytecode
@@ -286,9 +273,9 @@ fn test_compile_while_block {
     "compile_while_block" test_start
     reset_labels
     List::new(List[Op]) = ops
-    OpKind::OpWhileStart test_make_op ops.push
-    OpKind::OpWhileCondition test_make_op ops.push
-    OpKind::OpWhileEnd test_make_op ops.push
+    OpValue::WhileStart test_make_op ops.push
+    OpValue::WhileCondition test_make_op ops.push
+    OpValue::WhileEnd test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
     List::new(List[Inst]) = bytecode
@@ -307,7 +294,7 @@ fn test_compile_string_eq {
     "compile_string_eq" test_start
     reset_labels
     List::new(List[Op]) = ops
-    "str" OpKind::OpEq test_make_op_annotated ops.push
+    "str" OpValue::Eq test_make_op_annotated ops.push
 
     ops TEST_STORE make_compiler = compiler
     List::new(List[Inst]) = bytecode
@@ -320,7 +307,7 @@ fn test_compile_string_ne {
     "compile_string_ne" test_start
     reset_labels
     List::new(List[Op]) = ops
-    "str" OpKind::OpNe test_make_op_annotated ops.push
+    "str" OpValue::Ne test_make_op_annotated ops.push
 
     ops TEST_STORE make_compiler = compiler
     List::new(List[Inst]) = bytecode
@@ -337,7 +324,7 @@ fn test_compile_assign_increment {
     "counter" "" make_variable TEST_STORE.variables.set drop
 
     List::new(List[Op]) = ops
-    OpKind::OpAssignInc "counter" test_make_op_str ops.push
+    "counter" OpValue::AssignInc test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
     List::new(List[Inst]) = bytecode
@@ -358,7 +345,7 @@ fn test_compile_assign_decrement {
     "counter" "" make_variable TEST_STORE.variables.set drop
 
     List::new(List[Op]) = ops
-    OpKind::OpAssignDec "counter" test_make_op_str ops.push
+    "counter" OpValue::AssignDec test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
     List::new(List[Inst]) = bytecode
@@ -378,7 +365,7 @@ fn test_compile_push_bool_false {
     "compile_push_bool_false" test_start
     reset_labels
     List::new(List[Op]) = ops
-    OpKind::OpPushBool 0 test_make_op_int ops.push
+    0 OpValue::PushBool test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
     List::new(List[Inst]) = bytecode
@@ -392,23 +379,23 @@ fn test_compile_more_direct_ops {
     "compile_more_direct_ops" test_start
     reset_labels
     List::new(List[Op]) = ops
-    OpKind::OpMul test_make_op ops.push
-    OpKind::OpDiv test_make_op ops.push
-    OpKind::OpMod test_make_op ops.push
-    OpKind::OpShl test_make_op ops.push
-    OpKind::OpShr test_make_op ops.push
-    OpKind::OpAnd test_make_op ops.push
-    OpKind::OpOr test_make_op ops.push
-    OpKind::OpNot test_make_op ops.push
-    OpKind::OpEq test_make_op ops.push
-    OpKind::OpNe test_make_op ops.push
-    OpKind::OpGt test_make_op ops.push
-    OpKind::OpGe test_make_op ops.push
-    OpKind::OpLt test_make_op ops.push
-    OpKind::OpLe test_make_op ops.push
-    OpKind::OpSwap test_make_op ops.push
-    OpKind::OpOver test_make_op ops.push
-    OpKind::OpRot test_make_op ops.push
+    OpValue::Mul test_make_op ops.push
+    OpValue::Div test_make_op ops.push
+    OpValue::Mod test_make_op ops.push
+    OpValue::Shl test_make_op ops.push
+    OpValue::Shr test_make_op ops.push
+    OpValue::And test_make_op ops.push
+    OpValue::Or test_make_op ops.push
+    OpValue::Not test_make_op ops.push
+    OpValue::Eq test_make_op ops.push
+    OpValue::Ne test_make_op ops.push
+    OpValue::Gt test_make_op ops.push
+    OpValue::Ge test_make_op ops.push
+    OpValue::Lt test_make_op ops.push
+    OpValue::Le test_make_op ops.push
+    OpValue::Swap test_make_op ops.push
+    OpValue::Over test_make_op ops.push
+    OpValue::Rot test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
     List::new(List[Inst]) = bytecode
@@ -438,10 +425,10 @@ fn test_compile_direct_ops_bitwise {
     "compile_direct_ops_bitwise" test_start
     reset_labels
     List::new(List[Op]) = ops
-    OpKind::OpBitAnd test_make_op ops.push
-    OpKind::OpBitOr test_make_op ops.push
-    OpKind::OpBitXor test_make_op ops.push
-    OpKind::OpBitNot test_make_op ops.push
+    OpValue::BitAnd test_make_op ops.push
+    OpValue::BitOr test_make_op ops.push
+    OpValue::BitXor test_make_op ops.push
+    OpValue::BitNot test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
     List::new(List[Inst]) = bytecode
@@ -457,15 +444,15 @@ fn test_compile_direct_ops_memory {
     "compile_direct_ops_memory" test_start
     reset_labels
     List::new(List[Op]) = ops
-    OpKind::OpHeapAlloc test_make_op ops.push
-    OpKind::OpLoad8 test_make_op ops.push
-    OpKind::OpLoad16 test_make_op ops.push
-    OpKind::OpLoad32 test_make_op ops.push
-    OpKind::OpLoad64 test_make_op ops.push
-    OpKind::OpStore8 test_make_op ops.push
-    OpKind::OpStore16 test_make_op ops.push
-    OpKind::OpStore32 test_make_op ops.push
-    OpKind::OpStore64 test_make_op ops.push
+    OpValue::HeapAlloc test_make_op ops.push
+    OpValue::Load8 test_make_op ops.push
+    OpValue::Load16 test_make_op ops.push
+    OpValue::Load32 test_make_op ops.push
+    OpValue::Load64 test_make_op ops.push
+    OpValue::Store8 test_make_op ops.push
+    OpValue::Store16 test_make_op ops.push
+    OpValue::Store32 test_make_op ops.push
+    OpValue::Store64 test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
     List::new(List[Inst]) = bytecode
@@ -486,13 +473,13 @@ fn test_compile_direct_ops_syscall {
     "compile_direct_ops_syscall" test_start
     reset_labels
     List::new(List[Op]) = ops
-    OpKind::OpSyscall0 test_make_op ops.push
-    OpKind::OpSyscall1 test_make_op ops.push
-    OpKind::OpSyscall2 test_make_op ops.push
-    OpKind::OpSyscall3 test_make_op ops.push
-    OpKind::OpSyscall4 test_make_op ops.push
-    OpKind::OpSyscall5 test_make_op ops.push
-    OpKind::OpSyscall6 test_make_op ops.push
+    OpValue::Syscall0 test_make_op ops.push
+    OpValue::Syscall1 test_make_op ops.push
+    OpValue::Syscall2 test_make_op ops.push
+    OpValue::Syscall3 test_make_op ops.push
+    OpValue::Syscall4 test_make_op ops.push
+    OpValue::Syscall5 test_make_op ops.push
+    OpValue::Syscall6 test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
     List::new(List[Inst]) = bytecode
@@ -511,11 +498,11 @@ fn test_compile_direct_ops_print {
     "compile_direct_ops_print" test_start
     reset_labels
     List::new(List[Op]) = ops
-    OpKind::OpPrintInt test_make_op ops.push
-    OpKind::OpPrintStr test_make_op ops.push
-    OpKind::OpPrintChar test_make_op ops.push
-    OpKind::OpPrintCstr test_make_op ops.push
-    OpKind::OpPrintBool test_make_op ops.push
+    OpValue::PrintInt test_make_op ops.push
+    OpValue::PrintStr test_make_op ops.push
+    OpValue::PrintChar test_make_op ops.push
+    OpValue::PrintCstr test_make_op ops.push
+    OpValue::PrintBool test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
     List::new(List[Inst]) = bytecode
@@ -532,8 +519,8 @@ fn test_compile_direct_ops_fn {
     "compile_direct_ops_fn" test_start
     reset_labels
     List::new(List[Op]) = ops
-    OpKind::OpFnExec test_make_op ops.push
-    OpKind::OpFnReturn test_make_op ops.push
+    OpValue::FnExec test_make_op ops.push
+    OpValue::FnReturn test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
     List::new(List[Inst]) = bytecode
@@ -549,13 +536,13 @@ fn test_compile_push_array {
 
     # Create array items: [1, 2, 3]
     List::new(List[Op]) = items
-    OpKind::OpPushInt 1 test_make_op_int items.push
-    OpKind::OpPushInt 2 test_make_op_int items.push
-    OpKind::OpPushInt 3 test_make_op_int items.push
+    1 OpValue::PushInt test_make_op items.push
+    2 OpValue::PushInt test_make_op items.push
+    3 OpValue::PushInt test_make_op items.push
 
     # Create a PushArray op with the items list as value
     List::new(List[Op]) = ops
-    make_test_location OpKind::OpPushArray items OpValue::OpList make_op_v ops.push
+    make_test_location items OpValue::PushArray make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
     List::new(List[Inst]) = bytecode
@@ -596,12 +583,12 @@ fn test_compile_if_elif_else {
     reset_labels
     List::new(List[Op]) = ops
     # if ... then ... elif ... then ... else ... fi
-    OpKind::OpIfStart test_make_op ops.push
-    OpKind::OpIfCondition test_make_op ops.push
-    OpKind::OpIfElif test_make_op ops.push
-    OpKind::OpIfCondition test_make_op ops.push
-    OpKind::OpIfElse test_make_op ops.push
-    OpKind::OpIfEnd test_make_op ops.push
+    OpValue::IfStart test_make_op ops.push
+    OpValue::IfCondition test_make_op ops.push
+    OpValue::IfElif test_make_op ops.push
+    OpValue::IfCondition test_make_op ops.push
+    OpValue::IfElse test_make_op ops.push
+    OpValue::IfEnd test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
     List::new(List[Inst]) = bytecode
@@ -637,7 +624,7 @@ fn test_compile_fn_call {
     "greet" func TEST_STORE.functions.set drop
 
     List::new(List[Op]) = ops
-    OpKind::OpFnCall "greet" test_make_op_str ops.push
+    "greet" OpValue::FnCall test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
     List::new(List[Inst]) = bytecode
@@ -657,12 +644,12 @@ fn test_compile_fn_push {
 
     # Register a function in TEST_STORE.functions with has_deferred_methods = 0
     List::new(List[Op]) = fn_ops
-    OpKind::OpPushInt 1 test_make_op_int fn_ops.push
+    1 OpValue::PushInt test_make_op fn_ops.push
     make_test_location fn_ops "adder" make_function = func
     "adder" func TEST_STORE.functions.set drop
 
     List::new(List[Op]) = ops
-    OpKind::OpFnPush "adder" test_make_op_str ops.push
+    "adder" OpValue::FnPush test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
     List::new(List[Inst]) = bytecode

--- a/tests/compiler/test_display.casa
+++ b/tests/compiler/test_display.casa
@@ -45,11 +45,11 @@ fn display_test_typecheck_error code:str -> Signature {
     Option::None(Option[Function]) ops type_check_ops
 }
 
-fn count_op_kind ops:List[Op] kind:OpKind -> int {
+fn count_op_kind ops:List[Op] kind:OpValue -> int {
     0 = count_result
     0 = count_index
     while count_index ops.length > do
-        if kind count_index ops.get Op::kind == then
+        if count_index ops.get.value kind == then
             1 += count_result
         fi
         1 += count_index
@@ -69,7 +69,7 @@ fn test_parser_emits_fstring_to_str {
     0 = found_count
     0 = index
     while index ops.length > do
-        if OpKind::OpFstringToStr index ops.get Op::kind == then
+        if index ops.get.value OpValue::FstringToStr is then
             1 += found_count
         fi
         1 += index
@@ -83,7 +83,7 @@ fn test_parser_emits_fstring_to_str_multiple {
     0 = found_count
     0 = index
     while index ops.length > do
-        if OpKind::OpFstringToStr index ops.get Op::kind == then
+        if index ops.get.value OpValue::FstringToStr is then
             1 += found_count
         fi
         1 += index
@@ -97,7 +97,7 @@ fn test_parser_no_fstring_to_str_without_expressions {
     0 = found_count
     0 = index
     while index ops.length > do
-        if OpKind::OpFstringToStr index ops.get Op::kind == then
+        if index ops.get.value OpValue::FstringToStr is then
             1 += found_count
         fi
         1 += index

--- a/tests/compiler/test_enum.casa
+++ b/tests/compiler/test_enum.casa
@@ -50,14 +50,17 @@ fn compile_enum code:str -> Program {
     ops DEFAULT_PARSER.store compile_bytecode
 }
 
-fn count_ops ops:List[Op] kind:OpKind -> int {
+fn is_push_enum_variant value:OpValue -> bool { value OpValue::PushEnumVariant is }
+fn is_match_start value:OpValue -> bool { value OpValue::MatchStart is }
+fn is_match_arm value:OpValue -> bool { value OpValue::MatchArm is }
+fn is_match_end value:OpValue -> bool { value OpValue::MatchEnd is }
+
+fn count_ops ops:List[Op] predicate:fn[OpValue -> bool] -> int {
     0 = count
-    0 = index
-    while index ops.length > do
-        if kind index ops.get Op::kind == then
+    for cop in ops.iter do
+        if cop.value predicate exec then
             1 += count
         fi
-        1 += index
     done
     count
 }
@@ -251,7 +254,7 @@ fn test_parse_duplicate_type_var_raises {
 fn test_resolve_enum_variant {
     "resolve_enum_variant" test_start
     "enum Color { Red Green Blue }\nColor::Red" resolve_enum = ops
-    "has variant op" 0 OpKind::OpPushEnumVariant ops count_ops != assert_true
+    "has variant op" 0 &is_push_enum_variant ops count_ops != assert_true
 }
 
 fn test_resolve_enum_variant_ordinal_first {
@@ -259,7 +262,7 @@ fn test_resolve_enum_variant_ordinal_first {
     "enum Color { Red Green Blue }\nColor::Red" resolve_enum = ops
     0 = index
     while index ops.length > do
-        if OpKind::OpPushEnumVariant index ops.get Op::kind == then
+        if index ops.get.value OpValue::PushEnumVariant is then
             index ops.get enum_variant_of = variant
             "ordinal 0" 0 variant EnumVariant::ordinal.unwrap assert_eq
             "enum name" "Color" variant EnumVariant::enum_name assert_str_eq
@@ -274,7 +277,7 @@ fn test_resolve_enum_variant_ordinal_second {
     "enum Color { Red Green Blue }\nColor::Green" resolve_enum = ops
     0 = index
     while index ops.length > do
-        if OpKind::OpPushEnumVariant index ops.get Op::kind == then
+        if index ops.get.value OpValue::PushEnumVariant is then
             index ops.get enum_variant_of = variant
             "ordinal 1" 1 variant EnumVariant::ordinal.unwrap assert_eq
             "variant name" "Green" variant EnumVariant::variant_name assert_str_eq
@@ -288,7 +291,7 @@ fn test_resolve_enum_variant_ordinal_third {
     "enum Color { Red Green Blue }\nColor::Blue" resolve_enum = ops
     0 = index
     while index ops.length > do
-        if OpKind::OpPushEnumVariant index ops.get Op::kind == then
+        if index ops.get.value OpValue::PushEnumVariant is then
             index ops.get enum_variant_of = variant
             "ordinal 2" 2 variant EnumVariant::ordinal.unwrap assert_eq
             "variant name" "Blue" variant EnumVariant::variant_name assert_str_eq
@@ -300,7 +303,7 @@ fn test_resolve_enum_variant_ordinal_third {
 fn test_resolve_multiple_variants {
     "resolve_multiple_variants" test_start
     "enum Color { Red Green Blue }\nColor::Red Color::Green Color::Blue\n" resolve_enum = ops
-    "three variants" 3 OpKind::OpPushEnumVariant ops count_ops == assert_true
+    "three variants" 3 &is_push_enum_variant ops count_ops == assert_true
 }
 
 fn test_resolve_undefined_enum_raises {
@@ -518,27 +521,27 @@ fn test_data_enum_stores_ordinal {
 fn test_parse_match_produces_match_ops {
     "parse_match_produces_match_ops" test_start
     "enum Color { Red Green Blue }\nColor::Red match\n    Color::Red => 1\n    Color::Green => 2\n    Color::Blue => 3\nend\n" test_parse_code = ops
-    "has MATCH_START" 0 OpKind::OpMatchStart ops count_ops != assert_true
-    "has MATCH_ARM" 0 OpKind::OpMatchArm ops count_ops != assert_true
-    "has MATCH_END" 0 OpKind::OpMatchEnd ops count_ops != assert_true
+    "has MATCH_START" 0 &is_match_start ops count_ops != assert_true
+    "has MATCH_ARM" 0 &is_match_arm ops count_ops != assert_true
+    "has MATCH_END" 0 &is_match_end ops count_ops != assert_true
 }
 
 fn test_parse_match_arm_count {
     "parse_match_arm_count" test_start
     "enum Color { Red Green Blue }\nColor::Red match\n    Color::Red => 1\n    Color::Green => 2\n    Color::Blue => 3\nend\n" test_parse_code = ops
-    "three arms" 3 OpKind::OpMatchArm ops count_ops == assert_true
+    "three arms" 3 &is_match_arm ops count_ops == assert_true
 }
 
 fn test_parse_braced_arm {
     "parse_braced_arm" test_start
     "enum Color { Red Green Blue }\nColor::Red match\n    Color::Red => { 1 }\n    Color::Green => { 2 }\n    Color::Blue => { 3 }\nend\n" test_parse_code = ops
-    "three arms" 3 OpKind::OpMatchArm ops count_ops == assert_true
+    "three arms" 3 &is_match_arm ops count_ops == assert_true
 }
 
 fn test_parse_empty_braced_arm {
     "parse_empty_braced_arm" test_start
     "enum Color { Red Green Blue }\nColor::Red match\n    Color::Red => {}\n    Color::Green => {}\n    Color::Blue => {}\nend\n" test_parse_code = ops
-    "three arms" 3 OpKind::OpMatchArm ops count_ops == assert_true
+    "three arms" 3 &is_match_arm ops count_ops == assert_true
 }
 
 # ============================================================================
@@ -696,19 +699,19 @@ fn test_parse_generic_enum_type_var_order_preserved {
 fn test_parse_braced_arm_multiline_body {
     "parse_braced_arm_multiline_body" test_start
     "enum Color { Red Green Blue }\nColor::Red match\n    Color::Red => {\n        \"red\" print\n        \"\\n\" print\n    }\n    Color::Green => \"green\"\n    Color::Blue => \"blue\"\nend\n" test_parse_code = ops
-    "three arms" 3 OpKind::OpMatchArm ops count_ops == assert_true
+    "three arms" 3 &is_match_arm ops count_ops == assert_true
 }
 
 fn test_parse_mixed_braced_and_unbraced_arms {
     "parse_mixed_braced_and_unbraced_arms" test_start
     "enum Color { Red Green Blue }\nColor::Green match\n    Color::Red => 0\n    Color::Green => {\n        1\n    }\n    Color::Blue => 2\nend\n" test_parse_code = ops
-    "three arms" 3 OpKind::OpMatchArm ops count_ops == assert_true
+    "three arms" 3 &is_match_arm ops count_ops == assert_true
 }
 
 fn test_parse_braced_arm_with_destructuring {
     "parse_braced_arm_with_destructuring" test_start
     "enum Shape { Circle(int) Rectangle(int int) Point }\n10 Shape::Circle match\n    Shape::Circle(radius) => {\n        \"r=\" print\n        radius print\n    }\n    Shape::Rectangle(width height) => {\n        width height * print\n    }\n    Shape::Point => \"point\" print\nend\n" test_parse_code = ops
-    "three arms" 3 OpKind::OpMatchArm ops count_ops == assert_true
+    "three arms" 3 &is_match_arm ops count_ops == assert_true
 }
 
 # ============================================================================
@@ -902,7 +905,7 @@ fn test_is_check_resolves_ordinal {
     "enum Color { Red Green Blue }\nColor::Blue = c\nc Color::Blue is\n" resolve_enum = ops
     0 = index
     while index ops.length > do
-        if OpKind::OpIsCheck index ops.get Op::kind == then
+        if index ops.get.value OpValue::IsCheck is then
             index ops.get enum_variant_of = variant
             "ordinal 2" 2 variant EnumVariant::ordinal.unwrap assert_eq
         fi
@@ -915,7 +918,7 @@ fn test_is_check_with_bindings_parsed {
     "enum Shape { Circle(int) Rectangle(int int) Point }\n10 Shape::Circle = s\nif s Shape::Circle(r) is then\nr print\nfi\n" resolve_enum = ops
     0 = index
     while index ops.length > do
-        if OpKind::OpIsCheck index ops.get Op::kind == then
+        if index ops.get.value OpValue::IsCheck is then
             index ops.get enum_variant_of = variant
             "has binding" 1 variant EnumVariant::bindings.length assert_eq
             "binding name" "r" 0 variant EnumVariant::bindings.get assert_str_eq
@@ -929,7 +932,7 @@ fn test_is_check_multiple_bindings_parsed {
     "enum Shape { Circle(int) Rectangle(int int) Point }\n3 4 Shape::Rectangle = s\nif s Shape::Rectangle(w h) is then\nw print\nfi\n" resolve_enum = ops
     0 = index
     while index ops.length > do
-        if OpKind::OpIsCheck index ops.get Op::kind == then
+        if index ops.get.value OpValue::IsCheck is then
             index ops.get enum_variant_of = variant
             "has bindings" 2 variant EnumVariant::bindings.length assert_eq
             "binding w" "w" 0 variant EnumVariant::bindings.get assert_str_eq

--- a/tests/compiler/test_generic_structs.casa
+++ b/tests/compiler/test_generic_structs.casa
@@ -185,16 +185,16 @@ fn test_typecheck_generic_struct_in_function {
 fn test_resolve_generic_struct_new {
     "resolve_generic_struct_new" test_start
     "struct Box[T] { value: T }\n42 Box" resolve_gs = ops
-    OpKind::OpStructNew ops find_ops_by_kind = struct_new_ops
+    OpValue::StructNew ops find_ops_by_kind = struct_new_ops
     "has struct new op" 1 struct_new_ops.length assert_eq
 }
 
-fn find_ops_by_kind ops:List[Op] kind:OpKind -> List[Op] {
+fn find_ops_by_kind ops:List[Op] kind:OpValue -> List[Op] {
     List::new(List[Op]) = result
     0 = index
     while index ops.length > do
         index ops.get = op
-        if kind op Op::kind == then
+        if op.value kind == then
             op result.push
         fi
         1 += index

--- a/tests/compiler/test_lsp.casa
+++ b/tests/compiler/test_lsp.casa
@@ -260,7 +260,7 @@ fn test_find_op_at_position_finds_op {
     0 0 state find_op_at_position = result
     "is some" result.is_some assert_true
     result.unwrap = find
-    "kind is push int" OpKind::OpPushInt find FindResult::op Op::kind == assert_true
+    "kind is push int" find FindResult::op.value OpValue::PushInt is assert_true
     "no containing function" find FindResult::function.is_none assert_true
 }
 
@@ -270,7 +270,7 @@ fn test_find_op_at_position_finds_op_in_function {
     4 1 state find_op_at_position = result
     "is some" result.is_some assert_true
     result.unwrap = find
-    "kind is push int" OpKind::OpPushInt find FindResult::op Op::kind == assert_true
+    "kind is push int" find FindResult::op.value OpValue::PushInt is assert_true
     "has containing function" find FindResult::function.is_some assert_true
     "function is greet" "greet" find FindResult::function.unwrap Function::name assert_str_eq
 }

--- a/tests/compiler/test_parser.casa
+++ b/tests/compiler/test_parser.casa
@@ -13,7 +13,7 @@ fn test_parse_integer {
     "test" "42" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
     "count" 1 ops.length assert_eq
-    "kind" OpKind::OpPushInt 0 ops.get Op::kind == assert_true
+    "kind" 0 ops.get.value OpValue::PushInt is assert_true
     "value" 42 0 ops.get op_int_value assert_eq
 }
 
@@ -22,7 +22,7 @@ fn test_parse_negative_integer {
     "test" "-7" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
     "count" 1 ops.length assert_eq
-    "kind" OpKind::OpPushInt 0 ops.get Op::kind == assert_true
+    "kind" 0 ops.get.value OpValue::PushInt is assert_true
     "value" 0 7 - 0 ops.get op_int_value assert_eq
 }
 
@@ -31,7 +31,7 @@ fn test_parse_bool_true {
     "test" "true" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
     "count" 1 ops.length assert_eq
-    "kind" OpKind::OpPushBool 0 ops.get Op::kind == assert_true
+    "kind" 0 ops.get.value OpValue::PushBool is assert_true
     "value" 1 0 ops.get op_int_value assert_eq
 }
 
@@ -40,7 +40,7 @@ fn test_parse_bool_false {
     "test" "false" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
     "count" 1 ops.length assert_eq
-    "kind" OpKind::OpPushBool 0 ops.get Op::kind == assert_true
+    "kind" 0 ops.get.value OpValue::PushBool is assert_true
     "value" 0 0 ops.get op_int_value assert_eq
 }
 
@@ -49,7 +49,7 @@ fn test_parse_string {
     "test" "\"hello\"" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
     "count" 1 ops.length assert_eq
-    "kind" OpKind::OpPushStr 0 ops.get Op::kind == assert_true
+    "kind" 0 ops.get.value OpValue::PushStr is assert_true
     "value" "hello" 0 ops.get op_str_value assert_str_eq
 }
 
@@ -58,7 +58,7 @@ fn test_parse_char {
     "test" "'A'" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
     "count" 1 ops.length assert_eq
-    "kind" OpKind::OpPushChar 0 ops.get Op::kind == assert_true
+    "kind" 0 ops.get.value OpValue::PushChar is assert_true
     "value" 65 0 ops.get op_int_value assert_eq
 }
 
@@ -70,56 +70,56 @@ fn test_parse_keyword_if {
     "parse_keyword_if" test_start
     "test" "if" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpIfStart 0 ops.get Op::kind == assert_true
+    "kind" 0 ops.get.value OpValue::IfStart is assert_true
 }
 
 fn test_parse_keyword_then {
     "parse_keyword_then" test_start
     "test" "then" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpIfCondition 0 ops.get Op::kind == assert_true
+    "kind" 0 ops.get.value OpValue::IfCondition is assert_true
 }
 
 fn test_parse_keyword_else {
     "parse_keyword_else" test_start
     "test" "else" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpIfElse 0 ops.get Op::kind == assert_true
+    "kind" 0 ops.get.value OpValue::IfElse is assert_true
 }
 
 fn test_parse_keyword_fi {
     "parse_keyword_fi" test_start
     "test" "fi" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpIfEnd 0 ops.get Op::kind == assert_true
+    "kind" 0 ops.get.value OpValue::IfEnd is assert_true
 }
 
 fn test_parse_keyword_while {
     "parse_keyword_while" test_start
     "test" "while" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpWhileStart 0 ops.get Op::kind == assert_true
+    "kind" 0 ops.get.value OpValue::WhileStart is assert_true
 }
 
 fn test_parse_keyword_do {
     "parse_keyword_do" test_start
     "test" "do" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpWhileCondition 0 ops.get Op::kind == assert_true
+    "kind" 0 ops.get.value OpValue::WhileCondition is assert_true
 }
 
 fn test_parse_keyword_done {
     "parse_keyword_done" test_start
     "test" "done" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpWhileEnd 0 ops.get Op::kind == assert_true
+    "kind" 0 ops.get.value OpValue::WhileEnd is assert_true
 }
 
 fn test_parse_keyword_return {
     "parse_keyword_return" test_start
     "test" "return" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpFnReturn 0 ops.get Op::kind == assert_true
+    "kind" 0 ops.get.value OpValue::FnReturn is assert_true
 }
 
 # ============================================================================
@@ -130,42 +130,42 @@ fn test_parse_operator_add {
     "parse_operator_add" test_start
     "test" "+" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpAdd 0 ops.get Op::kind == assert_true
+    "kind" 0 ops.get.value OpValue::Add is assert_true
 }
 
 fn test_parse_operator_sub {
     "parse_operator_sub" test_start
     "test" "1 -" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpSub 1 ops.get Op::kind == assert_true
+    "kind" 1 ops.get.value OpValue::Sub is assert_true
 }
 
 fn test_parse_operator_eq {
     "parse_operator_eq" test_start
     "test" "==" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpEq 0 ops.get Op::kind == assert_true
+    "kind" 0 ops.get.value OpValue::Eq is assert_true
 }
 
 fn test_parse_operator_not {
     "parse_operator_not" test_start
     "test" "!" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpNot 0 ops.get Op::kind == assert_true
+    "kind" 0 ops.get.value OpValue::Not is assert_true
 }
 
 fn test_parse_operator_and {
     "parse_operator_and" test_start
     "test" "&&" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpAnd 0 ops.get Op::kind == assert_true
+    "kind" 0 ops.get.value OpValue::And is assert_true
 }
 
 fn test_parse_operator_or {
     "parse_operator_or" test_start
     "test" "||" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpOr 0 ops.get Op::kind == assert_true
+    "kind" 0 ops.get.value OpValue::Or is assert_true
 }
 
 # ============================================================================
@@ -176,28 +176,28 @@ fn test_parse_intrinsic_drop {
     "parse_intrinsic_drop" test_start
     "test" "drop" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpDrop 0 ops.get Op::kind == assert_true
+    "kind" 0 ops.get.value OpValue::Drop is assert_true
 }
 
 fn test_parse_intrinsic_dup {
     "parse_intrinsic_dup" test_start
     "test" "dup" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpDup 0 ops.get Op::kind == assert_true
+    "kind" 0 ops.get.value OpValue::Dup is assert_true
 }
 
 fn test_parse_intrinsic_swap {
     "parse_intrinsic_swap" test_start
     "test" "swap" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpSwap 0 ops.get Op::kind == assert_true
+    "kind" 0 ops.get.value OpValue::Swap is assert_true
 }
 
 fn test_parse_intrinsic_print {
     "parse_intrinsic_print" test_start
     "test" "print" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpPrint 0 ops.get Op::kind == assert_true
+    "kind" 0 ops.get.value OpValue::Print is assert_true
 }
 
 # ============================================================================
@@ -209,7 +209,7 @@ fn test_parse_type_cast {
     "test" "(int)" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
     "count" 1 ops.length assert_eq
-    "kind" OpKind::OpTypeCast 0 ops.get Op::kind == assert_true
+    "kind" 0 ops.get.value OpValue::TypeCast is assert_true
     "value" "int" 0 ops.get op_str_value assert_str_eq
 }
 
@@ -217,7 +217,7 @@ fn test_parse_type_cast_str {
     "parse_type_cast_str" test_start
     "test" "(str)" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpTypeCast 0 ops.get Op::kind == assert_true
+    "kind" 0 ops.get.value OpValue::TypeCast is assert_true
     "value" "str" 0 ops.get op_str_value assert_str_eq
 }
 
@@ -230,8 +230,8 @@ fn test_parse_variable_assign {
     "test" "42 = foo" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
     "count" 2 ops.length assert_eq
-    "push kind" OpKind::OpPushInt 0 ops.get Op::kind == assert_true
-    "assign kind" OpKind::OpAssignVar 1 ops.get Op::kind == assert_true
+    "push kind" 0 ops.get.value OpValue::PushInt is assert_true
+    "assign kind" 1 ops.get.value OpValue::AssignVar is assert_true
     "assign name" "foo" 1 ops.get op_str_value assert_str_eq
 }
 
@@ -239,8 +239,8 @@ fn test_parse_variable_inc {
     "parse_variable_inc" test_start
     "test" "1 += counter" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "push kind" OpKind::OpPushInt 0 ops.get Op::kind == assert_true
-    "inc kind" OpKind::OpAssignInc 1 ops.get Op::kind == assert_true
+    "push kind" 0 ops.get.value OpValue::PushInt is assert_true
+    "inc kind" 1 ops.get.value OpValue::AssignInc is assert_true
     "inc name" "counter" 1 ops.get op_str_value assert_str_eq
 }
 
@@ -252,7 +252,7 @@ fn test_parse_method_call {
     "parse_method_call" test_start
     "test" ".length" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpMethodCall 0 ops.get Op::kind == assert_true
+    "kind" 0 ops.get.value OpValue::MethodCall is assert_true
     "value" "length" 0 ops.get op_str_value assert_str_eq
 }
 
@@ -260,7 +260,7 @@ fn test_parse_setter_call {
     "parse_setter_call" test_start
     "test" "->name" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpMethodCall 0 ops.get Op::kind == assert_true
+    "kind" 0 ops.get.value OpValue::MethodCall is assert_true
     "value" "set_name" 0 ops.get op_str_value assert_str_eq
 }
 
@@ -272,7 +272,7 @@ fn test_parse_identifier {
     "parse_identifier" test_start
     "test" "foo" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpIdentifier 0 ops.get Op::kind == assert_true
+    "kind" 0 ops.get.value OpValue::Identifier is assert_true
     "value" "foo" 0 ops.get op_str_value assert_str_eq
 }
 
@@ -334,24 +334,24 @@ fn test_parse_if_construct {
     "parse_if_construct" test_start
     "test" "if true then 42 else 0 fi" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "if" OpKind::OpIfStart 0 ops.get Op::kind == assert_true
-    "true" OpKind::OpPushBool 1 ops.get Op::kind == assert_true
-    "then" OpKind::OpIfCondition 2 ops.get Op::kind == assert_true
-    "42" OpKind::OpPushInt 3 ops.get Op::kind == assert_true
-    "else" OpKind::OpIfElse 4 ops.get Op::kind == assert_true
-    "0" OpKind::OpPushInt 5 ops.get Op::kind == assert_true
-    "fi" OpKind::OpIfEnd 6 ops.get Op::kind == assert_true
+    "if" 0 ops.get.value OpValue::IfStart is assert_true
+    "true" 1 ops.get.value OpValue::PushBool is assert_true
+    "then" 2 ops.get.value OpValue::IfCondition is assert_true
+    "42" 3 ops.get.value OpValue::PushInt is assert_true
+    "else" 4 ops.get.value OpValue::IfElse is assert_true
+    "0" 5 ops.get.value OpValue::PushInt is assert_true
+    "fi" 6 ops.get.value OpValue::IfEnd is assert_true
 }
 
 fn test_parse_while_construct {
     "parse_while_construct" test_start
     "test" "while true do break done" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "while" OpKind::OpWhileStart 0 ops.get Op::kind == assert_true
-    "true" OpKind::OpPushBool 1 ops.get Op::kind == assert_true
-    "do" OpKind::OpWhileCondition 2 ops.get Op::kind == assert_true
-    "break" OpKind::OpWhileBreak 3 ops.get Op::kind == assert_true
-    "done" OpKind::OpWhileEnd 4 ops.get Op::kind == assert_true
+    "while" 0 ops.get.value OpValue::WhileStart is assert_true
+    "true" 1 ops.get.value OpValue::PushBool is assert_true
+    "do" 2 ops.get.value OpValue::WhileCondition is assert_true
+    "break" 3 ops.get.value OpValue::WhileBreak is assert_true
+    "done" 4 ops.get.value OpValue::WhileEnd is assert_true
 }
 
 # ============================================================================
@@ -362,7 +362,7 @@ fn test_parse_match_construct {
     "parse_match_construct" test_start
     "test" "enum Dir { Up Down }\nmatch Up => 1 Down => 2 end" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "match start" OpKind::OpMatchStart 0 ops.get Op::kind == assert_true
+    "match start" 0 ops.get.value OpValue::MatchStart is assert_true
 }
 
 # ============================================================================
@@ -374,10 +374,10 @@ fn test_parse_multiple_ops {
     "test" "1 2 + = result" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
     "count" 4 ops.length assert_eq
-    "push 1" OpKind::OpPushInt 0 ops.get Op::kind == assert_true
-    "push 2" OpKind::OpPushInt 1 ops.get Op::kind == assert_true
-    "add" OpKind::OpAdd 2 ops.get Op::kind == assert_true
-    "assign" OpKind::OpAssignVar 3 ops.get Op::kind == assert_true
+    "push 1" 0 ops.get.value OpValue::PushInt is assert_true
+    "push 2" 1 ops.get.value OpValue::PushInt is assert_true
+    "add" 2 ops.get.value OpValue::Add is assert_true
+    "assign" 3 ops.get.value OpValue::AssignVar is assert_true
 }
 
 # ============================================================================
@@ -388,63 +388,63 @@ fn test_parse_operator_mul {
     "parse_operator_mul" test_start
     "test" "1 2 *" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpMul 2 ops.get Op::kind == assert_true
+    "kind" 2 ops.get.value OpValue::Mul is assert_true
 }
 
 fn test_parse_operator_div {
     "parse_operator_div" test_start
     "test" "1 2 /" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpDiv 2 ops.get Op::kind == assert_true
+    "kind" 2 ops.get.value OpValue::Div is assert_true
 }
 
 fn test_parse_operator_mod {
     "parse_operator_mod" test_start
     "test" "1 2 %" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpMod 2 ops.get Op::kind == assert_true
+    "kind" 2 ops.get.value OpValue::Mod is assert_true
 }
 
 fn test_parse_operator_lt {
     "parse_operator_lt" test_start
     "test" "1 2 <" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpLt 2 ops.get Op::kind == assert_true
+    "kind" 2 ops.get.value OpValue::Lt is assert_true
 }
 
 fn test_parse_operator_gt {
     "parse_operator_gt" test_start
     "test" "1 2 >" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpGt 2 ops.get Op::kind == assert_true
+    "kind" 2 ops.get.value OpValue::Gt is assert_true
 }
 
 fn test_parse_operator_le {
     "parse_operator_le" test_start
     "test" "1 2 <=" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpLe 2 ops.get Op::kind == assert_true
+    "kind" 2 ops.get.value OpValue::Le is assert_true
 }
 
 fn test_parse_operator_ge {
     "parse_operator_ge" test_start
     "test" "1 2 >=" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpGe 2 ops.get Op::kind == assert_true
+    "kind" 2 ops.get.value OpValue::Ge is assert_true
 }
 
 fn test_parse_operator_ne {
     "parse_operator_ne" test_start
     "test" "1 2 !=" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpNe 2 ops.get Op::kind == assert_true
+    "kind" 2 ops.get.value OpValue::Ne is assert_true
 }
 
 fn test_parse_operator_bit_not {
     "parse_operator_bit_not" test_start
     "test" "1 ~" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpBitNot 1 ops.get Op::kind == assert_true
+    "kind" 1 ops.get.value OpValue::BitNot is assert_true
 }
 
 # ============================================================================
@@ -455,28 +455,28 @@ fn test_parse_intrinsic_over {
     "parse_intrinsic_over" test_start
     "test" "over" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpOver 0 ops.get Op::kind == assert_true
+    "kind" 0 ops.get.value OpValue::Over is assert_true
 }
 
 fn test_parse_intrinsic_rot {
     "parse_intrinsic_rot" test_start
     "test" "rot" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpRot 0 ops.get Op::kind == assert_true
+    "kind" 0 ops.get.value OpValue::Rot is assert_true
 }
 
 fn test_parse_intrinsic_typeof {
     "parse_intrinsic_typeof" test_start
     "test" "typeof" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpTypeof 0 ops.get Op::kind == assert_true
+    "kind" 0 ops.get.value OpValue::Typeof is assert_true
 }
 
 fn test_parse_intrinsic_alloc {
     "parse_intrinsic_alloc" test_start
     "test" "alloc" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpHeapAlloc 0 ops.get Op::kind == assert_true
+    "kind" 0 ops.get.value OpValue::HeapAlloc is assert_true
 }
 
 # ============================================================================
@@ -487,8 +487,8 @@ fn test_parse_variable_dec {
     "parse_variable_dec" test_start
     "test" "1 -= counter" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "push kind" OpKind::OpPushInt 0 ops.get Op::kind == assert_true
-    "dec kind" OpKind::OpAssignDec 1 ops.get Op::kind == assert_true
+    "push kind" 0 ops.get.value OpValue::PushInt is assert_true
+    "dec kind" 1 ops.get.value OpValue::AssignDec is assert_true
     "dec name" "counter" 1 ops.get op_str_value assert_str_eq
 }
 
@@ -500,7 +500,7 @@ fn test_parse_keyword_elif {
     "parse_keyword_elif" test_start
     "test" "elif" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpIfElif 0 ops.get Op::kind == assert_true
+    "kind" 0 ops.get.value OpValue::IfElif is assert_true
 }
 
 # ============================================================================
@@ -511,14 +511,14 @@ fn test_parse_keyword_break {
     "parse_keyword_break" test_start
     "test" "break" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpWhileBreak 0 ops.get Op::kind == assert_true
+    "kind" 0 ops.get.value OpValue::WhileBreak is assert_true
 }
 
 fn test_parse_keyword_continue {
     "parse_keyword_continue" test_start
     "test" "continue" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "kind" OpKind::OpWhileContinue 0 ops.get Op::kind == assert_true
+    "kind" 0 ops.get.value OpValue::WhileContinue is assert_true
 }
 
 fn test_parse_keyword_import {
@@ -527,7 +527,7 @@ fn test_parse_keyword_import {
     "test" "import \"/foo.casa\"" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
     "count" 1 ops.length assert_eq
-    "kind" OpKind::OpImportFile 0 ops.get Op::kind == assert_true
+    "kind" 0 ops.get.value OpValue::ImportFile is assert_true
     "path" "/foo.casa" 0 ops.get op_str_value assert_str_eq
 }
 
@@ -644,7 +644,7 @@ fn test_parse_string_with_escapes {
     "test" "\"hello\\nworld\"" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
     "count" 1 ops.length assert_eq
-    "kind" OpKind::OpPushStr 0 ops.get Op::kind == assert_true
+    "kind" 0 ops.get.value OpValue::PushStr is assert_true
     "value" "hello\nworld" 0 ops.get op_str_value assert_str_eq
 }
 

--- a/tests/compiler/test_pattern.casa
+++ b/tests/compiler/test_pattern.casa
@@ -14,20 +14,20 @@ import "../../lib/test.casa"
 fn make_enum_arm enum_name:str variant_name:str -> Op {
     Option::None variant_name enum_name make_enum_variant = variant
     List::new(List[Op]) variant PatternValue::EnumVariant make_match_arm = arm
-    empty_location OpKind::OpMatchArm arm OpValue::Match make_op_v
+    empty_location arm OpValue::MatchArm make_op
 }
 
 fn make_struct_arm struct_name:str -> Op {
     Map::new(Map[str str]) = bindings
     bindings struct_name StructPattern = struct_pat
     List::new(List[Op]) struct_pat PatternValue::Struct make_match_arm = arm
-    empty_location OpKind::OpMatchArm arm OpValue::Match make_op_v
+    empty_location arm OpValue::MatchArm make_op
 }
 
 fn make_literal_arm raw:str -> Op {
     raw 0 LiteralValue::Int LiteralPattern = literal_pat
     List::new(List[Op]) literal_pat PatternValue::Literal make_match_arm = arm
-    empty_location OpKind::OpMatchArm arm OpValue::Match make_op_v
+    empty_location arm OpValue::MatchArm make_op
 }
 
 # ============================================================================
@@ -103,7 +103,7 @@ fn test_pattern_bindings_enum_with_payload {
     "x" binds.push
     binds variant EnumVariant::set_bindings
     List::new(List[Op]) variant PatternValue::EnumVariant make_match_arm = arm
-    empty_location OpKind::OpMatchArm arm OpValue::Match make_op_v = op
+    empty_location arm OpValue::MatchArm make_op = op
     op pattern_bindings = out
     "count" 1 out.length assert_eq
     "name" "x" 0 out.get assert_str_eq
@@ -116,7 +116,7 @@ fn test_pattern_bindings_struct_fields {
     "col" "x" bindings.set drop
     bindings "Point" StructPattern = struct_pat
     List::new(List[Op]) struct_pat PatternValue::Struct make_match_arm = arm
-    empty_location OpKind::OpMatchArm arm OpValue::Match make_op_v = op
+    empty_location arm OpValue::MatchArm make_op = op
     op pattern_bindings = out
     "count" 2 out.length assert_eq
 }
@@ -170,7 +170,7 @@ fn test_guard_parser_collects_ops {
     0 = unguarded_count
     while arm_index ops.length > do
         arm_index ops.get = arm_op
-        if OpKind::OpMatchArm arm_op Op::kind == then
+        if arm_op.value OpValue::MatchArm is then
             if arm_op pattern_is_guarded then
                 1 += guarded_count
             else
@@ -189,9 +189,9 @@ fn test_guard_excluded_from_covered_key {
     "covered when unguarded" "__covered:42" unguarded pattern_covered_key assert_str_eq
     "42" 0 LiteralValue::Int LiteralPattern = literal_pat
     List::new(List[Op]) = guard_ops
-    empty_location OpKind::OpPushBool 1 make_op_int guard_ops.push
+    empty_location 1 OpValue::PushBool make_op guard_ops.push
     guard_ops literal_pat PatternValue::Literal make_match_arm = arm
-    empty_location OpKind::OpMatchArm arm OpValue::Match make_op_v = guarded
+    empty_location arm OpValue::MatchArm make_op = guarded
     "is guarded" guarded pattern_is_guarded assert_true
     "empty key when guarded" "" guarded pattern_covered_key assert_str_eq
 }

--- a/tests/compiler/test_struct_literal.casa
+++ b/tests/compiler/test_struct_literal.casa
@@ -40,14 +40,15 @@ fn sl_compile code:str -> Program {
     ops DEFAULT_PARSER.store compile_bytecode
 }
 
-fn sl_count_ops ops:List[Op] kind:OpKind -> int {
+fn sl_is_struct_literal value:OpValue -> bool { value OpValue::StructLiteral is }
+fn sl_is_match_arm value:OpValue -> bool { value OpValue::MatchArm is }
+
+fn sl_count_ops ops:List[Op] predicate:fn[OpValue -> bool] -> int {
     0 = count
-    0 = index
-    while index ops.length > do
-        if kind index ops.get Op::kind == then
+    for sl_op in ops.iter do
+        if sl_op.value predicate exec then
             1 += count
         fi
-        1 += index
     done
     count
 }
@@ -75,11 +76,11 @@ fn sl_has_inst_kind bytecode:List[Inst] kind:InstKind -> bool {
 fn test_basic_struct_literal {
     "basic_struct_literal" test_start
     "struct Point { x: int y: int }\nPoint { x: 1 y: 2 }" sl_parse = ops
-    "has struct literal op" 1 OpKind::OpStructLiteral ops sl_count_ops == assert_true
+    "has struct literal op" 1 &sl_is_struct_literal ops sl_count_ops == assert_true
     # Check the StructLiteral value
     0 = index
     while index ops.length > do
-        if OpKind::OpStructLiteral index ops.get Op::kind == then
+        if index ops.get.value OpValue::StructLiteral is then
             index ops.get struct_literal_of = literal
             "struct name" "Point" literal StructLiteral::struct_name assert_str_eq
             "field count" 2 literal StructLiteral::field_order.length assert_eq
@@ -95,7 +96,7 @@ fn test_reverse_field_order {
     "struct Point { x: int y: int }\nPoint { y: 2 x: 1 }" sl_parse = ops
     0 = index
     while index ops.length > do
-        if OpKind::OpStructLiteral index ops.get Op::kind == then
+        if index ops.get.value OpValue::StructLiteral is then
             index ops.get struct_literal_of = literal
             "field 0" "y" 0 literal StructLiteral::field_order.get assert_str_eq
             "field 1" "x" 1 literal StructLiteral::field_order.get assert_str_eq
@@ -107,10 +108,10 @@ fn test_reverse_field_order {
 fn test_struct_match_pattern {
     "struct_match_pattern" test_start
     "struct Point { x: int y: int }\n1 2 Point = p\np match\n    Point { x: px y: py } => px py +\nend" sl_parse = ops
-    "has match arm" 0 OpKind::OpMatchArm ops sl_count_ops != assert_true
+    "has match arm" 0 &sl_is_match_arm ops sl_count_ops != assert_true
     0 = index
     while index ops.length > do
-        if OpKind::OpMatchArm index ops.get Op::kind == then
+        if index ops.get.value OpValue::MatchArm is then
             if index ops.get pattern_value_of PatternValue::Struct(pattern) is then
                 "struct name" "Point" pattern.struct_name assert_str_eq
                 "binding x" "px" "x" pattern.bindings.get.unwrap assert_str_eq
@@ -126,7 +127,7 @@ fn test_partial_binding {
     "struct Point { x: int y: int }\n1 2 Point = p\np match\n    Point { x: px } => px\nend" sl_parse = ops
     0 = index
     while index ops.length > do
-        if OpKind::OpMatchArm index ops.get Op::kind == then
+        if index ops.get.value OpValue::MatchArm is then
             if index ops.get pattern_value_of PatternValue::Struct(pattern) is then
                 "binding x" "px" "x" pattern.bindings.get.unwrap assert_str_eq
                 "no y binding" "y" pattern.bindings.get.is_none assert_true
@@ -139,7 +140,7 @@ fn test_partial_binding {
 fn test_field_value_with_expression {
     "field_value_with_expression" test_start
     "struct Point { x: int y: int }\nPoint { x: 1 2 + y: 3 }" sl_parse = ops
-    "has struct literal op" 1 OpKind::OpStructLiteral ops sl_count_ops == assert_true
+    "has struct literal op" 1 &sl_is_struct_literal ops sl_count_ops == assert_true
 }
 
 # ============================================================================

--- a/tests/compiler/test_traits.casa
+++ b/tests/compiler/test_traits.casa
@@ -341,7 +341,7 @@ fn test_trait_hidden_params_creates_assign_ops {
     while index func Function::ops.length > do
         index func Function::ops.get = current_op
         if
-        OpKind::OpAssignVar current_op Op::kind ==
+        current_op.value OpValue::AssignVar is
         "__trait_K_hash" current_op op_str_value == &&
         then
             true = found
@@ -639,7 +639,7 @@ fn test_k_coloncolon_method_resolved_as_push_variable_exec {
     while index func Function::ops.length > do
         index func Function::ops.get = current_op
         if
-        OpKind::OpPushVar current_op Op::kind ==
+        current_op.value OpValue::PushVar is
         "__trait_K_hash" current_op op_str_value == &&
         then
             true = found_push_var
@@ -667,7 +667,7 @@ fn test_ampersand_k_coloncolon_method_resolved_as_push_variable {
     while index func Function::ops.length > do
         index func Function::ops.get = current_op
         if
-        OpKind::OpPushVar current_op Op::kind ==
+        current_op.value OpValue::PushVar is
         "__trait_K_hash" current_op op_str_value == &&
         then
             true = found_push_var

--- a/tests/compiler/test_type_annotations.casa
+++ b/tests/compiler/test_type_annotations.casa
@@ -33,7 +33,7 @@ fn find_assign_ops ops:List[Op] -> List[Op] {
     0 = index
     while index ops.length > do
         index ops.get = op
-        if OpKind::OpAssignVar op Op::kind == then
+        if op.value OpValue::AssignVar is then
             op result.push
         fi
         1 += index
@@ -41,12 +41,12 @@ fn find_assign_ops ops:List[Op] -> List[Op] {
     result
 }
 
-fn find_ops_by_kind ops:List[Op] kind:OpKind -> List[Op] {
+fn find_ops_by_kind ops:List[Op] kind:OpValue -> List[Op] {
     List::new(List[Op]) = result
     0 = index
     while index ops.length > do
         index ops.get = op
-        if kind op Op::kind == then
+        if op.value kind == then
             op result.push
         fi
         1 += index
@@ -155,7 +155,7 @@ fn test_annotation_char {
 fn test_no_annotation_on_increment {
     "no_annotation_on_increment" test_start
     "42 = x 1 += x" test_parse = ops
-    OpKind::OpAssignInc ops find_ops_by_kind = inc_ops
+    OpValue::AssignInc ops find_ops_by_kind = inc_ops
     "count" 1 inc_ops.length assert_eq
     "annotation empty" "" 0 inc_ops.get Op::type_annotation assert_str_eq
 }
@@ -163,7 +163,7 @@ fn test_no_annotation_on_increment {
 fn test_no_annotation_on_decrement {
     "no_annotation_on_decrement" test_start
     "42 = x 1 -= x" test_parse = ops
-    OpKind::OpAssignDec ops find_ops_by_kind = dec_ops
+    OpValue::AssignDec ops find_ops_by_kind = dec_ops
     "count" 1 dec_ops.length assert_eq
     "annotation empty" "" 0 dec_ops.get Op::type_annotation assert_str_eq
 }

--- a/tests/compiler/test_typechecker.casa
+++ b/tests/compiler/test_typechecker.casa
@@ -14,117 +14,117 @@ fn tc_check ops:List[Op] -> TypeChecker {
     0 = helper_i
     while helper_i ops.length > do
         helper_i ops.get = helper_op
-        helper_op Op::kind = helper_kind
+        helper_op Op::value = helper_kind
 
         # Literals
-        if OpKind::OpPushInt helper_kind == then
+        if helper_kind OpValue::PushInt is then
             "int" helper_tc stack_push
-        elif OpKind::OpPushStr helper_kind == then
+        elif helper_kind OpValue::PushStr is then
             "str" helper_tc stack_push
-        elif OpKind::OpPushBool helper_kind == then
+        elif helper_kind OpValue::PushBool is then
             "bool" helper_tc stack_push
-        elif OpKind::OpPushChar helper_kind == then
+        elif helper_kind OpValue::PushChar is then
             "char" helper_tc stack_push
             # Arithmetic
         elif
-        OpKind::OpAdd helper_kind ==
-        OpKind::OpSub helper_kind == ||
-        OpKind::OpMul helper_kind == ||
-        OpKind::OpDiv helper_kind == ||
-        OpKind::OpMod helper_kind == ||
+        helper_kind OpValue::Add is
+        helper_kind OpValue::Sub is ||
+        helper_kind OpValue::Mul is ||
+        helper_kind OpValue::Div is ||
+        helper_kind OpValue::Mod is ||
         then
             helper_op helper_tc check_arithmetic
             # Comparison
         elif
-        OpKind::OpEq helper_kind ==
-        OpKind::OpNe helper_kind == ||
-        OpKind::OpLt helper_kind == ||
-        OpKind::OpLe helper_kind == ||
-        OpKind::OpGt helper_kind == ||
-        OpKind::OpGe helper_kind == ||
+        helper_kind OpValue::Eq is
+        helper_kind OpValue::Ne is ||
+        helper_kind OpValue::Lt is ||
+        helper_kind OpValue::Le is ||
+        helper_kind OpValue::Gt is ||
+        helper_kind OpValue::Ge is ||
         then
             helper_op helper_tc check_comparison
             # Boolean
         elif
-        OpKind::OpAnd helper_kind ==
-        OpKind::OpOr helper_kind == ||
-        OpKind::OpNot helper_kind == ||
+        helper_kind OpValue::And is
+        helper_kind OpValue::Or is ||
+        helper_kind OpValue::Not is ||
         then
             helper_op helper_tc check_boolean
             # Bitwise
         elif
-        OpKind::OpBitAnd helper_kind ==
-        OpKind::OpBitOr helper_kind == ||
-        OpKind::OpBitXor helper_kind == ||
-        OpKind::OpBitNot helper_kind == ||
-        OpKind::OpShl helper_kind == ||
-        OpKind::OpShr helper_kind == ||
+        helper_kind OpValue::BitAnd is
+        helper_kind OpValue::BitOr is ||
+        helper_kind OpValue::BitXor is ||
+        helper_kind OpValue::BitNot is ||
+        helper_kind OpValue::Shl is ||
+        helper_kind OpValue::Shr is ||
         then
             helper_op helper_tc check_bitwise
             # Stack ops
         elif
-        OpKind::OpDrop helper_kind ==
-        OpKind::OpDup helper_kind == ||
-        OpKind::OpSwap helper_kind == ||
-        OpKind::OpOver helper_kind == ||
-        OpKind::OpRot helper_kind == ||
+        helper_kind OpValue::Drop is
+        helper_kind OpValue::Dup is ||
+        helper_kind OpValue::Swap is ||
+        helper_kind OpValue::Over is ||
+        helper_kind OpValue::Rot is ||
         then
             helper_op helper_tc check_stack_ops
             # Memory
         elif
-        OpKind::OpLoad8 helper_kind ==
-        OpKind::OpLoad16 helper_kind == ||
-        OpKind::OpLoad32 helper_kind == ||
-        OpKind::OpLoad64 helper_kind == ||
-        OpKind::OpStore8 helper_kind == ||
-        OpKind::OpStore16 helper_kind == ||
-        OpKind::OpStore32 helper_kind == ||
-        OpKind::OpStore64 helper_kind == ||
-        OpKind::OpHeapAlloc helper_kind == ||
+        helper_kind OpValue::Load8 is
+        helper_kind OpValue::Load16 is ||
+        helper_kind OpValue::Load32 is ||
+        helper_kind OpValue::Load64 is ||
+        helper_kind OpValue::Store8 is ||
+        helper_kind OpValue::Store16 is ||
+        helper_kind OpValue::Store32 is ||
+        helper_kind OpValue::Store64 is ||
+        helper_kind OpValue::HeapAlloc is ||
         then
             helper_op helper_tc check_memory
             # Print
-        elif OpKind::OpPrint helper_kind == then
+        elif helper_kind OpValue::Print is then
             helper_op helper_tc check_io
             # Typeof
-        elif OpKind::OpTypeof helper_kind == then
+        elif helper_kind OpValue::Typeof is then
             helper_op helper_tc check_typeof
             # Type cast
-        elif OpKind::OpTypeCast helper_kind == then
+        elif helper_kind OpValue::TypeCast is then
             helper_tc stack_pop drop
             helper_op op_str_value helper_tc stack_push
             # Syscalls
         elif
-        OpKind::OpSyscall0 helper_kind ==
-        OpKind::OpSyscall1 helper_kind == ||
-        OpKind::OpSyscall2 helper_kind == ||
-        OpKind::OpSyscall3 helper_kind == ||
-        OpKind::OpSyscall4 helper_kind == ||
-        OpKind::OpSyscall5 helper_kind == ||
-        OpKind::OpSyscall6 helper_kind == ||
+        helper_kind OpValue::Syscall0 is
+        helper_kind OpValue::Syscall1 is ||
+        helper_kind OpValue::Syscall2 is ||
+        helper_kind OpValue::Syscall3 is ||
+        helper_kind OpValue::Syscall4 is ||
+        helper_kind OpValue::Syscall5 is ||
+        helper_kind OpValue::Syscall6 is ||
         then
             helper_op helper_tc check_syscalls
             # Argc / Argv
-        elif OpKind::OpArgc helper_kind == then
+        elif helper_kind OpValue::Argc is then
             "int" helper_tc stack_push
-        elif OpKind::OpArgv helper_kind == then
+        elif helper_kind OpValue::Argv is then
             "ptr" helper_tc stack_push
             # Branch ops — routed to real handlers so tests can exercise the
             # BranchFrame sum type and the if/while/match branch algebra.
         elif
-        OpKind::OpIfStart helper_kind ==
-        OpKind::OpIfCondition helper_kind == ||
-        OpKind::OpIfElif helper_kind == ||
-        OpKind::OpIfElse helper_kind == ||
-        OpKind::OpIfEnd helper_kind == ||
+        helper_kind OpValue::IfStart is
+        helper_kind OpValue::IfCondition is ||
+        helper_kind OpValue::IfElif is ||
+        helper_kind OpValue::IfElse is ||
+        helper_kind OpValue::IfEnd is ||
         then
             helper_op helper_tc check_if_block
         elif
-        OpKind::OpWhileStart helper_kind ==
-        OpKind::OpWhileCondition helper_kind == ||
-        OpKind::OpWhileBreak helper_kind == ||
-        OpKind::OpWhileContinue helper_kind == ||
-        OpKind::OpWhileEnd helper_kind == ||
+        helper_kind OpValue::WhileStart is
+        helper_kind OpValue::WhileCondition is ||
+        helper_kind OpValue::WhileBreak is ||
+        helper_kind OpValue::WhileContinue is ||
+        helper_kind OpValue::WhileEnd is ||
         then
             helper_op helper_tc check_while_block
         fi
@@ -141,7 +141,7 @@ fn tc_check ops:List[Op] -> TypeChecker {
 fn test_push_int_stack {
     "push_int_stack" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushInt 42 make_op_int ops.push
+    empty_location 42 OpValue::PushInt make_op ops.push
     ops tc_check = result_tc
     "stack has one item" 1 result_tc TypeChecker::live TypedStack::types.length assert_eq
     "type is int" "int" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
@@ -154,9 +154,9 @@ fn test_push_int_stack {
 fn test_add_stack_effect {
     "add_stack_effect" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushInt 10 make_op_int ops.push
-    empty_location OpKind::OpPushInt 20 make_op_int ops.push
-    empty_location OpKind::OpAdd make_op ops.push
+    empty_location 10 OpValue::PushInt make_op ops.push
+    empty_location 20 OpValue::PushInt make_op ops.push
+    empty_location OpValue::Add make_op ops.push
     ops tc_check = result_tc
     "stack has one item after add" 1 result_tc TypeChecker::live TypedStack::types.length assert_eq
     "result type is int" "int" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
@@ -171,34 +171,34 @@ fn test_arithmetic_ops {
 
     # Sub
     List::new(List[Op]) = ops_sub
-    empty_location OpKind::OpPushInt 5 make_op_int ops_sub.push
-    empty_location OpKind::OpPushInt 3 make_op_int ops_sub.push
-    empty_location OpKind::OpSub make_op ops_sub.push
+    empty_location 5 OpValue::PushInt make_op ops_sub.push
+    empty_location 3 OpValue::PushInt make_op ops_sub.push
+    empty_location OpValue::Sub make_op ops_sub.push
     ops_sub tc_check = tc_sub
     "sub result" 1 tc_sub TypeChecker::live TypedStack::types.length assert_eq
     "sub type" "int" 0 tc_sub TypeChecker::live TypedStack::types.get assert_str_eq
 
     # Mul
     List::new(List[Op]) = ops_mul
-    empty_location OpKind::OpPushInt 2 make_op_int ops_mul.push
-    empty_location OpKind::OpPushInt 3 make_op_int ops_mul.push
-    empty_location OpKind::OpMul make_op ops_mul.push
+    empty_location 2 OpValue::PushInt make_op ops_mul.push
+    empty_location 3 OpValue::PushInt make_op ops_mul.push
+    empty_location OpValue::Mul make_op ops_mul.push
     ops_mul tc_check = tc_mul
     "mul type" "int" 0 tc_mul TypeChecker::live TypedStack::types.get assert_str_eq
 
     # Div
     List::new(List[Op]) = ops_div
-    empty_location OpKind::OpPushInt 10 make_op_int ops_div.push
-    empty_location OpKind::OpPushInt 2 make_op_int ops_div.push
-    empty_location OpKind::OpDiv make_op ops_div.push
+    empty_location 10 OpValue::PushInt make_op ops_div.push
+    empty_location 2 OpValue::PushInt make_op ops_div.push
+    empty_location OpValue::Div make_op ops_div.push
     ops_div tc_check = tc_div
     "div type" "int" 0 tc_div TypeChecker::live TypedStack::types.get assert_str_eq
 
     # Mod
     List::new(List[Op]) = ops_mod
-    empty_location OpKind::OpPushInt 10 make_op_int ops_mod.push
-    empty_location OpKind::OpPushInt 3 make_op_int ops_mod.push
-    empty_location OpKind::OpMod make_op ops_mod.push
+    empty_location 10 OpValue::PushInt make_op ops_mod.push
+    empty_location 3 OpValue::PushInt make_op ops_mod.push
+    empty_location OpValue::Mod make_op ops_mod.push
     ops_mod tc_check = tc_mod
     "mod type" "int" 0 tc_mod TypeChecker::live TypedStack::types.get assert_str_eq
 }
@@ -210,9 +210,9 @@ fn test_arithmetic_ops {
 fn test_comparison_produces_bool {
     "comparison_produces_bool" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushInt 1 make_op_int ops.push
-    empty_location OpKind::OpPushInt 2 make_op_int ops.push
-    empty_location OpKind::OpLt make_op ops.push
+    empty_location 1 OpValue::PushInt make_op ops.push
+    empty_location 2 OpValue::PushInt make_op ops.push
+    empty_location OpValue::Lt make_op ops.push
     ops tc_check = result_tc
     "stack after lt" 1 result_tc TypeChecker::live TypedStack::types.length assert_eq
     "lt result is bool" "bool" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
@@ -226,24 +226,24 @@ fn test_boolean_ops {
     "boolean_ops" test_start
     # AND
     List::new(List[Op]) = ops_and
-    empty_location OpKind::OpPushBool 1 make_op_int ops_and.push
-    empty_location OpKind::OpPushBool 0 make_op_int ops_and.push
-    empty_location OpKind::OpAnd make_op ops_and.push
+    empty_location 1 OpValue::PushBool make_op ops_and.push
+    empty_location 0 OpValue::PushBool make_op ops_and.push
+    empty_location OpValue::And make_op ops_and.push
     ops_and tc_check = tc_and
     "and result" "bool" 0 tc_and TypeChecker::live TypedStack::types.get assert_str_eq
 
     # OR
     List::new(List[Op]) = ops_or
-    empty_location OpKind::OpPushBool 1 make_op_int ops_or.push
-    empty_location OpKind::OpPushBool 0 make_op_int ops_or.push
-    empty_location OpKind::OpOr make_op ops_or.push
+    empty_location 1 OpValue::PushBool make_op ops_or.push
+    empty_location 0 OpValue::PushBool make_op ops_or.push
+    empty_location OpValue::Or make_op ops_or.push
     ops_or tc_check = tc_or
     "or result" "bool" 0 tc_or TypeChecker::live TypedStack::types.get assert_str_eq
 
     # NOT
     List::new(List[Op]) = ops_not
-    empty_location OpKind::OpPushBool 1 make_op_int ops_not.push
-    empty_location OpKind::OpNot make_op ops_not.push
+    empty_location 1 OpValue::PushBool make_op ops_not.push
+    empty_location OpValue::Not make_op ops_not.push
     ops_not tc_check = tc_not
     "not result" "bool" 0 tc_not TypeChecker::live TypedStack::types.get assert_str_eq
 }
@@ -255,8 +255,8 @@ fn test_boolean_ops {
 fn test_dup_stack_effect {
     "dup_stack_effect" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushInt 42 make_op_int ops.push
-    empty_location OpKind::OpDup make_op ops.push
+    empty_location 42 OpValue::PushInt make_op ops.push
+    empty_location OpValue::Dup make_op ops.push
     ops tc_check = result_tc
     "stack after dup" 2 result_tc TypeChecker::live TypedStack::types.length assert_eq
     "first is int" "int" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
@@ -270,9 +270,9 @@ fn test_dup_stack_effect {
 fn test_swap_stack_effect {
     "swap_stack_effect" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushInt 42 make_op_int ops.push
-    empty_location OpKind::OpPushStr "hello" make_op_str ops.push
-    empty_location OpKind::OpSwap make_op ops.push
+    empty_location 42 OpValue::PushInt make_op ops.push
+    empty_location "hello" OpValue::PushStr make_op ops.push
+    empty_location OpValue::Swap make_op ops.push
     ops tc_check = result_tc
     "stack after swap" 2 result_tc TypeChecker::live TypedStack::types.length assert_eq
     "bottom is str" "str" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
@@ -286,9 +286,9 @@ fn test_swap_stack_effect {
 fn test_over_stack_effect {
     "over_stack_effect" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushInt 42 make_op_int ops.push
-    empty_location OpKind::OpPushStr "hello" make_op_str ops.push
-    empty_location OpKind::OpOver make_op ops.push
+    empty_location 42 OpValue::PushInt make_op ops.push
+    empty_location "hello" OpValue::PushStr make_op ops.push
+    empty_location OpValue::Over make_op ops.push
     ops tc_check = result_tc
     "stack after over" 3 result_tc TypeChecker::live TypedStack::types.length assert_eq
     "bottom is int" "int" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
@@ -303,9 +303,9 @@ fn test_over_stack_effect {
 fn test_drop_stack_effect {
     "drop_stack_effect" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushInt 42 make_op_int ops.push
-    empty_location OpKind::OpPushStr "hello" make_op_str ops.push
-    empty_location OpKind::OpDrop make_op ops.push
+    empty_location 42 OpValue::PushInt make_op ops.push
+    empty_location "hello" OpValue::PushStr make_op ops.push
+    empty_location OpValue::Drop make_op ops.push
     ops tc_check = result_tc
     "stack after drop" 1 result_tc TypeChecker::live TypedStack::types.length assert_eq
     "remaining is int" "int" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
@@ -318,10 +318,10 @@ fn test_drop_stack_effect {
 fn test_rot_stack_effect {
     "rot_stack_effect" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushInt 42 make_op_int ops.push
-    empty_location OpKind::OpPushStr "hello" make_op_str ops.push
-    empty_location OpKind::OpPushBool 1 make_op_int ops.push
-    empty_location OpKind::OpRot make_op ops.push
+    empty_location 42 OpValue::PushInt make_op ops.push
+    empty_location "hello" OpValue::PushStr make_op ops.push
+    empty_location 1 OpValue::PushBool make_op ops.push
+    empty_location OpValue::Rot make_op ops.push
     ops tc_check = result_tc
     "stack after rot" 3 result_tc TypeChecker::live TypedStack::types.length assert_eq
     # ROT: pop t1(bool), t2(str), t3(int) -> push t2(str), t1(bool), t3(int)
@@ -337,8 +337,8 @@ fn test_rot_stack_effect {
 fn test_type_cast {
     "type_cast" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushInt 42 make_op_int ops.push
-    empty_location OpKind::OpTypeCast "str" make_op_str ops.push
+    empty_location 42 OpValue::PushInt make_op ops.push
+    empty_location "str" OpValue::TypeCast make_op ops.push
     ops tc_check = result_tc
     "stack after cast" 1 result_tc TypeChecker::live TypedStack::types.length assert_eq
     "cast to str" "str" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
@@ -351,10 +351,10 @@ fn test_type_cast {
 fn test_push_literals {
     "push_literals" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushInt 42 make_op_int ops.push
-    empty_location OpKind::OpPushStr "hi" make_op_str ops.push
-    empty_location OpKind::OpPushBool 1 make_op_int ops.push
-    empty_location OpKind::OpPushChar 65 make_op_int ops.push
+    empty_location 42 OpValue::PushInt make_op ops.push
+    empty_location "hi" OpValue::PushStr make_op ops.push
+    empty_location 1 OpValue::PushBool make_op ops.push
+    empty_location 65 OpValue::PushChar make_op ops.push
     ops tc_check = result_tc
     "four items on stack" 4 result_tc TypeChecker::live TypedStack::types.length assert_eq
     "int" "int" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
@@ -372,24 +372,24 @@ fn test_print_dispatch {
 
     # print str -> OpPrintStr
     List::new(List[Op]) = ops_str
-    empty_location OpKind::OpPushStr "hello" make_op_str ops_str.push
-    empty_location OpKind::OpPrint make_op ops_str.push
+    empty_location "hello" OpValue::PushStr make_op ops_str.push
+    empty_location OpValue::Print make_op ops_str.push
     ops_str tc_check drop
-    "print str resolved" OpKind::OpPrintStr 1 ops_str.get Op::kind == assert_true
+    "print str resolved" 1 ops_str.get.value OpValue::PrintStr is assert_true
 
     # print int -> OpPrintInt
     List::new(List[Op]) = ops_int
-    empty_location OpKind::OpPushInt 42 make_op_int ops_int.push
-    empty_location OpKind::OpPrint make_op ops_int.push
+    empty_location 42 OpValue::PushInt make_op ops_int.push
+    empty_location OpValue::Print make_op ops_int.push
     ops_int tc_check drop
-    "print int resolved" OpKind::OpPrintInt 1 ops_int.get Op::kind == assert_true
+    "print int resolved" 1 ops_int.get.value OpValue::PrintInt is assert_true
 
     # print bool -> OpPrintBool
     List::new(List[Op]) = ops_bool
-    empty_location OpKind::OpPushBool 1 make_op_int ops_bool.push
-    empty_location OpKind::OpPrint make_op ops_bool.push
+    empty_location 1 OpValue::PushBool make_op ops_bool.push
+    empty_location OpValue::Print make_op ops_bool.push
     ops_bool tc_check drop
-    "print bool resolved" OpKind::OpPrintBool 1 ops_bool.get Op::kind == assert_true
+    "print bool resolved" 1 ops_bool.get.value OpValue::PrintBool is assert_true
 }
 
 # ============================================================================
@@ -399,8 +399,8 @@ fn test_print_dispatch {
 fn test_typeof_effect {
     "typeof_effect" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushInt 42 make_op_int ops.push
-    empty_location OpKind::OpTypeof make_op ops.push
+    empty_location 42 OpValue::PushInt make_op ops.push
+    empty_location OpValue::Typeof make_op ops.push
     ops tc_check = result_tc
     "stack after typeof" 1 result_tc TypeChecker::live TypedStack::types.length assert_eq
     "typeof result is str" "str" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
@@ -415,24 +415,24 @@ fn test_bitwise_ops {
 
     # BIT_NOT
     List::new(List[Op]) = ops_bnot
-    empty_location OpKind::OpPushInt 42 make_op_int ops_bnot.push
-    empty_location OpKind::OpBitNot make_op ops_bnot.push
+    empty_location 42 OpValue::PushInt make_op ops_bnot.push
+    empty_location OpValue::BitNot make_op ops_bnot.push
     ops_bnot tc_check = tc_bnot
     "bitnot result" "int" 0 tc_bnot TypeChecker::live TypedStack::types.get assert_str_eq
 
     # SHL
     List::new(List[Op]) = ops_shl
-    empty_location OpKind::OpPushInt 1 make_op_int ops_shl.push
-    empty_location OpKind::OpPushInt 3 make_op_int ops_shl.push
-    empty_location OpKind::OpShl make_op ops_shl.push
+    empty_location 1 OpValue::PushInt make_op ops_shl.push
+    empty_location 3 OpValue::PushInt make_op ops_shl.push
+    empty_location OpValue::Shl make_op ops_shl.push
     ops_shl tc_check = tc_shl
     "shl result" "int" 0 tc_shl TypeChecker::live TypedStack::types.get assert_str_eq
 
     # BIT_AND
     List::new(List[Op]) = ops_band
-    empty_location OpKind::OpPushInt 0 make_op_int ops_band.push
-    empty_location OpKind::OpPushInt 1 make_op_int ops_band.push
-    empty_location OpKind::OpBitAnd make_op ops_band.push
+    empty_location 0 OpValue::PushInt make_op ops_band.push
+    empty_location 1 OpValue::PushInt make_op ops_band.push
+    empty_location OpValue::BitAnd make_op ops_band.push
     ops_band tc_check = tc_band
     "bitand result" "int" 0 tc_band TypeChecker::live TypedStack::types.get assert_str_eq
 }
@@ -446,8 +446,8 @@ fn test_memory_ops {
 
     # heap_alloc: int -> ptr
     List::new(List[Op]) = ops_alloc
-    empty_location OpKind::OpPushInt 100 make_op_int ops_alloc.push
-    empty_location OpKind::OpHeapAlloc make_op ops_alloc.push
+    empty_location 100 OpValue::PushInt make_op ops_alloc.push
+    empty_location OpValue::HeapAlloc make_op ops_alloc.push
     ops_alloc tc_check = tc_alloc
     "alloc result is ptr" "ptr" 0 tc_alloc TypeChecker::live TypedStack::types.get assert_str_eq
 }
@@ -459,8 +459,8 @@ fn test_memory_ops {
 fn test_argc_argv {
     "argc_argv" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpArgc make_op ops.push
-    empty_location OpKind::OpArgv make_op ops.push
+    empty_location OpValue::Argc make_op ops.push
+    empty_location OpValue::Argv make_op ops.push
     ops tc_check = result_tc
     "stack count" 2 result_tc TypeChecker::live TypedStack::types.length assert_eq
     "argc is int" "int" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
@@ -618,20 +618,20 @@ fn test_tc_pipeline_memory {
 fn test_print_dispatch_char {
     "print_dispatch_char" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushChar 65 make_op_int ops.push
-    empty_location OpKind::OpPrint make_op ops.push
+    empty_location 65 OpValue::PushChar make_op ops.push
+    empty_location OpValue::Print make_op ops.push
     ops tc_check drop
-    "print char resolved" OpKind::OpPrintChar 1 ops.get Op::kind == assert_true
+    "print char resolved" 1 ops.get.value OpValue::PrintChar is assert_true
 }
 
 fn test_print_dispatch_cstr {
     "print_dispatch_cstr" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushInt 42 make_op_int ops.push
-    empty_location OpKind::OpTypeCast "cstr" make_op_str ops.push
-    empty_location OpKind::OpPrint make_op ops.push
+    empty_location 42 OpValue::PushInt make_op ops.push
+    empty_location "cstr" OpValue::TypeCast make_op ops.push
+    empty_location OpValue::Print make_op ops.push
     ops tc_check drop
-    "print cstr resolved" OpKind::OpPrintCstr 2 ops.get Op::kind == assert_true
+    "print cstr resolved" 2 ops.get.value OpValue::PrintCstr is assert_true
 }
 
 # ============================================================================
@@ -641,8 +641,8 @@ fn test_print_dispatch_cstr {
 fn test_print_pops_stack {
     "print_pops_stack" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushInt 42 make_op_int ops.push
-    empty_location OpKind::OpPrint make_op ops.push
+    empty_location 42 OpValue::PushInt make_op ops.push
+    empty_location OpValue::Print make_op ops.push
     ops tc_check = result_tc
     "stack empty after print" 0 result_tc TypeChecker::live TypedStack::types.length assert_eq
 }
@@ -654,8 +654,8 @@ fn test_print_pops_stack {
 fn test_typeof_str {
     "typeof_str" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushStr "hi" make_op_str ops.push
-    empty_location OpKind::OpTypeof make_op ops.push
+    empty_location "hi" OpValue::PushStr make_op ops.push
+    empty_location OpValue::Typeof make_op ops.push
     ops tc_check = result_tc
     "typeof str result" "str" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
 }
@@ -663,8 +663,8 @@ fn test_typeof_str {
 fn test_typeof_bool {
     "typeof_bool" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushBool 1 make_op_int ops.push
-    empty_location OpKind::OpTypeof make_op ops.push
+    empty_location 1 OpValue::PushBool make_op ops.push
+    empty_location OpValue::Typeof make_op ops.push
     ops tc_check = result_tc
     "typeof bool result" "str" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
 }
@@ -678,41 +678,41 @@ fn test_all_comparison_ops {
 
     # Eq
     List::new(List[Op]) = ops_eq
-    empty_location OpKind::OpPushInt 1 make_op_int ops_eq.push
-    empty_location OpKind::OpPushInt 1 make_op_int ops_eq.push
-    empty_location OpKind::OpEq make_op ops_eq.push
+    empty_location 1 OpValue::PushInt make_op ops_eq.push
+    empty_location 1 OpValue::PushInt make_op ops_eq.push
+    empty_location OpValue::Eq make_op ops_eq.push
     ops_eq tc_check = tc_eq
     "eq is bool" "bool" 0 tc_eq TypeChecker::live TypedStack::types.get assert_str_eq
 
     # Ne
     List::new(List[Op]) = ops_ne
-    empty_location OpKind::OpPushInt 1 make_op_int ops_ne.push
-    empty_location OpKind::OpPushInt 2 make_op_int ops_ne.push
-    empty_location OpKind::OpNe make_op ops_ne.push
+    empty_location 1 OpValue::PushInt make_op ops_ne.push
+    empty_location 2 OpValue::PushInt make_op ops_ne.push
+    empty_location OpValue::Ne make_op ops_ne.push
     ops_ne tc_check = tc_ne
     "ne is bool" "bool" 0 tc_ne TypeChecker::live TypedStack::types.get assert_str_eq
 
     # Le
     List::new(List[Op]) = ops_le
-    empty_location OpKind::OpPushInt 1 make_op_int ops_le.push
-    empty_location OpKind::OpPushInt 2 make_op_int ops_le.push
-    empty_location OpKind::OpLe make_op ops_le.push
+    empty_location 1 OpValue::PushInt make_op ops_le.push
+    empty_location 2 OpValue::PushInt make_op ops_le.push
+    empty_location OpValue::Le make_op ops_le.push
     ops_le tc_check = tc_le
     "le is bool" "bool" 0 tc_le TypeChecker::live TypedStack::types.get assert_str_eq
 
     # Ge
     List::new(List[Op]) = ops_ge
-    empty_location OpKind::OpPushInt 1 make_op_int ops_ge.push
-    empty_location OpKind::OpPushInt 2 make_op_int ops_ge.push
-    empty_location OpKind::OpGe make_op ops_ge.push
+    empty_location 1 OpValue::PushInt make_op ops_ge.push
+    empty_location 2 OpValue::PushInt make_op ops_ge.push
+    empty_location OpValue::Ge make_op ops_ge.push
     ops_ge tc_check = tc_ge
     "ge is bool" "bool" 0 tc_ge TypeChecker::live TypedStack::types.get assert_str_eq
 
     # Gt
     List::new(List[Op]) = ops_gt
-    empty_location OpKind::OpPushInt 5 make_op_int ops_gt.push
-    empty_location OpKind::OpPushInt 2 make_op_int ops_gt.push
-    empty_location OpKind::OpGt make_op ops_gt.push
+    empty_location 5 OpValue::PushInt make_op ops_gt.push
+    empty_location 2 OpValue::PushInt make_op ops_gt.push
+    empty_location OpValue::Gt make_op ops_gt.push
     ops_gt tc_check = tc_gt
     "gt is bool" "bool" 0 tc_gt TypeChecker::live TypedStack::types.get assert_str_eq
 }
@@ -724,9 +724,9 @@ fn test_all_comparison_ops {
 fn test_string_comparison_annotation {
     "string_comparison_annotation" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushStr "a" make_op_str ops.push
-    empty_location OpKind::OpPushStr "b" make_op_str ops.push
-    empty_location OpKind::OpEq make_op ops.push
+    empty_location "a" OpValue::PushStr make_op ops.push
+    empty_location "b" OpValue::PushStr make_op ops.push
+    empty_location OpValue::Eq make_op ops.push
     ops tc_check = result_tc
     "str cmp is bool" "bool" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
     "annotation is str" "str" 2 ops.get Op::type_annotation assert_str_eq
@@ -739,9 +739,9 @@ fn test_string_comparison_annotation {
 fn test_bitwise_shr {
     "bitwise_shr" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushInt 8 make_op_int ops.push
-    empty_location OpKind::OpPushInt 2 make_op_int ops.push
-    empty_location OpKind::OpShr make_op ops.push
+    empty_location 8 OpValue::PushInt make_op ops.push
+    empty_location 2 OpValue::PushInt make_op ops.push
+    empty_location OpValue::Shr make_op ops.push
     ops tc_check = result_tc
     "shr result" "int" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
 }
@@ -749,9 +749,9 @@ fn test_bitwise_shr {
 fn test_bitwise_or {
     "bitwise_or" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushInt 5 make_op_int ops.push
-    empty_location OpKind::OpPushInt 3 make_op_int ops.push
-    empty_location OpKind::OpBitOr make_op ops.push
+    empty_location 5 OpValue::PushInt make_op ops.push
+    empty_location 3 OpValue::PushInt make_op ops.push
+    empty_location OpValue::BitOr make_op ops.push
     ops tc_check = result_tc
     "bitor result" "int" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
 }
@@ -759,9 +759,9 @@ fn test_bitwise_or {
 fn test_bitwise_xor {
     "bitwise_xor" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushInt 5 make_op_int ops.push
-    empty_location OpKind::OpPushInt 3 make_op_int ops.push
-    empty_location OpKind::OpBitXor make_op ops.push
+    empty_location 5 OpValue::PushInt make_op ops.push
+    empty_location 3 OpValue::PushInt make_op ops.push
+    empty_location OpValue::BitXor make_op ops.push
     ops tc_check = result_tc
     "bitxor result" "int" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
 }
@@ -775,25 +775,25 @@ fn test_memory_load_sizes {
 
     # load8
     List::new(List[Op]) = ops8
-    empty_location OpKind::OpPushInt 8 make_op_int ops8.push
-    empty_location OpKind::OpHeapAlloc make_op ops8.push
-    empty_location OpKind::OpLoad8 make_op ops8.push
+    empty_location 8 OpValue::PushInt make_op ops8.push
+    empty_location OpValue::HeapAlloc make_op ops8.push
+    empty_location OpValue::Load8 make_op ops8.push
     ops8 tc_check = tc8
     "load8 result" "int" 0 tc8 TypeChecker::live TypedStack::types.get assert_str_eq
 
     # load16
     List::new(List[Op]) = ops16
-    empty_location OpKind::OpPushInt 8 make_op_int ops16.push
-    empty_location OpKind::OpHeapAlloc make_op ops16.push
-    empty_location OpKind::OpLoad16 make_op ops16.push
+    empty_location 8 OpValue::PushInt make_op ops16.push
+    empty_location OpValue::HeapAlloc make_op ops16.push
+    empty_location OpValue::Load16 make_op ops16.push
     ops16 tc_check = tc16
     "load16 result" "int" 0 tc16 TypeChecker::live TypedStack::types.get assert_str_eq
 
     # load32
     List::new(List[Op]) = ops32
-    empty_location OpKind::OpPushInt 8 make_op_int ops32.push
-    empty_location OpKind::OpHeapAlloc make_op ops32.push
-    empty_location OpKind::OpLoad32 make_op ops32.push
+    empty_location 8 OpValue::PushInt make_op ops32.push
+    empty_location OpValue::HeapAlloc make_op ops32.push
+    empty_location OpValue::Load32 make_op ops32.push
     ops32 tc_check = tc32
     "load32 result" "int" 0 tc32 TypeChecker::live TypedStack::types.get assert_str_eq
 }
@@ -803,28 +803,28 @@ fn test_memory_store_sizes {
 
     # store8: value ptr -> (empty)
     List::new(List[Op]) = ops8
-    empty_location OpKind::OpPushInt 42 make_op_int ops8.push
-    empty_location OpKind::OpPushInt 8 make_op_int ops8.push
-    empty_location OpKind::OpHeapAlloc make_op ops8.push
-    empty_location OpKind::OpStore8 make_op ops8.push
+    empty_location 42 OpValue::PushInt make_op ops8.push
+    empty_location 8 OpValue::PushInt make_op ops8.push
+    empty_location OpValue::HeapAlloc make_op ops8.push
+    empty_location OpValue::Store8 make_op ops8.push
     ops8 tc_check = tc8
     "store8 empty" 0 tc8 TypeChecker::live TypedStack::types.length assert_eq
 
     # store16
     List::new(List[Op]) = ops16
-    empty_location OpKind::OpPushInt 42 make_op_int ops16.push
-    empty_location OpKind::OpPushInt 8 make_op_int ops16.push
-    empty_location OpKind::OpHeapAlloc make_op ops16.push
-    empty_location OpKind::OpStore16 make_op ops16.push
+    empty_location 42 OpValue::PushInt make_op ops16.push
+    empty_location 8 OpValue::PushInt make_op ops16.push
+    empty_location OpValue::HeapAlloc make_op ops16.push
+    empty_location OpValue::Store16 make_op ops16.push
     ops16 tc_check = tc16
     "store16 empty" 0 tc16 TypeChecker::live TypedStack::types.length assert_eq
 
     # store32
     List::new(List[Op]) = ops32
-    empty_location OpKind::OpPushInt 42 make_op_int ops32.push
-    empty_location OpKind::OpPushInt 8 make_op_int ops32.push
-    empty_location OpKind::OpHeapAlloc make_op ops32.push
-    empty_location OpKind::OpStore32 make_op ops32.push
+    empty_location 42 OpValue::PushInt make_op ops32.push
+    empty_location 8 OpValue::PushInt make_op ops32.push
+    empty_location OpValue::HeapAlloc make_op ops32.push
+    empty_location OpValue::Store32 make_op ops32.push
     ops32 tc_check = tc32
     "store32 empty" 0 tc32 TypeChecker::live TypedStack::types.length assert_eq
 }
@@ -1155,10 +1155,10 @@ fn test_store_accepts_any_value_type {
 fn test_memory_store64 {
     "memory_store64" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushInt 42 make_op_int ops.push
-    empty_location OpKind::OpPushInt 8 make_op_int ops.push
-    empty_location OpKind::OpHeapAlloc make_op ops.push
-    empty_location OpKind::OpStore64 make_op ops.push
+    empty_location 42 OpValue::PushInt make_op ops.push
+    empty_location 8 OpValue::PushInt make_op ops.push
+    empty_location OpValue::HeapAlloc make_op ops.push
+    empty_location OpValue::Store64 make_op ops.push
     ops tc_check = result_tc
     "store64 empty" 0 result_tc TypeChecker::live TypedStack::types.length assert_eq
 }
@@ -1213,28 +1213,28 @@ fn test_syscall_op_level {
 
     # syscall0: pops 1 (syscall number), pushes int
     List::new(List[Op]) = ops0
-    empty_location OpKind::OpPushInt 60 make_op_int ops0.push
-    empty_location OpKind::OpSyscall0 make_op ops0.push
+    empty_location 60 OpValue::PushInt make_op ops0.push
+    empty_location OpValue::Syscall0 make_op ops0.push
     ops0 tc_check = tc0
     "syscall0 result" 1 tc0 TypeChecker::live TypedStack::types.length assert_eq
     "syscall0 type" "int" 0 tc0 TypeChecker::live TypedStack::types.get assert_str_eq
 
     # syscall1: pops 2 (1 arg + syscall number), pushes int
     List::new(List[Op]) = ops1
-    empty_location OpKind::OpPushInt 0 make_op_int ops1.push
-    empty_location OpKind::OpPushInt 60 make_op_int ops1.push
-    empty_location OpKind::OpSyscall1 make_op ops1.push
+    empty_location 0 OpValue::PushInt make_op ops1.push
+    empty_location 60 OpValue::PushInt make_op ops1.push
+    empty_location OpValue::Syscall1 make_op ops1.push
     ops1 tc_check = tc1
     "syscall1 result" 1 tc1 TypeChecker::live TypedStack::types.length assert_eq
     "syscall1 type" "int" 0 tc1 TypeChecker::live TypedStack::types.get assert_str_eq
 
     # syscall3: pops 4 (3 args + syscall number), pushes int
     List::new(List[Op]) = ops3
-    empty_location OpKind::OpPushInt 0 make_op_int ops3.push
-    empty_location OpKind::OpPushInt 0 make_op_int ops3.push
-    empty_location OpKind::OpPushInt 0 make_op_int ops3.push
-    empty_location OpKind::OpPushInt 1 make_op_int ops3.push
-    empty_location OpKind::OpSyscall3 make_op ops3.push
+    empty_location 0 OpValue::PushInt make_op ops3.push
+    empty_location 0 OpValue::PushInt make_op ops3.push
+    empty_location 0 OpValue::PushInt make_op ops3.push
+    empty_location 1 OpValue::PushInt make_op ops3.push
+    empty_location OpValue::Syscall3 make_op ops3.push
     ops3 tc_check = tc3
     "syscall3 result" 1 tc3 TypeChecker::live TypedStack::types.length assert_eq
     "syscall3 type" "int" 0 tc3 TypeChecker::live TypedStack::types.get assert_str_eq
@@ -1247,8 +1247,8 @@ fn test_syscall_op_level {
 fn test_typeof_char {
     "typeof_char" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushChar 65 make_op_int ops.push
-    empty_location OpKind::OpTypeof make_op ops.push
+    empty_location 65 OpValue::PushChar make_op ops.push
+    empty_location OpValue::Typeof make_op ops.push
     ops tc_check = result_tc
     "typeof char result" "str" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
 }
@@ -1256,9 +1256,9 @@ fn test_typeof_char {
 fn test_typeof_ptr {
     "typeof_ptr" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushInt 10 make_op_int ops.push
-    empty_location OpKind::OpHeapAlloc make_op ops.push
-    empty_location OpKind::OpTypeof make_op ops.push
+    empty_location 10 OpValue::PushInt make_op ops.push
+    empty_location OpValue::HeapAlloc make_op ops.push
+    empty_location OpValue::Typeof make_op ops.push
     ops tc_check = result_tc
     "typeof ptr result" "str" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
 }
@@ -1270,8 +1270,8 @@ fn test_typeof_ptr {
 fn test_dup_preserves_str {
     "dup_preserves_str" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushStr "hello" make_op_str ops.push
-    empty_location OpKind::OpDup make_op ops.push
+    empty_location "hello" OpValue::PushStr make_op ops.push
+    empty_location OpValue::Dup make_op ops.push
     ops tc_check = result_tc
     "dup str count" 2 result_tc TypeChecker::live TypedStack::types.length assert_eq
     "dup str first" "str" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
@@ -1281,8 +1281,8 @@ fn test_dup_preserves_str {
 fn test_dup_preserves_bool {
     "dup_preserves_bool" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushBool 1 make_op_int ops.push
-    empty_location OpKind::OpDup make_op ops.push
+    empty_location 1 OpValue::PushBool make_op ops.push
+    empty_location OpValue::Dup make_op ops.push
     ops tc_check = result_tc
     "dup bool count" 2 result_tc TypeChecker::live TypedStack::types.length assert_eq
     "dup bool first" "bool" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
@@ -1367,7 +1367,7 @@ fn test_error_fn_signature_mismatch {
     # Build a function with declared sig "int -> str" but body returns int
     "int -> str" signature_from_str = bad_sig
     List::new(List[Op]) = bad_ops
-    empty_location OpKind::OpPushInt 42 make_op_int bad_ops.push
+    empty_location 42 OpValue::PushInt make_op bad_ops.push
     # RPN: sig location ops name make_function_with_sig
     bad_sig empty_location bad_ops "bad_fn" make_function_with_sig = bad_fn
     bad_fn Option::Some bad_ops type_check_ops drop
@@ -1515,12 +1515,12 @@ fn test_types_match_array_types {
 fn test_print_dispatch_ptr {
     "print_dispatch_ptr" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushInt 10 make_op_int ops.push
-    empty_location OpKind::OpHeapAlloc make_op ops.push
-    empty_location OpKind::OpPrint make_op ops.push
+    empty_location 10 OpValue::PushInt make_op ops.push
+    empty_location OpValue::HeapAlloc make_op ops.push
+    empty_location OpValue::Print make_op ops.push
     ops tc_check drop
     # ptr falls through to print_int
-    "print ptr resolved" OpKind::OpPrintInt 2 ops.get Op::kind == assert_true
+    "print ptr resolved" 2 ops.get.value OpValue::PrintInt is assert_true
 }
 
 # ============================================================================
@@ -1530,8 +1530,8 @@ fn test_print_dispatch_ptr {
 fn test_typeof_annotation {
     "typeof_annotation" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushInt 42 make_op_int ops.push
-    empty_location OpKind::OpTypeof make_op ops.push
+    empty_location 42 OpValue::PushInt make_op ops.push
+    empty_location OpValue::Typeof make_op ops.push
     ops tc_check drop
     "typeof annotation" "int" 1 ops.get Op::type_annotation assert_str_eq
 }
@@ -1543,8 +1543,8 @@ fn test_typeof_annotation {
 fn test_type_cast_str_to_int {
     "type_cast_str_to_int" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushStr "hello" make_op_str ops.push
-    empty_location OpKind::OpTypeCast "int" make_op_str ops.push
+    empty_location "hello" OpValue::PushStr make_op ops.push
+    empty_location "int" OpValue::TypeCast make_op ops.push
     ops tc_check = result_tc
     "cast str to int" 1 result_tc TypeChecker::live TypedStack::types.length assert_eq
     "cast result" "int" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
@@ -1553,8 +1553,8 @@ fn test_type_cast_str_to_int {
 fn test_type_cast_bool_to_int {
     "type_cast_bool_to_int" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpPushBool 1 make_op_int ops.push
-    empty_location OpKind::OpTypeCast "int" make_op_str ops.push
+    empty_location 1 OpValue::PushBool make_op ops.push
+    empty_location "int" OpValue::TypeCast make_op ops.push
     ops tc_check = result_tc
     "cast bool to int" "int" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
 }
@@ -1603,10 +1603,10 @@ fn test_error_str_lt_comparison {
 fn test_branch_if_empty_body {
     "branch_if_empty_body" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpIfStart make_op ops.push
-    empty_location OpKind::OpPushBool 1 make_op_int ops.push
-    empty_location OpKind::OpIfCondition make_op ops.push
-    empty_location OpKind::OpIfEnd make_op ops.push
+    empty_location OpValue::IfStart make_op ops.push
+    empty_location 1 OpValue::PushBool make_op ops.push
+    empty_location OpValue::IfCondition make_op ops.push
+    empty_location OpValue::IfEnd make_op ops.push
     ops tc_check = result_tc
     "live empty after empty if" 0 result_tc TypeChecker::live TypedStack::types.length assert_eq
     "frame stack empty" 0 result_tc TypeChecker::branched_stacks.length assert_eq
@@ -1616,13 +1616,13 @@ fn test_branch_if_empty_body {
 fn test_branch_if_else_agree_int {
     "branch_if_else_agree_int" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpIfStart make_op ops.push
-    empty_location OpKind::OpPushBool 1 make_op_int ops.push
-    empty_location OpKind::OpIfCondition make_op ops.push
-    empty_location OpKind::OpPushInt 10 make_op_int ops.push
-    empty_location OpKind::OpIfElse make_op ops.push
-    empty_location OpKind::OpPushInt 20 make_op_int ops.push
-    empty_location OpKind::OpIfEnd make_op ops.push
+    empty_location OpValue::IfStart make_op ops.push
+    empty_location 1 OpValue::PushBool make_op ops.push
+    empty_location OpValue::IfCondition make_op ops.push
+    empty_location 10 OpValue::PushInt make_op ops.push
+    empty_location OpValue::IfElse make_op ops.push
+    empty_location 20 OpValue::PushInt make_op ops.push
+    empty_location OpValue::IfEnd make_op ops.push
     ops tc_check = result_tc
     "live has one item" 1 result_tc TypeChecker::live TypedStack::types.length assert_eq
     "unified type is int" "int" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
@@ -1633,14 +1633,14 @@ fn test_branch_if_else_agree_int {
 fn test_branch_if_end_pops_frame {
     "branch_if_end_pops_frame" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpIfStart make_op ops.push
-    empty_location OpKind::OpPushBool 1 make_op_int ops.push
-    empty_location OpKind::OpIfCondition make_op ops.push
+    empty_location OpValue::IfStart make_op ops.push
+    empty_location 1 OpValue::PushBool make_op ops.push
+    empty_location OpValue::IfCondition make_op ops.push
     ops tc_check = result_tc
     "frame pushed on OpIfStart" 1 result_tc TypeChecker::branched_stacks.length assert_eq
     # Close the block
     List::new(List[Op]) = close_ops
-    empty_location OpKind::OpIfEnd make_op close_ops.push
+    empty_location OpValue::IfEnd make_op close_ops.push
     0 = ci
     while ci close_ops.length > do
         ci close_ops.get result_tc check_if_block
@@ -1653,10 +1653,10 @@ fn test_branch_if_end_pops_frame {
 fn test_branch_while_empty_body {
     "branch_while_empty_body" test_start
     List::new(List[Op]) = ops
-    empty_location OpKind::OpWhileStart make_op ops.push
-    empty_location OpKind::OpPushBool 0 make_op_int ops.push
-    empty_location OpKind::OpWhileCondition make_op ops.push
-    empty_location OpKind::OpWhileEnd make_op ops.push
+    empty_location OpValue::WhileStart make_op ops.push
+    empty_location 0 OpValue::PushBool make_op ops.push
+    empty_location OpValue::WhileCondition make_op ops.push
+    empty_location OpValue::WhileEnd make_op ops.push
     ops tc_check = result_tc
     "live empty" 0 result_tc TypeChecker::live TypedStack::types.length assert_eq
     "frame stack empty" 0 result_tc TypeChecker::branched_stacks.length assert_eq
@@ -1669,7 +1669,7 @@ fn test_branch_frame_kind_dispatch {
     "branch_frame_kind_dispatch" test_start
     make_typechecker = tc
     List::new(List[Op]) = ops
-    empty_location OpKind::OpIfStart make_op ops.push
+    empty_location OpValue::IfStart make_op ops.push
     0 = bd_i
     while bd_i ops.length > do
         bd_i ops.get tc check_if_block
@@ -1711,19 +1711,19 @@ fn test_branch_return_inside_if_restores_live {
     "int" tc stack_push
     # Begin an `if true then` block.
     List::new(List[Op]) = begin_ops
-    empty_location OpKind::OpIfStart make_op begin_ops.push
-    empty_location OpKind::OpPushBool 1 make_op_int begin_ops.push
-    empty_location OpKind::OpIfCondition make_op begin_ops.push
+    empty_location OpValue::IfStart make_op begin_ops.push
+    empty_location 1 OpValue::PushBool make_op begin_ops.push
+    empty_location OpValue::IfCondition make_op begin_ops.push
     0 = br_i
     while br_i begin_ops.length > do
         br_i begin_ops.get = br_op
-        br_op Op::kind = br_kind
+        br_op Op::value = br_kind
         if
-        OpKind::OpIfStart br_kind ==
-        OpKind::OpIfCondition br_kind == ||
+        OpValue::IfStart br_kind ==
+        OpValue::IfCondition br_kind == ||
         then
             br_op tc check_if_block
-        elif OpKind::OpPushBool br_kind == then
+        elif OpValue::PushBool br_kind == then
             "bool" tc stack_push
         fi
         1 += br_i

--- a/tests/compiler/test_typeof.casa
+++ b/tests/compiler/test_typeof.casa
@@ -82,7 +82,7 @@ fn test_parse_typeof {
     "parse_typeof" test_start
     "test" "42 typeof" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
-    "typeof kind" OpKind::OpTypeof 1 ops.get Op::kind == assert_true
+    "typeof kind" 1 ops.get.value OpValue::Typeof is assert_true
 }
 
 # ============================================================================


### PR DESCRIPTION
## Summary

- Drops `enum OpKind` and `Op::kind` field. All 87 op variants now live as `OpValue` tags carrying typed payloads (e.g. `OpValue::FnCall(str)`, `OpValue::PushInt(int)`, `OpValue::MatchArm(MatchArm)`).
- Constructors collapse to `make_op` / `make_op_annotated`; `make_op_str`, `make_op_int`, `make_op_v` removed.
- 6 `Map[K OpKind]` lookup tables converted to match-based functions: `intrinsic_to_op_value`, `direct_op_to_inst`, `keyword_to_op_value`, `operator_to_op_value`, `op_value_stack_effect`, `op_value_token_type`.
- `find_matching_label` / `require_matching` rebased on `OpValue`. New helper `find_next_match_arm_or_end` for the payload-bearing match-arm sentinel.
- Existing `op_str_value` / `op_int_value` / `enum_variant_of` / `op_list_of` / `casa_struct_of` / `struct_literal_of` / `match_arm_of` retained — used as workaround for the typechecker `is`-binding-type bug (binding infers as `any` instead of inner type).

Closes Track B of #128 (Track A shipped in #132, typed-payload work shipped in #135).

## Test plan

- [x] `tests/test_compiler.sh < /dev/null` — 25/25 passing
- [x] `tests/test_examples.sh` — 39/39 passing
- [x] Bootstrap fixed-point: stage1.s == stage2.s