### PR TITLE
refactor: destructure OpValue payloads at call sites

### DIFF
--- a/compiler/bytecode.casa
+++ b/compiler/bytecode.casa
@@ -487,7 +487,8 @@ fn compile_match_op
     next_arm:Option[int]
     bytecode:List[Inst]
 {
-    op pattern_value_of match
+    if op.value OpValue::MatchArm(arm) is ! then return fi
+    arm.pattern_value match
         PatternValue::Struct(struct_pattern) => {
             bytecode struct_pattern compiler emit_struct_arm
         }
@@ -499,7 +500,7 @@ fn compile_match_op
             bytecode next_arm is_last is_wildcard variant compiler emit_enum_arm
         }
     end
-    op pattern_guard_ops = guard_ops
+    arm.guard_ops = guard_ops
     if guard_ops.length 0 != then
         0 = guard_index
         while guard_index guard_ops.length > do
@@ -555,7 +556,7 @@ fn compile_match_block compiler:BytecodeCompiler op:Op op_index:int bytecode:Lis
 # ============================================================================
 
 fn compile_struct_new compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
-    op casa_struct_of = casa_struct
+    if op.value OpValue::StructNew(casa_struct) is ! then return fi
     casa_struct CasaStruct::members.length = count
     count WORD_SIZE * InstKind::InstPush make_inst_int bytecode.push
     InstKind::InstHeapAlloc make_inst bytecode.push
@@ -638,7 +639,7 @@ fn compile_enum_variant
 # ============================================================================
 
 fn compile_is_check compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
-    op enum_variant_of = variant
+    if op.value OpValue::IsCheck(variant) is ! then return fi
     variant EnumVariant::enum_name = enum_name
     enum_name compiler.store.enums.get.unwrap = casa_enum
 
@@ -698,7 +699,7 @@ fn compile_is_check compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
 # ============================================================================
 
 fn compile_struct_literal compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
-    op struct_literal_of = literal
+    if op.value OpValue::StructLiteral(literal) is ! then return fi
     literal StructLiteral::struct_name compiler.store.structs.get.unwrap = casa_struct
     casa_struct CasaStruct::members.length = count
 
@@ -741,7 +742,7 @@ fn compile_struct_literal compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
 # ============================================================================
 
 fn compile_push_array compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
-    op op_list_of = items
+    if op.value OpValue::PushArray(items) is ! then return fi
     items.length = length
 
     # Compile items in reverse order
