### PR TITLE
refactor(bytecode): migrate ResolvedVariable to payload-per-variant enum

### DIFF
--- a/compiler/bytecode.casa
+++ b/compiler/bytecode.casa
@@ -107,17 +107,17 @@ fn resolve_variable compiler:BytecodeCompiler variable_name:str -> ResolvedVaria
         variable_name function Function::variables variable_list_contains = is_local
         if is_local then
             variable_name function Function::variables variable_list_index = local_index
-            local_index InstKind::InstLocalSet InstKind::InstLocalGet ResolvedVariable return
+            local_index ResolvedVariable::Local return
         fi
     fi
     variable_name compiler.store.variables.has = is_global
     if is_global then
         variable_name compiler.store.variables.keys string_list_index = global_index
-        global_index InstKind::InstGlobalSet InstKind::InstGlobalGet ResolvedVariable return
+        global_index ResolvedVariable::Global return
     fi
     f"Variable `{variable_name}` is not defined\n" eprint
     1 exit
-    0 InstKind::InstAdd InstKind::InstAdd ResolvedVariable
+    0 ResolvedVariable::Local
 }
 
 # ============================================================================
@@ -240,23 +240,20 @@ fn require_matching
 fn compile_assignment compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
     op op_str_value = name
     name compiler resolve_variable = resolved
-    resolved ResolvedVariable::get_kind = get_kind
-    resolved ResolvedVariable::set_kind = set_kind
-    resolved ResolvedVariable::index = var_index
 
     op.value match
         OpValue::AssignDec => {
-            var_index get_kind make_inst_int bytecode.push
+            bytecode resolved.emit_get
             InstKind::InstSwap make_inst bytecode.push
             InstKind::InstSub make_inst bytecode.push
-            var_index set_kind make_inst_int bytecode.push
+            bytecode resolved.emit_set
         }
         OpValue::AssignInc => {
-            var_index get_kind make_inst_int bytecode.push
+            bytecode resolved.emit_get
             InstKind::InstAdd make_inst bytecode.push
-            var_index set_kind make_inst_int bytecode.push
+            bytecode resolved.emit_set
         }
-        OpValue::AssignVar => var_index set_kind make_inst_int bytecode.push
+        OpValue::AssignVar => bytecode resolved.emit_set
         _ => {
             "Internal error: compile_assignment called with non-assignment OpValue\n" eprint
             1 exit
@@ -386,7 +383,7 @@ fn emit_struct_arm compiler:BytecodeCompiler struct_pattern:StructPattern byteco
             fi
             InstKind::InstLoad64 make_inst bytecode.push
             var_name compiler resolve_variable = resolved
-            resolved ResolvedVariable::index resolved ResolvedVariable::set_kind make_inst_int bytecode.push
+            bytecode resolved.emit_set
         fi
         1 += index
     done
@@ -461,7 +458,7 @@ fn emit_enum_arm_bindings compiler:BytecodeCompiler bytecode:List[Inst] variant:
         InstKind::InstLoad64 make_inst bytecode.push
         index variant EnumVariant::bindings.get = var_name
         var_name compiler resolve_variable = resolved
-        resolved ResolvedVariable::index resolved ResolvedVariable::set_kind make_inst_int bytecode.push
+        bytecode resolved.emit_set
         1 += index
     done
 }
@@ -673,7 +670,7 @@ fn compile_is_check compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
         InstKind::InstLoad64 make_inst bytecode.push
         index variant EnumVariant::bindings.get = var_name
         var_name compiler resolve_variable = resolved
-        resolved ResolvedVariable::index resolved ResolvedVariable::set_kind make_inst_int bytecode.push
+        bytecode resolved.emit_set
         1 += index
     done
 
@@ -867,7 +864,7 @@ fn compile_function_ops compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
                 # pops fn_ptr first into record[0] and then captures into record[1..].
                 for capture in lambda Function::captures.iter do
                     capture Variable::name compiler resolve_variable = capture_resolved
-                    capture_resolved ResolvedVariable::index capture_resolved ResolvedVariable::get_kind make_inst_int bytecode.push
+                    bytecode capture_resolved.emit_get
                 done
                 name InstKind::InstFnPush make_inst_str bytecode.push
                 lambda Function::captures.length InstKind::InstClosureRecord make_inst_int bytecode.push
@@ -1022,7 +1019,7 @@ fn compile_op compiler:BytecodeCompiler op:Op op_index:int bytecode:List[Inst] {
         string_index InstKind::InstPushStr make_inst_int bytecode.push
     elif op_value OpValue::PushVar(var_name) is then
         var_name compiler resolve_variable = var_resolved
-        var_resolved ResolvedVariable::index var_resolved ResolvedVariable::get_kind make_inst_int bytecode.push
+        bytecode var_resolved.emit_get
         # Emit FN_EXEC after trait-bound variable push
         if "trait_exec" op Op::type_annotation == then
             InstKind::InstFnExec make_inst bytecode.push

--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -460,10 +460,33 @@ fn make_variable name:str -> Variable {
     "" name Variable
 }
 
-struct ResolvedVariable {
-    get_kind: InstKind
-    set_kind: InstKind
-    index:    int
+enum ResolvedVariable {
+    Local (int)
+    Global (int)
+}
+
+impl ResolvedVariable {
+    fn emit_get self:ResolvedVariable bytecode:List[Inst] {
+        self match
+            ResolvedVariable::Local(local_index) => {
+                local_index InstKind::InstLocalGet make_inst_int bytecode.push
+            }
+            ResolvedVariable::Global(global_index) => {
+                global_index InstKind::InstGlobalGet make_inst_int bytecode.push
+            }
+        end
+    }
+
+    fn emit_set self:ResolvedVariable bytecode:List[Inst] {
+        self match
+            ResolvedVariable::Local(local_index) => {
+                local_index InstKind::InstLocalSet make_inst_int bytecode.push
+            }
+            ResolvedVariable::Global(global_index) => {
+                global_index InstKind::InstGlobalSet make_inst_int bytecode.push
+            }
+        end
+    }
 }
 
 struct Member {


### PR DESCRIPTION
## Summary

- Replaces \`struct ResolvedVariable { get_kind: InstKind, set_kind: InstKind, index: int }\` (dual-tag with redundant fields) with \`enum ResolvedVariable { Local(int) Global(int) }\`. The kind pair always tracked the variant tag, so collapse them.
- New \`emit_get\` / \`emit_set\` methods on \`ResolvedVariable\` emit the matching \`InstLocalGet\`/\`InstLocalSet\` or \`InstGlobalGet\`/\`InstGlobalSet\` instruction directly. Call sites that previously did \`resolved ResolvedVariable::index resolved ResolvedVariable::set_kind make_inst_int bytecode.push\` now do \`bytecode resolved.emit_set\`.
- Captures use \`InstCaptureLoad\` directly (not via \`ResolvedVariable\`), so no \`Capture\` variant is needed.
- Same kind-tag → enum migration pattern as #142 (\`ArgDef\`) and #135–#138 (\`OpValue\`). \`Inst\` itself is the next migration target.

## Test plan

- [x] \`tests/test_examples.sh\` (39/39 pass)
- [x] \`tests/test_compiler.sh < /dev/null\` (25/25 pass)
- [x] \`./casafmt\` clean on changed files