### PR TITLE
ci: pin casac release binary to v1.9.0

### DIFF
--- a/.github/workflows/test-compiler.yml
+++ b/.github/workflows/test-compiler.yml
@@ -12,13 +12,15 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      CASAC_RELEASE_TAG: v1.9.0
     steps:
     - uses: actions/checkout@v5
     - name: Download casac release binary
       run: |
         curl --silent --location --fail \
           --output casac-release \
-          "https://github.com/frendsick/casa/releases/latest/download/casac"
+          "https://github.com/frendsick/casa/releases/download/${CASAC_RELEASE_TAG}/casac"
         chmod +x casac-release
     - name: Bootstrap stage1 compiler from branch
       run: ./casac-release -L lib casa.casa -o casac-stage1

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -12,13 +12,15 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      CASAC_RELEASE_TAG: v1.9.0
     steps:
     - uses: actions/checkout@v5
     - name: Download casac release binary
       run: |
         curl --silent --location --fail \
           --output casac-release \
-          "https://github.com/frendsick/casa/releases/latest/download/casac"
+          "https://github.com/frendsick/casa/releases/download/${CASAC_RELEASE_TAG}/casac"
         chmod +x casac-release
     - name: Bootstrap stage1 compiler from branch
       run: ./casac-release -L lib casa.casa -o casac-stage1


### PR DESCRIPTION
## Summary

- Replace `releases/latest/download/casac` with `releases/download/${CASAC_RELEASE_TAG}/casac`
- Hold the tag in a job-level `env` so future bumps touch one line per workflow

## Why

`releases/latest` is a moving target. Any PR that introduces new syntax to the compiler or `lib/std.casa` before that syntax exists in `main` would either need a transitional release (just shipped one for #159) or be blocked. Pinning the tag decouples branch CI from release-channel drift.

## Workflow on next release

1. Cut release `vX.Y.Z` from `main`
2. Same/follow-up PR bumps `CASAC_RELEASE_TAG` in both workflows

## Test plan

- [x] Both checks green on this PR using `v1.9.0` binary