### PR TITLE
refactor(bytecode): replace Inst struct + InstKind tag with InstValue enum

### DIFF
--- a/compiler/bytecode.casa
+++ b/compiler/bytecode.casa
@@ -1,7 +1,7 @@
-# Bytecode compiler: converts Op tree into flat Inst list.
+# Bytecode compiler: lowers Op tree into a flat List[InstValue].
 #
 # Translates high-level Ops (produced by the parser/typechecker) into
-# low-level Instructions suitable for code generation.
+# low-level instructions suitable for code generation.
 import "std"
 import "common"
 import "error"
@@ -237,20 +237,20 @@ fn require_matching
 # Compile assignment
 # ============================================================================
 
-fn compile_assignment compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
+fn compile_assignment compiler:BytecodeCompiler op:Op bytecode:List[InstValue] {
     op op_str_value = name
     name compiler resolve_variable = resolved
 
     op.value match
         OpValue::AssignDec => {
             bytecode resolved.emit_get
-            InstKind::InstSwap make_inst bytecode.push
-            InstKind::InstSub make_inst bytecode.push
+            InstValue::Swap bytecode.push
+            InstValue::Sub bytecode.push
             bytecode resolved.emit_set
         }
         OpValue::AssignInc => {
             bytecode resolved.emit_get
-            InstKind::InstAdd make_inst bytecode.push
+            InstValue::Add bytecode.push
             bytecode resolved.emit_set
         }
         OpValue::AssignVar => bytecode resolved.emit_set
@@ -265,7 +265,7 @@ fn compile_assignment compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
 # Compile if block
 # ============================================================================
 
-fn compile_if_block compiler:BytecodeCompiler op:Op op_index:int bytecode:List[Inst] {
+fn compile_if_block compiler:BytecodeCompiler op:Op op_index:int bytecode:List[InstValue] {
     compiler.ops = ops
     op Op::location = loc
 
@@ -287,26 +287,26 @@ fn compile_if_block compiler:BytecodeCompiler op:Op op_index:int bytecode:List[I
         OpValue::IfCondition => {
             true "`then` without matching `if`" loc start_targets OpValue::IfStart op_index ops require_matching drop
             false "`then` without matching `fi`" loc elif_else_end OpValue::IfEnd op_index ops require_matching = end_label
-            end_label InstKind::InstJumpNe make_inst_int bytecode.push
+            end_label InstValue::JumpNe bytecode.push
         }
         OpValue::IfElif => {
             true "`elif` without parent `if`" loc start_targets OpValue::IfStart op_index ops require_matching drop
             op_index compiler.ops.get op_to_label = elif_label
             false "`elif` without matching `fi`" loc end_targets OpValue::IfEnd op_index ops require_matching = end_label_2
-            end_label_2 InstKind::InstJump make_inst_int bytecode.push
-            elif_label InstKind::InstLabel make_inst_int bytecode.push
+            end_label_2 InstValue::Jump bytecode.push
+            elif_label InstValue::Label bytecode.push
         }
         OpValue::IfElse => {
             true "`else` without parent `if`" loc start_targets OpValue::IfStart op_index ops require_matching drop
             op_index compiler.ops.get op_to_label = else_label
             false "`else` without matching `fi`" loc end_targets OpValue::IfEnd op_index ops require_matching = end_label_3
-            end_label_3 InstKind::InstJump make_inst_int bytecode.push
-            else_label InstKind::InstLabel make_inst_int bytecode.push
+            end_label_3 InstValue::Jump bytecode.push
+            else_label InstValue::Label bytecode.push
         }
         OpValue::IfEnd => {
             true "`fi` without parent `if`" loc start_targets OpValue::IfStart op_index ops require_matching drop
             op_index compiler.ops.get op_to_label = fi_label
-            fi_label InstKind::InstLabel make_inst_int bytecode.push
+            fi_label InstValue::Label bytecode.push
         }
         OpValue::IfStart => false "`if` without matching `fi`" loc end_targets OpValue::IfEnd op_index ops require_matching drop
         _ => {
@@ -320,7 +320,7 @@ fn compile_if_block compiler:BytecodeCompiler op:Op op_index:int bytecode:List[I
 # Compile while block
 # ============================================================================
 
-fn compile_while_block compiler:BytecodeCompiler op:Op op_index:int bytecode:List[Inst] {
+fn compile_while_block compiler:BytecodeCompiler op:Op op_index:int bytecode:List[InstValue] {
     compiler.ops = ops
     op Op::location = loc
 
@@ -334,26 +334,26 @@ fn compile_while_block compiler:BytecodeCompiler op:Op op_index:int bytecode:Lis
         OpValue::WhileBreak => {
             true "`break` without parent `while`" loc start_targets OpValue::WhileStart op_index ops require_matching drop
             false "`break` without matching `done`" loc end_targets OpValue::WhileEnd op_index ops require_matching = end_label
-            end_label InstKind::InstJump make_inst_int bytecode.push
+            end_label InstValue::Jump bytecode.push
         }
         OpValue::WhileCondition => {
             true "`do` without parent `while`" loc start_targets OpValue::WhileStart op_index ops require_matching drop
             false "`do` without matching `done`" loc end_targets OpValue::WhileEnd op_index ops require_matching = end_label_2
-            end_label_2 InstKind::InstJumpNe make_inst_int bytecode.push
+            end_label_2 InstValue::JumpNe bytecode.push
         }
         OpValue::WhileContinue => {
             true "`continue` without parent `while`" loc start_targets OpValue::WhileStart op_index ops require_matching = continue_target
-            continue_target InstKind::InstJump make_inst_int bytecode.push
+            continue_target InstValue::Jump bytecode.push
         }
         OpValue::WhileEnd => {
             op_index compiler.ops.get op_to_label = while_label
             true "`done` without parent `while`" loc start_targets OpValue::WhileStart op_index ops require_matching = loop_start
-            loop_start InstKind::InstJump make_inst_int bytecode.push
-            while_label InstKind::InstLabel make_inst_int bytecode.push
+            loop_start InstValue::Jump bytecode.push
+            while_label InstValue::Label bytecode.push
         }
         OpValue::WhileStart => {
             op_index compiler.ops.get op_to_label = start_label
-            start_label InstKind::InstLabel make_inst_int bytecode.push
+            start_label InstValue::Label bytecode.push
         }
         _ => {
             "Internal error: compile_while_block called with non-while OpValue\n" eprint
@@ -369,19 +369,19 @@ fn compile_while_block compiler:BytecodeCompiler op:Op op_index:int bytecode:Lis
 # Replaces the three former compile_match_arm_* helpers and consolidates
 # literal / enum / struct emission behind a single pattern-driven function.
 
-fn emit_struct_arm compiler:BytecodeCompiler struct_pattern:StructPattern bytecode:List[Inst] {
+fn emit_struct_arm compiler:BytecodeCompiler struct_pattern:StructPattern bytecode:List[InstValue] {
     struct_pattern StructPattern::struct_name compiler.store.structs.get.unwrap = casa_struct
     0 = index
     while index casa_struct CasaStruct::members.length > do
         index casa_struct CasaStruct::members.get Member::name = field_name
         index WORD_SIZE * = offset
         if field_name struct_pattern StructPattern::bindings.get Option::Some(var_name) is then
-            InstKind::InstDup make_inst bytecode.push
+            InstValue::Dup bytecode.push
             if 0 offset > then
-                offset InstKind::InstPush make_inst_int bytecode.push
-                InstKind::InstAdd make_inst bytecode.push
+                offset InstValue::Push bytecode.push
+                InstValue::Add bytecode.push
             fi
-            InstKind::InstLoad64 make_inst bytecode.push
+            InstValue::Load64 bytecode.push
             var_name compiler resolve_variable = resolved
             bytecode resolved.emit_set
         fi
@@ -389,9 +389,9 @@ fn emit_struct_arm compiler:BytecodeCompiler struct_pattern:StructPattern byteco
     done
 }
 
-fn emit_int_eq value:int bytecode:List[Inst] {
-    value InstKind::InstPush make_inst_int bytecode.push
-    InstKind::InstEq make_inst bytecode.push
+fn emit_int_eq value:int bytecode:List[InstValue] {
+    value InstValue::Push bytecode.push
+    InstValue::Eq bytecode.push
 }
 
 fn emit_literal_arm
@@ -399,21 +399,21 @@ fn emit_literal_arm
     literal_pattern:LiteralPattern
     is_last:bool
     next_arm:Option[int]
-    bytecode:List[Inst]
+    bytecode:List[InstValue]
 {
     if is_last then return fi
-    InstKind::InstDup make_inst bytecode.push
+    InstValue::Dup bytecode.push
     literal_pattern.value match
         LiteralValue::Str(str_value) => {
             str_value compiler intern_string = str_index
-            str_index InstKind::InstPushStr make_inst_int bytecode.push
-            InstKind::InstStrEq make_inst bytecode.push
+            str_index InstValue::PushStr bytecode.push
+            InstValue::StrEq bytecode.push
         }
         LiteralValue::Int(int_value) => { bytecode int_value emit_int_eq }
         LiteralValue::Char(char_value) => { bytecode char_value emit_int_eq }
         LiteralValue::Bool(bool_value) => { bytecode bool_value (int) emit_int_eq }
     end
-    next_arm.unwrap InstKind::InstJumpNe make_inst_int bytecode.push
+    next_arm.unwrap InstValue::JumpNe bytecode.push
 }
 
 fn emit_enum_arm
@@ -422,7 +422,7 @@ fn emit_enum_arm
     is_wildcard:bool
     is_last:bool
     next_arm:Option[int]
-    bytecode:List[Inst]
+    bytecode:List[InstValue]
 {
     if is_wildcard then return fi
     variant EnumVariant::enum_name = enum_name
@@ -430,11 +430,11 @@ fn emit_enum_arm
         enum_name compiler.store.enums.get.unwrap = casa_enum
         if casa_enum has_inner_values then
             if is_last ! then
-                InstKind::InstDup make_inst bytecode.push
-                InstKind::InstLoad64 make_inst bytecode.push
-                variant EnumVariant::ordinal.unwrap InstKind::InstPush make_inst_int bytecode.push
-                InstKind::InstEq make_inst bytecode.push
-                next_arm.unwrap InstKind::InstJumpNe make_inst_int bytecode.push
+                InstValue::Dup bytecode.push
+                InstValue::Load64 bytecode.push
+                variant EnumVariant::ordinal.unwrap InstValue::Push bytecode.push
+                InstValue::Eq bytecode.push
+                next_arm.unwrap InstValue::JumpNe bytecode.push
             fi
             variant bytecode compiler emit_enum_arm_bindings
             return
@@ -442,20 +442,20 @@ fn emit_enum_arm
     fi
 
     if is_last then return fi
-    InstKind::InstDup make_inst bytecode.push
-    variant EnumVariant::ordinal.unwrap InstKind::InstPush make_inst_int bytecode.push
-    InstKind::InstEq make_inst bytecode.push
-    next_arm.unwrap InstKind::InstJumpNe make_inst_int bytecode.push
+    InstValue::Dup bytecode.push
+    variant EnumVariant::ordinal.unwrap InstValue::Push bytecode.push
+    InstValue::Eq bytecode.push
+    next_arm.unwrap InstValue::JumpNe bytecode.push
 }
 
-fn emit_enum_arm_bindings compiler:BytecodeCompiler bytecode:List[Inst] variant:EnumVariant {
+fn emit_enum_arm_bindings compiler:BytecodeCompiler bytecode:List[InstValue] variant:EnumVariant {
     0 = index
     while index variant EnumVariant::bindings.length > do
         index 1 + WORD_SIZE * = offset
-        InstKind::InstDup make_inst bytecode.push
-        offset InstKind::InstPush make_inst_int bytecode.push
-        InstKind::InstAdd make_inst bytecode.push
-        InstKind::InstLoad64 make_inst bytecode.push
+        InstValue::Dup bytecode.push
+        offset InstValue::Push bytecode.push
+        InstValue::Add bytecode.push
+        InstValue::Load64 bytecode.push
         index variant EnumVariant::bindings.get = var_name
         var_name compiler resolve_variable = resolved
         bytecode resolved.emit_set
@@ -468,7 +468,7 @@ fn compile_match_op
     op:Op
     is_last:bool
     next_arm:Option[int]
-    bytecode:List[Inst]
+    bytecode:List[InstValue]
 {
     if op.value OpValue::MatchArm(arm) is ! then return fi
     arm.pattern_value match
@@ -496,15 +496,15 @@ fn compile_match_op
         # required). Codegen may still run in RESILIENT_MODE after such
         # an error, so skip the fail-jump rather than unwrapping None.
         if next_arm.is_some then
-            next_arm.unwrap InstKind::InstJumpNe make_inst_int bytecode.push
+            next_arm.unwrap InstValue::JumpNe bytecode.push
         else
-            InstKind::InstDrop make_inst bytecode.push
+            InstValue::Drop bytecode.push
         fi
     fi
-    InstKind::InstDrop make_inst bytecode.push
+    InstValue::Drop bytecode.push
 }
 
-fn compile_match_block compiler:BytecodeCompiler op:Op op_index:int bytecode:List[Inst] {
+fn compile_match_block compiler:BytecodeCompiler op:Op op_index:int bytecode:List[InstValue] {
     compiler.ops = ops
     op.value = match_value
 
@@ -520,8 +520,8 @@ fn compile_match_block compiler:BytecodeCompiler op:Op op_index:int bytecode:Lis
         existing.is_some ! = is_first
 
         if is_first ! then
-            end_label InstKind::InstJump make_inst_int bytecode.push
-            existing.unwrap InstKind::InstLabel make_inst_int bytecode.push
+            end_label InstValue::Jump bytecode.push
+            existing.unwrap InstValue::Label bytecode.push
         fi
 
         op_index ops find_next_match_arm_or_end = next_arm
@@ -530,7 +530,7 @@ fn compile_match_block compiler:BytecodeCompiler op:Op op_index:int bytecode:Lis
         bytecode next_arm is_last op compiler compile_match_op
     elif match_value OpValue::MatchEnd is then
         op_index compiler.ops.get op_to_label = end_match_label
-        end_match_label InstKind::InstLabel make_inst_int bytecode.push
+        end_match_label InstValue::Label bytecode.push
     fi
 }
 
@@ -538,20 +538,20 @@ fn compile_match_block compiler:BytecodeCompiler op:Op op_index:int bytecode:Lis
 # Compile struct new
 # ============================================================================
 
-fn compile_struct_new compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
+fn compile_struct_new compiler:BytecodeCompiler op:Op bytecode:List[InstValue] {
     if op.value OpValue::StructNew(casa_struct) is ! then return fi
     casa_struct CasaStruct::members.length = count
-    count WORD_SIZE * InstKind::InstPush make_inst_int bytecode.push
-    InstKind::InstHeapAlloc make_inst bytecode.push
+    count WORD_SIZE * InstValue::Push bytecode.push
+    InstValue::HeapAlloc bytecode.push
     0 = index
     while index count > do
-        InstKind::InstSwap make_inst bytecode.push
-        InstKind::InstOver make_inst bytecode.push
+        InstValue::Swap bytecode.push
+        InstValue::Over bytecode.push
         if 0 index > then
-            index WORD_SIZE * InstKind::InstPush make_inst_int bytecode.push
-            InstKind::InstAdd make_inst bytecode.push
+            index WORD_SIZE * InstValue::Push bytecode.push
+            InstValue::Add bytecode.push
         fi
-        InstKind::InstStore64 make_inst bytecode.push
+        InstValue::Store64 bytecode.push
         1 += index
     done
 }
@@ -564,7 +564,7 @@ fn compile_enum_variant
     compiler:BytecodeCompiler
     variant:EnumVariant
     casa_enum:CasaEnum
-    bytecode:List[Inst]
+    bytecode:List[InstValue]
 {
     variant EnumVariant::variant_name = variant_name
     variant_name casa_enum CasaEnum::variant_types.get = types_opt
@@ -581,21 +581,21 @@ fn compile_enum_variant
         compiler.locals_count = local_index
         compiler.locals_count 1 + compiler->locals_count
         local_index temps.push
-        local_index InstKind::InstLocalSet make_inst_int bytecode.push
+        local_index InstValue::LocalSet bytecode.push
         1 += index
     done
 
     # Allocate heap
     compiler.locals_count = ptr_local
     compiler.locals_count 1 + compiler->locals_count
-    slot_count WORD_SIZE * InstKind::InstPush make_inst_int bytecode.push
-    InstKind::InstHeapAlloc make_inst bytecode.push
-    ptr_local InstKind::InstLocalSet make_inst_int bytecode.push
+    slot_count WORD_SIZE * InstValue::Push bytecode.push
+    InstValue::HeapAlloc bytecode.push
+    ptr_local InstValue::LocalSet bytecode.push
 
     # Store ordinal at offset 0
-    variant EnumVariant::ordinal.unwrap InstKind::InstPush make_inst_int bytecode.push
-    ptr_local InstKind::InstLocalGet make_inst_int bytecode.push
-    InstKind::InstStore64 make_inst bytecode.push
+    variant EnumVariant::ordinal.unwrap InstValue::Push bytecode.push
+    ptr_local InstValue::LocalGet bytecode.push
+    InstValue::Store64 bytecode.push
 
     # Store inner values at offsets 8, 16, ...
     # Reversed temp_locals
@@ -603,41 +603,41 @@ fn compile_enum_variant
     while inner_index inner_count > do
         inner_count 1 - inner_index - = reverse_index
         inner_index 1 + WORD_SIZE * = offset
-        ptr_local InstKind::InstLocalGet make_inst_int bytecode.push
-        offset InstKind::InstPush make_inst_int bytecode.push
-        InstKind::InstAdd make_inst bytecode.push
+        ptr_local InstValue::LocalGet bytecode.push
+        offset InstValue::Push bytecode.push
+        InstValue::Add bytecode.push
         reverse_index temps.get = temp_local
-        temp_local InstKind::InstLocalGet make_inst_int bytecode.push
-        InstKind::InstSwap make_inst bytecode.push
-        InstKind::InstStore64 make_inst bytecode.push
+        temp_local InstValue::LocalGet bytecode.push
+        InstValue::Swap bytecode.push
+        InstValue::Store64 bytecode.push
         1 += inner_index
     done
 
     # Push pointer
-    ptr_local InstKind::InstLocalGet make_inst_int bytecode.push
+    ptr_local InstValue::LocalGet bytecode.push
 }
 
 # ============================================================================
 # Compile is check
 # ============================================================================
 
-fn compile_is_check compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
+fn compile_is_check compiler:BytecodeCompiler op:Op bytecode:List[InstValue] {
     if op.value OpValue::IsCheck(variant) is ! then return fi
     variant EnumVariant::enum_name = enum_name
     enum_name compiler.store.enums.get.unwrap = casa_enum
 
     if casa_enum has_inner_values ! then
         # Plain enum: compare ordinal directly
-        variant EnumVariant::ordinal.unwrap InstKind::InstPush make_inst_int bytecode.push
-        InstKind::InstEq make_inst bytecode.push
+        variant EnumVariant::ordinal.unwrap InstValue::Push bytecode.push
+        InstValue::Eq bytecode.push
         return
     fi
 
     if 0 variant EnumVariant::bindings.length == then
         # Data-carrying enum, no bindings: load ordinal and compare
-        InstKind::InstLoad64 make_inst bytecode.push
-        variant EnumVariant::ordinal.unwrap InstKind::InstPush make_inst_int bytecode.push
-        InstKind::InstEq make_inst bytecode.push
+        InstValue::Load64 bytecode.push
+        variant EnumVariant::ordinal.unwrap InstValue::Push bytecode.push
+        InstValue::Eq bytecode.push
         return
     fi
 
@@ -648,40 +648,40 @@ fn compile_is_check compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
     new_label = skip_bindings
 
     # Save enum pointer
-    temp_ptr InstKind::InstLocalSet make_inst_int bytecode.push
+    temp_ptr InstValue::LocalSet bytecode.push
 
     # Load ordinal and compare
-    temp_ptr InstKind::InstLocalGet make_inst_int bytecode.push
-    InstKind::InstLoad64 make_inst bytecode.push
-    variant EnumVariant::ordinal.unwrap InstKind::InstPush make_inst_int bytecode.push
-    InstKind::InstEq make_inst bytecode.push
+    temp_ptr InstValue::LocalGet bytecode.push
+    InstValue::Load64 bytecode.push
+    variant EnumVariant::ordinal.unwrap InstValue::Push bytecode.push
+    InstValue::Eq bytecode.push
 
     # Duplicate bool
-    InstKind::InstDup make_inst bytecode.push
-    skip_bindings InstKind::InstJumpNe make_inst_int bytecode.push
+    InstValue::Dup bytecode.push
+    skip_bindings InstValue::JumpNe bytecode.push
 
     # Extract bindings
     0 = index
     while index variant EnumVariant::bindings.length > do
         index 1 + WORD_SIZE * = offset
-        temp_ptr InstKind::InstLocalGet make_inst_int bytecode.push
-        offset InstKind::InstPush make_inst_int bytecode.push
-        InstKind::InstAdd make_inst bytecode.push
-        InstKind::InstLoad64 make_inst bytecode.push
+        temp_ptr InstValue::LocalGet bytecode.push
+        offset InstValue::Push bytecode.push
+        InstValue::Add bytecode.push
+        InstValue::Load64 bytecode.push
         index variant EnumVariant::bindings.get = var_name
         var_name compiler resolve_variable = resolved
         bytecode resolved.emit_set
         1 += index
     done
 
-    skip_bindings InstKind::InstLabel make_inst_int bytecode.push
+    skip_bindings InstValue::Label bytecode.push
 }
 
 # ============================================================================
 # Compile struct literal
 # ============================================================================
 
-fn compile_struct_literal compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
+fn compile_struct_literal compiler:BytecodeCompiler op:Op bytecode:List[InstValue] {
     if op.value OpValue::StructLiteral(literal) is ! then return fi
     literal StructLiteral::struct_name compiler.store.structs.get.unwrap = casa_struct
     casa_struct CasaStruct::members.length = count
@@ -695,27 +695,27 @@ fn compile_struct_literal compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
         compiler.locals_count 1 + compiler->locals_count
         field_index literal StructLiteral::field_order.get = field_name
         field_name local_index temp_locals.set = temp_locals
-        local_index InstKind::InstLocalSet make_inst_int bytecode.push
+        local_index InstValue::LocalSet bytecode.push
         field_index 1 - = field_index
     done
 
     # Allocate struct on heap
-    count WORD_SIZE * InstKind::InstPush make_inst_int bytecode.push
-    InstKind::InstHeapAlloc make_inst bytecode.push
+    count WORD_SIZE * InstValue::Push bytecode.push
+    InstValue::HeapAlloc bytecode.push
 
     # Store each field at its correct offset
     0 = member_index
     while member_index casa_struct CasaStruct::members.length > do
         member_index casa_struct CasaStruct::members.get Member::name = member_name
         member_index WORD_SIZE * = member_offset
-        InstKind::InstDup make_inst bytecode.push
+        InstValue::Dup bytecode.push
         if 0 member_offset > then
-            member_offset InstKind::InstPush make_inst_int bytecode.push
-            InstKind::InstAdd make_inst bytecode.push
+            member_offset InstValue::Push bytecode.push
+            InstValue::Add bytecode.push
         fi
-        member_name temp_locals.get.unwrap InstKind::InstLocalGet make_inst_int bytecode.push
-        InstKind::InstSwap make_inst bytecode.push
-        InstKind::InstStore64 make_inst bytecode.push
+        member_name temp_locals.get.unwrap InstValue::LocalGet bytecode.push
+        InstValue::Swap bytecode.push
+        InstValue::Store64 bytecode.push
         1 += member_index
     done
 }
@@ -724,7 +724,7 @@ fn compile_struct_literal compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
 # Compile push array
 # ============================================================================
 
-fn compile_push_array compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
+fn compile_push_array compiler:BytecodeCompiler op:Op bytecode:List[InstValue] {
     if op.value OpValue::PushArray(items) is ! then return fi
     items.length = length
 
@@ -739,58 +739,58 @@ fn compile_push_array compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
     # Allocate memory: header (data_ptr + length) + elements
     compiler.locals_count = list_local
     compiler.locals_count 1 + compiler->locals_count
-    length 2 + WORD_SIZE * InstKind::InstPush make_inst_int bytecode.push
-    InstKind::InstHeapAlloc make_inst bytecode.push
-    list_local InstKind::InstLocalSet make_inst_int bytecode.push
+    length 2 + WORD_SIZE * InstValue::Push bytecode.push
+    InstValue::HeapAlloc bytecode.push
+    list_local InstValue::LocalSet bytecode.push
 
     # Store data_ptr (allocation + 16) at offset 0
-    list_local InstKind::InstLocalGet make_inst_int bytecode.push
-    16 InstKind::InstPush make_inst_int bytecode.push
-    InstKind::InstAdd make_inst bytecode.push
-    list_local InstKind::InstLocalGet make_inst_int bytecode.push
-    InstKind::InstStore64 make_inst bytecode.push
+    list_local InstValue::LocalGet bytecode.push
+    16 InstValue::Push bytecode.push
+    InstValue::Add bytecode.push
+    list_local InstValue::LocalGet bytecode.push
+    InstValue::Store64 bytecode.push
 
     # Store length at offset WORD_SIZE
-    length InstKind::InstPush make_inst_int bytecode.push
-    list_local InstKind::InstLocalGet make_inst_int bytecode.push
-    WORD_SIZE InstKind::InstPush make_inst_int bytecode.push
-    InstKind::InstAdd make_inst bytecode.push
-    InstKind::InstStore64 make_inst bytecode.push
+    length InstValue::Push bytecode.push
+    list_local InstValue::LocalGet bytecode.push
+    WORD_SIZE InstValue::Push bytecode.push
+    InstValue::Add bytecode.push
+    InstValue::Store64 bytecode.push
 
     # Store elements starting at offset 16
     compiler.locals_count = index_local
     compiler.locals_count 1 + compiler->locals_count
-    16 InstKind::InstPush make_inst_int bytecode.push
-    index_local InstKind::InstLocalSet make_inst_int bytecode.push
+    16 InstValue::Push bytecode.push
+    index_local InstValue::LocalSet bytecode.push
 
     new_label = start_label
     new_label = end_label
 
     # while index limit > do
-    start_label InstKind::InstLabel make_inst_int bytecode.push
-    index_local InstKind::InstLocalGet make_inst_int bytecode.push
-    length 2 + WORD_SIZE * InstKind::InstPush make_inst_int bytecode.push
-    InstKind::InstGt make_inst bytecode.push
-    end_label InstKind::InstJumpNe make_inst_int bytecode.push
+    start_label InstValue::Label bytecode.push
+    index_local InstValue::LocalGet bytecode.push
+    length 2 + WORD_SIZE * InstValue::Push bytecode.push
+    InstValue::Gt bytecode.push
+    end_label InstValue::JumpNe bytecode.push
 
     # list index + store64
-    list_local InstKind::InstLocalGet make_inst_int bytecode.push
-    index_local InstKind::InstLocalGet make_inst_int bytecode.push
-    InstKind::InstAdd make_inst bytecode.push
-    InstKind::InstStore64 make_inst bytecode.push
+    list_local InstValue::LocalGet bytecode.push
+    index_local InstValue::LocalGet bytecode.push
+    InstValue::Add bytecode.push
+    InstValue::Store64 bytecode.push
 
     # WORD_SIZE += index
-    index_local InstKind::InstLocalGet make_inst_int bytecode.push
-    WORD_SIZE InstKind::InstPush make_inst_int bytecode.push
-    InstKind::InstAdd make_inst bytecode.push
-    index_local InstKind::InstLocalSet make_inst_int bytecode.push
+    index_local InstValue::LocalGet bytecode.push
+    WORD_SIZE InstValue::Push bytecode.push
+    InstValue::Add bytecode.push
+    index_local InstValue::LocalSet bytecode.push
 
     # done
-    start_label InstKind::InstJump make_inst_int bytecode.push
-    end_label InstKind::InstLabel make_inst_int bytecode.push
+    start_label InstValue::Jump bytecode.push
+    end_label InstValue::Label bytecode.push
 
     # Push array pointer
-    list_local InstKind::InstLocalGet make_inst_int bytecode.push
+    list_local InstValue::LocalGet bytecode.push
 }
 
 # ============================================================================
@@ -807,7 +807,7 @@ fn compile_function compiler:BytecodeCompiler function:Function op:Op {
     # Mark as being compiled to prevent infinite recursion on recursive calls
     function Function::name COMPILED_FUNCTIONS.add = COMPILED_FUNCTIONS
 
-    List::new(List[Inst]) = function_bytecode
+    List::new(List[InstValue]) = function_bytecode
     compiler.constants_table compiler.string_table function Option::Some ops compiler.store make_compiler_with_tables = function_compiler
     function_bytecode function_compiler compile_ops
 
@@ -815,20 +815,20 @@ fn compile_function compiler:BytecodeCompiler function:Function op:Op {
     function_compiler.locals_count = locals_count
     if locals_count 0 < then
         # Build new list with LOCALS_INIT at front
-        List::new(List[Inst]) = final_bytecode
-        locals_count InstKind::InstLocalsInit make_inst_int final_bytecode.push
+        List::new(List[InstValue]) = final_bytecode
+        locals_count InstValue::LocalsInit final_bytecode.push
 
         for inst in function_bytecode.iter do
-            if InstKind::InstFnReturn inst Inst::kind == then
-                locals_count InstKind::InstLocalsUninit make_inst_int final_bytecode.push
+            if inst InstValue::FnReturn is then
+                locals_count InstValue::LocalsUninit final_bytecode.push
             fi
             inst final_bytecode.push
         done
-        locals_count InstKind::InstLocalsUninit make_inst_int final_bytecode.push
-        InstKind::InstFnReturn make_inst final_bytecode.push
+        locals_count InstValue::LocalsUninit final_bytecode.push
+        InstValue::FnReturn final_bytecode.push
         final_bytecode = function_bytecode
     else
-        InstKind::InstFnReturn make_inst function_bytecode.push
+        InstValue::FnReturn function_bytecode.push
     fi
 
     # Store bytecode on the function
@@ -837,14 +837,14 @@ fn compile_function compiler:BytecodeCompiler function:Function op:Op {
     done
 }
 
-fn compile_function_ops compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
+fn compile_function_ops compiler:BytecodeCompiler op:Op bytecode:List[InstValue] {
     op op_str_value = name
 
     op.value match
         OpValue::FnCall => {
             name compiler.store.functions.get.unwrap = function
             op function compiler compile_function
-            name InstKind::InstFnCall make_inst_str bytecode.push
+            name InstValue::FnCall bytecode.push
         }
         OpValue::FnPush => {
             name compiler.store.functions.get = function_opt
@@ -858,7 +858,7 @@ fn compile_function_ops compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
             # Zero-capture closures share a single static record so trait
             # dispatch and named-function pushes do not allocate per call.
             if 0 lambda Function::captures.length == then
-                name InstKind::InstFnPushStatic make_inst_str bytecode.push
+                name InstValue::FnPushStatic bytecode.push
             else
                 # Captures are pushed before the function pointer so InstClosureRecord
                 # pops fn_ptr first into record[0] and then captures into record[1..].
@@ -866,8 +866,8 @@ fn compile_function_ops compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
                     capture Variable::name compiler resolve_variable = capture_resolved
                     bytecode capture_resolved.emit_get
                 done
-                name InstKind::InstFnPush make_inst_str bytecode.push
-                lambda Function::captures.length InstKind::InstClosureRecord make_inst_int bytecode.push
+                name InstValue::FnPush bytecode.push
+                lambda Function::captures.length InstValue::ClosureRecord bytecode.push
             fi
         }
         _ => {
@@ -881,21 +881,25 @@ fn compile_function_ops compiler:BytecodeCompiler op:Op bytecode:List[Inst] {
 # Compile enum comparison (data-carrying enums)
 # ============================================================================
 
-fn compile_enum_comparison compiler:BytecodeCompiler compare_kind:InstKind bytecode:List[Inst] {
+fn compile_enum_comparison
+    compiler:BytecodeCompiler
+    compare_value:InstValue
+    bytecode:List[InstValue]
+{
     compiler.locals_count = local_a
     compiler.locals_count 1 + compiler->locals_count
-    local_a InstKind::InstLocalSet make_inst_int bytecode.push
-    InstKind::InstLoad64 make_inst bytecode.push
-    local_a InstKind::InstLocalGet make_inst_int bytecode.push
-    InstKind::InstLoad64 make_inst bytecode.push
-    compare_kind make_inst bytecode.push
+    local_a InstValue::LocalSet bytecode.push
+    InstValue::Load64 bytecode.push
+    local_a InstValue::LocalGet bytecode.push
+    InstValue::Load64 bytecode.push
+    compare_value bytecode.push
 }
 
 # ============================================================================
 # Compile single op
 # ============================================================================
 
-fn compile_op compiler:BytecodeCompiler op:Op op_index:int bytecode:List[Inst] {
+fn compile_op compiler:BytecodeCompiler op:Op op_index:int bytecode:List[InstValue] {
     op.value = op_value
     op_value direct_op_to_inst = direct_inst_opt
 
@@ -921,19 +925,19 @@ fn compile_op compiler:BytecodeCompiler op:Op op_index:int bytecode:List[Inst] {
         op_value OpValue::Ne is ||
         "str" op Op::type_annotation == &&
         then
-            InstKind::InstStrEq make_inst bytecode.push
+            InstValue::StrEq bytecode.push
             if op_value OpValue::Ne is then
-                InstKind::InstNot make_inst bytecode.push
+                InstValue::Not bytecode.push
             fi
             return
         fi
         # Data-carrying enum print
         if op_value OpValue::PrintInt is "" op Op::type_annotation != && then
-            InstKind::InstLoad64 make_inst bytecode.push
-            InstKind::InstPrintInt make_inst bytecode.push
+            InstValue::Load64 bytecode.push
+            InstValue::PrintInt bytecode.push
             return
         fi
-        direct_inst_opt.unwrap make_inst bytecode.push
+        direct_inst_opt.unwrap bytecode.push
         return
     fi
 
@@ -945,7 +949,7 @@ fn compile_op compiler:BytecodeCompiler op:Op op_index:int bytecode:List[Inst] {
     then
         bytecode op compiler compile_assignment
     elif op_value OpValue::FstringConcat(fstring_count) is then
-        fstring_count InstKind::InstFstringConcat make_inst_int bytecode.push
+        fstring_count InstValue::FstringConcat bytecode.push
     elif op_value OpValue::FstringToStr is then
         # Identity no-op: str expression already left on stack by the preceding lambda.
         # Non-str cases are rewritten to OpMethodCall during type checking.
@@ -955,7 +959,7 @@ fn compile_op compiler:BytecodeCompiler op:Op op_index:int bytecode:List[Inst] {
             if function_opt.is_some then
                 function_opt.unwrap = function_check
                 if function_check Function::has_deferred_methods then
-                    0 InstKind::InstPush make_inst_int bytecode.push
+                    0 InstValue::Push bytecode.push
                     return
                 fi
             fi
@@ -979,7 +983,7 @@ fn compile_op compiler:BytecodeCompiler op:Op op_index:int bytecode:List[Inst] {
         if casa_enum has_inner_values then
             bytecode casa_enum variant compiler compile_enum_variant
         else
-            variant EnumVariant::ordinal.unwrap InstKind::InstPush make_inst_int bytecode.push
+            variant EnumVariant::ordinal.unwrap InstValue::Push bytecode.push
         fi
     elif op_value OpValue::IsCheck is then
         bytecode op compiler compile_is_check
@@ -998,31 +1002,31 @@ fn compile_op compiler:BytecodeCompiler op:Op op_index:int bytecode:List[Inst] {
     elif op_value OpValue::Typeof is then
         op Op::type_annotation = type_name
         type_name compiler intern_string = typeof_index
-        InstKind::InstDrop make_inst bytecode.push
-        typeof_index InstKind::InstPushStr make_inst_int bytecode.push
-        InstKind::InstPrintStr make_inst bytecode.push
+        InstValue::Drop bytecode.push
+        typeof_index InstValue::PushStr bytecode.push
+        InstValue::PrintStr bytecode.push
     elif op_value OpValue::PushArray is then
         bytecode op compiler compile_push_array
     elif op_value OpValue::PushBool(bool_value) is then
-        bool_value InstKind::InstPush make_inst_int bytecode.push
+        bool_value InstValue::Push bytecode.push
     elif op_value OpValue::PushChar(char_value) is then
-        char_value InstKind::InstPushChar make_inst_int bytecode.push
+        char_value InstValue::PushChar bytecode.push
     elif op_value OpValue::PushCapture(capture_name) is then
         if compiler.function Option::Some(function) is then
             capture_name function Function::captures variable_list_index = capture_index
-            capture_index InstKind::InstCaptureLoad make_inst_int bytecode.push
+            capture_index InstValue::CaptureLoad bytecode.push
         fi
     elif op_value OpValue::PushInt(int_value) is then
-        int_value InstKind::InstPush make_inst_int bytecode.push
+        int_value InstValue::Push bytecode.push
     elif op_value OpValue::PushStr(str_value) is then
         str_value compiler intern_string = string_index
-        string_index InstKind::InstPushStr make_inst_int bytecode.push
+        string_index InstValue::PushStr bytecode.push
     elif op_value OpValue::PushVar(var_name) is then
         var_name compiler resolve_variable = var_resolved
         bytecode var_resolved.emit_get
         # Emit FN_EXEC after trait-bound variable push
         if "trait_exec" op Op::type_annotation == then
-            InstKind::InstFnExec make_inst bytecode.push
+            InstValue::FnExec bytecode.push
         fi
     elif op_value OpValue::StructNew is then
         bytecode op compiler compile_struct_new
@@ -1043,7 +1047,7 @@ fn compile_op compiler:BytecodeCompiler op:Op op_index:int bytecode:List[Inst] {
 # Compile ops list
 # ============================================================================
 
-fn compile_ops compiler:BytecodeCompiler bytecode:List[Inst] {
+fn compile_ops compiler:BytecodeCompiler bytecode:List[InstValue] {
     # Set locals_count from function variables
     if compiler.function Option::Some(function) is then
         function Function::variables.length = var_count
@@ -1052,7 +1056,7 @@ fn compile_ops compiler:BytecodeCompiler bytecode:List[Inst] {
 
     # Function label
     new_label = function_label
-    function_label InstKind::InstLabel make_inst_int bytecode.push
+    function_label InstValue::Label bytecode.push
 
     0 = index
     while index compiler.ops.length > do
@@ -1069,12 +1073,12 @@ fn compile_ops compiler:BytecodeCompiler bytecode:List[Inst] {
 fn compile_bytecode store:SymbolStore ops:List[Op] -> Program {
     reset_labels
 
-    List::new(List[Inst]) = bytecode
+    List::new(List[InstValue]) = bytecode
     ops store make_compiler = compiler
 
     # Emit globals init if needed
     if 0 compiler.store.variables.length != then
-        compiler.store.variables.length InstKind::InstGlobalsInit make_inst_int bytecode.push
+        compiler.store.variables.length InstValue::GlobalsInit bytecode.push
     fi
 
     bytecode compiler compile_ops
@@ -1082,17 +1086,17 @@ fn compile_bytecode store:SymbolStore ops:List[Op] -> Program {
     # Handle locals for global scope
     compiler.locals_count = locals_count
     if locals_count 0 < then
-        List::new(List[Inst]) = final_bytecode
-        locals_count InstKind::InstLocalsInit make_inst_int final_bytecode.push
+        List::new(List[InstValue]) = final_bytecode
+        locals_count InstValue::LocalsInit final_bytecode.push
         for inst in bytecode.iter do
             inst final_bytecode.push
         done
-        locals_count InstKind::InstLocalsUninit make_inst_int final_bytecode.push
+        locals_count InstValue::LocalsUninit final_bytecode.push
         final_bytecode = bytecode
     fi
 
     # Compile all used functions
-    Map::new(Map[str List[Inst]]) = functions
+    Map::new(Map[str List[InstValue]]) = functions
     compiler.store.functions.keys = function_names
     for function_name in function_names.iter do
         function_name compiler.store.functions.get.unwrap = function

--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -138,100 +138,104 @@ enum OperatorKind {
 # variants carry typed inner values, payloadless variants stand alone.
 
 # ============================================================================
-# InstKind enum (69 variants)
+# InstValue enum
+#
+# One variant per low-level instruction. Payload-bearing variants pack the
+# inner value directly so call sites destructure with `is`/`match`; bytecode
+# is `List[InstValue]` with no per-element wrapper.
 # ============================================================================
 
-enum InstKind {
+enum InstValue {
     # Stack
-    InstDrop
-    InstDup
-    InstOver
-    InstPush
-    InstPushChar
-    InstPushStr
-    InstRot
-    InstSwap
+    Drop
+    Dup
+    Over
+    Push (int)
+    PushChar (int)
+    PushStr (int)
+    Rot
+    Swap
     # IO
-    InstPrintBool
-    InstPrintChar
-    InstPrintCstr
-    InstPrintInt
-    InstPrintStr
+    PrintBool
+    PrintChar
+    PrintCstr
+    PrintInt
+    PrintStr
     # Memory
-    InstHeapAlloc
-    InstLoad8
-    InstLoad16
-    InstLoad32
-    InstLoad64
-    InstStore8
-    InstStore16
-    InstStore32
-    InstStore64
+    HeapAlloc
+    Load8
+    Load16
+    Load32
+    Load64
+    Store8
+    Store16
+    Store32
+    Store64
     # Arithmetic
-    InstAdd
-    InstDiv
-    InstMod
-    InstMul
-    InstSub
+    Add
+    Div
+    Mod
+    Mul
+    Sub
     # Bitshift
-    InstShl
-    InstShr
+    Shl
+    Shr
     # Bitwise
-    InstBitAnd
-    InstBitOr
-    InstBitXor
-    InstBitNot
+    BitAnd
+    BitOr
+    BitXor
+    BitNot
     # Boolean
-    InstAnd
-    InstOr
-    InstNot
+    And
+    Or
+    Not
     # Comparison
-    InstEq
-    InstGe
-    InstGt
-    InstLe
-    InstLt
-    InstNe
+    Eq
+    Ge
+    Gt
+    Le
+    Lt
+    Ne
     # Functions
-    InstFnCall
-    InstFnExec
-    InstFnPush
-    InstFnReturn
+    FnCall (str)
+    FnExec
+    FnPush (str)
+    FnReturn
     # Jumps
-    InstLabel
-    InstJump
-    InstJumpNe
+    Label (int)
+    Jump (int)
+    JumpNe (int)
     # Locals
-    InstLocalsInit
-    InstLocalsUninit
-    InstLocalGet
-    InstLocalSet
+    LocalsInit (int)
+    LocalsUninit (int)
+    LocalGet (int)
+    LocalSet (int)
     # Globals
-    InstGlobalsInit
-    InstGlobalGet
-    InstGlobalSet
+    GlobalsInit (int)
+    GlobalGet (int)
+    GlobalSet (int)
     # Constants
-    InstConstantLoad
-    InstConstantStore
+    ConstantLoad (int)
+    ConstantStore (int)
     # Closures
-    InstCaptureLoad
-    InstClosureRecord
-    InstFnPushStatic
+    CaptureLoad (int)
+    ClosureRecord (int)
+    FnPushStatic (str)
     # Strings
-    InstStrEq
+    StrEq
     # F-strings
-    InstFstringConcat
+    FstringConcat (int)
     # Syscalls
-    InstSyscall0
-    InstSyscall1
-    InstSyscall2
-    InstSyscall3
-    InstSyscall4
-    InstSyscall5
-    InstSyscall6
+    Syscall0
+    Syscall1
+    Syscall2
+    Syscall3
+    Syscall4
+    Syscall5
+    Syscall6
     # Command-line arguments
-    InstArgc
-    InstArgv
+    Argc
+    Argv
 }
 
 # ============================================================================
@@ -290,11 +294,6 @@ impl DelimiterKind {
 impl OperatorKind {
     fn hash self:OperatorKind -> int { self (int) int_hash }
     fn eq self:OperatorKind other:OperatorKind -> bool { self other == }
-}
-
-impl InstKind {
-    fn hash self:InstKind -> int { self (int) int_hash }
-    fn eq self:InstKind other:InstKind -> bool { self other == }
 }
 
 # ============================================================================
@@ -386,28 +385,6 @@ fn substitute_ops_types ops:List[Op] subs:Map[str str] {
 }
 
 # ============================================================================
-# Instruction
-# ============================================================================
-
-struct Inst {
-    kind:    InstKind
-    int_arg: int
-    str_arg: str
-}
-
-fn make_inst kind:InstKind -> Inst {
-    "" 0 kind Inst
-}
-
-fn make_inst_int kind:InstKind arg:int -> Inst {
-    "" arg kind Inst
-}
-
-fn make_inst_str kind:InstKind arg:str -> Inst {
-    arg 0 kind Inst
-}
-
-# ============================================================================
 # Function signature types
 # ============================================================================
 
@@ -466,24 +443,24 @@ enum ResolvedVariable {
 }
 
 impl ResolvedVariable {
-    fn emit_get self:ResolvedVariable bytecode:List[Inst] {
+    fn emit_get self:ResolvedVariable bytecode:List[InstValue] {
         self match
             ResolvedVariable::Local(local_index) => {
-                local_index InstKind::InstLocalGet make_inst_int bytecode.push
+                local_index InstValue::LocalGet bytecode.push
             }
             ResolvedVariable::Global(global_index) => {
-                global_index InstKind::InstGlobalGet make_inst_int bytecode.push
+                global_index InstValue::GlobalGet bytecode.push
             }
         end
     }
 
-    fn emit_set self:ResolvedVariable bytecode:List[Inst] {
+    fn emit_set self:ResolvedVariable bytecode:List[InstValue] {
         self match
             ResolvedVariable::Local(local_index) => {
-                local_index InstKind::InstLocalSet make_inst_int bytecode.push
+                local_index InstValue::LocalSet bytecode.push
             }
             ResolvedVariable::Global(global_index) => {
-                global_index InstKind::InstGlobalSet make_inst_int bytecode.push
+                global_index InstValue::GlobalSet bytecode.push
             }
         end
     }
@@ -851,7 +828,7 @@ struct Function {
     ops:                  List[Op]
     location:             Location
     signature:            Signature
-    bytecode:             List[Inst]
+    bytecode:             List[InstValue]
     is_used:              bool
     is_typechecked:       bool
     variables:            List[Variable]
@@ -860,11 +837,11 @@ struct Function {
 }
 
 fn make_function name:str ops:List[Op] location:Location -> Function {
-    false List::new(List[Variable]) List::new(List[Variable]) false false List::new(List[Inst]) empty_signature location ops name Function
+    false List::new(List[Variable]) List::new(List[Variable]) false false List::new(List[InstValue]) empty_signature location ops name Function
 }
 
 fn make_function_with_sig name:str ops:List[Op] location:Location sig:Signature -> Function {
-    false List::new(List[Variable]) List::new(List[Variable]) false false List::new(List[Inst]) sig location ops name Function
+    false List::new(List[Variable]) List::new(List[Variable]) false false List::new(List[InstValue]) sig location ops name Function
 }
 
 # ============================================================================
@@ -872,8 +849,8 @@ fn make_function_with_sig name:str ops:List[Op] location:Location sig:Signature 
 # ============================================================================
 
 struct Program {
-    bytecode:        List[Inst]
-    functions:       Map[str List[Inst]]
+    bytecode:        List[InstValue]
+    functions:       Map[str List[InstValue]]
     strings:         List[str]
     globals_count:   int
     constants_count: int
@@ -1421,62 +1398,62 @@ fn intrinsic_to_op_value intrinsic_kind:IntrinsicKind -> Option[OpValue] {
 }
 
 # ============================================================================
-# Direct OpValue -> InstKind lowering (for ops that translate 1:1)
+# Direct OpValue -> InstValue lowering (for ops that translate 1:1)
 # ============================================================================
 
-fn direct_op_to_inst value:OpValue -> Option[InstKind] {
+fn direct_op_to_inst value:OpValue -> Option[InstValue] {
     value match
-        OpValue::Add => InstKind::InstAdd Option::Some
-        OpValue::And => InstKind::InstAnd Option::Some
-        OpValue::BitAnd => InstKind::InstBitAnd Option::Some
-        OpValue::BitNot => InstKind::InstBitNot Option::Some
-        OpValue::BitOr => InstKind::InstBitOr Option::Some
-        OpValue::BitXor => InstKind::InstBitXor Option::Some
-        OpValue::Div => InstKind::InstDiv Option::Some
-        OpValue::Drop => InstKind::InstDrop Option::Some
-        OpValue::Dup => InstKind::InstDup Option::Some
-        OpValue::Eq => InstKind::InstEq Option::Some
-        OpValue::FnExec => InstKind::InstFnExec Option::Some
-        OpValue::FnReturn => InstKind::InstFnReturn Option::Some
-        OpValue::Ge => InstKind::InstGe Option::Some
-        OpValue::Gt => InstKind::InstGt Option::Some
-        OpValue::HeapAlloc => InstKind::InstHeapAlloc Option::Some
-        OpValue::Le => InstKind::InstLe Option::Some
-        OpValue::Load8 => InstKind::InstLoad8 Option::Some
-        OpValue::Load16 => InstKind::InstLoad16 Option::Some
-        OpValue::Load32 => InstKind::InstLoad32 Option::Some
-        OpValue::Load64 => InstKind::InstLoad64 Option::Some
-        OpValue::Lt => InstKind::InstLt Option::Some
-        OpValue::Mod => InstKind::InstMod Option::Some
-        OpValue::Mul => InstKind::InstMul Option::Some
-        OpValue::Ne => InstKind::InstNe Option::Some
-        OpValue::Not => InstKind::InstNot Option::Some
-        OpValue::Or => InstKind::InstOr Option::Some
-        OpValue::Over => InstKind::InstOver Option::Some
-        OpValue::PrintBool => InstKind::InstPrintBool Option::Some
-        OpValue::PrintChar => InstKind::InstPrintChar Option::Some
-        OpValue::PrintCstr => InstKind::InstPrintCstr Option::Some
-        OpValue::PrintInt => InstKind::InstPrintInt Option::Some
-        OpValue::PrintStr => InstKind::InstPrintStr Option::Some
-        OpValue::Rot => InstKind::InstRot Option::Some
-        OpValue::Shl => InstKind::InstShl Option::Some
-        OpValue::Shr => InstKind::InstShr Option::Some
-        OpValue::Store8 => InstKind::InstStore8 Option::Some
-        OpValue::Store16 => InstKind::InstStore16 Option::Some
-        OpValue::Store32 => InstKind::InstStore32 Option::Some
-        OpValue::Store64 => InstKind::InstStore64 Option::Some
-        OpValue::Sub => InstKind::InstSub Option::Some
-        OpValue::Swap => InstKind::InstSwap Option::Some
-        OpValue::Syscall0 => InstKind::InstSyscall0 Option::Some
-        OpValue::Syscall1 => InstKind::InstSyscall1 Option::Some
-        OpValue::Syscall2 => InstKind::InstSyscall2 Option::Some
-        OpValue::Syscall3 => InstKind::InstSyscall3 Option::Some
-        OpValue::Syscall4 => InstKind::InstSyscall4 Option::Some
-        OpValue::Syscall5 => InstKind::InstSyscall5 Option::Some
-        OpValue::Syscall6 => InstKind::InstSyscall6 Option::Some
-        OpValue::Argc => InstKind::InstArgc Option::Some
-        OpValue::Argv => InstKind::InstArgv Option::Some
-        _ => Option::None(Option[InstKind])
+        OpValue::Add => InstValue::Add Option::Some
+        OpValue::And => InstValue::And Option::Some
+        OpValue::BitAnd => InstValue::BitAnd Option::Some
+        OpValue::BitNot => InstValue::BitNot Option::Some
+        OpValue::BitOr => InstValue::BitOr Option::Some
+        OpValue::BitXor => InstValue::BitXor Option::Some
+        OpValue::Div => InstValue::Div Option::Some
+        OpValue::Drop => InstValue::Drop Option::Some
+        OpValue::Dup => InstValue::Dup Option::Some
+        OpValue::Eq => InstValue::Eq Option::Some
+        OpValue::FnExec => InstValue::FnExec Option::Some
+        OpValue::FnReturn => InstValue::FnReturn Option::Some
+        OpValue::Ge => InstValue::Ge Option::Some
+        OpValue::Gt => InstValue::Gt Option::Some
+        OpValue::HeapAlloc => InstValue::HeapAlloc Option::Some
+        OpValue::Le => InstValue::Le Option::Some
+        OpValue::Load8 => InstValue::Load8 Option::Some
+        OpValue::Load16 => InstValue::Load16 Option::Some
+        OpValue::Load32 => InstValue::Load32 Option::Some
+        OpValue::Load64 => InstValue::Load64 Option::Some
+        OpValue::Lt => InstValue::Lt Option::Some
+        OpValue::Mod => InstValue::Mod Option::Some
+        OpValue::Mul => InstValue::Mul Option::Some
+        OpValue::Ne => InstValue::Ne Option::Some
+        OpValue::Not => InstValue::Not Option::Some
+        OpValue::Or => InstValue::Or Option::Some
+        OpValue::Over => InstValue::Over Option::Some
+        OpValue::PrintBool => InstValue::PrintBool Option::Some
+        OpValue::PrintChar => InstValue::PrintChar Option::Some
+        OpValue::PrintCstr => InstValue::PrintCstr Option::Some
+        OpValue::PrintInt => InstValue::PrintInt Option::Some
+        OpValue::PrintStr => InstValue::PrintStr Option::Some
+        OpValue::Rot => InstValue::Rot Option::Some
+        OpValue::Shl => InstValue::Shl Option::Some
+        OpValue::Shr => InstValue::Shr Option::Some
+        OpValue::Store8 => InstValue::Store8 Option::Some
+        OpValue::Store16 => InstValue::Store16 Option::Some
+        OpValue::Store32 => InstValue::Store32 Option::Some
+        OpValue::Store64 => InstValue::Store64 Option::Some
+        OpValue::Sub => InstValue::Sub Option::Some
+        OpValue::Swap => InstValue::Swap Option::Some
+        OpValue::Syscall0 => InstValue::Syscall0 Option::Some
+        OpValue::Syscall1 => InstValue::Syscall1 Option::Some
+        OpValue::Syscall2 => InstValue::Syscall2 Option::Some
+        OpValue::Syscall3 => InstValue::Syscall3 Option::Some
+        OpValue::Syscall4 => InstValue::Syscall4 Option::Some
+        OpValue::Syscall5 => InstValue::Syscall5 Option::Some
+        OpValue::Syscall6 => InstValue::Syscall6 Option::Some
+        OpValue::Argc => InstValue::Argc Option::Some
+        OpValue::Argv => InstValue::Argv Option::Some
+        _ => Option::None(Option[InstValue])
     end
 }
 

--- a/compiler/emitter.casa
+++ b/compiler/emitter.casa
@@ -318,7 +318,7 @@ fn emit_start asm:StringBuilder program:Program {
 # Emit bytecode sequence
 # ============================================================================
 
-fn emit_bytecode asm:StringBuilder bytecode:List[Inst] is_global:bool {
+fn emit_bytecode asm:StringBuilder bytecode:List[InstValue] is_global:bool {
     for inst in bytecode.iter do
         is_global inst asm emit_inst
     done
@@ -387,10 +387,9 @@ fn emit_store asm:StringBuilder mov_op:str src_reg:str {
 # Emit stack operations
 # ============================================================================
 
-fn emit_stack_ops asm:StringBuilder inst:Inst {
-    inst Inst::kind match
-        InstKind::InstPush => {
-            inst Inst::int_arg = value
+fn emit_stack_ops asm:StringBuilder inst:InstValue {
+    inst match
+        InstValue::Push(value) => {
             if
             INT32_MIN value >=
             INT32_MAX value <= &&
@@ -401,21 +400,21 @@ fn emit_stack_ops asm:StringBuilder inst:Inst {
                 "pushq %rax" asm emit_indent
             fi
         }
-        InstKind::InstPushStr => {
-            f"leaq str_{inst Inst::int_arg}(%rip), %rax" asm emit_indent
+        InstValue::PushStr(str_index) => {
+            f"leaq str_{str_index}(%rip), %rax" asm emit_indent
             "pushq %rax" asm emit_indent
         }
-        InstKind::InstPushChar => f"pushq ${inst Inst::int_arg}" asm emit_indent
-        InstKind::InstDrop => "addq $8, %rsp" asm emit_indent
-        InstKind::InstDup => "pushq (%rsp)" asm emit_indent
-        InstKind::InstSwap => {
+        InstValue::PushChar(char_value) => f"pushq ${char_value}" asm emit_indent
+        InstValue::Drop => "addq $8, %rsp" asm emit_indent
+        InstValue::Dup => "pushq (%rsp)" asm emit_indent
+        InstValue::Swap => {
             "popq %rax" asm emit_indent
             "popq %rbx" asm emit_indent
             "pushq %rax" asm emit_indent
             "pushq %rbx" asm emit_indent
         }
-        InstKind::InstOver => "pushq 8(%rsp)" asm emit_indent
-        InstKind::InstRot => {
+        InstValue::Over => "pushq 8(%rsp)" asm emit_indent
+        InstValue::Rot => {
             "popq %rax" asm emit_indent
             "popq %rbx" asm emit_indent
             "popq %rcx" asm emit_indent
@@ -424,7 +423,7 @@ fn emit_stack_ops asm:StringBuilder inst:Inst {
             "pushq %rcx" asm emit_indent
         }
         _ => {
-            "Internal error: emit_stack_ops called with non-stack InstKind\n" eprint
+            "Internal error: emit_stack_ops called with non-stack InstValue\n" eprint
             1 exit
         }
     end
@@ -434,57 +433,57 @@ fn emit_stack_ops asm:StringBuilder inst:Inst {
 # Emit arithmetic / bitwise / boolean / comparison operations
 # ============================================================================
 
-fn emit_arithmetic asm:StringBuilder inst:Inst {
-    inst Inst::kind match
-        InstKind::InstAdd => {
+fn emit_arithmetic asm:StringBuilder inst:InstValue {
+    inst match
+        InstValue::Add => {
             "popq %rax" asm emit_indent
             "addq %rax, (%rsp)" asm emit_indent
         }
-        InstKind::InstSub => {
+        InstValue::Sub => {
             "popq %rax" asm emit_indent
             "subq %rax, (%rsp)" asm emit_indent
         }
-        InstKind::InstMul => {
+        InstValue::Mul => {
             "popq %rax" asm emit_indent
             "imulq (%rsp), %rax" asm emit_indent
             "movq %rax, (%rsp)" asm emit_indent
         }
-        InstKind::InstDiv => {
+        InstValue::Div => {
             "popq %rbx" asm emit_indent
             "popq %rax" asm emit_indent
             "cqto" asm emit_indent
             "idivq %rbx" asm emit_indent
             "pushq %rax" asm emit_indent
         }
-        InstKind::InstMod => {
+        InstValue::Mod => {
             "popq %rbx" asm emit_indent
             "popq %rax" asm emit_indent
             "cqto" asm emit_indent
             "idivq %rbx" asm emit_indent
             "pushq %rdx" asm emit_indent
         }
-        InstKind::InstShl => {
+        InstValue::Shl => {
             "popq %rcx" asm emit_indent
             "shlq %cl, (%rsp)" asm emit_indent
         }
-        InstKind::InstShr => {
+        InstValue::Shr => {
             "popq %rcx" asm emit_indent
             "sarq %cl, (%rsp)" asm emit_indent
         }
-        InstKind::InstBitAnd => {
+        InstValue::BitAnd => {
             "popq %rax" asm emit_indent
             "andq %rax, (%rsp)" asm emit_indent
         }
-        InstKind::InstBitOr => {
+        InstValue::BitOr => {
             "popq %rax" asm emit_indent
             "orq %rax, (%rsp)" asm emit_indent
         }
-        InstKind::InstBitXor => {
+        InstValue::BitXor => {
             "popq %rax" asm emit_indent
             "xorq %rax, (%rsp)" asm emit_indent
         }
-        InstKind::InstBitNot => "notq (%rsp)" asm emit_indent
-        InstKind::InstAnd => {
+        InstValue::BitNot => "notq (%rsp)" asm emit_indent
+        InstValue::And => {
             "popq %rax" asm emit_indent
             "testq %rax, %rax" asm emit_indent
             "setne %al" asm emit_indent
@@ -494,27 +493,27 @@ fn emit_arithmetic asm:StringBuilder inst:Inst {
             "movzbq %al, %rax" asm emit_indent
             "movq %rax, (%rsp)" asm emit_indent
         }
-        InstKind::InstOr => {
+        InstValue::Or => {
             "popq %rax" asm emit_indent
             "orq %rax, (%rsp)" asm emit_indent
             "setne %al" asm emit_indent
             "movzbq %al, %rax" asm emit_indent
             "movq %rax, (%rsp)" asm emit_indent
         }
-        InstKind::InstNot => {
+        InstValue::Not => {
             "cmpq $0, (%rsp)" asm emit_indent
             "sete %al" asm emit_indent
             "movzbq %al, %rax" asm emit_indent
             "movq %rax, (%rsp)" asm emit_indent
         }
-        InstKind::InstEq => asm "sete" emit_comparison
-        InstKind::InstNe => asm "setne" emit_comparison
-        InstKind::InstLt => asm "setl" emit_comparison
-        InstKind::InstLe => asm "setle" emit_comparison
-        InstKind::InstGt => asm "setg" emit_comparison
-        InstKind::InstGe => asm "setge" emit_comparison
+        InstValue::Eq => asm "sete" emit_comparison
+        InstValue::Ne => asm "setne" emit_comparison
+        InstValue::Lt => asm "setl" emit_comparison
+        InstValue::Le => asm "setle" emit_comparison
+        InstValue::Gt => asm "setg" emit_comparison
+        InstValue::Ge => asm "setge" emit_comparison
         _ => {
-            "Internal error: emit_arithmetic called with non-arithmetic InstKind\n" eprint
+            "Internal error: emit_arithmetic called with non-arithmetic InstValue\n" eprint
             1 exit
         }
     end
@@ -524,30 +523,29 @@ fn emit_arithmetic asm:StringBuilder inst:Inst {
 # Emit control flow / variable / function operations
 # ============================================================================
 
-fn emit_control_flow asm:StringBuilder inst:Inst is_global:bool {
-    inst Inst::kind match
-        InstKind::InstLabel => f".L{inst Inst::int_arg}:" asm emit_line
-        InstKind::InstJump => f"jmp .L{inst Inst::int_arg}" asm emit_indent
-        InstKind::InstJumpNe => {
+fn emit_control_flow asm:StringBuilder inst:InstValue is_global:bool {
+    inst match
+        InstValue::Label(label) => f".L{label}:" asm emit_line
+        InstValue::Jump(label) => f"jmp .L{label}" asm emit_indent
+        InstValue::JumpNe(label) => {
             "popq %rax" asm emit_indent
             "testq %rax, %rax" asm emit_indent
-            f"jz .L{inst Inst::int_arg}" asm emit_indent
+            f"jz .L{label}" asm emit_indent
         }
-        InstKind::InstGlobalsInit => {
+        InstValue::GlobalsInit => {
             # Nothing needed, BSS handles it
         }
-        InstKind::InstGlobalGet => {
-            inst Inst::int_arg WORD_SIZE * = offset
+        InstValue::GlobalGet(global_index) => {
+            global_index WORD_SIZE * = offset
             f"movq globals+{offset}(%rip), %rax" asm emit_indent
             "pushq %rax" asm emit_indent
         }
-        InstKind::InstGlobalSet => {
-            inst Inst::int_arg WORD_SIZE * = offset
+        InstValue::GlobalSet(global_index) => {
+            global_index WORD_SIZE * = offset
             "popq %rax" asm emit_indent
             f"movq %rax, globals+{offset}(%rip)" asm emit_indent
         }
-        InstKind::InstLocalsInit => {
-            inst Inst::int_arg = count
+        InstValue::LocalsInit(count) => {
             if 0 count != then
                 "movq %r14, %rdi" asm emit_indent
                 f"movq ${count}, %rcx" asm emit_indent
@@ -556,37 +554,36 @@ fn emit_control_flow asm:StringBuilder inst:Inst is_global:bool {
                 f"addq ${count WORD_SIZE *}, %r14" asm emit_indent
             fi
         }
-        InstKind::InstLocalsUninit => {
-            inst Inst::int_arg = count
+        InstValue::LocalsUninit(count) => {
             if 0 count != then
                 f"subq ${count WORD_SIZE *}, %r14" asm emit_indent
             fi
         }
-        InstKind::InstLocalGet => {
-            inst Inst::int_arg 1 + WORD_SIZE * = offset
+        InstValue::LocalGet(local_index) => {
+            local_index 1 + WORD_SIZE * = offset
             f"movq -{offset}(%r14), %rax" asm emit_indent
             "pushq %rax" asm emit_indent
         }
-        InstKind::InstLocalSet => {
-            inst Inst::int_arg 1 + WORD_SIZE * = offset
+        InstValue::LocalSet(local_index) => {
+            local_index 1 + WORD_SIZE * = offset
             "popq %rax" asm emit_indent
             f"movq %rax, -{offset}(%r14)" asm emit_indent
         }
-        InstKind::InstConstantLoad => {
-            inst Inst::int_arg WORD_SIZE * = offset
+        InstValue::ConstantLoad(constant_index) => {
+            constant_index WORD_SIZE * = offset
             f"movq constants+{offset}(%rip), %rax" asm emit_indent
             "pushq %rax" asm emit_indent
         }
-        InstKind::InstConstantStore => {
-            inst Inst::int_arg WORD_SIZE * = offset
+        InstValue::ConstantStore(constant_index) => {
+            constant_index WORD_SIZE * = offset
             "popq %rax" asm emit_indent
             f"movq %rax, constants+{offset}(%rip)" asm emit_indent
         }
-        InstKind::InstFnCall => {
-            inst Inst::str_arg sanitize_name = label
-            "ret" f"fn_{label}" asm emit_call_via_return_stack
+        InstValue::FnCall(fn_name) => {
+            fn_name sanitize_name = fn_label
+            "ret" f"fn_{fn_label}" asm emit_call_via_return_stack
         }
-        InstKind::InstFnExec => {
+        InstValue::FnExec => {
             emit_uid = uid
             # Save the caller's active closure env on the env stack and switch
             # current_env to the popped closure record so its body can access
@@ -613,14 +610,13 @@ fn emit_control_flow asm:StringBuilder inst:Inst is_global:bool {
             "movq env_stack(%rcx), %rax" asm emit_indent
             "movq %rax, current_env(%rip)" asm emit_indent
         }
-        InstKind::InstCaptureLoad => {
-            inst Inst::int_arg 1 + WORD_SIZE * = offset
+        InstValue::CaptureLoad(capture_index) => {
+            capture_index 1 + WORD_SIZE * = offset
             "movq current_env(%rip), %rax" asm emit_indent
             f"movq {offset}(%rax), %rax" asm emit_indent
             "pushq %rax" asm emit_indent
         }
-        InstKind::InstClosureRecord => {
-            inst Inst::int_arg = capture_count
+        InstValue::ClosureRecord(capture_count) => {
             capture_count 1 + WORD_SIZE * = record_size
             # Bump-allocate the record from the heap.
             "leaq heap(%rip), %rbx" asm emit_indent
@@ -643,17 +639,17 @@ fn emit_control_flow asm:StringBuilder inst:Inst is_global:bool {
             done
             "pushq %rdx" asm emit_indent
         }
-        InstKind::InstFnPush => {
-            inst Inst::str_arg sanitize_name = label
-            f"leaq fn_{label}(%rip), %rax" asm emit_indent
+        InstValue::FnPush(fn_name) => {
+            fn_name sanitize_name = fn_label
+            f"leaq fn_{fn_label}(%rip), %rax" asm emit_indent
             "pushq %rax" asm emit_indent
         }
-        InstKind::InstFnPushStatic => {
-            inst Inst::str_arg sanitize_name = label
-            f"leaq closure_{label}(%rip), %rax" asm emit_indent
+        InstValue::FnPushStatic(fn_name) => {
+            fn_name sanitize_name = fn_label
+            f"leaq closure_{fn_label}(%rip), %rax" asm emit_indent
             "pushq %rax" asm emit_indent
         }
-        InstKind::InstFnReturn => {
+        InstValue::FnReturn => {
             if is_global then
                 "movq $60, %rax" asm emit_indent
                 "xorq %rdi, %rdi" asm emit_indent
@@ -664,7 +660,7 @@ fn emit_control_flow asm:StringBuilder inst:Inst is_global:bool {
             fi
         }
         _ => {
-            "Internal error: emit_control_flow called with non-control-flow InstKind\n" eprint
+            "Internal error: emit_control_flow called with non-control-flow InstValue\n" eprint
             1 exit
         }
     end
@@ -674,9 +670,9 @@ fn emit_control_flow asm:StringBuilder inst:Inst is_global:bool {
 # Emit memory operations
 # ============================================================================
 
-fn emit_memory asm:StringBuilder inst:Inst {
-    inst Inst::kind match
-        InstKind::InstHeapAlloc => {
+fn emit_memory asm:StringBuilder inst:InstValue {
+    inst match
+        InstValue::HeapAlloc => {
             "popq %rax" asm emit_indent
             "leaq heap(%rip), %rbx" asm emit_indent
             "movq heap_ptr(%rip), %rcx" asm emit_indent
@@ -685,16 +681,16 @@ fn emit_memory asm:StringBuilder inst:Inst {
             "addq %rax, %rcx" asm emit_indent
             "movq %rcx, heap_ptr(%rip)" asm emit_indent
         }
-        InstKind::InstLoad8 => "%eax" "movzbl" asm emit_load
-        InstKind::InstLoad16 => "%eax" "movzwl" asm emit_load
-        InstKind::InstLoad32 => "%eax" "movl" asm emit_load
-        InstKind::InstLoad64 => "%rax" "movq" asm emit_load
-        InstKind::InstStore8 => "%bl" "movb" asm emit_store
-        InstKind::InstStore16 => "%bx" "movw" asm emit_store
-        InstKind::InstStore32 => "%ebx" "movl" asm emit_store
-        InstKind::InstStore64 => "%rbx" "movq" asm emit_store
+        InstValue::Load8 => "%eax" "movzbl" asm emit_load
+        InstValue::Load16 => "%eax" "movzwl" asm emit_load
+        InstValue::Load32 => "%eax" "movl" asm emit_load
+        InstValue::Load64 => "%rax" "movq" asm emit_load
+        InstValue::Store8 => "%bl" "movb" asm emit_store
+        InstValue::Store16 => "%bx" "movw" asm emit_store
+        InstValue::Store32 => "%ebx" "movl" asm emit_store
+        InstValue::Store64 => "%rbx" "movq" asm emit_store
         _ => {
-            "Internal error: emit_memory called with non-memory InstKind\n" eprint
+            "Internal error: emit_memory called with non-memory InstValue\n" eprint
             1 exit
         }
     end
@@ -704,13 +700,13 @@ fn emit_memory asm:StringBuilder inst:Inst {
 # Emit IO operations
 # ============================================================================
 
-fn emit_io_ops asm:StringBuilder inst:Inst {
-    inst Inst::kind match
-        InstKind::InstPrintInt => {
+fn emit_io_ops asm:StringBuilder inst:InstValue {
+    inst match
+        InstValue::PrintInt => {
             "popq %rdi" asm emit_indent
             "print_done" "print_int" asm emit_call_via_return_stack
         }
-        InstKind::InstPrintBool => {
+        InstValue::PrintBool => {
             emit_uid = uid
             "popq %rax" asm emit_indent
             "testq %rax, %rax" asm emit_indent
@@ -726,11 +722,11 @@ fn emit_io_ops asm:StringBuilder inst:Inst {
             "movq $1, %rax" asm emit_indent
             "syscall" asm emit_indent
         }
-        InstKind::InstPrintStr => {
+        InstValue::PrintStr => {
             "popq %rdi" asm emit_indent
             "print_done" "print_str" asm emit_call_via_return_stack
         }
-        InstKind::InstPrintChar => {
+        InstValue::PrintChar => {
             "popq %rax" asm emit_indent
             "movb %al, -1(%rsp)" asm emit_indent
             "leaq -1(%rsp), %rsi" asm emit_indent
@@ -739,7 +735,7 @@ fn emit_io_ops asm:StringBuilder inst:Inst {
             "movq $1, %rax" asm emit_indent
             "syscall" asm emit_indent
         }
-        InstKind::InstPrintCstr => {
+        InstValue::PrintCstr => {
             emit_uid = uid
             "popq %rsi" asm emit_indent
             "movq %rsi, %rdi" asm emit_indent
@@ -756,12 +752,12 @@ fn emit_io_ops asm:StringBuilder inst:Inst {
             "movq $1, %rax" asm emit_indent
             "syscall" asm emit_indent
         }
-        InstKind::InstFstringConcat => {
-            f"movq ${inst Inst::int_arg}, %rdi" asm emit_indent
+        InstValue::FstringConcat(fstring_count) => {
+            f"movq ${fstring_count}, %rdi" asm emit_indent
             "concat_done" "str_concat" asm emit_call_via_return_stack
         }
         _ => {
-            "Internal error: emit_io_ops called with non-IO InstKind\n" eprint
+            "Internal error: emit_io_ops called with non-IO InstValue\n" eprint
             1 exit
         }
     end
@@ -793,98 +789,98 @@ fn emit_str_eq asm:StringBuilder {
 # Emit single instruction (main dispatch)
 # ============================================================================
 
-fn emit_inst asm:StringBuilder inst:Inst is_global:bool {
-    inst Inst::kind match
+fn emit_inst asm:StringBuilder inst:InstValue is_global:bool {
+    inst match
         # Stack operations
-        InstKind::InstDrop => inst asm emit_stack_ops
-        InstKind::InstDup => inst asm emit_stack_ops
-        InstKind::InstOver => inst asm emit_stack_ops
-        InstKind::InstPush => inst asm emit_stack_ops
-        InstKind::InstPushChar => inst asm emit_stack_ops
-        InstKind::InstPushStr => inst asm emit_stack_ops
-        InstKind::InstRot => inst asm emit_stack_ops
-        InstKind::InstSwap => inst asm emit_stack_ops
+        InstValue::Drop => inst asm emit_stack_ops
+        InstValue::Dup => inst asm emit_stack_ops
+        InstValue::Over => inst asm emit_stack_ops
+        InstValue::Push => inst asm emit_stack_ops
+        InstValue::PushChar => inst asm emit_stack_ops
+        InstValue::PushStr => inst asm emit_stack_ops
+        InstValue::Rot => inst asm emit_stack_ops
+        InstValue::Swap => inst asm emit_stack_ops
 
         # Arithmetic / bitshift / bitwise / boolean / comparison
-        InstKind::InstAdd => inst asm emit_arithmetic
-        InstKind::InstSub => inst asm emit_arithmetic
-        InstKind::InstMul => inst asm emit_arithmetic
-        InstKind::InstDiv => inst asm emit_arithmetic
-        InstKind::InstMod => inst asm emit_arithmetic
-        InstKind::InstShl => inst asm emit_arithmetic
-        InstKind::InstShr => inst asm emit_arithmetic
-        InstKind::InstBitAnd => inst asm emit_arithmetic
-        InstKind::InstBitOr => inst asm emit_arithmetic
-        InstKind::InstBitXor => inst asm emit_arithmetic
-        InstKind::InstBitNot => inst asm emit_arithmetic
-        InstKind::InstAnd => inst asm emit_arithmetic
-        InstKind::InstOr => inst asm emit_arithmetic
-        InstKind::InstNot => inst asm emit_arithmetic
-        InstKind::InstEq => inst asm emit_arithmetic
-        InstKind::InstNe => inst asm emit_arithmetic
-        InstKind::InstLt => inst asm emit_arithmetic
-        InstKind::InstLe => inst asm emit_arithmetic
-        InstKind::InstGt => inst asm emit_arithmetic
-        InstKind::InstGe => inst asm emit_arithmetic
+        InstValue::Add => inst asm emit_arithmetic
+        InstValue::Sub => inst asm emit_arithmetic
+        InstValue::Mul => inst asm emit_arithmetic
+        InstValue::Div => inst asm emit_arithmetic
+        InstValue::Mod => inst asm emit_arithmetic
+        InstValue::Shl => inst asm emit_arithmetic
+        InstValue::Shr => inst asm emit_arithmetic
+        InstValue::BitAnd => inst asm emit_arithmetic
+        InstValue::BitOr => inst asm emit_arithmetic
+        InstValue::BitXor => inst asm emit_arithmetic
+        InstValue::BitNot => inst asm emit_arithmetic
+        InstValue::And => inst asm emit_arithmetic
+        InstValue::Or => inst asm emit_arithmetic
+        InstValue::Not => inst asm emit_arithmetic
+        InstValue::Eq => inst asm emit_arithmetic
+        InstValue::Ne => inst asm emit_arithmetic
+        InstValue::Lt => inst asm emit_arithmetic
+        InstValue::Le => inst asm emit_arithmetic
+        InstValue::Gt => inst asm emit_arithmetic
+        InstValue::Ge => inst asm emit_arithmetic
 
         # Control flow / variables / functions
-        InstKind::InstLabel => is_global inst asm emit_control_flow
-        InstKind::InstJump => is_global inst asm emit_control_flow
-        InstKind::InstJumpNe => is_global inst asm emit_control_flow
-        InstKind::InstGlobalsInit => is_global inst asm emit_control_flow
-        InstKind::InstGlobalGet => is_global inst asm emit_control_flow
-        InstKind::InstGlobalSet => is_global inst asm emit_control_flow
-        InstKind::InstLocalsInit => is_global inst asm emit_control_flow
-        InstKind::InstLocalsUninit => is_global inst asm emit_control_flow
-        InstKind::InstLocalGet => is_global inst asm emit_control_flow
-        InstKind::InstLocalSet => is_global inst asm emit_control_flow
-        InstKind::InstConstantLoad => is_global inst asm emit_control_flow
-        InstKind::InstConstantStore => is_global inst asm emit_control_flow
-        InstKind::InstCaptureLoad => is_global inst asm emit_control_flow
-        InstKind::InstClosureRecord => is_global inst asm emit_control_flow
-        InstKind::InstFnCall => is_global inst asm emit_control_flow
-        InstKind::InstFnExec => is_global inst asm emit_control_flow
-        InstKind::InstFnPush => is_global inst asm emit_control_flow
-        InstKind::InstFnPushStatic => is_global inst asm emit_control_flow
-        InstKind::InstFnReturn => is_global inst asm emit_control_flow
+        InstValue::Label => is_global inst asm emit_control_flow
+        InstValue::Jump => is_global inst asm emit_control_flow
+        InstValue::JumpNe => is_global inst asm emit_control_flow
+        InstValue::GlobalsInit => is_global inst asm emit_control_flow
+        InstValue::GlobalGet => is_global inst asm emit_control_flow
+        InstValue::GlobalSet => is_global inst asm emit_control_flow
+        InstValue::LocalsInit => is_global inst asm emit_control_flow
+        InstValue::LocalsUninit => is_global inst asm emit_control_flow
+        InstValue::LocalGet => is_global inst asm emit_control_flow
+        InstValue::LocalSet => is_global inst asm emit_control_flow
+        InstValue::ConstantLoad => is_global inst asm emit_control_flow
+        InstValue::ConstantStore => is_global inst asm emit_control_flow
+        InstValue::CaptureLoad => is_global inst asm emit_control_flow
+        InstValue::ClosureRecord => is_global inst asm emit_control_flow
+        InstValue::FnCall => is_global inst asm emit_control_flow
+        InstValue::FnExec => is_global inst asm emit_control_flow
+        InstValue::FnPush => is_global inst asm emit_control_flow
+        InstValue::FnPushStatic => is_global inst asm emit_control_flow
+        InstValue::FnReturn => is_global inst asm emit_control_flow
 
         # Memory operations
-        InstKind::InstHeapAlloc => inst asm emit_memory
-        InstKind::InstLoad8 => inst asm emit_memory
-        InstKind::InstLoad16 => inst asm emit_memory
-        InstKind::InstLoad32 => inst asm emit_memory
-        InstKind::InstLoad64 => inst asm emit_memory
-        InstKind::InstStore8 => inst asm emit_memory
-        InstKind::InstStore16 => inst asm emit_memory
-        InstKind::InstStore32 => inst asm emit_memory
-        InstKind::InstStore64 => inst asm emit_memory
+        InstValue::HeapAlloc => inst asm emit_memory
+        InstValue::Load8 => inst asm emit_memory
+        InstValue::Load16 => inst asm emit_memory
+        InstValue::Load32 => inst asm emit_memory
+        InstValue::Load64 => inst asm emit_memory
+        InstValue::Store8 => inst asm emit_memory
+        InstValue::Store16 => inst asm emit_memory
+        InstValue::Store32 => inst asm emit_memory
+        InstValue::Store64 => inst asm emit_memory
 
         # IO operations
-        InstKind::InstPrintInt => inst asm emit_io_ops
-        InstKind::InstPrintBool => inst asm emit_io_ops
-        InstKind::InstPrintStr => inst asm emit_io_ops
-        InstKind::InstPrintChar => inst asm emit_io_ops
-        InstKind::InstPrintCstr => inst asm emit_io_ops
-        InstKind::InstFstringConcat => inst asm emit_io_ops
+        InstValue::PrintInt => inst asm emit_io_ops
+        InstValue::PrintBool => inst asm emit_io_ops
+        InstValue::PrintStr => inst asm emit_io_ops
+        InstValue::PrintChar => inst asm emit_io_ops
+        InstValue::PrintCstr => inst asm emit_io_ops
+        InstValue::FstringConcat => inst asm emit_io_ops
 
         # String equality
-        InstKind::InstStrEq => asm emit_str_eq
+        InstValue::StrEq => asm emit_str_eq
 
         # Syscalls
-        InstKind::InstSyscall0 => asm 0 emit_syscall
-        InstKind::InstSyscall1 => asm 1 emit_syscall
-        InstKind::InstSyscall2 => asm 2 emit_syscall
-        InstKind::InstSyscall3 => asm 3 emit_syscall
-        InstKind::InstSyscall4 => asm 4 emit_syscall
-        InstKind::InstSyscall5 => asm 5 emit_syscall
-        InstKind::InstSyscall6 => asm 6 emit_syscall
+        InstValue::Syscall0 => asm 0 emit_syscall
+        InstValue::Syscall1 => asm 1 emit_syscall
+        InstValue::Syscall2 => asm 2 emit_syscall
+        InstValue::Syscall3 => asm 3 emit_syscall
+        InstValue::Syscall4 => asm 4 emit_syscall
+        InstValue::Syscall5 => asm 5 emit_syscall
+        InstValue::Syscall6 => asm 6 emit_syscall
 
         # argc / argv
-        InstKind::InstArgc => {
+        InstValue::Argc => {
             "movq __argc(%rip), %rax" asm emit_indent
             "pushq %rax" asm emit_indent
         }
-        InstKind::InstArgv => {
+        InstValue::Argv => {
             "movq __argv(%rip), %rax" asm emit_indent
             "pushq %rax" asm emit_indent
         }

--- a/tests/compiler/test_argv.casa
+++ b/tests/compiler/test_argv.casa
@@ -121,11 +121,11 @@ fn test_typecheck_argv_with_load {
 # Bytecode tests
 # ============================================================================
 
-fn has_inst_kind bytecode:List[Inst] kind:InstKind -> bool {
+fn has_inst_kind bytecode:List[InstValue] kind:InstValue -> bool {
     false = found
     0 = index
     while index bytecode.length > do
-        if kind index bytecode.get Inst::kind == then
+        if kind index bytecode.get == then
             true = found
         fi
         1 += index
@@ -136,37 +136,13 @@ fn has_inst_kind bytecode:List[Inst] kind:InstKind -> bool {
 fn test_bytecode_argc {
     "bytecode_argc" test_start
     "argc" compile_string_argv = prog
-    "has ARGC inst" InstKind::InstArgc prog Program::bytecode has_inst_kind assert_true
+    "has ARGC inst" InstValue::Argc prog Program::bytecode has_inst_kind assert_true
 }
 
 fn test_bytecode_argv {
     "bytecode_argv" test_start
     "argv" compile_string_argv = prog
-    "has ARGV inst" InstKind::InstArgv prog Program::bytecode has_inst_kind assert_true
-}
-
-fn test_bytecode_argc_no_args {
-    "bytecode_argc_no_args" test_start
-    "argc" compile_string_argv = prog
-    0 = index
-    while index prog Program::bytecode.length > do
-        if InstKind::InstArgc index prog Program::bytecode.get Inst::kind == then
-            "argc has no int_arg" 0 index prog Program::bytecode.get Inst::int_arg assert_eq
-        fi
-        1 += index
-    done
-}
-
-fn test_bytecode_argv_no_args {
-    "bytecode_argv_no_args" test_start
-    "argv" compile_string_argv = prog
-    0 = index
-    while index prog Program::bytecode.length > do
-        if InstKind::InstArgv index prog Program::bytecode.get Inst::kind == then
-            "argv has no int_arg" 0 index prog Program::bytecode.get Inst::int_arg assert_eq
-        fi
-        1 += index
-    done
+    "has ARGV inst" InstValue::Argv prog Program::bytecode has_inst_kind assert_true
 }
 
 # ============================================================================
@@ -216,8 +192,6 @@ test_typecheck_argc_in_arithmetic
 test_typecheck_argv_with_load
 test_bytecode_argc
 test_bytecode_argv
-test_bytecode_argc_no_args
-test_bytecode_argv_no_args
 test_emit_argc_loads_from_bss
 test_emit_argv_loads_from_bss
 test_emit_bss_has_argc_argv_slots

--- a/tests/compiler/test_bytecode.casa
+++ b/tests/compiler/test_bytecode.casa
@@ -70,16 +70,19 @@ fn test_compile_push_int {
     42 OpValue::PushInt test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
-    List::new(List[Inst]) = bytecode
-    # compile_ops compiler:BytecodeCompiler bytecode:List[Inst]
+    List::new(List[InstValue]) = bytecode
+    # compile_ops compiler:BytecodeCompiler bytecode:List[InstValue]
     # param1=compiler, param2=bytecode -> bytecode compiler compile_ops
     bytecode compiler compile_ops
 
     # Should have: LABEL, PUSH(42)
     "push_int bytecode length" 2 bytecode.length assert_eq
-    "push_int label kind" InstKind::InstLabel 0 bytecode.get Inst::kind == assert_true
-    "push_int inst kind" InstKind::InstPush 1 bytecode.get Inst::kind == assert_true
-    "push_int value" 42 1 bytecode.get Inst::int_arg assert_eq
+    "push_int label kind" 0 bytecode.get InstValue::Label is assert_true
+    if 1 bytecode.get InstValue::Push(value) is then
+        "push_int value" 42 value assert_eq
+    else
+        "push_int inst kind" false assert_true
+    fi
 }
 
 fn test_compile_push_bool {
@@ -89,11 +92,14 @@ fn test_compile_push_bool {
     1 OpValue::PushBool test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
-    List::new(List[Inst]) = bytecode
+    List::new(List[InstValue]) = bytecode
     bytecode compiler compile_ops
 
-    "push_bool inst kind" InstKind::InstPush 1 bytecode.get Inst::kind == assert_true
-    "push_bool true value" 1 1 bytecode.get Inst::int_arg assert_eq
+    if 1 bytecode.get InstValue::Push(value) is then
+        "push_bool true value" 1 value assert_eq
+    else
+        "push_bool inst kind" false assert_true
+    fi
 }
 
 fn test_compile_push_str {
@@ -103,11 +109,14 @@ fn test_compile_push_str {
     "hello" OpValue::PushStr test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
-    List::new(List[Inst]) = bytecode
+    List::new(List[InstValue]) = bytecode
     bytecode compiler compile_ops
 
-    "push_str inst kind" InstKind::InstPushStr 1 bytecode.get Inst::kind == assert_true
-    "push_str string index" 0 1 bytecode.get Inst::int_arg assert_eq
+    if 1 bytecode.get InstValue::PushStr(string_index) is then
+        "push_str string index" 0 string_index assert_eq
+    else
+        "push_str inst kind" false assert_true
+    fi
     "string table entry" "hello" 0 compiler BytecodeCompiler::string_table.get assert_str_eq
 }
 
@@ -118,11 +127,14 @@ fn test_compile_push_char {
     'A' (int) OpValue::PushChar test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
-    List::new(List[Inst]) = bytecode
+    List::new(List[InstValue]) = bytecode
     bytecode compiler compile_ops
 
-    "push_char inst kind" InstKind::InstPushChar 1 bytecode.get Inst::kind == assert_true
-    "push_char value" 65 1 bytecode.get Inst::int_arg assert_eq
+    if 1 bytecode.get InstValue::PushChar(char_value) is then
+        "push_char value" 65 char_value assert_eq
+    else
+        "push_char inst kind" false assert_true
+    fi
 }
 
 fn test_compile_direct_ops {
@@ -135,14 +147,14 @@ fn test_compile_direct_ops {
     OpValue::Drop test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
-    List::new(List[Inst]) = bytecode
+    List::new(List[InstValue]) = bytecode
     bytecode compiler compile_ops
 
     # Index 0 is label
-    "add inst" InstKind::InstAdd 1 bytecode.get Inst::kind == assert_true
-    "sub inst" InstKind::InstSub 2 bytecode.get Inst::kind == assert_true
-    "dup inst" InstKind::InstDup 3 bytecode.get Inst::kind == assert_true
-    "drop inst" InstKind::InstDrop 4 bytecode.get Inst::kind == assert_true
+    "add inst" 1 bytecode.get InstValue::Add is assert_true
+    "sub inst" 2 bytecode.get InstValue::Sub is assert_true
+    "dup inst" 3 bytecode.get InstValue::Dup is assert_true
+    "drop inst" 4 bytecode.get InstValue::Drop is assert_true
 }
 
 fn test_compile_variable_assign_and_push {
@@ -159,12 +171,12 @@ fn test_compile_variable_assign_and_push {
     "x" OpValue::PushVar test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
-    List::new(List[Inst]) = bytecode
+    List::new(List[InstValue]) = bytecode
     bytecode compiler compile_ops
 
     # Index 0 is label, 1 is GLOBAL_SET, 2 is GLOBAL_GET
-    "assign var kind" InstKind::InstGlobalSet 1 bytecode.get Inst::kind == assert_true
-    "push var kind" InstKind::InstGlobalGet 2 bytecode.get Inst::kind == assert_true
+    "assign var kind" 1 bytecode.get InstValue::GlobalSet is assert_true
+    "push var kind" 2 bytecode.get InstValue::GlobalGet is assert_true
 
     # Clean up
     Map::new(Map[str Variable]) TEST_STORE SymbolStore::set_variables
@@ -184,15 +196,21 @@ fn test_compile_local_variable {
     make_test_location fn_ops "test_fn" make_function = func
     "y" make_variable func Function::variables.push
 
-    List::new(List[Inst]) = bytecode
+    List::new(List[InstValue]) = bytecode
     List::new(List[str]) List::new(List[str]) func Option::Some fn_ops TEST_STORE make_compiler_with_tables = compiler
     bytecode compiler compile_ops
 
     # Index 0 is label, 1 is LOCAL_SET, 2 is LOCAL_GET
-    "local assign kind" InstKind::InstLocalSet 1 bytecode.get Inst::kind == assert_true
-    "local assign index" 0 1 bytecode.get Inst::int_arg assert_eq
-    "local push kind" InstKind::InstLocalGet 2 bytecode.get Inst::kind == assert_true
-    "local push index" 0 2 bytecode.get Inst::int_arg assert_eq
+    if 1 bytecode.get InstValue::LocalSet(set_index) is then
+        "local assign index" 0 set_index assert_eq
+    else
+        "local assign kind" false assert_true
+    fi
+    if 2 bytecode.get InstValue::LocalGet(get_index) is then
+        "local push index" 0 get_index assert_eq
+    else
+        "local push kind" false assert_true
+    fi
 }
 
 fn test_compile_fstring_concat {
@@ -202,11 +220,14 @@ fn test_compile_fstring_concat {
     3 OpValue::FstringConcat test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
-    List::new(List[Inst]) = bytecode
+    List::new(List[InstValue]) = bytecode
     bytecode compiler compile_ops
 
-    "fstring concat kind" InstKind::InstFstringConcat 1 bytecode.get Inst::kind == assert_true
-    "fstring concat count" 3 1 bytecode.get Inst::int_arg assert_eq
+    if 1 bytecode.get InstValue::FstringConcat(fstring_count) is then
+        "fstring concat count" 3 fstring_count assert_eq
+    else
+        "fstring concat kind" false assert_true
+    fi
 }
 
 fn test_compile_type_cast_no_output {
@@ -216,7 +237,7 @@ fn test_compile_type_cast_no_output {
     "" OpValue::TypeCast test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
-    List::new(List[Inst]) = bytecode
+    List::new(List[InstValue]) = bytecode
     bytecode compiler compile_ops
 
     # Only the label should be emitted, no instruction for type cast
@@ -230,7 +251,7 @@ fn test_compile_import_no_output {
     "" OpValue::ImportFile test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
-    List::new(List[Inst]) = bytecode
+    List::new(List[InstValue]) = bytecode
     bytecode compiler compile_ops
 
     "import produces no inst" 1 bytecode.length assert_eq
@@ -261,14 +282,14 @@ fn test_compile_if_block {
     "op 2 is if_end" 2 ops.get.value OpValue::IfEnd is assert_true
 
     ops TEST_STORE make_compiler = compiler
-    List::new(List[Inst]) = bytecode
+    List::new(List[InstValue]) = bytecode
     bytecode compiler compile_ops
 
     # Expected: LABEL, JUMP_NE(end_label), LABEL(end_label)
     "if block bytecode length" 3 bytecode.length assert_eq
-    "if block has label" InstKind::InstLabel 0 bytecode.get Inst::kind == assert_true
-    "if condition jump_ne" InstKind::InstJumpNe 1 bytecode.get Inst::kind == assert_true
-    "if end label" InstKind::InstLabel 2 bytecode.get Inst::kind == assert_true
+    "if block has label" 0 bytecode.get InstValue::Label is assert_true
+    "if condition jump_ne" 1 bytecode.get InstValue::JumpNe is assert_true
+    "if end label" 2 bytecode.get InstValue::Label is assert_true
 }
 
 fn test_compile_while_block {
@@ -280,16 +301,16 @@ fn test_compile_while_block {
     OpValue::WhileEnd test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
-    List::new(List[Inst]) = bytecode
+    List::new(List[InstValue]) = bytecode
     bytecode compiler compile_ops
 
     # Expected: LABEL(fn), LABEL(start), JUMP_NE(end), JUMP(start), LABEL(end)
     "while block bytecode length" 5 bytecode.length assert_eq
-    "while fn label" InstKind::InstLabel 0 bytecode.get Inst::kind == assert_true
-    "while start label" InstKind::InstLabel 1 bytecode.get Inst::kind == assert_true
-    "while condition jump_ne" InstKind::InstJumpNe 2 bytecode.get Inst::kind == assert_true
-    "while end jump" InstKind::InstJump 3 bytecode.get Inst::kind == assert_true
-    "while end label" InstKind::InstLabel 4 bytecode.get Inst::kind == assert_true
+    "while fn label" 0 bytecode.get InstValue::Label is assert_true
+    "while start label" 1 bytecode.get InstValue::Label is assert_true
+    "while condition jump_ne" 2 bytecode.get InstValue::JumpNe is assert_true
+    "while end jump" 3 bytecode.get InstValue::Jump is assert_true
+    "while end label" 4 bytecode.get InstValue::Label is assert_true
 }
 
 fn test_compile_string_eq {
@@ -299,10 +320,10 @@ fn test_compile_string_eq {
     "str" OpValue::Eq test_make_op_annotated ops.push
 
     ops TEST_STORE make_compiler = compiler
-    List::new(List[Inst]) = bytecode
+    List::new(List[InstValue]) = bytecode
     bytecode compiler compile_ops
 
-    "str_eq inst" InstKind::InstStrEq 1 bytecode.get Inst::kind == assert_true
+    "str_eq inst" 1 bytecode.get InstValue::StrEq is assert_true
 }
 
 fn test_compile_string_ne {
@@ -312,12 +333,12 @@ fn test_compile_string_ne {
     "str" OpValue::Ne test_make_op_annotated ops.push
 
     ops TEST_STORE make_compiler = compiler
-    List::new(List[Inst]) = bytecode
+    List::new(List[InstValue]) = bytecode
     bytecode compiler compile_ops
 
     # Should emit STR_EQ + NOT
-    "str_ne has str_eq" InstKind::InstStrEq 1 bytecode.get Inst::kind == assert_true
-    "str_ne has not" InstKind::InstNot 2 bytecode.get Inst::kind == assert_true
+    "str_ne has str_eq" 1 bytecode.get InstValue::StrEq is assert_true
+    "str_ne has not" 2 bytecode.get InstValue::Not is assert_true
 }
 
 fn test_compile_assign_increment {
@@ -329,14 +350,14 @@ fn test_compile_assign_increment {
     "counter" OpValue::AssignInc test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
-    List::new(List[Inst]) = bytecode
+    List::new(List[InstValue]) = bytecode
     bytecode compiler compile_ops
 
     # Expected: LABEL, GLOBAL_GET, ADD, GLOBAL_SET
     "inc bytecode length" 4 bytecode.length assert_eq
-    "inc get" InstKind::InstGlobalGet 1 bytecode.get Inst::kind == assert_true
-    "inc add" InstKind::InstAdd 2 bytecode.get Inst::kind == assert_true
-    "inc set" InstKind::InstGlobalSet 3 bytecode.get Inst::kind == assert_true
+    "inc get" 1 bytecode.get InstValue::GlobalGet is assert_true
+    "inc add" 2 bytecode.get InstValue::Add is assert_true
+    "inc set" 3 bytecode.get InstValue::GlobalSet is assert_true
 
     Map::new(Map[str Variable]) TEST_STORE SymbolStore::set_variables
 }
@@ -350,15 +371,15 @@ fn test_compile_assign_decrement {
     "counter" OpValue::AssignDec test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
-    List::new(List[Inst]) = bytecode
+    List::new(List[InstValue]) = bytecode
     bytecode compiler compile_ops
 
     # Expected: LABEL, GLOBAL_GET, SWAP, SUB, GLOBAL_SET
     "dec bytecode length" 5 bytecode.length assert_eq
-    "dec get" InstKind::InstGlobalGet 1 bytecode.get Inst::kind == assert_true
-    "dec swap" InstKind::InstSwap 2 bytecode.get Inst::kind == assert_true
-    "dec sub" InstKind::InstSub 3 bytecode.get Inst::kind == assert_true
-    "dec set" InstKind::InstGlobalSet 4 bytecode.get Inst::kind == assert_true
+    "dec get" 1 bytecode.get InstValue::GlobalGet is assert_true
+    "dec swap" 2 bytecode.get InstValue::Swap is assert_true
+    "dec sub" 3 bytecode.get InstValue::Sub is assert_true
+    "dec set" 4 bytecode.get InstValue::GlobalSet is assert_true
 
     Map::new(Map[str Variable]) TEST_STORE SymbolStore::set_variables
 }
@@ -370,11 +391,14 @@ fn test_compile_push_bool_false {
     0 OpValue::PushBool test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
-    List::new(List[Inst]) = bytecode
+    List::new(List[InstValue]) = bytecode
     bytecode compiler compile_ops
 
-    "push_bool_false inst kind" InstKind::InstPush 1 bytecode.get Inst::kind == assert_true
-    "push_bool_false value" 0 1 bytecode.get Inst::int_arg assert_eq
+    if 1 bytecode.get InstValue::Push(value) is then
+        "push_bool_false value" 0 value assert_eq
+    else
+        "push_bool_false inst kind" false assert_true
+    fi
 }
 
 fn test_compile_more_direct_ops {
@@ -400,27 +424,27 @@ fn test_compile_more_direct_ops {
     OpValue::Rot test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
-    List::new(List[Inst]) = bytecode
+    List::new(List[InstValue]) = bytecode
     bytecode compiler compile_ops
 
     # Index 0 is label
-    "mul inst" InstKind::InstMul 1 bytecode.get Inst::kind == assert_true
-    "div inst" InstKind::InstDiv 2 bytecode.get Inst::kind == assert_true
-    "mod inst" InstKind::InstMod 3 bytecode.get Inst::kind == assert_true
-    "shl inst" InstKind::InstShl 4 bytecode.get Inst::kind == assert_true
-    "shr inst" InstKind::InstShr 5 bytecode.get Inst::kind == assert_true
-    "and inst" InstKind::InstAnd 6 bytecode.get Inst::kind == assert_true
-    "or inst" InstKind::InstOr 7 bytecode.get Inst::kind == assert_true
-    "not inst" InstKind::InstNot 8 bytecode.get Inst::kind == assert_true
-    "eq inst" InstKind::InstEq 9 bytecode.get Inst::kind == assert_true
-    "ne inst" InstKind::InstNe 10 bytecode.get Inst::kind == assert_true
-    "gt inst" InstKind::InstGt 11 bytecode.get Inst::kind == assert_true
-    "ge inst" InstKind::InstGe 12 bytecode.get Inst::kind == assert_true
-    "lt inst" InstKind::InstLt 13 bytecode.get Inst::kind == assert_true
-    "le inst" InstKind::InstLe 14 bytecode.get Inst::kind == assert_true
-    "swap inst" InstKind::InstSwap 15 bytecode.get Inst::kind == assert_true
-    "over inst" InstKind::InstOver 16 bytecode.get Inst::kind == assert_true
-    "rot inst" InstKind::InstRot 17 bytecode.get Inst::kind == assert_true
+    "mul inst" 1 bytecode.get InstValue::Mul is assert_true
+    "div inst" 2 bytecode.get InstValue::Div is assert_true
+    "mod inst" 3 bytecode.get InstValue::Mod is assert_true
+    "shl inst" 4 bytecode.get InstValue::Shl is assert_true
+    "shr inst" 5 bytecode.get InstValue::Shr is assert_true
+    "and inst" 6 bytecode.get InstValue::And is assert_true
+    "or inst" 7 bytecode.get InstValue::Or is assert_true
+    "not inst" 8 bytecode.get InstValue::Not is assert_true
+    "eq inst" 9 bytecode.get InstValue::Eq is assert_true
+    "ne inst" 10 bytecode.get InstValue::Ne is assert_true
+    "gt inst" 11 bytecode.get InstValue::Gt is assert_true
+    "ge inst" 12 bytecode.get InstValue::Ge is assert_true
+    "lt inst" 13 bytecode.get InstValue::Lt is assert_true
+    "le inst" 14 bytecode.get InstValue::Le is assert_true
+    "swap inst" 15 bytecode.get InstValue::Swap is assert_true
+    "over inst" 16 bytecode.get InstValue::Over is assert_true
+    "rot inst" 17 bytecode.get InstValue::Rot is assert_true
 }
 
 fn test_compile_direct_ops_bitwise {
@@ -433,13 +457,13 @@ fn test_compile_direct_ops_bitwise {
     OpValue::BitNot test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
-    List::new(List[Inst]) = bytecode
+    List::new(List[InstValue]) = bytecode
     bytecode compiler compile_ops
 
-    "bit_and inst" InstKind::InstBitAnd 1 bytecode.get Inst::kind == assert_true
-    "bit_or inst" InstKind::InstBitOr 2 bytecode.get Inst::kind == assert_true
-    "bit_xor inst" InstKind::InstBitXor 3 bytecode.get Inst::kind == assert_true
-    "bit_not inst" InstKind::InstBitNot 4 bytecode.get Inst::kind == assert_true
+    "bit_and inst" 1 bytecode.get InstValue::BitAnd is assert_true
+    "bit_or inst" 2 bytecode.get InstValue::BitOr is assert_true
+    "bit_xor inst" 3 bytecode.get InstValue::BitXor is assert_true
+    "bit_not inst" 4 bytecode.get InstValue::BitNot is assert_true
 }
 
 fn test_compile_direct_ops_memory {
@@ -457,18 +481,18 @@ fn test_compile_direct_ops_memory {
     OpValue::Store64 test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
-    List::new(List[Inst]) = bytecode
+    List::new(List[InstValue]) = bytecode
     bytecode compiler compile_ops
 
-    "heap_alloc inst" InstKind::InstHeapAlloc 1 bytecode.get Inst::kind == assert_true
-    "load8 inst" InstKind::InstLoad8 2 bytecode.get Inst::kind == assert_true
-    "load16 inst" InstKind::InstLoad16 3 bytecode.get Inst::kind == assert_true
-    "load32 inst" InstKind::InstLoad32 4 bytecode.get Inst::kind == assert_true
-    "load64 inst" InstKind::InstLoad64 5 bytecode.get Inst::kind == assert_true
-    "store8 inst" InstKind::InstStore8 6 bytecode.get Inst::kind == assert_true
-    "store16 inst" InstKind::InstStore16 7 bytecode.get Inst::kind == assert_true
-    "store32 inst" InstKind::InstStore32 8 bytecode.get Inst::kind == assert_true
-    "store64 inst" InstKind::InstStore64 9 bytecode.get Inst::kind == assert_true
+    "heap_alloc inst" 1 bytecode.get InstValue::HeapAlloc is assert_true
+    "load8 inst" 2 bytecode.get InstValue::Load8 is assert_true
+    "load16 inst" 3 bytecode.get InstValue::Load16 is assert_true
+    "load32 inst" 4 bytecode.get InstValue::Load32 is assert_true
+    "load64 inst" 5 bytecode.get InstValue::Load64 is assert_true
+    "store8 inst" 6 bytecode.get InstValue::Store8 is assert_true
+    "store16 inst" 7 bytecode.get InstValue::Store16 is assert_true
+    "store32 inst" 8 bytecode.get InstValue::Store32 is assert_true
+    "store64 inst" 9 bytecode.get InstValue::Store64 is assert_true
 }
 
 fn test_compile_direct_ops_syscall {
@@ -484,16 +508,16 @@ fn test_compile_direct_ops_syscall {
     OpValue::Syscall6 test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
-    List::new(List[Inst]) = bytecode
+    List::new(List[InstValue]) = bytecode
     bytecode compiler compile_ops
 
-    "syscall0 inst" InstKind::InstSyscall0 1 bytecode.get Inst::kind == assert_true
-    "syscall1 inst" InstKind::InstSyscall1 2 bytecode.get Inst::kind == assert_true
-    "syscall2 inst" InstKind::InstSyscall2 3 bytecode.get Inst::kind == assert_true
-    "syscall3 inst" InstKind::InstSyscall3 4 bytecode.get Inst::kind == assert_true
-    "syscall4 inst" InstKind::InstSyscall4 5 bytecode.get Inst::kind == assert_true
-    "syscall5 inst" InstKind::InstSyscall5 6 bytecode.get Inst::kind == assert_true
-    "syscall6 inst" InstKind::InstSyscall6 7 bytecode.get Inst::kind == assert_true
+    "syscall0 inst" 1 bytecode.get InstValue::Syscall0 is assert_true
+    "syscall1 inst" 2 bytecode.get InstValue::Syscall1 is assert_true
+    "syscall2 inst" 3 bytecode.get InstValue::Syscall2 is assert_true
+    "syscall3 inst" 4 bytecode.get InstValue::Syscall3 is assert_true
+    "syscall4 inst" 5 bytecode.get InstValue::Syscall4 is assert_true
+    "syscall5 inst" 6 bytecode.get InstValue::Syscall5 is assert_true
+    "syscall6 inst" 7 bytecode.get InstValue::Syscall6 is assert_true
 }
 
 fn test_compile_direct_ops_print {
@@ -507,14 +531,14 @@ fn test_compile_direct_ops_print {
     OpValue::PrintBool test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
-    List::new(List[Inst]) = bytecode
+    List::new(List[InstValue]) = bytecode
     bytecode compiler compile_ops
 
-    "print_int inst" InstKind::InstPrintInt 1 bytecode.get Inst::kind == assert_true
-    "print_str inst" InstKind::InstPrintStr 2 bytecode.get Inst::kind == assert_true
-    "print_char inst" InstKind::InstPrintChar 3 bytecode.get Inst::kind == assert_true
-    "print_cstr inst" InstKind::InstPrintCstr 4 bytecode.get Inst::kind == assert_true
-    "print_bool inst" InstKind::InstPrintBool 5 bytecode.get Inst::kind == assert_true
+    "print_int inst" 1 bytecode.get InstValue::PrintInt is assert_true
+    "print_str inst" 2 bytecode.get InstValue::PrintStr is assert_true
+    "print_char inst" 3 bytecode.get InstValue::PrintChar is assert_true
+    "print_cstr inst" 4 bytecode.get InstValue::PrintCstr is assert_true
+    "print_bool inst" 5 bytecode.get InstValue::PrintBool is assert_true
 }
 
 fn test_compile_direct_ops_fn {
@@ -525,11 +549,11 @@ fn test_compile_direct_ops_fn {
     OpValue::FnReturn test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
-    List::new(List[Inst]) = bytecode
+    List::new(List[InstValue]) = bytecode
     bytecode compiler compile_ops
 
-    "fn_exec inst" InstKind::InstFnExec 1 bytecode.get Inst::kind == assert_true
-    "fn_return inst" InstKind::InstFnReturn 2 bytecode.get Inst::kind == assert_true
+    "fn_exec inst" 1 bytecode.get InstValue::FnExec is assert_true
+    "fn_return inst" 2 bytecode.get InstValue::FnReturn is assert_true
 }
 
 fn test_compile_push_array {
@@ -547,7 +571,7 @@ fn test_compile_push_array {
     make_test_location items OpValue::PushArray make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
-    List::new(List[Inst]) = bytecode
+    List::new(List[InstValue]) = bytecode
     bytecode compiler compile_ops
 
     # Should contain: PUSH instructions for items, HEAP_ALLOC, STORE64, LABEL, JUMP, JUMP_NE
@@ -559,16 +583,16 @@ fn test_compile_push_array {
     0 = has_jump_ne
     0 = i
     while i bytecode.length > do
-        i bytecode.get Inst::kind = kind
-        if InstKind::InstHeapAlloc kind == then
+        i bytecode.get = inst_value
+        if inst_value InstValue::HeapAlloc is then
             1 = has_alloc
-        elif InstKind::InstStore64 kind == then
+        elif inst_value InstValue::Store64 is then
             1 = has_store
-        elif InstKind::InstLabel kind == then
+        elif inst_value InstValue::Label is then
             1 = has_label
-        elif InstKind::InstJump kind == then
+        elif inst_value InstValue::Jump is then
             1 = has_jump
-        elif InstKind::InstJumpNe kind == then
+        elif inst_value InstValue::JumpNe is then
             1 = has_jump_ne
         fi
         1 += i
@@ -593,7 +617,7 @@ fn test_compile_if_elif_else {
     OpValue::IfEnd test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
-    List::new(List[Inst]) = bytecode
+    List::new(List[InstValue]) = bytecode
     bytecode compiler compile_ops
 
     # Expected bytecode layout:
@@ -606,14 +630,14 @@ fn test_compile_if_elif_else {
     # 6: LABEL (else label)
     # 7: LABEL (fi label)
     "elif bytecode length" 8 bytecode.length assert_eq
-    "elif fn label" InstKind::InstLabel 0 bytecode.get Inst::kind == assert_true
-    "elif if jump_ne" InstKind::InstJumpNe 1 bytecode.get Inst::kind == assert_true
-    "elif jump to fi" InstKind::InstJump 2 bytecode.get Inst::kind == assert_true
-    "elif label" InstKind::InstLabel 3 bytecode.get Inst::kind == assert_true
-    "elif cond jump_ne" InstKind::InstJumpNe 4 bytecode.get Inst::kind == assert_true
-    "else jump to fi" InstKind::InstJump 5 bytecode.get Inst::kind == assert_true
-    "else label" InstKind::InstLabel 6 bytecode.get Inst::kind == assert_true
-    "fi label" InstKind::InstLabel 7 bytecode.get Inst::kind == assert_true
+    "elif fn label" 0 bytecode.get InstValue::Label is assert_true
+    "elif if jump_ne" 1 bytecode.get InstValue::JumpNe is assert_true
+    "elif jump to fi" 2 bytecode.get InstValue::Jump is assert_true
+    "elif label" 3 bytecode.get InstValue::Label is assert_true
+    "elif cond jump_ne" 4 bytecode.get InstValue::JumpNe is assert_true
+    "else jump to fi" 5 bytecode.get InstValue::Jump is assert_true
+    "else label" 6 bytecode.get InstValue::Label is assert_true
+    "fi label" 7 bytecode.get InstValue::Label is assert_true
 }
 
 fn test_compile_fn_call {
@@ -629,12 +653,12 @@ fn test_compile_fn_call {
     "greet" OpValue::FnCall test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
-    List::new(List[Inst]) = bytecode
+    List::new(List[InstValue]) = bytecode
     bytecode compiler compile_ops
 
     # Should have: LABEL, FN_CALL
     "fn_call bytecode length" 2 bytecode.length assert_eq
-    "fn_call inst kind" InstKind::InstFnCall 1 bytecode.get Inst::kind == assert_true
+    "fn_call inst kind" 1 bytecode.get InstValue::FnCall is assert_true
 
     # Clean up
     Map::new(Map[str Function]) TEST_STORE SymbolStore::set_functions
@@ -654,7 +678,7 @@ fn test_compile_fn_push {
     "adder" OpValue::FnPush test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
-    List::new(List[Inst]) = bytecode
+    List::new(List[InstValue]) = bytecode
     bytecode compiler compile_ops
 
     # FnPush should emit FN_PUSH instruction with function name

--- a/tests/compiler/test_emitter.casa
+++ b/tests/compiler/test_emitter.casa
@@ -20,15 +20,20 @@ fn assert_contains needle:str haystack:str msg:str {
 fn make_empty_program -> Program {
     0 0
     List::new(List[str])
-    Map::new(Map[str List[Inst]])
-    List::new(List[Inst])
+    Map::new(Map[str List[InstValue]])
+    List::new(List[InstValue])
     Program
 }
 # Helper: build a program with given bytecode and strings
 
-fn make_simple_program bytecode:List[Inst] strings:List[str] globals:int constants:int -> Program {
+fn make_simple_program
+    bytecode:List[InstValue]
+    strings:List[str]
+    globals:int
+    constants:int
+-> Program {
     constants globals strings
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program
 }
@@ -57,8 +62,8 @@ fn test_emit_bss {
     2 = constants
     constants globals
     List::new(List[str])
-    Map::new(Map[str List[Inst]])
-    List::new(List[Inst])
+    Map::new(Map[str List[InstValue]])
+    List::new(List[InstValue])
     Program = program
 
     StringBuilder::new = asm_builder
@@ -83,8 +88,8 @@ fn test_emit_data {
     "world" strings.push
 
     0 0 strings
-    Map::new(Map[str List[Inst]])
-    List::new(List[Inst])
+    Map::new(Map[str List[InstValue]])
+    List::new(List[InstValue])
     Program = program
 
     StringBuilder::new = asm_builder
@@ -103,11 +108,11 @@ fn test_emit_data {
 
 fn test_emit_push {
     "emit_push" test_start
-    List::new(List[Inst]) = bytecode
-    42 InstKind::InstPush make_inst_int bytecode.push
+    List::new(List[InstValue]) = bytecode
+    42 InstValue::Push bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -117,14 +122,14 @@ fn test_emit_push {
 
 fn test_emit_push_str {
     "emit_push_str" test_start
-    List::new(List[Inst]) = bytecode
-    0 InstKind::InstPushStr make_inst_int bytecode.push
+    List::new(List[InstValue]) = bytecode
+    0 InstValue::PushStr bytecode.push
 
     List::new(List[str]) = strings
     "test" strings.push
 
     0 0 strings
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -134,11 +139,11 @@ fn test_emit_push_str {
 
 fn test_emit_add {
     "emit_add" test_start
-    List::new(List[Inst]) = bytecode
-    InstKind::InstAdd make_inst bytecode.push
+    List::new(List[InstValue]) = bytecode
+    InstValue::Add bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -148,12 +153,12 @@ fn test_emit_add {
 
 fn test_emit_label_and_jump {
     "emit_label_and_jump" test_start
-    List::new(List[Inst]) = bytecode
-    7 InstKind::InstLabel make_inst_int bytecode.push
-    7 InstKind::InstJump make_inst_int bytecode.push
+    List::new(List[InstValue]) = bytecode
+    7 InstValue::Label bytecode.push
+    7 InstValue::Jump bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -164,12 +169,12 @@ fn test_emit_label_and_jump {
 
 fn test_emit_fn_call {
     "emit_fn_call" test_start
-    List::new(List[Inst]) = bytecode
-    "my_func" InstKind::InstFnCall make_inst_str bytecode.push
+    List::new(List[InstValue]) = bytecode
+    "my_func" InstValue::FnCall bytecode.push
 
-    List::new(List[Inst]) = fn_bytecode
+    List::new(List[InstValue]) = fn_bytecode
 
-    Map::new(Map[str List[Inst]]) = functions
+    Map::new(Map[str List[InstValue]]) = functions
     "my_func" fn_bytecode functions.set = functions
 
     0 0 List::new(List[str]) functions bytecode Program = program
@@ -180,11 +185,11 @@ fn test_emit_fn_call {
 
 fn test_emit_fn_call_sanitized {
     "emit_fn_call_sanitized" test_start
-    List::new(List[Inst]) = bytecode
-    "Foo::bar" InstKind::InstFnCall make_inst_str bytecode.push
+    List::new(List[InstValue]) = bytecode
+    "Foo::bar" InstValue::FnCall bytecode.push
 
-    List::new(List[Inst]) = fn_bytecode
-    Map::new(Map[str List[Inst]]) = functions
+    List::new(List[InstValue]) = fn_bytecode
+    Map::new(Map[str List[InstValue]]) = functions
     "Foo::bar" fn_bytecode functions.set = functions
 
     0 0 List::new(List[str]) functions bytecode Program = program
@@ -212,11 +217,11 @@ fn test_emit_helpers_present {
 
 fn test_emit_comparison {
     "emit_comparison" test_start
-    List::new(List[Inst]) = bytecode
-    InstKind::InstEq make_inst bytecode.push
+    List::new(List[InstValue]) = bytecode
+    InstValue::Eq bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -227,11 +232,11 @@ fn test_emit_comparison {
 
 fn test_emit_syscall {
     "emit_syscall" test_start
-    List::new(List[Inst]) = bytecode
-    InstKind::InstSyscall3 make_inst bytecode.push
+    List::new(List[InstValue]) = bytecode
+    InstValue::Syscall3 bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -246,14 +251,14 @@ fn test_emit_syscall {
 
 fn test_emit_local_ops {
     "emit_local_ops" test_start
-    List::new(List[Inst]) = bytecode
-    3 InstKind::InstLocalsInit make_inst_int bytecode.push
-    0 InstKind::InstLocalGet make_inst_int bytecode.push
-    1 InstKind::InstLocalSet make_inst_int bytecode.push
-    3 InstKind::InstLocalsUninit make_inst_int bytecode.push
+    List::new(List[InstValue]) = bytecode
+    3 InstValue::LocalsInit bytecode.push
+    0 InstValue::LocalGet bytecode.push
+    1 InstValue::LocalSet bytecode.push
+    3 InstValue::LocalsUninit bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -267,12 +272,12 @@ fn test_emit_local_ops {
 
 fn test_emit_global_ops {
     "emit_global_ops" test_start
-    List::new(List[Inst]) = bytecode
-    2 InstKind::InstGlobalGet make_inst_int bytecode.push
-    3 InstKind::InstGlobalSet make_inst_int bytecode.push
+    List::new(List[InstValue]) = bytecode
+    2 InstValue::GlobalGet bytecode.push
+    3 InstValue::GlobalSet bytecode.push
 
     5 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -283,12 +288,12 @@ fn test_emit_global_ops {
 
 fn test_emit_memory_ops {
     "emit_memory_ops" test_start
-    List::new(List[Inst]) = bytecode
-    InstKind::InstLoad64 make_inst bytecode.push
-    InstKind::InstStore64 make_inst bytecode.push
+    List::new(List[InstValue]) = bytecode
+    InstValue::Load64 bytecode.push
+    InstValue::Store64 bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -300,11 +305,11 @@ fn test_emit_memory_ops {
 fn test_emit_full_program {
     "emit_full_program" test_start
     # Emit a program with one PUSH instruction
-    List::new(List[Inst]) = bytecode
-    99 InstKind::InstPush make_inst_int bytecode.push
+    List::new(List[InstValue]) = bytecode
+    99 InstValue::Push bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -321,11 +326,11 @@ fn test_emit_full_program {
 
 fn test_emit_drop {
     "emit_drop" test_start
-    List::new(List[Inst]) = bytecode
-    InstKind::InstDrop make_inst bytecode.push
+    List::new(List[InstValue]) = bytecode
+    InstValue::Drop bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -335,11 +340,11 @@ fn test_emit_drop {
 
 fn test_emit_dup {
     "emit_dup" test_start
-    List::new(List[Inst]) = bytecode
-    InstKind::InstDup make_inst bytecode.push
+    List::new(List[InstValue]) = bytecode
+    InstValue::Dup bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -349,11 +354,11 @@ fn test_emit_dup {
 
 fn test_emit_swap {
     "emit_swap" test_start
-    List::new(List[Inst]) = bytecode
-    InstKind::InstSwap make_inst bytecode.push
+    List::new(List[InstValue]) = bytecode
+    InstValue::Swap bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -366,11 +371,11 @@ fn test_emit_swap {
 
 fn test_emit_over {
     "emit_over" test_start
-    List::new(List[Inst]) = bytecode
-    InstKind::InstOver make_inst bytecode.push
+    List::new(List[InstValue]) = bytecode
+    InstValue::Over bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -380,11 +385,11 @@ fn test_emit_over {
 
 fn test_emit_rot {
     "emit_rot" test_start
-    List::new(List[Inst]) = bytecode
-    InstKind::InstRot make_inst bytecode.push
+    List::new(List[InstValue]) = bytecode
+    InstValue::Rot bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -403,11 +408,11 @@ fn test_emit_rot {
 
 fn test_emit_push_char {
     "emit_push_char" test_start
-    List::new(List[Inst]) = bytecode
-    97 InstKind::InstPushChar make_inst_int bytecode.push
+    List::new(List[InstValue]) = bytecode
+    97 InstValue::PushChar bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -417,11 +422,11 @@ fn test_emit_push_char {
 
 fn test_emit_push_large_int {
     "emit_push_large_int" test_start
-    List::new(List[Inst]) = bytecode
-    4294967296 InstKind::InstPush make_inst_int bytecode.push
+    List::new(List[InstValue]) = bytecode
+    4294967296 InstValue::Push bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -431,11 +436,11 @@ fn test_emit_push_large_int {
 
 fn test_emit_push_negative_int {
     "emit_push_negative_int" test_start
-    List::new(List[Inst]) = bytecode
-    0 42 - InstKind::InstPush make_inst_int bytecode.push
+    List::new(List[InstValue]) = bytecode
+    0 42 - InstValue::Push bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -449,11 +454,11 @@ fn test_emit_push_negative_int {
 
 fn test_emit_sub {
     "emit_sub" test_start
-    List::new(List[Inst]) = bytecode
-    InstKind::InstSub make_inst bytecode.push
+    List::new(List[InstValue]) = bytecode
+    InstValue::Sub bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -463,11 +468,11 @@ fn test_emit_sub {
 
 fn test_emit_mul {
     "emit_mul" test_start
-    List::new(List[Inst]) = bytecode
-    InstKind::InstMul make_inst bytecode.push
+    List::new(List[InstValue]) = bytecode
+    InstValue::Mul bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -477,11 +482,11 @@ fn test_emit_mul {
 
 fn test_emit_div {
     "emit_div" test_start
-    List::new(List[Inst]) = bytecode
-    InstKind::InstDiv make_inst bytecode.push
+    List::new(List[InstValue]) = bytecode
+    InstValue::Div bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -491,11 +496,11 @@ fn test_emit_div {
 
 fn test_emit_mod {
     "emit_mod" test_start
-    List::new(List[Inst]) = bytecode
-    InstKind::InstMod make_inst bytecode.push
+    List::new(List[InstValue]) = bytecode
+    InstValue::Mod bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -510,11 +515,11 @@ fn test_emit_mod {
 
 fn test_emit_shl {
     "emit_shl" test_start
-    List::new(List[Inst]) = bytecode
-    InstKind::InstShl make_inst bytecode.push
+    List::new(List[InstValue]) = bytecode
+    InstValue::Shl bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -524,11 +529,11 @@ fn test_emit_shl {
 
 fn test_emit_shr {
     "emit_shr" test_start
-    List::new(List[Inst]) = bytecode
-    InstKind::InstShr make_inst bytecode.push
+    List::new(List[InstValue]) = bytecode
+    InstValue::Shr bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -542,11 +547,11 @@ fn test_emit_shr {
 
 fn test_emit_bit_and {
     "emit_bit_and" test_start
-    List::new(List[Inst]) = bytecode
-    InstKind::InstBitAnd make_inst bytecode.push
+    List::new(List[InstValue]) = bytecode
+    InstValue::BitAnd bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -556,11 +561,11 @@ fn test_emit_bit_and {
 
 fn test_emit_bit_or {
     "emit_bit_or" test_start
-    List::new(List[Inst]) = bytecode
-    InstKind::InstBitOr make_inst bytecode.push
+    List::new(List[InstValue]) = bytecode
+    InstValue::BitOr bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -570,11 +575,11 @@ fn test_emit_bit_or {
 
 fn test_emit_bit_xor {
     "emit_bit_xor" test_start
-    List::new(List[Inst]) = bytecode
-    InstKind::InstBitXor make_inst bytecode.push
+    List::new(List[InstValue]) = bytecode
+    InstValue::BitXor bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -584,11 +589,11 @@ fn test_emit_bit_xor {
 
 fn test_emit_bit_not {
     "emit_bit_not" test_start
-    List::new(List[Inst]) = bytecode
-    InstKind::InstBitNot make_inst bytecode.push
+    List::new(List[InstValue]) = bytecode
+    InstValue::BitNot bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -602,11 +607,11 @@ fn test_emit_bit_not {
 
 fn test_emit_bool_and {
     "emit_bool_and" test_start
-    List::new(List[Inst]) = bytecode
-    InstKind::InstAnd make_inst bytecode.push
+    List::new(List[InstValue]) = bytecode
+    InstValue::And bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -616,11 +621,11 @@ fn test_emit_bool_and {
 
 fn test_emit_bool_or {
     "emit_bool_or" test_start
-    List::new(List[Inst]) = bytecode
-    InstKind::InstOr make_inst bytecode.push
+    List::new(List[InstValue]) = bytecode
+    InstValue::Or bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -630,11 +635,11 @@ fn test_emit_bool_or {
 
 fn test_emit_bool_not {
     "emit_bool_not" test_start
-    List::new(List[Inst]) = bytecode
-    InstKind::InstNot make_inst bytecode.push
+    List::new(List[InstValue]) = bytecode
+    InstValue::Not bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -648,11 +653,11 @@ fn test_emit_bool_not {
 
 fn test_emit_ne {
     "emit_ne" test_start
-    List::new(List[Inst]) = bytecode
-    InstKind::InstNe make_inst bytecode.push
+    List::new(List[InstValue]) = bytecode
+    InstValue::Ne bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -663,11 +668,11 @@ fn test_emit_ne {
 
 fn test_emit_lt {
     "emit_lt" test_start
-    List::new(List[Inst]) = bytecode
-    InstKind::InstLt make_inst bytecode.push
+    List::new(List[InstValue]) = bytecode
+    InstValue::Lt bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -677,11 +682,11 @@ fn test_emit_lt {
 
 fn test_emit_le {
     "emit_le" test_start
-    List::new(List[Inst]) = bytecode
-    InstKind::InstLe make_inst bytecode.push
+    List::new(List[InstValue]) = bytecode
+    InstValue::Le bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -691,11 +696,11 @@ fn test_emit_le {
 
 fn test_emit_gt {
     "emit_gt" test_start
-    List::new(List[Inst]) = bytecode
-    InstKind::InstGt make_inst bytecode.push
+    List::new(List[InstValue]) = bytecode
+    InstValue::Gt bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -705,11 +710,11 @@ fn test_emit_gt {
 
 fn test_emit_ge {
     "emit_ge" test_start
-    List::new(List[Inst]) = bytecode
-    InstKind::InstGe make_inst bytecode.push
+    List::new(List[InstValue]) = bytecode
+    InstValue::Ge bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -723,11 +728,11 @@ fn test_emit_ge {
 
 fn test_emit_heap_alloc {
     "emit_heap_alloc" test_start
-    List::new(List[Inst]) = bytecode
-    InstKind::InstHeapAlloc make_inst bytecode.push
+    List::new(List[InstValue]) = bytecode
+    InstValue::HeapAlloc bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -738,11 +743,11 @@ fn test_emit_heap_alloc {
 
 fn test_emit_load8 {
     "emit_load8" test_start
-    List::new(List[Inst]) = bytecode
-    InstKind::InstLoad8 make_inst bytecode.push
+    List::new(List[InstValue]) = bytecode
+    InstValue::Load8 bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -752,11 +757,11 @@ fn test_emit_load8 {
 
 fn test_emit_load16 {
     "emit_load16" test_start
-    List::new(List[Inst]) = bytecode
-    InstKind::InstLoad16 make_inst bytecode.push
+    List::new(List[InstValue]) = bytecode
+    InstValue::Load16 bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -766,11 +771,11 @@ fn test_emit_load16 {
 
 fn test_emit_load32 {
     "emit_load32" test_start
-    List::new(List[Inst]) = bytecode
-    InstKind::InstLoad32 make_inst bytecode.push
+    List::new(List[InstValue]) = bytecode
+    InstValue::Load32 bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -780,11 +785,11 @@ fn test_emit_load32 {
 
 fn test_emit_store8 {
     "emit_store8" test_start
-    List::new(List[Inst]) = bytecode
-    InstKind::InstStore8 make_inst bytecode.push
+    List::new(List[InstValue]) = bytecode
+    InstValue::Store8 bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -794,11 +799,11 @@ fn test_emit_store8 {
 
 fn test_emit_store16 {
     "emit_store16" test_start
-    List::new(List[Inst]) = bytecode
-    InstKind::InstStore16 make_inst bytecode.push
+    List::new(List[InstValue]) = bytecode
+    InstValue::Store16 bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -808,11 +813,11 @@ fn test_emit_store16 {
 
 fn test_emit_store32 {
     "emit_store32" test_start
-    List::new(List[Inst]) = bytecode
-    InstKind::InstStore32 make_inst bytecode.push
+    List::new(List[InstValue]) = bytecode
+    InstValue::Store32 bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -826,11 +831,11 @@ fn test_emit_store32 {
 
 fn test_emit_syscall0 {
     "emit_syscall0" test_start
-    List::new(List[Inst]) = bytecode
-    InstKind::InstSyscall0 make_inst bytecode.push
+    List::new(List[InstValue]) = bytecode
+    InstValue::Syscall0 bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -842,11 +847,11 @@ fn test_emit_syscall0 {
 
 fn test_emit_syscall1 {
     "emit_syscall1" test_start
-    List::new(List[Inst]) = bytecode
-    InstKind::InstSyscall1 make_inst bytecode.push
+    List::new(List[InstValue]) = bytecode
+    InstValue::Syscall1 bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -859,11 +864,11 @@ fn test_emit_syscall1 {
 
 fn test_emit_syscall2 {
     "emit_syscall2" test_start
-    List::new(List[Inst]) = bytecode
-    InstKind::InstSyscall2 make_inst bytecode.push
+    List::new(List[InstValue]) = bytecode
+    InstValue::Syscall2 bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -877,11 +882,11 @@ fn test_emit_syscall2 {
 
 fn test_emit_syscall4 {
     "emit_syscall4" test_start
-    List::new(List[Inst]) = bytecode
-    InstKind::InstSyscall4 make_inst bytecode.push
+    List::new(List[InstValue]) = bytecode
+    InstValue::Syscall4 bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -897,11 +902,11 @@ fn test_emit_syscall4 {
 
 fn test_emit_syscall5 {
     "emit_syscall5" test_start
-    List::new(List[Inst]) = bytecode
-    InstKind::InstSyscall5 make_inst bytecode.push
+    List::new(List[InstValue]) = bytecode
+    InstValue::Syscall5 bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -918,11 +923,11 @@ fn test_emit_syscall5 {
 
 fn test_emit_syscall6 {
     "emit_syscall6" test_start
-    List::new(List[Inst]) = bytecode
-    InstKind::InstSyscall6 make_inst bytecode.push
+    List::new(List[InstValue]) = bytecode
+    InstValue::Syscall6 bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -945,13 +950,13 @@ fn test_emit_syscall6 {
 fn test_emit_fn_return {
     "emit_fn_return" test_start
     # In a non-global context, fn_return emits jmpq *(%r14)
-    List::new(List[Inst]) = bytecode
-    InstKind::InstFnReturn make_inst bytecode.push
+    List::new(List[InstValue]) = bytecode
+    InstValue::FnReturn bytecode.push
 
-    List::new(List[Inst]) = fn_bytecode
-    InstKind::InstFnReturn make_inst fn_bytecode.push
+    List::new(List[InstValue]) = fn_bytecode
+    InstValue::FnReturn fn_bytecode.push
 
-    Map::new(Map[str List[Inst]]) = functions
+    Map::new(Map[str List[InstValue]]) = functions
     "test_fn" fn_bytecode functions.set = functions
 
     0 0 List::new(List[str]) functions bytecode Program = program
@@ -961,11 +966,11 @@ fn test_emit_fn_return {
 
 fn test_emit_fn_exec {
     "emit_fn_exec" test_start
-    List::new(List[Inst]) = bytecode
-    InstKind::InstFnExec make_inst bytecode.push
+    List::new(List[InstValue]) = bytecode
+    InstValue::FnExec bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -975,11 +980,11 @@ fn test_emit_fn_exec {
 
 fn test_emit_fn_push {
     "emit_fn_push" test_start
-    List::new(List[Inst]) = bytecode
-    "my_lambda" InstKind::InstFnPush make_inst_str bytecode.push
+    List::new(List[InstValue]) = bytecode
+    "my_lambda" InstValue::FnPush bytecode.push
 
-    List::new(List[Inst]) = fn_bytecode
-    Map::new(Map[str List[Inst]]) = functions
+    List::new(List[InstValue]) = fn_bytecode
+    Map::new(Map[str List[InstValue]]) = functions
     "my_lambda" fn_bytecode functions.set = functions
 
     0 0 List::new(List[str]) functions bytecode Program = program
@@ -993,11 +998,11 @@ fn test_emit_fn_push {
 
 fn test_emit_print_int {
     "emit_print_int" test_start
-    List::new(List[Inst]) = bytecode
-    InstKind::InstPrintInt make_inst bytecode.push
+    List::new(List[InstValue]) = bytecode
+    InstValue::PrintInt bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -1007,11 +1012,11 @@ fn test_emit_print_int {
 
 fn test_emit_print_str {
     "emit_print_str" test_start
-    List::new(List[Inst]) = bytecode
-    InstKind::InstPrintStr make_inst bytecode.push
+    List::new(List[InstValue]) = bytecode
+    InstValue::PrintStr bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -1021,11 +1026,11 @@ fn test_emit_print_str {
 
 fn test_emit_print_bool {
     "emit_print_bool" test_start
-    List::new(List[Inst]) = bytecode
-    InstKind::InstPrintBool make_inst bytecode.push
+    List::new(List[InstValue]) = bytecode
+    InstValue::PrintBool bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -1036,11 +1041,11 @@ fn test_emit_print_bool {
 
 fn test_emit_print_char {
     "emit_print_char" test_start
-    List::new(List[Inst]) = bytecode
-    InstKind::InstPrintChar make_inst bytecode.push
+    List::new(List[InstValue]) = bytecode
+    InstValue::PrintChar bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -1050,11 +1055,11 @@ fn test_emit_print_char {
 
 fn test_emit_print_cstr {
     "emit_print_cstr" test_start
-    List::new(List[Inst]) = bytecode
-    InstKind::InstPrintCstr make_inst bytecode.push
+    List::new(List[InstValue]) = bytecode
+    InstValue::PrintCstr bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -1068,11 +1073,11 @@ fn test_emit_print_cstr {
 
 fn test_emit_str_eq {
     "emit_str_eq" test_start
-    List::new(List[Inst]) = bytecode
-    InstKind::InstStrEq make_inst bytecode.push
+    List::new(List[InstValue]) = bytecode
+    InstValue::StrEq bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -1082,11 +1087,11 @@ fn test_emit_str_eq {
 
 fn test_emit_fstring_concat {
     "emit_fstring_concat" test_start
-    List::new(List[Inst]) = bytecode
-    3 InstKind::InstFstringConcat make_inst_int bytecode.push
+    List::new(List[InstValue]) = bytecode
+    3 InstValue::FstringConcat bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -1101,11 +1106,11 @@ fn test_emit_fstring_concat {
 
 fn test_emit_constant_load {
     "emit_constant_load" test_start
-    List::new(List[Inst]) = bytecode
-    0 InstKind::InstConstantLoad make_inst_int bytecode.push
+    List::new(List[InstValue]) = bytecode
+    0 InstValue::ConstantLoad bytecode.push
 
     0 1 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -1115,11 +1120,11 @@ fn test_emit_constant_load {
 
 fn test_emit_constant_store {
     "emit_constant_store" test_start
-    List::new(List[Inst]) = bytecode
-    1 InstKind::InstConstantStore make_inst_int bytecode.push
+    List::new(List[InstValue]) = bytecode
+    1 InstValue::ConstantStore bytecode.push
 
     0 2 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -1133,11 +1138,11 @@ fn test_emit_constant_store {
 
 fn test_emit_jump_ne {
     "emit_jump_ne" test_start
-    List::new(List[Inst]) = bytecode
-    5 InstKind::InstJumpNe make_inst_int bytecode.push
+    List::new(List[InstValue]) = bytecode
+    5 InstValue::JumpNe bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -1152,11 +1157,11 @@ fn test_emit_jump_ne {
 
 fn test_emit_argc {
     "emit_argc" test_start
-    List::new(List[Inst]) = bytecode
-    InstKind::InstArgc make_inst bytecode.push
+    List::new(List[InstValue]) = bytecode
+    InstValue::Argc bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -1166,11 +1171,11 @@ fn test_emit_argc {
 
 fn test_emit_argv {
     "emit_argv" test_start
-    List::new(List[Inst]) = bytecode
-    InstKind::InstArgv make_inst bytecode.push
+    List::new(List[InstValue]) = bytecode
+    InstValue::Argv bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -1195,12 +1200,12 @@ fn test_emit_exit_syscall {
 
 fn test_emit_globals_init {
     "emit_globals_init" test_start
-    List::new(List[Inst]) = bytecode
-    5 InstKind::InstGlobalsInit make_inst_int bytecode.push
-    42 InstKind::InstPush make_inst_int bytecode.push
+    List::new(List[InstValue]) = bytecode
+    5 InstValue::GlobalsInit bytecode.push
+    42 InstValue::Push bytecode.push
 
     0 5 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -1217,16 +1222,16 @@ fn test_emit_globals_init {
 
 fn test_emit_while_loop_pattern {
     "emit_while_loop_pattern" test_start
-    List::new(List[Inst]) = bytecode
+    List::new(List[InstValue]) = bytecode
     # while loop: label 10, condition check, jump_ne 11, body, jump 10, label 11
-    10 InstKind::InstLabel make_inst_int bytecode.push
-    1 InstKind::InstPush make_inst_int bytecode.push
-    11 InstKind::InstJumpNe make_inst_int bytecode.push
-    10 InstKind::InstJump make_inst_int bytecode.push
-    11 InstKind::InstLabel make_inst_int bytecode.push
+    10 InstValue::Label bytecode.push
+    1 InstValue::Push bytecode.push
+    11 InstValue::JumpNe bytecode.push
+    10 InstValue::Jump bytecode.push
+    11 InstValue::Label bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -1248,8 +1253,8 @@ fn test_emit_data_escape_sequences {
     "col1\tcol2" strings.push
 
     0 0 strings
-    Map::new(Map[str List[Inst]])
-    List::new(List[Inst])
+    Map::new(Map[str List[InstValue]])
+    List::new(List[InstValue])
     Program = program
 
     StringBuilder::new = asm_builder
@@ -1266,12 +1271,12 @@ fn test_emit_data_escape_sequences {
 
 fn test_emit_locals_rep_stosq {
     "emit_locals_rep_stosq" test_start
-    List::new(List[Inst]) = bytecode
-    4 InstKind::InstLocalsInit make_inst_int bytecode.push
-    4 InstKind::InstLocalsUninit make_inst_int bytecode.push
+    List::new(List[InstValue]) = bytecode
+    4 InstValue::LocalsInit bytecode.push
+    4 InstValue::LocalsUninit bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -1287,11 +1292,11 @@ fn test_emit_locals_rep_stosq {
 
 fn test_emit_load64 {
     "emit_load64" test_start
-    List::new(List[Inst]) = bytecode
-    InstKind::InstLoad64 make_inst bytecode.push
+    List::new(List[InstValue]) = bytecode
+    InstValue::Load64 bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -1307,11 +1312,11 @@ fn test_emit_load64 {
 
 fn test_emit_store64 {
     "emit_store64" test_start
-    List::new(List[Inst]) = bytecode
-    InstKind::InstStore64 make_inst bytecode.push
+    List::new(List[InstValue]) = bytecode
+    InstValue::Store64 bytecode.push
 
     0 0 List::new(List[str])
-    Map::new(Map[str List[Inst]])
+    Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
 
@@ -1327,18 +1332,18 @@ fn test_emit_store64 {
 
 fn test_emit_fn_with_body {
     "emit_fn_with_body" test_start
-    List::new(List[Inst]) = bytecode
-    "adder" InstKind::InstFnCall make_inst_str bytecode.push
+    List::new(List[InstValue]) = bytecode
+    "adder" InstValue::FnCall bytecode.push
 
-    List::new(List[Inst]) = fn_bytecode
-    2 InstKind::InstLocalsInit make_inst_int fn_bytecode.push
-    0 InstKind::InstLocalGet make_inst_int fn_bytecode.push
-    1 InstKind::InstLocalGet make_inst_int fn_bytecode.push
-    InstKind::InstAdd make_inst fn_bytecode.push
-    2 InstKind::InstLocalsUninit make_inst_int fn_bytecode.push
-    InstKind::InstFnReturn make_inst fn_bytecode.push
+    List::new(List[InstValue]) = fn_bytecode
+    2 InstValue::LocalsInit fn_bytecode.push
+    0 InstValue::LocalGet fn_bytecode.push
+    1 InstValue::LocalGet fn_bytecode.push
+    InstValue::Add fn_bytecode.push
+    2 InstValue::LocalsUninit fn_bytecode.push
+    InstValue::FnReturn fn_bytecode.push
 
-    Map::new(Map[str List[Inst]]) = functions
+    Map::new(Map[str List[InstValue]]) = functions
     "adder" fn_bytecode functions.set = functions
 
     0 0 List::new(List[str]) functions bytecode Program = program
@@ -1355,17 +1360,17 @@ fn test_emit_fn_with_body {
 
 fn test_emit_multiple_functions {
     "emit_multiple_functions" test_start
-    List::new(List[Inst]) = bytecode
-    "alpha" InstKind::InstFnCall make_inst_str bytecode.push
-    "beta" InstKind::InstFnCall make_inst_str bytecode.push
+    List::new(List[InstValue]) = bytecode
+    "alpha" InstValue::FnCall bytecode.push
+    "beta" InstValue::FnCall bytecode.push
 
-    List::new(List[Inst]) = alpha_bytecode
-    InstKind::InstFnReturn make_inst alpha_bytecode.push
+    List::new(List[InstValue]) = alpha_bytecode
+    InstValue::FnReturn alpha_bytecode.push
 
-    List::new(List[Inst]) = beta_bytecode
-    InstKind::InstFnReturn make_inst beta_bytecode.push
+    List::new(List[InstValue]) = beta_bytecode
+    InstValue::FnReturn beta_bytecode.push
 
-    Map::new(Map[str List[Inst]]) = functions
+    Map::new(Map[str List[InstValue]]) = functions
     "alpha" alpha_bytecode functions.set = functions
     "beta" beta_bytecode functions.set = functions
 

--- a/tests/compiler/test_enum.casa
+++ b/tests/compiler/test_enum.casa
@@ -68,11 +68,11 @@ fn count_ops ops:List[Op] predicate:fn[OpValue -> bool] -> int {
     count
 }
 
-fn count_insts bytecode:List[Inst] kind:InstKind -> int {
+fn count_insts bytecode:List[InstValue] predicate:fn[InstValue -> bool] -> int {
     0 = count
     0 = index
     while index bytecode.length > do
-        if kind index bytecode.get Inst::kind == then
+        if index bytecode.get predicate exec then
             1 += count
         fi
         1 += index
@@ -80,18 +80,31 @@ fn count_insts bytecode:List[Inst] kind:InstKind -> int {
     count
 }
 
-fn has_inst_kind bytecode:List[Inst] kind:InstKind -> bool {
-    0 kind bytecode count_insts !=
+fn has_inst_kind bytecode:List[InstValue] predicate:fn[InstValue -> bool] -> bool {
+    0 predicate bytecode count_insts !=
 }
 
-fn has_push_value bytecode:List[Inst] value:int -> bool {
+fn is_dup_inst value:InstValue -> bool { value InstValue::Dup is }
+
+fn is_eq_inst value:InstValue -> bool { value InstValue::Eq is }
+
+fn is_jump_ne_inst value:InstValue -> bool { value InstValue::JumpNe is }
+
+fn is_print_int_inst value:InstValue -> bool { value InstValue::PrintInt is }
+
+fn is_heap_alloc_inst value:InstValue -> bool { value InstValue::HeapAlloc is }
+
+fn is_store64_inst value:InstValue -> bool { value InstValue::Store64 is }
+
+fn is_load64_inst value:InstValue -> bool { value InstValue::Load64 is }
+
+fn has_push_value bytecode:List[InstValue] value:int -> bool {
     false = found
     0 = index
     while index bytecode.length > do
-        index bytecode.get = inst
         if
-        InstKind::InstPush inst Inst::kind ==
-        value inst Inst::int_arg == &&
+        index bytecode.get InstValue::Push(push_value) is
+        value push_value == &&
         then
             true = found
         fi
@@ -491,27 +504,27 @@ fn test_enum_variant_compiles_to_push_ordinal_2 {
 fn test_match_compiles_to_dup_eq_jump_pattern {
     "match_compiles_to_dup_eq_jump_pattern" test_start
     "enum Color { Red Green Blue }\nColor::Red match\n    Color::Red => 1 drop\n    Color::Green => 2 drop\n    Color::Blue => 3 drop\nend\n" compile_enum = prog
-    "has DUP" 0 InstKind::InstDup prog Program::bytecode count_insts != assert_true
-    "has EQ" 0 InstKind::InstEq prog Program::bytecode count_insts != assert_true
-    "has JUMP_NE" 0 InstKind::InstJumpNe prog Program::bytecode count_insts != assert_true
+    "has DUP" 0 &is_dup_inst prog Program::bytecode count_insts != assert_true
+    "has EQ" 0 &is_eq_inst prog Program::bytecode count_insts != assert_true
+    "has JUMP_NE" 0 &is_jump_ne_inst prog Program::bytecode count_insts != assert_true
 }
 
 fn test_enum_print_compiles_to_print_int {
     "enum_print_compiles_to_print_int" test_start
     "enum Color { Red Green Blue }\nColor::Red print\n" compile_enum = prog
-    "has PRINT_INT" InstKind::InstPrintInt prog Program::bytecode has_inst_kind assert_true
+    "has PRINT_INT" &is_print_int_inst prog Program::bytecode has_inst_kind assert_true
 }
 
 fn test_data_enum_variant_compiles_to_heap_alloc {
     "data_enum_variant_compiles_to_heap_alloc" test_start
     "enum Shape { Circle(int) Rectangle(int int) Point }\n10 Shape::Circle\n" compile_enum = prog
-    "has HEAP_ALLOC" InstKind::InstHeapAlloc prog Program::bytecode has_inst_kind assert_true
+    "has HEAP_ALLOC" &is_heap_alloc_inst prog Program::bytecode has_inst_kind assert_true
 }
 
 fn test_data_enum_stores_ordinal {
     "data_enum_stores_ordinal" test_start
     "enum Shape { Circle(int) Rectangle(int int) Point }\n10 Shape::Circle\n" compile_enum = prog
-    "has STORE64" InstKind::InstStore64 prog Program::bytecode has_inst_kind assert_true
+    "has STORE64" &is_store64_inst prog Program::bytecode has_inst_kind assert_true
 }
 
 # ============================================================================
@@ -968,7 +981,7 @@ fn test_is_check_multiple_bindings_parsed {
 fn test_data_enum_match_loads_ordinal {
     "data_enum_match_loads_ordinal" test_start
     "enum Shape { Circle(int) Rectangle(int int) Point }\n10 Shape::Circle match\n    Shape::Circle(r) => r drop\n    Shape::Rectangle(w h) => w drop\n    Shape::Point => 0 drop\nend\n" compile_enum = prog
-    "has LOAD64" InstKind::InstLoad64 prog Program::bytecode has_inst_kind assert_true
+    "has LOAD64" &is_load64_inst prog Program::bytecode has_inst_kind assert_true
 }
 
 fn test_braced_arm_as_expression_typechecks {

--- a/tests/compiler/test_struct_literal.casa
+++ b/tests/compiler/test_struct_literal.casa
@@ -54,11 +54,11 @@ fn sl_count_ops ops:List[Op] predicate:fn[OpValue -> bool] -> int {
     count
 }
 
-fn sl_count_insts bytecode:List[Inst] kind:InstKind -> int {
+fn sl_count_insts bytecode:List[InstValue] kind:InstValue -> int {
     0 = count
     0 = index
     while index bytecode.length > do
-        if kind index bytecode.get Inst::kind == then
+        if kind index bytecode.get == then
             1 += count
         fi
         1 += index
@@ -66,7 +66,7 @@ fn sl_count_insts bytecode:List[Inst] kind:InstKind -> int {
     count
 }
 
-fn sl_has_inst_kind bytecode:List[Inst] kind:InstKind -> bool {
+fn sl_has_inst_kind bytecode:List[InstValue] kind:InstValue -> bool {
     0 kind bytecode sl_count_insts !=
 }
 
@@ -335,15 +335,15 @@ fn test_stack_and_literal_coexist {
 fn test_compile_struct_literal {
     "compile_struct_literal" test_start
     "struct Point { x: int y: int }\nPoint { x: 1 y: 2 } = p\np.x drop" sl_compile = prog
-    "has HEAP_ALLOC" InstKind::InstHeapAlloc prog Program::bytecode sl_has_inst_kind assert_true
-    "has STORE64" InstKind::InstStore64 prog Program::bytecode sl_has_inst_kind assert_true
+    "has HEAP_ALLOC" InstValue::HeapAlloc prog Program::bytecode sl_has_inst_kind assert_true
+    "has STORE64" InstValue::Store64 prog Program::bytecode sl_has_inst_kind assert_true
 }
 
 fn test_compile_struct_literal_reverse_order {
     "compile_struct_literal_reverse_order" test_start
     "struct Point { x: int y: int }\nPoint { y: 99 x: 42 } = p\np.x drop" sl_compile = prog
-    "has HEAP_ALLOC" InstKind::InstHeapAlloc prog Program::bytecode sl_has_inst_kind assert_true
-    "has STORE64" InstKind::InstStore64 prog Program::bytecode sl_has_inst_kind assert_true
+    "has HEAP_ALLOC" InstValue::HeapAlloc prog Program::bytecode sl_has_inst_kind assert_true
+    "has STORE64" InstValue::Store64 prog Program::bytecode sl_has_inst_kind assert_true
 }
 
 fn test_compile_struct_match {

--- a/tests/compiler/test_typeof.casa
+++ b/tests/compiler/test_typeof.casa
@@ -39,17 +39,23 @@ fn assert_contains needle:str haystack:str msg:str {
     fi
 }
 
-fn has_inst_kind bytecode:List[Inst] kind:InstKind -> bool {
+fn has_inst_kind bytecode:List[InstValue] predicate:fn[InstValue -> bool] -> bool {
     false = found
     0 = index
     while index bytecode.length > do
-        if kind index bytecode.get Inst::kind == then
+        if index bytecode.get predicate exec then
             true = found
         fi
         1 += index
     done
     found
 }
+
+fn is_drop_inst value:InstValue -> bool { value InstValue::Drop is }
+
+fn is_push_str_inst value:InstValue -> bool { value InstValue::PushStr is }
+
+fn is_print_str_inst value:InstValue -> bool { value InstValue::PrintStr is }
 
 fn string_table_contains table:List[str] needle:str -> bool {
     false = found
@@ -140,9 +146,9 @@ fn test_typecheck_typeof_ptr {
 fn test_bytecode_typeof_int {
     "bytecode_typeof_int" test_start
     "42 typeof" compile_typeof = prog
-    "has DROP" InstKind::InstDrop prog Program::bytecode has_inst_kind assert_true
-    "has PUSH_STR" InstKind::InstPushStr prog Program::bytecode has_inst_kind assert_true
-    "has PRINT_STR" InstKind::InstPrintStr prog Program::bytecode has_inst_kind assert_true
+    "has DROP" &is_drop_inst prog Program::bytecode has_inst_kind assert_true
+    "has PUSH_STR" &is_push_str_inst prog Program::bytecode has_inst_kind assert_true
+    "has PRINT_STR" &is_print_str_inst prog Program::bytecode has_inst_kind assert_true
     "int in strings" "int" prog Program::strings string_table_contains assert_true
 }
 
@@ -165,13 +171,13 @@ fn test_bytecode_typeof_instruction_sequence {
     false = found_seq
     0 = index
     while index prog Program::bytecode.length 2 - > do
-        index prog Program::bytecode.get Inst::kind = kind0
-        index 1 + prog Program::bytecode.get Inst::kind = kind1
-        index 2 + prog Program::bytecode.get Inst::kind = kind2
+        index prog Program::bytecode.get = inst0_value
+        index 1 + prog Program::bytecode.get = inst1_value
+        index 2 + prog Program::bytecode.get = inst2_value
         if
-        InstKind::InstDrop kind0 ==
-        InstKind::InstPushStr kind1 == &&
-        InstKind::InstPrintStr kind2 == &&
+        inst0_value InstValue::Drop is
+        inst1_value InstValue::PushStr is &&
+        inst2_value InstValue::PrintStr is &&
         then
             true = found_seq
         fi


### PR DESCRIPTION
## Summary

- Drop `struct Inst { kind, int_arg, str_arg }` and the 69-variant `enum InstKind`. Bytecode is now `List[InstValue]`, a single tagged enum where each variant carries its payload directly (`Push(int)`, `FnCall(str)`, `Label(int)`, ...).
- Eliminate one heap allocation per instruction (no more per-Inst wrapper) and replace field-accessor reads (`inst.int_arg`) with explicit payload destructuring at match arms.
- Constructors `make_inst` / `make_inst_int` / `make_inst_str` collapse into direct variant construction at call sites; `direct_op_to_inst` now returns `Option[InstValue]`; the `InstKind` Hashable impl is dropped.

Mirrors the `OpValue` migration (#135–#138) and `ResolvedVariable` migration (#143).

## Test plan

- [x] `./tests/test_compiler.sh ./casac < /dev/null` — 25 passed, 0 failed (including self_compilation and fixed_point)
- [x] `./tests/test_examples.sh ./casac` — 39 passed, 0 failed
- [x] `./casafmt` applied to all changed files