### PR TITLE
refactor(bytecode): type OP_LABEL_MAP by Op identity

### DIFF
--- a/compiler/bytecode.casa
+++ b/compiler/bytecode.casa
@@ -11,7 +11,7 @@ import "pattern"
 # Label management
 # ============================================================================
 0 = LABEL_COUNTER
-Map::new(Map[int int]) = OP_LABEL_MAP
+Map::new(Map[Op int]) = OP_LABEL_MAP
 Set::new(Set[str]) = COMPILED_FUNCTIONS
 
 fn new_label -> int {
@@ -22,30 +22,16 @@ fn new_label -> int {
 
 fn reset_labels {
     0 = LABEL_COUNTER
-    Map::new(Map[int int]) = OP_LABEL_MAP
+    Map::new(Map[Op int]) = OP_LABEL_MAP
     Set::new(Set[str]) = COMPILED_FUNCTIONS
 }
 
-fn op_index_to_label op_index:int -> int {
-    # Return a stable label for an op index, allocating on first access.
-    # Use the Op pointer as key to ensure uniqueness across functions
-    if op_index OP_LABEL_MAP.get Option::Some(existing) is then
+fn op_to_label op:Op -> int {
+    if op OP_LABEL_MAP.get Option::Some(existing) is then
         existing
     else
         new_label = label
-        op_index label OP_LABEL_MAP.set = OP_LABEL_MAP
-        label
-    fi
-}
-
-fn op_ptr_to_label ops:List[Op] op_index:int -> int {
-    # Use op's memory address as unique key for labels
-    op_index ops.get (int) = key
-    if key OP_LABEL_MAP.get Option::Some(existing) is then
-        existing
-    else
-        new_label = label
-        key label OP_LABEL_MAP.set = OP_LABEL_MAP
+        op label OP_LABEL_MAP.set = OP_LABEL_MAP
         label
     fi
 }
@@ -172,7 +158,7 @@ fn find_matching_label
         other_op.value = other_value
         if 1 depth <= then
             if other_value target_values op_value_list_contains then
-                index ops op_ptr_to_label Option::Some return
+                index ops.get op_to_label Option::Some return
             fi
         fi
         if other_value is_block_start_value then
@@ -211,7 +197,7 @@ fn find_next_match_arm_or_end ops:List[Op] op_index:int -> Option[int] {
         other_op.value = other_value
         if 1 depth <= then
             if other_value OpValue::MatchArm is then
-                index ops op_ptr_to_label Option::Some return
+                index ops.get op_to_label Option::Some return
             fi
         fi
         if other_value is_block_start_value then
@@ -308,21 +294,21 @@ fn compile_if_block compiler:BytecodeCompiler op:Op op_index:int bytecode:List[I
         }
         OpValue::IfElif => {
             true "`elif` without parent `if`" loc start_targets OpValue::IfStart op_index ops require_matching drop
-            op_index compiler.ops op_ptr_to_label = elif_label
+            op_index compiler.ops.get op_to_label = elif_label
             false "`elif` without matching `fi`" loc end_targets OpValue::IfEnd op_index ops require_matching = end_label_2
             end_label_2 InstKind::InstJump make_inst_int bytecode.push
             elif_label InstKind::InstLabel make_inst_int bytecode.push
         }
         OpValue::IfElse => {
             true "`else` without parent `if`" loc start_targets OpValue::IfStart op_index ops require_matching drop
-            op_index compiler.ops op_ptr_to_label = else_label
+            op_index compiler.ops.get op_to_label = else_label
             false "`else` without matching `fi`" loc end_targets OpValue::IfEnd op_index ops require_matching = end_label_3
             end_label_3 InstKind::InstJump make_inst_int bytecode.push
             else_label InstKind::InstLabel make_inst_int bytecode.push
         }
         OpValue::IfEnd => {
             true "`fi` without parent `if`" loc start_targets OpValue::IfStart op_index ops require_matching drop
-            op_index compiler.ops op_ptr_to_label = fi_label
+            op_index compiler.ops.get op_to_label = fi_label
             fi_label InstKind::InstLabel make_inst_int bytecode.push
         }
         OpValue::IfStart => false "`if` without matching `fi`" loc end_targets OpValue::IfEnd op_index ops require_matching drop
@@ -363,13 +349,13 @@ fn compile_while_block compiler:BytecodeCompiler op:Op op_index:int bytecode:Lis
             continue_target InstKind::InstJump make_inst_int bytecode.push
         }
         OpValue::WhileEnd => {
-            op_index compiler.ops op_ptr_to_label = while_label
+            op_index compiler.ops.get op_to_label = while_label
             true "`done` without parent `while`" loc start_targets OpValue::WhileStart op_index ops require_matching = loop_start
             loop_start InstKind::InstJump make_inst_int bytecode.push
             while_label InstKind::InstLabel make_inst_int bytecode.push
         }
         OpValue::WhileStart => {
-            op_index compiler.ops op_ptr_to_label = start_label
+            op_index compiler.ops.get op_to_label = start_label
             start_label InstKind::InstLabel make_inst_int bytecode.push
         }
         _ => {
@@ -533,7 +519,7 @@ fn compile_match_block compiler:BytecodeCompiler op:Op op_index:int bytecode:Lis
 
         false "`match` arm without matching `end`" loc end_targets OpValue::MatchEnd op_index ops require_matching = end_label
 
-        op_index ops.get (int) OP_LABEL_MAP.get = existing
+        op_index ops.get OP_LABEL_MAP.get = existing
         existing.is_some ! = is_first
 
         if is_first ! then
@@ -546,7 +532,7 @@ fn compile_match_block compiler:BytecodeCompiler op:Op op_index:int bytecode:Lis
 
         bytecode next_arm is_last op compiler compile_match_op
     elif match_value OpValue::MatchEnd is then
-        op_index compiler.ops op_ptr_to_label = end_match_label
+        op_index compiler.ops.get op_to_label = end_match_label
         end_match_label InstKind::InstLabel make_inst_int bytecode.push
     fi
 }

--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -352,6 +352,14 @@ fn make_op value:OpValue location:Location -> Op {
 fn make_op_annotated value:OpValue location:Location annotation:str -> Op {
     value "" annotation location Op
 }
+# Op identity is its heap address: two Op values compare equal iff the same
+# allocation. Required so labels map by Op identity (Map[Op int]), not by an
+# int reinterpretation of an Op pointer at every read site.
+
+impl Op {
+    fn hash self:Op -> int { self (int) int_hash }
+    fn eq self:Op other:Op -> bool { self (int) other (int) == }
+}
 
 fn clone_ops ops:List[Op] -> List[Op] {
     List::new(List[Op]) = result

--- a/tests/compiler/test_bytecode.casa
+++ b/tests/compiler/test_bytecode.casa
@@ -236,14 +236,16 @@ fn test_compile_import_no_output {
     "import produces no inst" 1 bytecode.length assert_eq
 }
 
-fn test_op_index_to_label_stability {
-    "op_index_to_label_stability" test_start
+fn test_op_to_label_identity {
+    "op_to_label_identity" test_start
     reset_labels
-    42 op_index_to_label = stable_first
-    42 op_index_to_label = stable_second
-    "same index same label" stable_first stable_second assert_eq
-    99 op_index_to_label = other_label
-    "different index different label" stable_first other_label != assert_true
+    OpValue::Add test_make_op = op_a
+    OpValue::Add test_make_op = op_b
+    op_a op_to_label = label_a_first
+    op_a op_to_label = label_a_second
+    op_b op_to_label = label_b
+    "same op same label" label_a_first label_a_second assert_eq
+    "different op different label" label_a_first label_b != assert_true
 }
 
 fn test_compile_if_block {
@@ -679,7 +681,7 @@ test_compile_local_variable
 test_compile_fstring_concat
 test_compile_type_cast_no_output
 test_compile_import_no_output
-test_op_index_to_label_stability
+test_op_to_label_identity
 test_compile_if_block
 test_compile_while_block
 test_compile_string_eq


### PR DESCRIPTION
## Summary

- Replace `OP_LABEL_MAP: Map[int int]` (keyed by an Op pointer reinterpreted as int via `(int)` cast) with `Map[Op int]`.
- Collapse `op_index_to_label` and `op_ptr_to_label` into a single `op_to_label op:Op -> int`. The former had buggy semantics (raw int as Op identity); the latter required an explicit pointer-cast at every read site.
- Add `impl Op { hash, eq }` (pointer identity) so `Op` satisfies `Hashable` and can be used as a `Map` key directly.

This is the last remaining `int`-as-pointer site; the others (`BytecodeCompiler::function`, `LiteralPattern`, all `(StructName)` casts on Op-style fields) were already migrated by #132 and #135–#138.

Closes #130.

## Test plan

- [x] `tests/test_compiler.sh < /dev/null` — 25/25 (incl. self_compilation + fixed_point bootstrap)
- [x] `tests/test_examples.sh < /dev/null` — 39/39
- [x] Triple-bootstrap: stage2.s == stage3.s
- [x] casafmt idempotent on changed files
- [x] New test `test_op_to_label_identity` pins same-Op→same-label and different-Op→different-label contract

## Diff stat

```
 compiler/bytecode.casa            | 42 +++++++++++++--------------------------
 compiler/common.casa              |  8 ++++++++
 tests/compiler/test_bytecode.casa | 18 +++++++++--------
 3 files changed, 32 insertions(+), 36 deletions(-)
```