@@ -960,14 +961,14 @@ fn compile_op compiler:BytecodeCompiler op:Op op_index:int bytecode:List[Inst] {
     op_value OpValue::AssignVar is ||
     then
         bytecode op compiler compile_assignment
-    elif op_value OpValue::FstringConcat is then
-        op op_int_value InstKind::InstFstringConcat make_inst_int bytecode.push
+    elif op_value OpValue::FstringConcat(fstring_count) is then
+        fstring_count InstKind::InstFstringConcat make_inst_int bytecode.push
     elif op_value OpValue::FstringToStr is then
         # Identity no-op: str expression already left on stack by the preceding lambda.
         # Non-str cases are rewritten to OpMethodCall during type checking.
     elif op_value OpValue::FnCall is op_value OpValue::FnPush is || then
-        if op_value OpValue::FnPush is then
-            op op_str_value compiler.store.functions.get = function_opt
+        if op_value OpValue::FnPush(fn_push_name) is then
+            fn_push_name compiler.store.functions.get = function_opt
             if function_opt.is_some then
                 function_opt.unwrap = function_check
                 if function_check Function::has_deferred_methods then
@@ -977,8 +978,8 @@ fn compile_op compiler:BytecodeCompiler op:Op op_index:int bytecode:List[Inst] {
             fi
         fi
         bytecode op compiler compile_function_ops
-    elif op_value OpValue::Identifier is then
-        f"Identifier `{op op_str_value}` should be resolved by the parser\n" eprint
+    elif op_value OpValue::Identifier(ident_name) is then
+        f"Identifier `{ident_name}` should be resolved by the parser\n" eprint
         1 exit
     elif
     op_value OpValue::IfCondition is
@@ -990,8 +991,7 @@ fn compile_op compiler:BytecodeCompiler op:Op op_index:int bytecode:List[Inst] {
         bytecode op_index op compiler compile_if_block
     elif op_value OpValue::ImportFile is op_value OpValue::TypeCast is || then
         # No instruction emitted
-    elif op_value OpValue::PushEnumVariant is then
-        op enum_variant_of = variant
+    elif op_value OpValue::PushEnumVariant(variant) is then
         variant EnumVariant::enum_name compiler.store.enums.get.unwrap = casa_enum
         if casa_enum has_inner_values then
             bytecode casa_enum variant compiler compile_enum_variant
@@ -1020,23 +1020,21 @@ fn compile_op compiler:BytecodeCompiler op:Op op_index:int bytecode:List[Inst] {
         InstKind::InstPrintStr make_inst bytecode.push
     elif op_value OpValue::PushArray is then
         bytecode op compiler compile_push_array
-    elif op_value OpValue::PushBool is then
-        op op_int_value InstKind::InstPush make_inst_int bytecode.push
-    elif op_value OpValue::PushChar is then
-        op op_int_value InstKind::InstPushChar make_inst_int bytecode.push
-    elif op_value OpValue::PushCapture is then
-        op op_str_value = capture_name
+    elif op_value OpValue::PushBool(bool_value) is then
+        bool_value InstKind::InstPush make_inst_int bytecode.push
+    elif op_value OpValue::PushChar(char_value) is then
+        char_value InstKind::InstPushChar make_inst_int bytecode.push
+    elif op_value OpValue::PushCapture(capture_name) is then
         if compiler.function Option::Some(function) is then
             capture_name function Function::captures variable_list_index = capture_index
             capture_index InstKind::InstCaptureLoad make_inst_int bytecode.push
         fi
-    elif op_value OpValue::PushInt is then
-        op op_int_value InstKind::InstPush make_inst_int bytecode.push
-    elif op_value OpValue::PushStr is then
-        op op_str_value compiler intern_string = string_index
+    elif op_value OpValue::PushInt(int_value) is then
+        int_value InstKind::InstPush make_inst_int bytecode.push
+    elif op_value OpValue::PushStr(str_value) is then
+        str_value compiler intern_string = string_index
         string_index InstKind::InstPushStr make_inst_int bytecode.push
-    elif op_value OpValue::PushVar is then
-        op op_str_value = var_name
+    elif op_value OpValue::PushVar(var_name) is then
         var_name compiler resolve_variable = var_resolved
         var_resolved ResolvedVariable::index var_resolved ResolvedVariable::get_kind make_inst_int bytecode.push
         # Emit FN_EXEC after trait-bound variable push

--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -630,12 +630,9 @@ enum OpValue {
     Identifier (str)
 }
 
-# ============================================================================
-# OpValue accessors — extract a typed payload from any variant in a payload
-# family (str, int, etc.). Aborts when the op carries a different payload
-# type. Workaround for is-binding-type bug: direct destructure infers the
-# binding as `any`, so call sites pipe through these typed helpers instead.
-# ============================================================================
+# OpValue family accessors — unwrap the typed payload shared by a family of
+# variants. For call sites that gate on multiple variants (e.g. FnCall || FnPush)
+# without duplicating the unwrap. Single-variant gates should destructure directly.
 
 fn op_str_value op:Op -> str {
     if op.value OpValue::FnCall(value) is then value return fi
@@ -665,39 +662,12 @@ fn op_int_value op:Op -> int {
     0
 }
 
-fn op_list_of op:Op -> List[Op] {
-    if op.value OpValue::PushArray(items) is then
-        items return
-    fi
-    "Internal error: op_list_of called on non-PushArray op\n" eprint
-    1 exit
-    List::new(List[Op])
-}
-
 fn enum_variant_of op:Op -> EnumVariant {
     if op.value OpValue::PushEnumVariant(variant) is then variant return fi
     if op.value OpValue::IsCheck(variant) is then variant return fi
     "Internal error: enum_variant_of called on non-EnumVariant op\n" eprint
     1 exit
     Option::None(Option[int]) "" "" make_enum_variant
-}
-
-fn casa_struct_of op:Op -> CasaStruct {
-    if op.value OpValue::StructNew(casa_struct) is then
-        casa_struct return
-    fi
-    "Internal error: casa_struct_of called on non-StructNew op\n" eprint
-    1 exit
-    List::new(List[str]) empty_location List::new(List[Member]) "" CasaStruct
-}
-
-fn struct_literal_of op:Op -> StructLiteral {
-    if op.value OpValue::StructLiteral(literal) is then
-        literal return
-    fi
-    "Internal error: struct_literal_of called on non-StructLiteral op\n" eprint
-    1 exit
-    List::new(List[str]) "" StructLiteral
 }
 # MatchArm — wrapper stored on OpValue::MatchArm. Carries the pattern payload
 # (typed via PatternValue) and an optional guard expression. `guard_ops` is
@@ -714,23 +684,18 @@ fn make_match_arm pattern_value:PatternValue guard_ops:List[Op] -> MatchArm {
     guard_ops pattern_value MatchArm
 }
 
-fn match_arm_of op:Op -> MatchArm {
-    if op.value OpValue::MatchArm(arm) is then
-        arm return
-    fi
-    "Internal error: match_arm_of called on non-MatchArm op\n" eprint
-    1 exit
-    List::new(List[Op])
-    "" 0 LiteralValue::Int LiteralPattern PatternValue::Literal
-    make_match_arm
-}
-
 fn pattern_value_of op:Op -> PatternValue {
-    op match_arm_of.pattern_value
+    if op.value OpValue::MatchArm(arm) is then arm.pattern_value return fi
+    "Internal error: pattern_value_of called on non-MatchArm op\n" eprint
+    1 exit
+    "" 0 LiteralValue::Int LiteralPattern PatternValue::Literal
 }
 
 fn pattern_guard_ops op:Op -> List[Op] {
-    op match_arm_of MatchArm::guard_ops
+    if op.value OpValue::MatchArm(arm) is then arm.guard_ops return fi
+    "Internal error: pattern_guard_ops called on non-MatchArm op\n" eprint
+    1 exit
+    List::new(List[Op])
 }
 
 # ============================================================================

--- a/compiler/syntax.casa
+++ b/compiler/syntax.casa
@@ -2174,8 +2174,7 @@ fn parse_ops parser:Parser tokens:List[Token] -> List[Op] {
 
 fn gather_captures parser:Parser lambda_function:Function function:Function {
     for op in lambda_function Function::ops.iter do
-        if op.value OpValue::Identifier is ! then continue fi
-        op op_str_value = name
+        if op.value OpValue::Identifier(name) is ! then continue fi
         false = captured
 
         # Check enclosing function variables
@@ -2199,10 +2198,9 @@ fn gather_captures parser:Parser lambda_function:Function function:Function {
 
 fn resolve_array_identifiers parser:Parser items:List[Op] function:Function errors:List[CasaError] {
     for rai_item in items.iter do
-        if rai_item.value OpValue::PushArray is then
-            errors function rai_item op_list_of parser resolve_array_identifiers
-        elif rai_item.value OpValue::Identifier is then
-            rai_item op_str_value = rai_name
+        if rai_item.value OpValue::PushArray(inner_items) is then
+            errors function inner_items parser resolve_array_identifiers
+        elif rai_item.value OpValue::Identifier(rai_name) is then
             if rai_name function Function::variables variable_list_contains then
                 rai_name OpValue::PushVar rai_item Op::set_value
             elif rai_name function Function::captures variable_list_contains then
@@ -2279,7 +2277,8 @@ fn register_struct_pattern_binding parser:Parser function:Function binding_name:
 }
 
 fn resolve_match_op parser:Parser function:Function op:Op errors:List[CasaError] {
-    op pattern_value_of match
+    if op.value OpValue::MatchArm(arm) is ! then return fi
+    arm.pattern_value match
         PatternValue::Struct(struct_pattern) => {
             struct_pattern.bindings.keys = pattern_keys
             for pattern_key in pattern_keys.iter do
@@ -2294,10 +2293,9 @@ fn resolve_match_op parser:Parser function:Function op:Op errors:List[CasaError]
     end
     # Resolve identifiers inside the guard expression (bindings registered
     # by the pattern above are now in scope).
-    op pattern_guard_ops = guard_ops
+    arm.guard_ops = guard_ops
     if guard_ops.length 0 != then
         function guard_ops parser resolve_identifiers_fn = resolved_guard
-        op match_arm_of = arm
         resolved_guard arm MatchArm::set_guard_ops
     fi
 }
@@ -2433,8 +2431,7 @@ fn resolve_identifiers_fn parser:Parser ops:List[Op] function:Function -> List[O
         1 += op_index
 
         # ASSIGN_VARIABLE: register variable
-        if current_op.value OpValue::AssignVar is then
-            current_op op_str_value = var_name
+        if current_op.value OpValue::AssignVar(var_name) is then
             var_name make_variable = variable
             # Global scope: store in parser.store.variables
             if GLOBAL_SCOPE_LABEL function Function::name == then
@@ -2451,8 +2448,7 @@ fn resolve_identifiers_fn parser:Parser ops:List[Op] function:Function -> List[O
         fi
 
         # FN_PUSH: resolve lambda captures and identifiers
-        if current_op.value OpValue::FnPush is then
-            current_op op_str_value = fn_name
+        if current_op.value OpValue::FnPush(fn_name) is then
             fn_name parser.store.functions.get = lambda_opt
             if lambda_opt.is_some then
                 lambda_opt.unwrap = lambda
@@ -2465,15 +2461,13 @@ fn resolve_identifiers_fn parser:Parser ops:List[Op] function:Function -> List[O
         fi
 
         # PUSH_ARRAY: resolve identifiers inside array literals
-        if current_op.value OpValue::PushArray is then
-            current_op op_list_of = items_inner
+        if current_op.value OpValue::PushArray(items_inner) is then
             resolve_errors function items_inner parser resolve_array_identifiers
             continue
         fi
 
         # IDENTIFIER: resolve to specific op kinds
-        if current_op.value OpValue::Identifier is then
-            current_op op_str_value = ident
+        if current_op.value OpValue::Identifier(ident) is then
             if resolve_errors ident current_op function parser try_resolve_fn_ref then continue fi
             if resolve_errors ident current_op parser try_resolve_enum_variant_ident then continue fi
             if ident current_op function parser try_resolve_trait_method_call then continue fi
@@ -2488,15 +2482,13 @@ fn resolve_identifiers_fn parser:Parser ops:List[Op] function:Function -> List[O
         fi
 
         # IS_CHECK: resolve enum variant
-        if current_op.value OpValue::IsCheck is then
-            current_op enum_variant_of = is_enum_variant
+        if current_op.value OpValue::IsCheck(is_enum_variant) is then
             resolve_errors function current_op is_enum_variant parser resolve_enum_variant
             continue
         fi
 
         # IMPORT_FILE: process imported file
-        if current_op.value OpValue::ImportFile is then
-            current_op op_str_value = import_path
+        if current_op.value OpValue::ImportFile(import_path) is then
             # Resilient mode may produce an empty path when resolve_import
             # already reported a "module not found" error; skip the read.
             if 0 import_path.length == then

--- a/compiler/typechecker.casa
+++ b/compiler/typechecker.casa
@@ -810,7 +810,7 @@ fn check_memory tc:TypeChecker op:Op {
 # `scope` ("local" / "global") is only used in the error message.
 
 fn unify_variable_assignment op:Op variable:Variable effective_type:str scope:str {
-    op op_str_value = var_name
+    variable Variable::name = var_name
     if
     "" variable Variable::typ ==
     ANY_TYPE variable Variable::typ == effective_type ANY_TYPE != && ||
@@ -833,7 +833,7 @@ fn check_assignment tc:TypeChecker op:Op function_opt:Option[Function] {
         "int" tc expect_type drop
         return
     fi
-    op op_str_value = var_name
+    if op.value OpValue::AssignVar(var_name) is ! then return fi
     tc stack_peek = stack_type
     "" op Op::type_annotation != = has_annotation
     stack_type = effective_type
@@ -895,8 +895,7 @@ fn simulate_trait_exec tc:TypeChecker function:Function var_name:str {
 }
 
 fn check_push_var tc:TypeChecker op:Op function_opt:Option[Function] {
-    if op.value OpValue::PushCapture is then
-        op op_str_value = capture_name
+    if op.value OpValue::PushCapture(capture_name) is then
         if function_opt.is_some then
             function_opt.unwrap = function
             capture_name function Function::captures variable_list_index = capture_index
@@ -913,7 +912,7 @@ fn check_push_var tc:TypeChecker op:Op function_opt:Option[Function] {
     fi
 
     # PUSH_VARIABLE
-    op op_str_value = var_name
+    if op.value OpValue::PushVar(var_name) is ! then return fi
     "trait_exec" op Op::type_annotation == = is_trait_exec
 
     # Check local variables first
@@ -1379,8 +1378,7 @@ fn inject_trait_fn_ptrs
     # Check TYPE_CAST lookahead for return type binding
     if op_index ops.length > then
         op_index ops.get = next_op
-        if next_op.value OpValue::TypeCast is then
-            next_op op_str_value = cast_type
+        if next_op.value OpValue::TypeCast(cast_type) is then
             for return_type in sig Signature::return_types.iter do
                 sig Signature::type_vars cast_type return_type bindings bind_generic_params_standalone = bindings
             done
@@ -1492,8 +1490,7 @@ fn check_function_ops
     function_opt:Option[Function]
 -> int {
     op.value = fn_value
-    if fn_value OpValue::FnCall is then
-        op op_str_value = fn_name
+    if fn_value OpValue::FnCall(fn_name) is then
         fn_name tc.store.functions.get = fn_opt
         if fn_opt.is_some then
             fn_opt.unwrap = function
@@ -1515,8 +1512,7 @@ fn check_function_ops
                 "exec" sig_str_opt.unwrap signature_from_str tc apply_signature
             fi
         fi
-    elif fn_value OpValue::FnPush is then
-        op op_str_value = push_name
+    elif fn_value OpValue::FnPush(push_name) is then
         push_name tc.store.functions.get = push_fn_opt
         if push_fn_opt.is_some then
             push_fn_opt.unwrap = push_fn
@@ -1561,8 +1557,7 @@ fn check_literals tc:TypeChecker op:Op {
     elif literal_value OpValue::PushArray is then
         # Array literals: pop N items of same type
         "array[any]" tc stack_push
-    elif literal_value OpValue::FstringConcat is then
-        op op_int_value = count
+    elif literal_value OpValue::FstringConcat(count) is then
         0 = index
         while index count > do
             "str" tc expect_type drop
@@ -1630,7 +1625,7 @@ fn check_syscalls tc:TypeChecker op:Op {
 # ============================================================================
 
 fn check_enum_variant tc:TypeChecker op:Op {
-    op enum_variant_of = variant
+    if op.value OpValue::PushEnumVariant(variant) is ! then return fi
     variant EnumVariant::enum_name = enum_name
     enum_name tc.store.enums.get = enum_opt
     if enum_opt.is_none then
@@ -1699,7 +1694,10 @@ fn check_is tc:TypeChecker op:Op function_opt:Option[Function] {
         return
     fi
     base tc.store.enums.get.unwrap = casa_enum
-    op enum_variant_of = variant
+    if op.value OpValue::IsCheck(variant) is ! then
+        "bool" tc stack_push
+        return
+    fi
     # Validate the variant belongs to the correct enum
     if "" variant EnumVariant::enum_name != then
         if variant EnumVariant::enum_name casa_enum CasaEnum::name != then
@@ -1892,7 +1890,7 @@ fn check_match tc:TypeChecker op:Op function_opt:Option[Function] {
 # ============================================================================
 
 fn check_struct_new tc:TypeChecker op:Op {
-    op casa_struct_of = casa_struct
+    if op.value OpValue::StructNew(casa_struct) is ! then return fi
     casa_struct CasaStruct::name = name
     # Build type variable bindings from actual stack values
     Map::new(Map[str str]) = bindings
@@ -1919,7 +1917,7 @@ fn check_struct_new tc:TypeChecker op:Op {
 # ============================================================================
 
 fn check_struct_literal tc:TypeChecker op:Op {
-    op struct_literal_of = literal
+    if op.value OpValue::StructLiteral(literal) is ! then return fi
     literal StructLiteral::struct_name = name
     name tc.store.structs.get = struct_opt
     if struct_opt.is_none then
@@ -2174,7 +2172,7 @@ fn check_method_call
     op_index:int
     function_opt:Option[Function]
 -> int {
-    op op_str_value = method_name
+    if op.value OpValue::MethodCall(method_name) is ! then op_index return fi
     tc stack_peek = receiver
 
     # Check if receiver is a trait-bounded type variable
@@ -2549,9 +2547,9 @@ fn run_type_check_ops checker:TypeChecker ops:List[Op] function_opt:Option[Funct
         fi
 
         # Type cast
-        if op_value OpValue::TypeCast is then
+        if op_value OpValue::TypeCast(cast_type) is then
             checker stack_pop drop
-            current_op op_str_value checker stack_push
+            cast_type checker stack_push
             continue
         fi
 

--- a/lsp.casa
+++ b/lsp.casa
@@ -697,8 +697,7 @@ fn handle_did_save message:JsonValue {
 
 fn find_best_assignment name:str ops:List[Op] usage_offset:int best:Option[Op] -> Option[Op] {
     for op in ops.iter do
-        if op.value OpValue::AssignVar is then
-            op op_str_value = assign_name
+        if op.value OpValue::AssignVar(assign_name) is then
             if assign_name name == then
                 if op Op::location Location::span Span::offset usage_offset > then
                     op Option::Some = best
@@ -788,14 +787,13 @@ fn compute_definition state:DocumentState line:int col:int -> Option[LspLocation
     fi
 
     # STRUCT_NEW
-    if op_value OpValue::StructNew is then
-        op casa_struct_of CasaStruct::location casa_location_to_lsp Option::Some
+    if op_value OpValue::StructNew(casa_struct) is then
+        casa_struct CasaStruct::location casa_location_to_lsp Option::Some
         return
     fi
 
     # PUSH_ENUM_VARIANT
-    if op_value OpValue::PushEnumVariant is then
-        op enum_variant_of = enum_variant
+    if op_value OpValue::PushEnumVariant(enum_variant) is then
         enum_variant EnumVariant::enum_name = enum_name
         if enum_name state DocumentState::enums.has ! then
             Option::None(Option[LspLocation])
@@ -812,8 +810,7 @@ fn compute_definition state:DocumentState line:int col:int -> Option[LspLocation
     fi
 
     # TYPE_CAST
-    if op_value OpValue::TypeCast is then
-        op op_str_value = cast_type
+    if op_value OpValue::TypeCast(cast_type) is then
         if cast_type state DocumentState::structs.has then
             cast_type state DocumentState::structs.get.unwrap CasaStruct::location casa_location_to_lsp Option::Some
             return
@@ -939,8 +936,7 @@ fn format_hover op:Op state:DocumentState func:Option[Function] -> Option[str] {
     fi
 
     # Struct new
-    if op_value OpValue::StructNew is then
-        op casa_struct_of = struct_val
+    if op_value OpValue::StructNew(struct_val) is then
         StringBuilder::new = struct_builder
         "struct " struct_builder.append
         struct_val CasaStruct::name struct_builder.append
@@ -960,42 +956,40 @@ fn format_hover op:Op state:DocumentState func:Option[Function] -> Option[str] {
     fi
 
     # Enum variant
-    if op_value OpValue::PushEnumVariant is then
-        op enum_variant_of = variant
+    if op_value OpValue::PushEnumVariant(variant) is then
         f"{variant EnumVariant::enum_name}::{variant EnumVariant::variant_name}" Option::Some
         return
     fi
 
     # Literals
-    if op_value OpValue::PushInt is then
-        f"(int) {op op_int_value}" Option::Some
+    if op_value OpValue::PushInt(int_value) is then
+        f"(int) {int_value}" Option::Some
         return
     fi
-    if op_value OpValue::PushStr is then
-        f"(str) \"{op op_str_value}\"" Option::Some
+    if op_value OpValue::PushStr(str_value) is then
+        f"(str) \"{str_value}\"" Option::Some
         return
     fi
-    if op_value OpValue::PushBool is then
-        if op op_int_value 0 != then
+    if op_value OpValue::PushBool(bool_value) is then
+        if bool_value 0 != then
             "(bool) true" Option::Some
         else
             "(bool) false" Option::Some
         fi
         return
     fi
-    if op_value OpValue::PushChar is then
+    if op_value OpValue::PushChar(char_value) is then
         # Build char string manually
         10 alloc (str) = char_buf
         1 char_buf (ptr) store64
-        op op_int_value (char) 0 char_buf.set
+        char_value (char) 0 char_buf.set
         0 (char) 1 char_buf.set
         f"(char) '{char_buf}'" Option::Some
         return
     fi
 
     # Assignment
-    if op_value OpValue::AssignVar is then
-        op op_str_value = assign_name
+    if op_value OpValue::AssignVar(assign_name) is then
         state func assign_name resolve_variable_type = assign_type
         if assign_type.is_some then
             f"= {assign_name}: {assign_type.unwrap}" Option::Some
@@ -1510,12 +1504,12 @@ fn collect_var_refs ops:List[Op] name:str results:List[LspLocation] {
 
 fn collect_struct_refs ops:List[Op] name:str results:List[LspLocation] {
     for op in ops.iter do
-        if op.value OpValue::StructNew is then
-            if op casa_struct_of CasaStruct::name name == then
+        if op.value OpValue::StructNew(casa_struct) is then
+            if casa_struct CasaStruct::name name == then
                 op Op::location casa_location_to_lsp results.push
             fi
-        elif op.value OpValue::TypeCast is then
-            if op op_str_value name == then
+        elif op.value OpValue::TypeCast(cast_type) is then
+            if cast_type name == then
                 op Op::location casa_location_to_lsp results.push
             fi
         fi
@@ -1524,8 +1518,8 @@ fn collect_struct_refs ops:List[Op] name:str results:List[LspLocation] {
 
 fn collect_enum_refs ops:List[Op] enum_name:str results:List[LspLocation] {
     for op in ops.iter do
-        if op.value OpValue::PushEnumVariant is then
-            if op enum_variant_of EnumVariant::enum_name enum_name == then
+        if op.value OpValue::PushEnumVariant(variant) is then
+            if variant EnumVariant::enum_name enum_name == then
                 op Op::location casa_location_to_lsp results.push
             fi
         fi
@@ -1608,8 +1602,7 @@ fn find_all_references
     fi
 
     # Struct
-    if op_value OpValue::StructNew is then
-        op casa_struct_of = casa_struct
+    if op_value OpValue::StructNew(casa_struct) is then
         casa_struct CasaStruct::name = struct_name
         if include_declaration then
             casa_struct CasaStruct::location casa_location_to_lsp results.push
@@ -1621,8 +1614,8 @@ fn find_all_references
     fi
 
     # Enum variant
-    if op_value OpValue::PushEnumVariant is then
-        op enum_variant_of EnumVariant::enum_name = enum_name
+    if op_value OpValue::PushEnumVariant(variant) is then
+        variant EnumVariant::enum_name = enum_name
         if include_declaration enum_name state DocumentState::enums.has && then
             enum_name state DocumentState::enums.get.unwrap CasaEnum::location casa_location_to_lsp results.push
         fi

--- a/tests/compiler/test_enum.casa
+++ b/tests/compiler/test_enum.casa
@@ -265,8 +265,7 @@ fn test_resolve_enum_variant_ordinal_first {
     "enum Color { Red Green Blue }\nColor::Red" resolve_enum = ops
     0 = index
     while index ops.length > do
-        if index ops.get.value OpValue::PushEnumVariant is then
-            index ops.get enum_variant_of = variant
+        if index ops.get.value OpValue::PushEnumVariant(variant) is then
             "ordinal 0" 0 variant EnumVariant::ordinal.unwrap assert_eq
             "enum name" "Color" variant EnumVariant::enum_name assert_str_eq
             "variant name" "Red" variant EnumVariant::variant_name assert_str_eq
@@ -280,8 +279,7 @@ fn test_resolve_enum_variant_ordinal_second {
     "enum Color { Red Green Blue }\nColor::Green" resolve_enum = ops
     0 = index
     while index ops.length > do
-        if index ops.get.value OpValue::PushEnumVariant is then
-            index ops.get enum_variant_of = variant
+        if index ops.get.value OpValue::PushEnumVariant(variant) is then
             "ordinal 1" 1 variant EnumVariant::ordinal.unwrap assert_eq
             "variant name" "Green" variant EnumVariant::variant_name assert_str_eq
         fi
@@ -294,8 +292,7 @@ fn test_resolve_enum_variant_ordinal_third {
     "enum Color { Red Green Blue }\nColor::Blue" resolve_enum = ops
     0 = index
     while index ops.length > do
-        if index ops.get.value OpValue::PushEnumVariant is then
-            index ops.get enum_variant_of = variant
+        if index ops.get.value OpValue::PushEnumVariant(variant) is then
             "ordinal 2" 2 variant EnumVariant::ordinal.unwrap assert_eq
             "variant name" "Blue" variant EnumVariant::variant_name assert_str_eq
         fi
@@ -930,8 +927,7 @@ fn test_is_check_resolves_ordinal {
     "enum Color { Red Green Blue }\nColor::Blue = c\nc Color::Blue is\n" resolve_enum = ops
     0 = index
     while index ops.length > do
-        if index ops.get.value OpValue::IsCheck is then
-            index ops.get enum_variant_of = variant
+        if index ops.get.value OpValue::IsCheck(variant) is then
             "ordinal 2" 2 variant EnumVariant::ordinal.unwrap assert_eq
         fi
         1 += index
@@ -943,8 +939,7 @@ fn test_is_check_with_bindings_parsed {
     "enum Shape { Circle(int) Rectangle(int int) Point }\n10 Shape::Circle = s\nif s Shape::Circle(r) is then\nr print\nfi\n" resolve_enum = ops
     0 = index
     while index ops.length > do
-        if index ops.get.value OpValue::IsCheck is then
-            index ops.get enum_variant_of = variant
+        if index ops.get.value OpValue::IsCheck(variant) is then
             "has binding" 1 variant EnumVariant::bindings.length assert_eq
             "binding name" "r" 0 variant EnumVariant::bindings.get assert_str_eq
         fi
@@ -957,8 +952,7 @@ fn test_is_check_multiple_bindings_parsed {
     "enum Shape { Circle(int) Rectangle(int int) Point }\n3 4 Shape::Rectangle = s\nif s Shape::Rectangle(w h) is then\nw print\nfi\n" resolve_enum = ops
     0 = index
     while index ops.length > do
-        if index ops.get.value OpValue::IsCheck is then
-            index ops.get enum_variant_of = variant
+        if index ops.get.value OpValue::IsCheck(variant) is then
             "has bindings" 2 variant EnumVariant::bindings.length assert_eq
             "binding w" "w" 0 variant EnumVariant::bindings.get assert_str_eq
             "binding h" "h" 1 variant EnumVariant::bindings.get assert_str_eq

--- a/tests/compiler/test_struct_literal.casa
+++ b/tests/compiler/test_struct_literal.casa
@@ -41,6 +41,7 @@ fn sl_compile code:str -> Program {
 }
 
 fn sl_is_struct_literal value:OpValue -> bool { value OpValue::StructLiteral is }
+
 fn sl_is_match_arm value:OpValue -> bool { value OpValue::MatchArm is }
 
 fn sl_count_ops ops:List[Op] predicate:fn[OpValue -> bool] -> int {
@@ -80,8 +81,7 @@ fn test_basic_struct_literal {
     # Check the StructLiteral value
     0 = index
     while index ops.length > do
-        if index ops.get.value OpValue::StructLiteral is then
-            index ops.get struct_literal_of = literal
+        if index ops.get.value OpValue::StructLiteral(literal) is then
             "struct name" "Point" literal StructLiteral::struct_name assert_str_eq
             "field count" 2 literal StructLiteral::field_order.length assert_eq
             "field 0" "x" 0 literal StructLiteral::field_order.get assert_str_eq
@@ -96,8 +96,7 @@ fn test_reverse_field_order {
     "struct Point { x: int y: int }\nPoint { y: 2 x: 1 }" sl_parse = ops
     0 = index
     while index ops.length > do
-        if index ops.get.value OpValue::StructLiteral is then
-            index ops.get struct_literal_of = literal
+        if index ops.get.value OpValue::StructLiteral(literal) is then
             "field 0" "y" 0 literal StructLiteral::field_order.get assert_str_eq
             "field 1" "x" 1 literal StructLiteral::field_order.get assert_str_eq
         fi


### PR DESCRIPTION
## Summary

- Convert workaround pattern `if op.value OpValue::Foo is then op X_of = name` to direct destructure `if op.value OpValue::Foo(name) is then ... fi` now that #137 fixed is-binding payload type propagation.
- Drop single-variant helpers `op_list_of`, `casa_struct_of`, `struct_literal_of`, `match_arm_of`.
- Retain multi-variant family helpers `op_str_value`, `op_int_value`, `enum_variant_of` for sites that gate on multiple variants in a payload family (e.g. `FnCall || FnPush`) without duplicating unwrap logic.
- `pattern_value_of` and `pattern_guard_ops` remain as MatchArm field-accessor wrappers used across `pattern.casa` and tests; both now destructure directly.

Net: -61 lines (99 ins / 160 del) across typechecker, bytecode, syntax, lsp, and parser/enum/struct-literal tests.

## Test plan

- [x] `tests/test_compiler.sh < /dev/null` — 25/25 passing
- [x] `tests/test_examples.sh` — 39/39 passing
- [x] Bootstrap stable: `stage1.s == stage2.s`