### PR TITLE
fix(typechecker): propagate is-binding payload types

### DIFF
--- a/compiler/typechecker.casa
+++ b/compiler/typechecker.casa
@@ -1716,6 +1716,7 @@ fn check_is tc:TypeChecker op:Op function_opt:Option[Function] {
             fi
         fi
     fi
+    typ variant function_opt tc register_enum_pattern_bindings
     "bool" tc stack_push
 }
 

--- a/tests/compiler/test_enum.casa
+++ b/tests/compiler/test_enum.casa
@@ -51,8 +51,11 @@ fn compile_enum code:str -> Program {
 }
 
 fn is_push_enum_variant value:OpValue -> bool { value OpValue::PushEnumVariant is }
+
 fn is_match_start value:OpValue -> bool { value OpValue::MatchStart is }
+
 fn is_match_arm value:OpValue -> bool { value OpValue::MatchArm is }
+
 fn is_match_end value:OpValue -> bool { value OpValue::MatchEnd is }
 
 fn count_ops ops:List[Op] predicate:fn[OpValue -> bool] -> int {
@@ -900,6 +903,28 @@ fn test_is_generic_with_bindings {
     "passes" true assert_true
 }
 
+fn test_is_binding_propagates_inner_type {
+    "is_binding_propagates_inner_type" test_start
+    "enum Foo { Bar(int) Baz(str) }\n42 Foo::Bar = x\nif x Foo::Bar(n) is then\nn drop\nfi\n" tc_enum drop
+    "n" DEFAULT_PARSER.store.variables.get = n_opt
+    if n_opt Option::Some(n_var) is then
+        "n typed as int" "int" n_var.typ assert_str_eq
+    else
+        "n exists" false assert_true
+    fi
+}
+
+fn test_is_binding_propagates_generic_type {
+    "is_binding_propagates_generic_type" test_start
+    "enum Option[T] { None Some(T) }\n42 Option::Some = m\nif m Option::Some(v) is then\nv drop\nfi\n" tc_enum drop
+    "v" DEFAULT_PARSER.store.variables.get = v_opt
+    if v_opt Option::Some(v_var) is then
+        "v typed as int" "int" v_var.typ assert_str_eq
+    else
+        "v exists" false assert_true
+    fi
+}
+
 fn test_is_check_resolves_ordinal {
     "is_check_resolves_ordinal" test_start
     "enum Color { Red Green Blue }\nColor::Blue = c\nc Color::Blue is\n" resolve_enum = ops
@@ -1063,6 +1088,8 @@ test_is_wrong_binding_count_raises
 test_is_bindings_on_plain_variant_raises
 test_is_generic_enum
 test_is_generic_with_bindings
+test_is_binding_propagates_inner_type
+test_is_binding_propagates_generic_type
 test_is_check_resolves_ordinal
 test_is_check_with_bindings_parsed
 test_is_check_multiple_bindings_parsed


### PR DESCRIPTION
## Summary

`if x OpValue::Foo(name) is then ...` was leaving `name` typed as `any` instead of the variant's payload type. Workaround across the compiler was to extract via typed helpers (`op_str_value`, `op_int_value`, etc.) — see #133 / PR #136 description.

Fix routes `check_is` through `register_enum_pattern_bindings` (compiler/pattern.casa) — the same helper `check_match` already uses for arm-binding type registration. Generic enums (e.g. `Option::Some(v)`) resolve correctly via the existing `apply_enum_bindings` substitution logic.

## Test plan

- [x] `tests/test_compiler.sh < /dev/null` — 25/25 pass (test_enum 130 → 132 with two new assertions)
- [x] `tests/test_examples.sh` — 39/39 pass
- [x] Bootstrap stable: `casac` → stage1 → stage2 produces identical `.s`
- [ ] Follow-up PR: refactor call sites currently using `op_*_value` workaround back to direct destructure