### PR TITLE
Type AST migration (#140): replace string-based types with structured Type enum

### DIFF
--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -974,6 +974,78 @@ impl Type {
             }
         end
     }
+
+    fn is_type_var self:Type -> bool {
+        self match
+            Type::TypeVar(_) => { true }
+            _ => { false }
+        end
+    }
+
+    fn base self:Type -> Option[str] {
+        self match
+            Type::Generic(generic) => {
+                if 0 generic.params.length == then
+                    Option::None
+                else
+                    generic.base Option::Some
+                fi
+            }
+            _ => { Option::None }
+        end
+    }
+
+    fn type_params self:Type -> Option[List[Type]] {
+        self match
+            Type::Generic(generic) => {
+                if 0 generic.params.length == then
+                    Option::None
+                else
+                    generic.params Option::Some
+                fi
+            }
+            _ => { Option::None }
+        end
+    }
+
+    fn substitute self:Type subs:Map[str str] -> Type {
+        self match
+            Type::Unknown => { Type::Unknown }
+            Type::Builtin(builtin) => { builtin Type::Builtin }
+            Type::TypeVar(name) => {
+                if name subs.get Option::Some(bound) is then
+                    bound parse_type_str
+                else
+                    name Type::TypeVar
+                fi
+            }
+            Type::Generic(generic) => {
+                generic.base = base
+                if 0 generic.params.length == then
+                    if base subs.get Option::Some(bound) is then
+                        bound parse_type_str return
+                    fi
+                    generic.params base GenericType Type::Generic return
+                fi
+                List::new(List[Type]) = new_params
+                for param in generic.params.iter do
+                    subs param.substitute new_params.push
+                done
+                new_params base GenericType Type::Generic
+            }
+            Type::Function(fn_type) => {
+                List::new(List[Type]) = new_params
+                for param in fn_type.parameters.iter do
+                    subs param.substitute new_params.push
+                done
+                List::new(List[Type]) = new_returns
+                for ret in fn_type.return_types.iter do
+                    subs ret.substitute new_returns.push
+                done
+                new_returns new_params FunctionType Type::Function
+            }
+        end
+    }
 }
 
 fn parse_type_str source:str -> Type {
@@ -1384,12 +1456,12 @@ fn apply_type_subs_to_sig sig:Signature subs:Map[str str] -> Signature {
     fi
     List::new(List[Parameter]) = params
     for param in sig Signature::parameters.iter do
-        subs param Parameter::typ.format substitute_type_params = new_typ
-        param Parameter::name new_typ make_named_param params.push
+        subs param Parameter::typ.substitute = new_typ
+        param Parameter::name new_typ.format make_named_param params.push
     done
     List::new(List[str]) = returns
     for return_type in sig Signature::return_types.iter do
-        subs return_type.format substitute_type_params returns.push
+        subs return_type.substitute.format returns.push
     done
     returns params make_signature
 }

--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -1063,7 +1063,7 @@ fn parse_type_str source:str -> Type {
     if "fn" source == then
         List::new(List[Type]) List::new(List[Type]) FunctionType Type::Function return
     fi
-    if "fn[" source str::starts_with source "]" str::ends_with && then
+    if source "fn[" str::starts_with source "]" str::ends_with && then
         source.length 4 - = inner_length
         source 3 inner_length str::substring = fn_inner
         List::new(List[Type]) = fn_params
@@ -1107,8 +1107,8 @@ fn parse_type_str source:str -> Type {
         fn_returns fn_params FunctionType Type::Function return
     fi
     # Generic: Name[params]
-    if "[" source str::contains source "]" str::ends_with && then
-        "[" source str::find = bracket_pos
+    if source "[" str::contains source "]" str::ends_with && then
+        source "[" str::find = bracket_pos
         source 0 bracket_pos str::substring = base
         source.length base.length - 2 - = inner_len
         source base.length 1 + inner_len str::substring = inner

--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -401,11 +401,11 @@ fn make_signature params:List[Parameter] returns:List[str] -> Signature {
 
 struct Variable {
     name: str
-    typ:  str
+    typ:  Type
 }
 
 fn make_variable name:str -> Variable {
-    "" name Variable
+    Type::Unknown name Variable
 }
 
 enum ResolvedVariable {
@@ -439,7 +439,7 @@ impl ResolvedVariable {
 
 struct Member {
     name: str
-    typ:  str
+    typ:  Type
 }
 
 # ============================================================================
@@ -889,6 +889,7 @@ struct FunctionType {
 }
 
 enum Type {
+    Unknown
     Builtin (BuiltinType)
     Generic (GenericType)
     Function (FunctionType)
@@ -925,6 +926,7 @@ fn parse_generic_params source:str -> List[Type] {
 impl Type {
     fn format self:Type -> str {
         self match
+            Type::Unknown => { "" }
             Type::Builtin(builtin) => { builtin.format }
             Type::TypeVar(name) => { name }
             Type::Generic(generic) => {
@@ -971,6 +973,7 @@ impl Type {
 }
 
 fn parse_type_str source:str -> Type {
+    if "" source == then Type::Unknown return fi
     if source builtin_from_str Option::Some(builtin) is then
         builtin Type::Builtin return
     fi

--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -840,10 +840,6 @@ struct Program {
 
 # ============================================================================
 # Type AST
-#
-# Structured representation of types. Foundation for replacing string-based
-# type slots (Parameter.typ, Variable.typ, Member.typ, Signature.return_types,
-# TypedStack.types) — see PRD #140.
 # ============================================================================
 
 enum BuiltinType {
@@ -897,29 +893,10 @@ enum Type {
 }
 
 fn parse_generic_params source:str -> List[Type] {
-    # Recursively parse space-separated type tokens from inside brackets.
     List::new(List[Type]) = params
-    StringBuilder::new = current
-    0 = depth
-    for ch in source.iter do
-        if '[' ch == then
-            1 += depth
-            ch current.append_char
-        elif ']' ch == then
-            depth 1 - = depth
-            ch current.append_char
-        elif ' ' ch == 0 depth == && then
-            if 0 current.length != then
-                current.build parse_type_str params.push
-                StringBuilder::new = current
-            fi
-        else
-            ch current.append_char
-        fi
+    for token in source split_type_tokens.iter do
+        token parse_type_str params.push
     done
-    if 0 current.length != then
-        current.build parse_type_str params.push
-    fi
     params
 }
 
@@ -1280,6 +1257,18 @@ fn signature_to_str sig:Signature -> str {
         done
     fi
     builder.build
+}
+
+fn signature_to_function_type sig:Signature -> Type {
+    List::new(List[Type]) = fn_params
+    for fn_param in sig Signature::parameters.iter do
+        fn_param Parameter::typ fn_params.push
+    done
+    List::new(List[Type]) = fn_returns
+    for fn_return in sig Signature::return_types.iter do
+        fn_return fn_returns.push
+    done
+    fn_returns fn_params FunctionType Type::Function
 }
 
 fn signature_from_str sig_str:str -> Signature {

--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -360,16 +360,16 @@ fn substitute_ops_types ops:List[Op] subs:Map[str str] {
 # ============================================================================
 
 struct Parameter {
-    typ:  str
+    typ:  Type
     name: str
 }
 
 fn make_param typ:str -> Parameter {
-    "" typ Parameter
+    "" typ parse_type_str Parameter
 }
 
 fn make_named_param typ:str name:str -> Parameter {
-    name typ Parameter
+    name typ parse_type_str Parameter
 }
 
 struct Signature {
@@ -1187,7 +1187,7 @@ fn signature_to_str sig:Signature -> str {
             if 0 index != then
                 " " builder.append
             fi
-            index sig Signature::parameters.get Parameter::typ builder.append
+            index sig Signature::parameters.get Parameter::typ.format builder.append
             1 += index
         done
     fi
@@ -1259,8 +1259,8 @@ fn signature_matches sig_a:Signature sig_b:Signature -> bool {
 
     0 = index
     while index sig_a Signature::parameters.length > do
-        index sig_a Signature::parameters.get Parameter::typ = type_a
-        index sig_b Signature::parameters.get Parameter::typ = type_b
+        index sig_a Signature::parameters.get Parameter::typ.format = type_a
+        index sig_b Signature::parameters.get Parameter::typ.format = type_b
         if type_a type_b != TYPE_UNKNOWN type_a != && TYPE_UNKNOWN type_b != && then
             type_b extract_generic_base = base_b
             type_a extract_generic_base = base_a
@@ -1377,7 +1377,7 @@ fn apply_type_subs_to_sig sig:Signature subs:Map[str str] -> Signature {
     fi
     List::new(List[Parameter]) = params
     for param in sig Signature::parameters.iter do
-        subs param Parameter::typ substitute_type_params = new_typ
+        subs param Parameter::typ.format substitute_type_params = new_typ
         param Parameter::name new_typ make_named_param params.push
     done
     List::new(List[str]) = returns
@@ -1391,7 +1391,7 @@ fn resolve_trait_sig sig:Signature type_var:str -> Signature {
     # Replace 'self' type with type_var in a trait method signature.
     List::new(List[Parameter]) = params
     for param in sig Signature::parameters.iter do
-        param Parameter::typ = typ
+        param Parameter::typ.format = typ
         if TRAIT_SELF_TYPE typ == then
             type_var = typ
         fi

--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -1024,6 +1024,30 @@ impl Type {
         end
     }
 
+    fn type_var_name self:Type -> Option[str] {
+        self match
+            Type::TypeVar(name) => { name Option::Some }
+            Type::Generic(generic) => {
+                if 0 generic.params.length == then
+                    generic.base Option::Some
+                else
+                    Option::None
+                fi
+            }
+            _ => { Option::None }
+        end
+    }
+
+    fn is_unknown_placeholder self:Type -> bool {
+        self match
+            Type::Unknown => { true }
+            Type::Generic(generic) => {
+                0 generic.params.length == TYPE_UNKNOWN generic.base == &&
+            }
+            _ => { false }
+        end
+    }
+
     fn is_fn_type_t self:Type -> bool {
         self match
             Type::Function(_) => { true }
@@ -1302,6 +1326,18 @@ fn build_resolved_type base:str type_vars:List[str] bindings:Map[str str] -> str
         fi
     done
     params base build_parameterized_type
+}
+
+fn build_resolved_type_t base:str type_vars:List[str] bindings:Map[str Type] -> Type {
+    List::new(List[Type]) = params
+    for type_var in type_vars.iter do
+        if type_var bindings.get Option::Some(bound) is then
+            bound params.push
+        else
+            type_var Type::TypeVar params.push
+        fi
+    done
+    params base GenericType Type::Generic
 }
 
 fn is_builtin_type typ:str -> bool {

--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -735,7 +735,7 @@ struct CasaTrait {
 
 struct HiddenTraitMethod {
     var_name: str # e.g. "__trait_I_next"
-    fn_type:  str # e.g. "fn[I -> Option[int]]"
+    fn_type:  Type # e.g. fn[I -> Option[int]]
 }
 
 # A generic trait bound attached to a type variable in a function or impl

--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -833,6 +833,14 @@ struct Program {
 "_" = MATCH_WILDCARD
 "self" = TRAIT_SELF_TYPE
 8 = WORD_SIZE
+BuiltinType::Int Type::Builtin = TYPE_INT_T
+BuiltinType::Bool Type::Builtin = TYPE_BOOL_T
+BuiltinType::Char Type::Builtin = TYPE_CHAR_T
+BuiltinType::Cstr Type::Builtin = TYPE_CSTR_T
+BuiltinType::Str Type::Builtin = TYPE_STR_T
+BuiltinType::Ptr Type::Builtin = TYPE_PTR_T
+List::new(List[Type]) "?" GenericType Type::Generic = TYPE_UNKNOWN_T
+List::new(List[Type]) "<missing>" GenericType Type::Generic = TYPE_MISSING_T
 
 # ============================================================================
 # Type AST
@@ -1008,6 +1016,98 @@ impl Type {
             }
         end
     }
+
+    fn is_unknown self:Type -> bool {
+        self match
+            Type::Unknown => { true }
+            _ => { false }
+        end
+    }
+
+    fn is_fn_type_t self:Type -> bool {
+        self match
+            Type::Function(_) => { true }
+            _ => { false }
+        end
+    }
+
+    fn is_self_type self:Type -> bool {
+        self match
+            Type::Generic(generic) => {
+                0 generic.params.length == TRAIT_SELF_TYPE generic.base == &&
+            }
+            Type::TypeVar(name) => { TRAIT_SELF_TYPE name == }
+            _ => { false }
+        end
+    }
+
+    fn eq self:Type other:Type -> bool {
+        self match
+            Type::Unknown => {
+                other match
+                    Type::Unknown => { true }
+                    _ => { false }
+                end
+            }
+            Type::Builtin(b_self) => {
+                other match
+                    Type::Builtin(b_other) => { b_other b_self == }
+                    _ => { false }
+                end
+            }
+            Type::TypeVar(n_self) => {
+                other match
+                    Type::TypeVar(n_other) => { n_other n_self == }
+                    _ => { false }
+                end
+            }
+            Type::Generic(g_self) => {
+                other match
+                    Type::Generic(g_other) => {
+                        if g_other.base g_self.base != then false return fi
+                        if g_other.params.length g_self.params.length != then false return fi
+                        0 = eq_index
+                        while eq_index g_self.params.length > do
+                            if eq_index g_other.params.get eq_index g_self.params.get.eq ! then
+                                false return
+                            fi
+                            1 += eq_index
+                        done
+                        true
+                    }
+                    _ => { false }
+                end
+            }
+            Type::Function(f_self) => {
+                other match
+                    Type::Function(f_other) => {
+                        if f_other.parameters.length f_self.parameters.length != then false return fi
+                        if f_other.return_types.length f_self.return_types.length != then false return fi
+                        0 = eq_index
+                        while eq_index f_self.parameters.length > do
+                            if eq_index f_other.parameters.get eq_index f_self.parameters.get.eq ! then
+                                false return
+                            fi
+                            1 += eq_index
+                        done
+                        0 = eq_index
+                        while eq_index f_self.return_types.length > do
+                            if eq_index f_other.return_types.get eq_index f_self.return_types.get.eq ! then
+                                false return
+                            fi
+                            1 += eq_index
+                        done
+                        true
+                    }
+                    _ => { false }
+                end
+            }
+        end
+    }
+}
+
+fn make_named_type name:str -> Type {
+    List::new(List[Type]) name GenericType Type::Generic
 }
 
 fn parse_type_str source:str -> Type {
@@ -1445,7 +1545,7 @@ fn resolve_trait_sig sig:Signature type_var:str -> Signature {
     type_var parse_type_str = self_replacement
     List::new(List[Parameter]) = params
     for param in sig Signature::parameters.iter do
-        if TRAIT_SELF_TYPE param Parameter::typ.format == then
+        if param Parameter::typ.is_self_type then
             self_replacement
         else
             param Parameter::typ
@@ -1455,7 +1555,7 @@ fn resolve_trait_sig sig:Signature type_var:str -> Signature {
 
     List::new(List[Type]) = returns
     for ret in sig Signature::return_types.iter do
-        if TRAIT_SELF_TYPE ret.format == then
+        if ret.is_self_type then
             self_replacement returns.push
         else
             ret returns.push

--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -1464,22 +1464,24 @@ fn apply_type_subs_to_sig sig:Signature subs:Map[str str] -> Signature {
 
 fn resolve_trait_sig sig:Signature type_var:str -> Signature {
     # Replace 'self' type with type_var in a trait method signature.
+    type_var parse_type_str = self_replacement
     List::new(List[Parameter]) = params
     for param in sig Signature::parameters.iter do
-        param Parameter::typ.format = typ_str
-        if TRAIT_SELF_TYPE typ_str == then
-            type_var = typ_str
-        fi
-        param Parameter::name typ_str parse_type_str make_named_param params.push
+        if TRAIT_SELF_TYPE param Parameter::typ.format == then
+            self_replacement
+        else
+            param Parameter::typ
+        fi = new_typ
+        param Parameter::name new_typ make_named_param params.push
     done
 
     List::new(List[Type]) = returns
     for ret in sig Signature::return_types.iter do
-        ret.format = ret_str
-        if TRAIT_SELF_TYPE ret_str == then
-            type_var = ret_str
+        if TRAIT_SELF_TYPE ret.format == then
+            self_replacement returns.push
+        else
+            ret returns.push
         fi
-        ret_str parse_type_str returns.push
     done
 
     returns params make_signature

--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -457,10 +457,6 @@ fn make_enum_variant enum_name:str variant_name:str ordinal:Option[int] -> EnumV
     List::new(List[str]) ordinal variant_name enum_name EnumVariant
 }
 
-fn is_wildcard_variant variant:EnumVariant -> bool {
-    "_" variant EnumVariant::variant_name ==
-}
-
 struct StructLiteral {
     struct_name: str
     field_order: List[str]
@@ -945,13 +941,6 @@ impl Type {
                 "]" builder.append
                 builder.build
             }
-        end
-    }
-
-    fn is_type_var self:Type -> bool {
-        self match
-            Type::TypeVar(_) => { true }
-            _ => { false }
         end
     }
 

--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -1468,21 +1468,18 @@ fn resolve_trait_sig sig:Signature type_var:str -> Signature {
     for param in sig Signature::parameters.iter do
         param Parameter::typ.format = typ_str
         if TRAIT_SELF_TYPE typ_str == then
-            type_var parse_type_str = new_typ
-        else
-            typ_str parse_type_str = new_typ
+            type_var = typ_str
         fi
-        param Parameter::name new_typ make_named_param params.push
+        param Parameter::name typ_str parse_type_str make_named_param params.push
     done
 
     List::new(List[Type]) = returns
     for ret in sig Signature::return_types.iter do
         ret.format = ret_str
         if TRAIT_SELF_TYPE ret_str == then
-            type_var parse_type_str returns.push
-        else
-            ret_str parse_type_str returns.push
+            type_var = ret_str
         fi
+        ret_str parse_type_str returns.push
     done
 
     returns params make_signature

--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -368,8 +368,8 @@ fn make_param typ:str -> Parameter {
     "" typ parse_type_str Parameter
 }
 
-fn make_named_param typ:str name:str -> Parameter {
-    name typ parse_type_str Parameter
+fn make_named_param typ:Type name:str -> Parameter {
+    name typ Parameter
 }
 
 struct Signature {
@@ -382,19 +382,15 @@ struct Signature {
 fn empty_signature -> Signature {
     Map::new(Map[str TraitBound])
     Set::new(Set[str])
-    List::new(List[str])
+    List::new(List[Type])
     List::new(List[Parameter])
     Signature
 }
 
-fn make_signature params:List[Parameter] returns:List[str] -> Signature {
-    List::new(List[Type]) = typed_returns
-    for ret_str in returns.iter do
-        ret_str parse_type_str typed_returns.push
-    done
+fn make_signature params:List[Parameter] returns:List[Type] -> Signature {
     Map::new(Map[str TraitBound])
     Set::new(Set[str])
-    typed_returns
+    returns
     params
     Signature
 }
@@ -1302,7 +1298,7 @@ fn signature_from_str sig_str:str -> Signature {
     done
 
     List::new(List[Parameter]) = params
-    List::new(List[str]) = returns
+    List::new(List[Type]) = returns
 
     # Parameters: tokens before ->
     0 = index
@@ -1319,7 +1315,7 @@ fn signature_from_str sig_str:str -> Signature {
     while index tokens.length > do
         index tokens.get = token
         if "None" token != then
-            token returns.push
+            token parse_type_str returns.push
         fi
         1 += index
     done
@@ -1457,11 +1453,11 @@ fn apply_type_subs_to_sig sig:Signature subs:Map[str str] -> Signature {
     List::new(List[Parameter]) = params
     for param in sig Signature::parameters.iter do
         subs param Parameter::typ.substitute = new_typ
-        param Parameter::name new_typ.format make_named_param params.push
+        param Parameter::name new_typ make_named_param params.push
     done
-    List::new(List[str]) = returns
+    List::new(List[Type]) = returns
     for return_type in sig Signature::return_types.iter do
-        subs return_type.substitute.format returns.push
+        subs return_type.substitute returns.push
     done
     returns params make_signature
 }
@@ -1470,19 +1466,22 @@ fn resolve_trait_sig sig:Signature type_var:str -> Signature {
     # Replace 'self' type with type_var in a trait method signature.
     List::new(List[Parameter]) = params
     for param in sig Signature::parameters.iter do
-        param Parameter::typ.format = typ
-        if TRAIT_SELF_TYPE typ == then
-            type_var = typ
+        param Parameter::typ.format = typ_str
+        if TRAIT_SELF_TYPE typ_str == then
+            type_var parse_type_str = new_typ
+        else
+            typ_str parse_type_str = new_typ
         fi
-        param Parameter::name typ make_named_param params.push
+        param Parameter::name new_typ make_named_param params.push
     done
 
-    List::new(List[str]) = returns
+    List::new(List[Type]) = returns
     for ret in sig Signature::return_types.iter do
-        if TRAIT_SELF_TYPE ret.format == then
-            type_var returns.push
+        ret.format = ret_str
+        if TRAIT_SELF_TYPE ret_str == then
+            type_var parse_type_str returns.push
         else
-            ret.format returns.push
+            ret_str parse_type_str returns.push
         fi
     done
 

--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -839,6 +839,209 @@ struct Program {
 8 = WORD_SIZE
 
 # ============================================================================
+# Type AST
+#
+# Structured representation of types. Foundation for replacing string-based
+# type slots (Parameter.typ, Variable.typ, Member.typ, Signature.return_types,
+# TypedStack.types) — see PRD #140.
+# ============================================================================
+
+enum BuiltinType {
+    Int
+    Bool
+    Char
+    Cstr
+    Str
+    Ptr
+}
+
+impl BuiltinType {
+    fn format self:BuiltinType -> str {
+        self match
+            BuiltinType::Int => { "int" }
+            BuiltinType::Bool => { "bool" }
+            BuiltinType::Char => { "char" }
+            BuiltinType::Cstr => { "cstr" }
+            BuiltinType::Str => { "str" }
+            BuiltinType::Ptr => { "ptr" }
+        end
+    }
+}
+
+fn builtin_from_str source:str -> Option[BuiltinType] {
+    if "int" source == then BuiltinType::Int Option::Some return fi
+    if "bool" source == then BuiltinType::Bool Option::Some return fi
+    if "char" source == then BuiltinType::Char Option::Some return fi
+    if "cstr" source == then BuiltinType::Cstr Option::Some return fi
+    if "str" source == then BuiltinType::Str Option::Some return fi
+    if "ptr" source == then BuiltinType::Ptr Option::Some return fi
+    Option::None
+}
+
+struct GenericType {
+    base:   str
+    params: List[Type]
+}
+
+struct FunctionType {
+    parameters:   List[Type]
+    return_types: List[Type]
+}
+
+enum Type {
+    Builtin (BuiltinType)
+    Generic (GenericType)
+    Function (FunctionType)
+    TypeVar (str)
+}
+
+fn parse_generic_params source:str -> List[Type] {
+    # Recursively parse space-separated type tokens from inside brackets.
+    List::new(List[Type]) = params
+    StringBuilder::new = current
+    0 = depth
+    for ch in source.iter do
+        if '[' ch == then
+            1 += depth
+            ch current.append_char
+        elif ']' ch == then
+            depth 1 - = depth
+            ch current.append_char
+        elif ' ' ch == 0 depth == && then
+            if 0 current.length != then
+                current.build parse_type_str params.push
+                StringBuilder::new = current
+            fi
+        else
+            ch current.append_char
+        fi
+    done
+    if 0 current.length != then
+        current.build parse_type_str params.push
+    fi
+    params
+}
+
+impl Type {
+    fn format self:Type -> str {
+        self match
+            Type::Builtin(builtin) => { builtin.format }
+            Type::TypeVar(name) => { name }
+            Type::Generic(generic) => {
+                if 0 generic.params.length == then
+                    generic.base return
+                fi
+                StringBuilder::new = builder
+                generic.base builder.append
+                "[" builder.append
+                0 = index
+                while index generic.params.length > do
+                    if 0 index != then " " builder.append fi
+                    index generic.params.get.format builder.append
+                    1 += index
+                done
+                "]" builder.append
+                builder.build
+            }
+            Type::Function(fn_type) => {
+                if 0 fn_type.parameters.length == 0 fn_type.return_types.length == && then
+                    "fn" return
+                fi
+                StringBuilder::new = builder
+                "fn[" builder.append
+                0 = index
+                while index fn_type.parameters.length > do
+                    if 0 index != then " " builder.append fi
+                    index fn_type.parameters.get.format builder.append
+                    1 += index
+                done
+                if 0 fn_type.return_types.length != then
+                    if 0 fn_type.parameters.length != then " " builder.append fi
+                    "->" builder.append
+                    for return_type in fn_type.return_types.iter do
+                        " " builder.append
+                        return_type.format builder.append
+                    done
+                fi
+                "]" builder.append
+                builder.build
+            }
+        end
+    }
+}
+
+fn parse_type_str source:str -> Type {
+    if source builtin_from_str Option::Some(builtin) is then
+        builtin Type::Builtin return
+    fi
+    # TypeVar: single uppercase letter
+    if 1 source.length == then
+        if 0 source.at.is_upper then
+            source Type::TypeVar return
+        fi
+    fi
+    # Function type: bare "fn" or "fn[...]"
+    if "fn" source == then
+        List::new(List[Type]) List::new(List[Type]) FunctionType Type::Function return
+    fi
+    if "fn[" source str::starts_with source "]" str::ends_with && then
+        source.length 4 - = inner_length
+        source 3 inner_length str::substring = fn_inner
+        List::new(List[Type]) = fn_params
+        List::new(List[Type]) = fn_returns
+        false = past_arrow
+        StringBuilder::new = current
+        0 = depth
+        for ch in fn_inner.iter do
+            if '[' ch == then
+                1 += depth
+                ch current.append_char
+            elif ']' ch == then
+                depth 1 - = depth
+                ch current.append_char
+            elif ' ' ch == 0 depth == && then
+                if 0 current.length != then
+                    current.build = token
+                    if "->" token == then
+                        true = past_arrow
+                    elif past_arrow then
+                        token parse_type_str fn_returns.push
+                    else
+                        token parse_type_str fn_params.push
+                    fi
+                    StringBuilder::new = current
+                fi
+            else
+                ch current.append_char
+            fi
+        done
+        if 0 current.length != then
+            current.build = last_token
+            if "->" last_token == then
+                # bare arrow at end — nothing
+            elif past_arrow then
+                last_token parse_type_str fn_returns.push
+            else
+                last_token parse_type_str fn_params.push
+            fi
+        fi
+        fn_returns fn_params FunctionType Type::Function return
+    fi
+    # Generic: Name[params]
+    if "[" source str::contains source "]" str::ends_with && then
+        "[" source str::find = bracket_pos
+        source 0 bracket_pos str::substring = base
+        source.length base.length - 2 - = inner_len
+        source base.length 1 + inner_len str::substring = inner
+        inner parse_generic_params = params
+        params base GenericType Type::Generic return
+    fi
+    # Named type with no params (user struct/enum)
+    List::new(List[Type]) = empty_params
+    empty_params source GenericType Type::Generic
+}
+
+# ============================================================================
 # Type utility functions
 # ============================================================================
 

--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -374,7 +374,7 @@ fn make_named_param typ:str name:str -> Parameter {
 
 struct Signature {
     parameters:   List[Parameter]
-    return_types: List[str]
+    return_types: List[Type]
     type_vars:    Set[str]
     trait_bounds: Map[str TraitBound]
 }
@@ -388,9 +388,13 @@ fn empty_signature -> Signature {
 }
 
 fn make_signature params:List[Parameter] returns:List[str] -> Signature {
+    List::new(List[Type]) = typed_returns
+    for ret_str in returns.iter do
+        ret_str parse_type_str typed_returns.push
+    done
     Map::new(Map[str TraitBound])
     Set::new(Set[str])
-    returns
+    typed_returns
     params
     Signature
 }
@@ -1203,7 +1207,7 @@ fn signature_to_str sig:Signature -> str {
             if 0 index != then
                 " " builder.append
             fi
-            index sig Signature::return_types.get builder.append
+            index sig Signature::return_types.get.format builder.append
             1 += index
         done
     fi
@@ -1278,8 +1282,8 @@ fn signature_matches sig_a:Signature sig_b:Signature -> bool {
 
     0 = index
     while index sig_a Signature::return_types.length > do
-        index sig_a Signature::return_types.get = return_a
-        index sig_b Signature::return_types.get = return_b
+        index sig_a Signature::return_types.get.format = return_a
+        index sig_b Signature::return_types.get.format = return_b
         if return_a return_b != TYPE_UNKNOWN return_a != && TYPE_UNKNOWN return_b != && then
             return_b extract_generic_base = return_base_b
             return_a extract_generic_base = return_base_a
@@ -1385,7 +1389,7 @@ fn apply_type_subs_to_sig sig:Signature subs:Map[str str] -> Signature {
     done
     List::new(List[str]) = returns
     for return_type in sig Signature::return_types.iter do
-        subs return_type substitute_type_params returns.push
+        subs return_type.format substitute_type_params returns.push
     done
     returns params make_signature
 }
@@ -1403,10 +1407,10 @@ fn resolve_trait_sig sig:Signature type_var:str -> Signature {
 
     List::new(List[str]) = returns
     for ret in sig Signature::return_types.iter do
-        if TRAIT_SELF_TYPE ret == then
+        if TRAIT_SELF_TYPE ret.format == then
             type_var returns.push
         else
-            ret returns.push
+            ret.format returns.push
         fi
     done
 

--- a/compiler/pattern.casa
+++ b/compiler/pattern.casa
@@ -286,7 +286,7 @@ fn typecheck_match_op tc:TypeChecker function_opt:Option[Function] op:Op {
             guard_checker TypeChecker::live TypedStack::types = guard_stack
             false = guard_ok
             if 1 guard_stack.length == then
-                if "bool" 0 guard_stack.get == then
+                if "bool" 0 guard_stack.get.format == then
                     true = guard_ok
                 fi
             fi

--- a/compiler/pattern.casa
+++ b/compiler/pattern.casa
@@ -147,7 +147,7 @@ fn assign_struct_binding_type
 {
     for member in matched_struct CasaStruct::members.iter do
         if field_name member Member::name == then
-            function_opt member Member::typ bound_var set_binding_type
+            function_opt member Member::typ.format bound_var set_binding_type
         fi
     done
 }

--- a/compiler/syntax.casa
+++ b/compiler/syntax.casa
@@ -928,7 +928,7 @@ fn build_hidden_trait_methods
                 if 0 bound_method TraitMethod::default_ops.length == then
                     f"__trait_{bound_type_var}_{bound_method TraitMethod::name}" = hidden_name
                     bound_subs bound_type_var bound_method TraitMethod::signature resolve_trait_sig apply_type_subs_to_sig = hidden_sig
-                    f"fn[{hidden_sig signature_to_str}]" = hidden_type
+                    f"fn[{hidden_sig signature_to_str}]" parse_type_str = hidden_type
                     hidden_type hidden_name HiddenTraitMethod result.push
                 fi
             done
@@ -975,8 +975,8 @@ fn parse_function parser:Parser cursor:TokenCursor -> Function {
         for hidden in hidden_methods.iter do
             hidden HiddenTraitMethod::var_name = hidden_name
             hidden HiddenTraitMethod::fn_type = hidden_type
-            hidden_name hidden_type parse_type_str make_named_param hidden_params.push
-            hidden_type parse_type_str hidden_name Variable variables.push
+            hidden_name hidden_type make_named_param hidden_params.push
+            hidden_type hidden_name Variable variables.push
             name_token Token::location hidden_name OpValue::AssignVar make_op ops.push
         done
         # Prepend hidden params to signature parameters
@@ -1427,7 +1427,7 @@ fn inject_impl_trait_params
     for hidden in hidden_methods.iter do
         hidden HiddenTraitMethod::var_name = hidden_name
         hidden HiddenTraitMethod::fn_type = hidden_type
-        hidden_name hidden_type parse_type_str make_named_param hidden_params.push
+        hidden_name hidden_type make_named_param hidden_params.push
         hidden_name make_variable function Function::variables.push
         function Function::location hidden_name OpValue::AssignVar make_op = assign_op
         insert_pos assign_op function Function::ops.insert

--- a/compiler/syntax.casa
+++ b/compiler/syntax.casa
@@ -188,15 +188,14 @@ fn expect_delimiter cursor:TokenCursor expected_value:str -> bool {
 # parse_type - parse a type expression
 # ============================================================================
 
-fn parse_type cursor:TokenCursor -> str {
+fn parse_type_ast cursor:TokenCursor -> Type {
     cursor.peek = peek_opt
     if peek_opt.is_none then
         empty_location "Expected type" ErrorKind::UnexpectedToken raise_error
-        "" return
+        Type::Unknown return
     fi
     peek_opt.unwrap = peek
 
-    # Allow fn keyword as type base
     if "fn" peek Token::value == then
         cursor.pop drop
         "fn" = base
@@ -208,45 +207,39 @@ fn parse_type cursor:TokenCursor -> str {
         base_token Token::value = base
     fi
 
-    # Check for parameterized type
     cursor.peek = next_opt
-    if next_opt.is_none then base return fi
-    if "[" next_opt.unwrap Token::value != then base return fi
+    if next_opt.is_none then base parse_type_str return fi
+    if "[" next_opt.unwrap Token::value != then base parse_type_str return fi
     cursor.advance # consume [
 
-    # fn types: balanced bracket tracking
     if "fn" base == then
-        StringBuilder::new = fn_builder
-        0 = fn_depth
+        List::new(List[Type]) = fn_params
+        List::new(List[Type]) = fn_returns
+        false = past_arrow
         while cursor.is_finished ! do
-            cursor.pop = fn_token_opt
-            if fn_token_opt.is_none then break fi
-            fn_token_opt.unwrap = fn_token
-            if "[" fn_token Token::value == then
-                1 += fn_depth
-                "[" fn_builder.append
-            elif "]" fn_token Token::value == then
-                if 0 fn_depth == then break fi
-                fn_depth 1 - = fn_depth
-                "]" fn_builder.append
+            cursor.peek = inner_opt
+            if inner_opt.is_none then break fi
+            inner_opt.unwrap Token::value = ival
+            if "]" ival == then
+                cursor.pop drop
+                break
+            fi
+            if "->" ival == then
+                cursor.pop drop
+                true = past_arrow
+                continue
+            fi
+            cursor parse_type_ast = inner_type
+            if past_arrow then
+                inner_type fn_returns.push
             else
-                if 0 fn_builder.length != then
-                    fn_builder.build = fn_prev
-                    if fn_prev.length 0 != then
-                        fn_prev.length 1 - fn_prev.at = fn_last
-                        if '[' fn_last != "]" fn_token Token::value != && then
-                            " " fn_builder.append
-                        fi
-                    fi
-                fi
-                fn_token Token::value fn_builder.append
+                inner_type fn_params.push
             fi
         done
-        f"fn[{fn_builder.build}]" return
+        fn_returns fn_params FunctionType Type::Function return
     fi
 
-    # Regular parameterized type
-    List::new(List[str]) = inner_types
+    List::new(List[Type]) = inner_types
     while true do
         cursor.peek = inner_opt
         if inner_opt.is_some then
@@ -255,21 +248,16 @@ fn parse_type cursor:TokenCursor -> str {
                 break
             fi
         fi
-        cursor parse_type inner_types.push
+        cursor parse_type_ast inner_types.push
     done
     if 0 inner_types.length == then
         empty_location f"Expected type parameter inside `{base}[...]`" ErrorKind::UnexpectedToken raise_error
     fi
+    inner_types base GenericType Type::Generic
+}
 
-    # Join inner types with spaces
-    StringBuilder::new = join_builder
-    0 = join_index
-    while join_index inner_types.length > do
-        if 0 join_index != then " " join_builder.append fi
-        join_index inner_types.get join_builder.append
-        1 += join_index
-    done
-    f"{base}[{join_builder.build}]"
+fn parse_type cursor:TokenCursor -> str {
+    cursor parse_type_ast.format
 }
 
 # ============================================================================
@@ -783,7 +771,7 @@ fn parse_parameter_maybe_named cursor:TokenCursor token:Token -> Parameter {
     cursor.peek = next_opt
     if next_opt.is_some ":" next_opt.unwrap Token::value == && then
         cursor.advance # consume :
-        cursor parse_type parse_type_str = param_type
+        cursor parse_type_ast = param_type
         token Token::value param_type make_named_param return
     fi
     cursor.retreat
@@ -835,7 +823,7 @@ fn parse_return_types cursor:TokenCursor -> List[Type] {
         if "{" peek_opt.unwrap Token::value == then
             types return
         fi
-        cursor parse_type parse_type_str types.push
+        cursor parse_type_ast types.push
     done
     types
 }
@@ -1272,7 +1260,7 @@ fn parse_trait_method_signature cursor:TokenCursor -> Signature {
                 then
                     break
                 fi
-                cursor parse_type parse_type_str returns.push
+                cursor parse_type_ast returns.push
             done
         fi
     fi

--- a/compiler/syntax.casa
+++ b/compiler/syntax.casa
@@ -783,7 +783,7 @@ fn parse_parameter_maybe_named cursor:TokenCursor token:Token -> Parameter {
     cursor.peek = next_opt
     if next_opt.is_some ":" next_opt.unwrap Token::value == && then
         cursor.advance # consume :
-        cursor parse_type = param_type
+        cursor parse_type parse_type_str = param_type
         token Token::value param_type make_named_param return
     fi
     cursor.retreat
@@ -825,8 +825,8 @@ fn parse_parameters cursor:TokenCursor -> List[Parameter] {
 # parse_return_types - parse return types after ->
 # ============================================================================
 
-fn parse_return_types cursor:TokenCursor -> List[str] {
-    List::new(List[str]) = types
+fn parse_return_types cursor:TokenCursor -> List[Type] {
+    List::new(List[Type]) = types
     while true do
         cursor.peek = peek_opt
         if peek_opt.is_none then
@@ -835,7 +835,7 @@ fn parse_return_types cursor:TokenCursor -> List[str] {
         if "{" peek_opt.unwrap Token::value == then
             types return
         fi
-        cursor parse_type types.push
+        cursor parse_type parse_type_str types.push
     done
     types
 }
@@ -846,7 +846,7 @@ fn parse_return_types cursor:TokenCursor -> List[str] {
 
 fn parse_signature cursor:TokenCursor -> Signature {
     cursor parse_parameters = params
-    List::new(List[str]) = returns
+    List::new(List[Type]) = returns
 
     cursor.peek = next_opt
     if next_opt.is_none then
@@ -975,7 +975,7 @@ fn parse_function parser:Parser cursor:TokenCursor -> Function {
         for hidden in hidden_methods.iter do
             hidden HiddenTraitMethod::var_name = hidden_name
             hidden HiddenTraitMethod::fn_type = hidden_type
-            hidden_name hidden_type make_named_param hidden_params.push
+            hidden_name hidden_type parse_type_str make_named_param hidden_params.push
             hidden_type parse_type_str hidden_name Variable variables.push
             name_token Token::location hidden_name OpValue::AssignVar make_op ops.push
         done
@@ -1088,8 +1088,8 @@ fn synthesize_hashable_for_enum parser:Parser casa_enum:CasaEnum {
         location "int" OpValue::TypeCast make_op hash_ops.push
         List::new(List[Parameter]) = hash_params
         enum_name make_param hash_params.push
-        List::new(List[str]) = hash_returns
-        "int" hash_returns.push
+        List::new(List[Type]) = hash_returns
+        "int" parse_type_str hash_returns.push
         hash_returns hash_params make_signature = hash_sig
         hash_sig location hash_ops hash_name make_function_with_sig = hash_fn
         hash_name hash_fn parser.store.functions.set drop
@@ -1102,8 +1102,8 @@ fn synthesize_hashable_for_enum parser:Parser casa_enum:CasaEnum {
         List::new(List[Parameter]) = eq_params
         enum_name make_param eq_params.push
         enum_name make_param eq_params.push
-        List::new(List[str]) = eq_returns
-        "bool" eq_returns.push
+        List::new(List[Type]) = eq_returns
+        "bool" parse_type_str eq_returns.push
         eq_returns eq_params make_signature = eq_sig
         eq_sig location eq_ops eq_name make_function_with_sig = eq_fn
         eq_name eq_fn parser.store.functions.set drop
@@ -1152,8 +1152,8 @@ fn create_member_accessor
 
     List::new(List[Parameter]) = getter_params
     param_type make_param getter_params.push
-    List::new(List[str]) = getter_returns
-    member_type getter_returns.push
+    List::new(List[Type]) = getter_returns
+    member_type parse_type_str getter_returns.push
     getter_returns getter_params make_signature = getter_sig
     sig_type_vars getter_sig Signature::set_type_vars
     getter_sig location getter_ops getter_name make_function_with_sig = getter
@@ -1174,7 +1174,7 @@ fn create_member_accessor
     List::new(List[Parameter]) = setter_params
     param_type make_param setter_params.push
     member_type make_param setter_params.push
-    List::new(List[str]) = setter_returns
+    List::new(List[Type]) = setter_returns
     setter_returns setter_params make_signature = setter_sig
     sig_type_vars setter_sig Signature::set_type_vars
     setter_sig location setter_ops setter_name make_function_with_sig = setter
@@ -1257,7 +1257,7 @@ fn parse_trait_method_signature cursor:TokenCursor -> Signature {
         peek cursor parse_parameter_maybe_named params.push
     done
 
-    List::new(List[str]) = returns
+    List::new(List[Type]) = returns
     cursor.peek = arrow_opt
     if arrow_opt.is_some then
         if "->" arrow_opt.unwrap Token::value == then
@@ -1272,7 +1272,7 @@ fn parse_trait_method_signature cursor:TokenCursor -> Signature {
                 then
                     break
                 fi
-                cursor parse_type returns.push
+                cursor parse_type parse_type_str returns.push
             done
         fi
     fi
@@ -1427,7 +1427,7 @@ fn inject_impl_trait_params
     for hidden in hidden_methods.iter do
         hidden HiddenTraitMethod::var_name = hidden_name
         hidden HiddenTraitMethod::fn_type = hidden_type
-        hidden_name hidden_type make_named_param hidden_params.push
+        hidden_name hidden_type parse_type_str make_named_param hidden_params.push
         hidden_name make_variable function Function::variables.push
         function Function::location hidden_name OpValue::AssignVar make_op = assign_op
         insert_pos assign_op function Function::ops.insert

--- a/compiler/syntax.casa
+++ b/compiler/syntax.casa
@@ -990,7 +990,7 @@ fn parse_function parser:Parser cursor:TokenCursor -> Function {
     for param in sig Signature::parameters.iter do
         if "" param Parameter::name != then
             if param Parameter::name "__trait_" str::starts_with ! then
-                param Parameter::typ param Parameter::name Variable variables.push
+                param Parameter::typ.format param Parameter::name Variable variables.push
                 name_token Token::location param Parameter::name OpValue::AssignVar make_op ops.push
             fi
         fi

--- a/compiler/syntax.casa
+++ b/compiler/syntax.casa
@@ -976,7 +976,7 @@ fn parse_function parser:Parser cursor:TokenCursor -> Function {
             hidden HiddenTraitMethod::var_name = hidden_name
             hidden HiddenTraitMethod::fn_type = hidden_type
             hidden_name hidden_type make_named_param hidden_params.push
-            hidden_type hidden_name Variable variables.push
+            hidden_type parse_type_str hidden_name Variable variables.push
             name_token Token::location hidden_name OpValue::AssignVar make_op ops.push
         done
         # Prepend hidden params to signature parameters
@@ -990,7 +990,7 @@ fn parse_function parser:Parser cursor:TokenCursor -> Function {
     for param in sig Signature::parameters.iter do
         if "" param Parameter::name != then
             if param Parameter::name "__trait_" str::starts_with ! then
-                param Parameter::typ.format param Parameter::name Variable variables.push
+                param Parameter::typ param Parameter::name Variable variables.push
                 name_token Token::location param Parameter::name OpValue::AssignVar make_op ops.push
             fi
         fi
@@ -1219,7 +1219,7 @@ fn parse_struct parser:Parser cursor:TokenCursor -> CasaStruct {
         cursor parse_type = member_type
 
         type_vars member_token Token::location members.length member_type member_token Token::value name_token Token::value parser create_member_accessor
-        member_type member_token Token::value Member members.push
+        member_type parse_type_str member_token Token::value Member members.push
     done
 
     type_vars name_token Token::location members name_token Token::value CasaStruct

--- a/compiler/syntax.casa
+++ b/compiler/syntax.casa
@@ -1479,12 +1479,6 @@ fn parse_impl_block parser:Parser cursor:TokenCursor {
 # parse_match_block - parse a full match construct (match ... end)
 # ============================================================================
 
-fn token_line token:Token -> int {
-    token Token::location Location::file SOURCE_CACHE.get = source_opt
-    if source_opt.is_none then 0 return fi
-    token Token::location Location::span Span::offset source_opt.unwrap offset_to_line_col
-}
-
 fn is_match_arm_boundary parser:Parser cursor:TokenCursor -> bool {
     cursor TokenCursor::pos = pos
     cursor TokenCursor::tokens = token_list

--- a/compiler/syntax.casa
+++ b/compiler/syntax.casa
@@ -916,7 +916,7 @@ fn build_hidden_trait_methods
                 if 0 bound_method TraitMethod::default_ops.length == then
                     f"__trait_{bound_type_var}_{bound_method TraitMethod::name}" = hidden_name
                     bound_subs bound_type_var bound_method TraitMethod::signature resolve_trait_sig apply_type_subs_to_sig = hidden_sig
-                    f"fn[{hidden_sig signature_to_str}]" parse_type_str = hidden_type
+                    hidden_sig signature_to_function_type = hidden_type
                     hidden_type hidden_name HiddenTraitMethod result.push
                 fi
             done

--- a/compiler/typechecker.casa
+++ b/compiler/typechecker.casa
@@ -174,9 +174,13 @@ fn raise_type_mismatch tc:TypeChecker message:str {
 # Stack operations
 # ============================================================================
 
-fn stack_push tc:TypeChecker typ:str {
-    typ parse_type_str tc TypeChecker::live TypedStack::types.push
+fn stack_push_type tc:TypeChecker typ:Type {
+    typ tc TypeChecker::live TypedStack::types.push
     tc TypeChecker::current_location tc TypeChecker::live TypedStack::origins.push
+}
+
+fn stack_push tc:TypeChecker typ:str {
+    typ parse_type_str tc stack_push_type
 }
 
 fn report_stack_underflow tc:TypeChecker message:str {
@@ -217,6 +221,43 @@ fn stack_pop tc:TypeChecker -> str {
     tc TypeChecker::live TypedStack::types.pop.format
 }
 
+fn stack_peek_type tc:TypeChecker -> Type {
+    if 0 tc TypeChecker::live TypedStack::types.length == then
+        if tc within_param_cap then
+            TYPE_UNKNOWN_T return
+        fi
+        tc stack_underflow_message tc report_stack_underflow
+        TYPE_MISSING_T return
+    fi
+    tc TypeChecker::live TypedStack::types.length 1 - tc TypeChecker::live TypedStack::types.get
+}
+
+fn stack_pop_type tc:TypeChecker -> Type {
+    if 0 tc TypeChecker::live TypedStack::types.length == then
+        if tc within_param_cap then
+            TYPE_UNKNOWN make_param tc TypeChecker::parameters.push
+            TYPE_UNKNOWN_T return
+        fi
+        tc stack_underflow_message tc report_stack_underflow
+        TYPE_MISSING_T return
+    fi
+    tc TypeChecker::live TypedStack::origins.pop drop
+    tc TypeChecker::live TypedStack::types.pop
+}
+
+fn stack_pop_drop tc:TypeChecker {
+    if 0 tc TypeChecker::live TypedStack::types.length == then
+        if tc within_param_cap then
+            TYPE_UNKNOWN make_param tc TypeChecker::parameters.push
+            return
+        fi
+        tc stack_underflow_message tc report_stack_underflow
+        return
+    fi
+    tc TypeChecker::live TypedStack::origins.pop drop
+    tc TypeChecker::live TypedStack::types.pop drop
+}
+
 fn expect_type tc:TypeChecker expected:str -> str {
     if 0 tc TypeChecker::live TypedStack::types.length == then
         if tc within_param_cap then
@@ -242,6 +283,29 @@ fn expect_type tc:TypeChecker expected:str -> str {
     fi
     et_actual expected tc TypeChecker::current_location et_message ErrorKind::TypeMismatch add_error_expected
     expected
+}
+
+fn expect_type_t tc:TypeChecker expected:Type {
+    if 0 tc TypeChecker::live TypedStack::types.length == then
+        if tc within_param_cap then
+            expected.format make_param tc TypeChecker::parameters.push
+            return
+        fi
+        f"Stack underflow: expected `{expected.format}` but stack is empty" tc report_stack_underflow
+        return
+    fi
+    tc TypeChecker::live TypedStack::origins.pop drop
+    tc TypeChecker::live TypedStack::types.pop = et_actual_t
+    if expected et_actual_t.eq then return fi
+    et_actual_t.format = et_actual
+    expected.format = et_expected
+    if et_expected et_actual types_match then return fi
+    if et_actual et_expected types_match then return fi
+    "Type mismatch" = et_message
+    if "" tc TypeChecker::current_op_context != then
+        f"Type mismatch in {tc TypeChecker::current_op_context}" = et_message
+    fi
+    et_actual et_expected tc TypeChecker::current_location et_message ErrorKind::TypeMismatch add_error_expected
 }
 
 # ============================================================================
@@ -460,11 +524,15 @@ fn stacks_compatible stack_a:List[Type] stack_b:List[Type] -> List[Type] {
     List::new(List[Type]) = result
     0 = index
     while index stack_a.length > do
-        index stack_b.get.format index stack_a.get.format unify_type = unified
-        if "" unified == then
-            List::new(List[Type]) return
+        if index stack_b.get index stack_a.get.eq then
+            index stack_a.get result.push
+        else
+            index stack_b.get.format index stack_a.get.format unify_type = unified
+            if "" unified == then
+                List::new(List[Type]) return
+            fi
+            unified parse_type_str result.push
         fi
-        unified parse_type_str result.push
         1 += index
     done
     result
@@ -474,7 +542,7 @@ fn stacks_equal stack_a:List[Type] stack_b:List[Type] -> bool {
     if stack_a.length stack_b.length != then false return fi
     0 = index
     while index stack_a.length > do
-        if index stack_a.get.format index stack_b.get.format != then false return fi
+        if index stack_b.get index stack_a.get.eq ! then false return fi
         1 += index
     done
     true
@@ -684,12 +752,12 @@ fn apply_signature tc:TypeChecker sig:Signature name:str {
             if "" name != then
                 f"parameter {index 1 +} of `{name}`" tc TypeChecker::set_current_expect_ctx
             fi
-            index sig Signature::parameters.get Parameter::typ.format tc expect_type drop
+            index sig Signature::parameters.get Parameter::typ tc expect_type_t
             1 += index
         done
         "" tc TypeChecker::set_current_expect_ctx
         for return_type in sig Signature::return_types.iter do
-            return_type.format tc stack_push
+            return_type tc stack_push_type
         done
         return
     fi
@@ -746,13 +814,12 @@ fn check_arithmetic tc:TypeChecker op:Op {
     op_value OpValue::Add is
     op_value OpValue::Sub is ||
     then
-        "int" tc expect_type drop
-        tc stack_pop = top_type
-        top_type tc stack_push
+        TYPE_INT_T tc expect_type_t
+        tc stack_pop_type tc stack_push_type
     else
-        "int" tc expect_type drop
-        "int" tc expect_type drop
-        "int" tc stack_push
+        TYPE_INT_T tc expect_type_t
+        TYPE_INT_T tc expect_type_t
+        TYPE_INT_T tc stack_push_type
     fi
 }
 
@@ -811,7 +878,7 @@ fn check_comparison
     TYPE_MISSING type1 == ||
     TYPE_MISSING type2 == ||
     then
-        "bool" tc stack_push
+        TYPE_BOOL_T tc stack_push_type
         op_index return
     fi
     type1 resolve_match_type = base1
@@ -821,7 +888,7 @@ fn check_comparison
     # Same-type rule applies before any specialization.
     if type1 type2 != then
         f"Cannot compare `{type2}` with `{type1}`" tc raise_type_mismatch
-        "bool" tc stack_push
+        TYPE_BOOL_T tc stack_push_type
         op_index return
     fi
     # Enums: tag comparison via bytecode; data-carrying variants need annotation.
@@ -832,7 +899,7 @@ fn check_comparison
                 base1 op Op::set_type_annotation
             fi
         fi
-        "bool" tc stack_push
+        TYPE_BOOL_T tc stack_push_type
         op_index return
     fi
     # str: only ==/!=, annotated for the bytecode emitter.
@@ -841,19 +908,19 @@ fn check_comparison
             "Type `str` only supports `==` and `!=` comparison" tc raise_type_mismatch
         fi
         "str" op Op::set_type_annotation
-        "bool" tc stack_push
+        TYPE_BOOL_T tc stack_push_type
         op_index return
     fi
     # Other primitives: bytecode handles the comparison directly.
     if type1 is_primitive_compare_type then
-        "bool" tc stack_push
+        TYPE_BOOL_T tc stack_push_type
         op_index return
     fi
     # User-defined types must satisfy Eq (or Ord) explicitly.
     if function_opt trait_name type1 type_satisfies_trait ! then
         cmp_value comparison_op_str = cmp_str
         op Op::location f"Type `{type1}` cannot be compared with `{cmp_str}`: does not satisfy trait `{trait_name}`" ErrorKind::MissingTraitMethod add_error
-        "bool" tc stack_push
+        TYPE_BOOL_T tc stack_push_type
         op_index return
     fi
     # Lower the operator to the corresponding trait method call.
@@ -870,12 +937,12 @@ fn check_comparison
 
 fn check_boolean tc:TypeChecker op:Op {
     if op.value OpValue::Not is then
-        tc stack_pop drop
+        tc stack_pop_drop
     else
-        tc stack_pop drop
-        tc stack_pop drop
+        tc stack_pop_drop
+        tc stack_pop_drop
     fi
-    "bool" tc stack_push
+    TYPE_BOOL_T tc stack_push_type
 }
 
 # ============================================================================
@@ -885,19 +952,18 @@ fn check_boolean tc:TypeChecker op:Op {
 fn check_bitwise tc:TypeChecker op:Op {
     op.value = bitwise_value
     if bitwise_value OpValue::BitNot is then
-        "int" tc expect_type drop
-        "int" tc stack_push
+        TYPE_INT_T tc expect_type_t
+        TYPE_INT_T tc stack_push_type
     elif
     bitwise_value OpValue::Shl is
     bitwise_value OpValue::Shr is ||
     then
-        "int" tc expect_type drop
-        tc stack_pop = shift_top
-        shift_top tc stack_push
+        TYPE_INT_T tc expect_type_t
+        tc stack_pop_type tc stack_push_type
     else
-        "int" tc expect_type drop
-        "int" tc expect_type drop
-        "int" tc stack_push
+        TYPE_INT_T tc expect_type_t
+        TYPE_INT_T tc expect_type_t
+        TYPE_INT_T tc stack_push_type
     fi
 }
 
@@ -909,7 +975,7 @@ fn check_stack_ops tc:TypeChecker op:Op {
     op.value = stack_value
     if stack_value OpValue::Drop is then
         "value for `drop`" tc TypeChecker::set_current_expect_ctx
-        tc stack_pop drop
+        tc stack_pop_drop
     elif stack_value OpValue::Dup is then
         "value for `dup`" tc TypeChecker::set_current_expect_ctx
         tc stack_pop = typ
@@ -917,11 +983,11 @@ fn check_stack_ops tc:TypeChecker op:Op {
         typ tc stack_push
     elif stack_value OpValue::Swap is then
         "argument 1 of `swap`" tc TypeChecker::set_current_expect_ctx
-        tc stack_pop = type1
+        tc stack_pop_type = type1_t
         "argument 2 of `swap`" tc TypeChecker::set_current_expect_ctx
-        tc stack_pop = type2
-        type1 tc stack_push
-        type2 tc stack_push
+        tc stack_pop_type = type2_t
+        type1_t tc stack_push_type
+        type2_t tc stack_push_type
     elif stack_value OpValue::Over is then
         "argument 1 of `over`" tc TypeChecker::set_current_expect_ctx
         tc stack_pop = type1
@@ -932,14 +998,14 @@ fn check_stack_ops tc:TypeChecker op:Op {
         type2 tc stack_push
     elif stack_value OpValue::Rot is then
         "argument 1 of `rot`" tc TypeChecker::set_current_expect_ctx
-        tc stack_pop = type1
+        tc stack_pop_type = type1_t
         "argument 2 of `rot`" tc TypeChecker::set_current_expect_ctx
-        tc stack_pop = type2
+        tc stack_pop_type = type2_t
         "argument 3 of `rot`" tc TypeChecker::set_current_expect_ctx
-        tc stack_pop = type3
-        type2 tc stack_push
-        type1 tc stack_push
-        type3 tc stack_push
+        tc stack_pop_type = type3_t
+        type2_t tc stack_push_type
+        type1_t tc stack_push_type
+        type3_t tc stack_push_type
     fi
 }
 
@@ -984,20 +1050,20 @@ fn check_memory tc:TypeChecker op:Op function_opt:Option[Function] {
     mem_value OpValue::Load32 is ||
     mem_value OpValue::Load64 is ||
     then
-        "ptr" tc expect_type drop
-        "int" tc stack_push
+        TYPE_PTR_T tc expect_type_t
+        TYPE_INT_T tc stack_push_type
     elif
     mem_value OpValue::Store8 is
     mem_value OpValue::Store16 is ||
     mem_value OpValue::Store32 is ||
     mem_value OpValue::Store64 is ||
     then
-        "ptr" tc expect_type drop
+        TYPE_PTR_T tc expect_type_t
         tc stack_pop = stored_type
         function_opt stored_type op tc assert_word_bound
     elif mem_value OpValue::HeapAlloc is then
-        "int" tc expect_type drop
-        "ptr" tc stack_push
+        TYPE_INT_T tc expect_type_t
+        TYPE_PTR_T tc stack_push_type
     fi
 }
 
@@ -1009,9 +1075,10 @@ fn check_memory tc:TypeChecker op:Op function_opt:Option[Function] {
 
 fn unify_variable_assignment op:Op variable:Variable effective_type:str scope:str {
     variable Variable::name = var_name
+    variable Variable::typ.format = pre_str
     if
-    "" variable Variable::typ.format ==
-    TYPE_UNKNOWN variable Variable::typ.format == effective_type TYPE_UNKNOWN != && ||
+    "" pre_str ==
+    TYPE_UNKNOWN pre_str == effective_type TYPE_UNKNOWN != && ||
     then
         effective_type parse_type_str variable Variable::set_typ
     fi
@@ -1028,7 +1095,7 @@ fn check_assignment tc:TypeChecker op:Op function_opt:Option[Function] {
     op.value OpValue::AssignDec is
     op.value OpValue::AssignInc is ||
     then
-        "int" tc expect_type drop
+        TYPE_INT_T tc expect_type_t
         return
     fi
     if op.value OpValue::AssignVar(var_name) is ! then return fi
@@ -1087,7 +1154,7 @@ fn simulate_trait_exec tc:TypeChecker function:Function var_name:str {
     trait_def_opt.unwrap = trait_def
     for trait_method_entry in trait_def DEFAULT_PARSER collect_trait_methods.iter do
         if trait_method_name trait_method_entry TraitMethod::name == then
-            tc stack_pop drop
+            tc stack_pop_drop
             trait_type_var trait_method_entry TraitMethod::signature resolve_trait_sig = resolved_exec_sig
             f"{trait_type_var}::{trait_method_name}" resolved_exec_sig tc apply_signature
             return
@@ -1101,14 +1168,13 @@ fn check_push_var tc:TypeChecker op:Op function_opt:Option[Function] {
             function_opt.unwrap = function
             capture_name function Function::captures variable_list_index = capture_index
             if 0 capture_index >= then
-                capture_index function Function::captures.get Variable::typ.format = capture_type
-                if "" capture_type != then
-                    capture_type tc stack_push
+                if capture_index function Function::captures.get Variable::typ.is_unknown ! then
+                    capture_index function Function::captures.get Variable::typ tc stack_push_type
                     return
                 fi
             fi
         fi
-        TYPE_UNKNOWN tc stack_push
+        TYPE_UNKNOWN_T tc stack_push_type
         return
     fi
 
@@ -1121,11 +1187,10 @@ fn check_push_var tc:TypeChecker op:Op function_opt:Option[Function] {
         function_opt.unwrap = function
         var_name function Function::variables variable_list_index = local_index
         if 0 local_index >= then
-            local_index function Function::variables.get Variable::typ.format = local_type
-            if "" local_type != then
-                local_type tc stack_push
+            if local_index function Function::variables.get Variable::typ.is_unknown ! then
+                local_index function Function::variables.get Variable::typ tc stack_push_type
             else
-                TYPE_UNKNOWN tc stack_push
+                TYPE_UNKNOWN_T tc stack_push_type
             fi
             if is_trait_exec then
                 var_name function tc simulate_trait_exec
@@ -1137,11 +1202,10 @@ fn check_push_var tc:TypeChecker op:Op function_opt:Option[Function] {
     # Check global variables
     var_name tc.store.variables.get = global_opt
     if global_opt.is_some then
-        global_opt.unwrap Variable::typ.format = global_type
-        if "" global_type != then
-            global_type tc stack_push
+        if global_opt.unwrap Variable::typ.is_unknown ! then
+            global_opt.unwrap Variable::typ tc stack_push_type
         else
-            TYPE_UNKNOWN tc stack_push
+            TYPE_UNKNOWN_T tc stack_push_type
         fi
         return
     fi
@@ -1163,7 +1227,7 @@ fn check_if_block tc:TypeChecker op:Op {
         true tc TypeChecker::set_in_branch_condition
     elif if_value OpValue::IfCondition is then
         false tc TypeChecker::set_in_branch_condition
-        "bool" tc expect_type drop
+        TYPE_BOOL_T tc expect_type_t
         if 0 tc TypeChecker::branched_stacks.length == then return fi
         tc TypeChecker::branched_stacks.length 1 - tc TypeChecker::branched_stacks.get = top_frame
         if top_frame BranchFrame::BranchIf(if_ctx) is then
@@ -1246,7 +1310,7 @@ fn check_while_block tc:TypeChecker op:Op {
         while_ctx BranchFrame::BranchWhile = while_frame
         while_frame tc TypeChecker::branched_stacks.push
     elif while_value OpValue::WhileCondition is then
-        "bool" tc expect_type drop
+        TYPE_BOOL_T tc expect_type_t
         if 0 tc TypeChecker::branched_stacks.length == then return fi
         tc TypeChecker::branched_stacks.length 1 - tc TypeChecker::branched_stacks.get = top_frame
         if top_frame BranchFrame::BranchWhile(while_ctx) is then
@@ -1634,7 +1698,7 @@ fn inject_trait_fn_ptrs
                     1 += insert_pos
                     1 += inserted
                     concrete method TraitMethod::signature resolve_trait_sig = forward_sig
-                    f"fn[{forward_sig signature_to_str}]" tc stack_push
+                    forward_sig signature_to_function_type tc stack_push_type
                 fi
                 method_index 1 - = method_index
             done
@@ -1662,7 +1726,7 @@ fn inject_trait_fn_ptrs
                         insert_pos push_op ops.insert
                         1 += insert_pos
                         1 += inserted
-                        f"fn[{global_fn Function::signature signature_to_str}]" tc stack_push
+                        global_fn Function::signature signature_to_function_type tc stack_push_type
                     else
                         location f"Function `{fn_name}` required by trait `{trait_name}` not found" ErrorKind::TypeMismatch raise_error
                     fi
@@ -1714,7 +1778,7 @@ fn check_function_ops
         if push_fn_opt.is_some then
             push_fn_opt.unwrap = push_fn
             push_fn ensure_typechecked
-            f"fn[{push_fn Function::signature signature_to_str}]" tc stack_push
+            push_fn Function::signature signature_to_function_type tc stack_push_type
         else
             "fn" tc stack_push
         fi
@@ -1744,13 +1808,13 @@ fn check_function_ops
 fn check_literals tc:TypeChecker op:Op function_opt:Option[Function] {
     op.value = literal_value
     if literal_value OpValue::PushInt is then
-        "int" tc stack_push
+        TYPE_INT_T tc stack_push_type
     elif literal_value OpValue::PushStr is then
-        "str" tc stack_push
+        TYPE_STR_T tc stack_push_type
     elif literal_value OpValue::PushBool is then
-        "bool" tc stack_push
+        TYPE_BOOL_T tc stack_push_type
     elif literal_value OpValue::PushChar is then
-        "char" tc stack_push
+        TYPE_CHAR_T tc stack_push_type
     elif literal_value OpValue::PushArray(items) is then
         if 0 items.length == then
             List::new(List[str]) = empty_params
@@ -1777,10 +1841,10 @@ fn check_literals tc:TypeChecker op:Op function_opt:Option[Function] {
     elif literal_value OpValue::FstringConcat(count) is then
         0 = index
         while index count > do
-            "str" tc expect_type drop
+            TYPE_STR_T tc expect_type_t
             1 += index
         done
-        "str" tc stack_push
+        TYPE_STR_T tc stack_push_type
     fi
 }
 
@@ -1790,39 +1854,40 @@ fn check_literals tc:TypeChecker op:Op function_opt:Option[Function] {
 
 fn check_io tc:TypeChecker op:Op ops:List[Op] op_index:int function_opt:Option[Function] -> int {
     "value with trait `Display`" tc TypeChecker::set_current_expect_ctx
-    tc stack_peek = typ
+    tc stack_peek_type = peek_t
+    peek_t.format = typ
     if "str" typ == then
-        tc stack_pop drop
+        tc stack_pop_drop
         OpValue::PrintStr op Op::set_value
         op_index return
     fi
     if "bool" typ == then
-        tc stack_pop drop
+        tc stack_pop_drop
         OpValue::PrintBool op Op::set_value
         op_index return
     fi
     if "char" typ == then
-        tc stack_pop drop
+        tc stack_pop_drop
         OpValue::PrintChar op Op::set_value
         op_index return
     fi
     if "cstr" typ == then
-        tc stack_pop drop
+        tc stack_pop_drop
         OpValue::PrintCstr op Op::set_value
         op_index return
     fi
     if "int" typ == then
-        tc stack_pop drop
+        tc stack_pop_drop
         OpValue::PrintInt op Op::set_value
         op_index return
     fi
     if TYPE_MISSING typ == then
-        tc stack_pop drop
+        tc stack_pop_drop
         op_index return
     fi
     if function_opt "Display" typ type_satisfies_trait ! then
         op Op::location f"Type `{typ}` cannot be printed: does not satisfy trait `Display`" ErrorKind::MissingTraitMethod add_error
-        tc stack_pop drop
+        tc stack_pop_drop
         op_index return
     fi
     "to_str" OpValue::MethodCall op Op::set_value
@@ -1839,7 +1904,7 @@ fn check_io tc:TypeChecker op:Op ops:List[Op] op_index:int function_opt:Option[F
 fn check_typeof tc:TypeChecker op:Op {
     tc stack_pop = typ
     typ op Op::set_type_annotation
-    "str" tc stack_push
+    TYPE_STR_T tc stack_push_type
 }
 
 # ============================================================================
@@ -1857,14 +1922,14 @@ fn check_syscalls tc:TypeChecker op:Op function_opt:Option[Function] {
         OpValue::Syscall6 => 6
         _ => -1
     end = arg_count
-    "int" tc expect_type drop
+    TYPE_INT_T tc expect_type_t
     0 = index
     while index arg_count > do
         tc stack_pop = arg_type
         function_opt arg_type op tc assert_word_bound
         1 += index
     done
-    "int" tc stack_push
+    TYPE_INT_T tc stack_push_type
 }
 
 # ============================================================================
@@ -1876,7 +1941,7 @@ fn check_enum_variant tc:TypeChecker op:Op {
     variant EnumVariant::enum_name = enum_name
     enum_name tc.store.enums.get = enum_opt
     if enum_opt.is_none then
-        enum_name tc stack_push
+        enum_name make_named_type tc stack_push_type
         return
     fi
     enum_opt.unwrap = casa_enum
@@ -1886,7 +1951,7 @@ fn check_enum_variant tc:TypeChecker op:Op {
         if 0 casa_enum CasaEnum::type_vars.length != then
             casa_enum CasaEnum::type_vars enum_name build_parameterized_type tc stack_push
         else
-            enum_name tc stack_push
+            enum_name make_named_type tc stack_push_type
         fi
         return
     fi
@@ -1895,7 +1960,7 @@ fn check_enum_variant tc:TypeChecker op:Op {
         if 0 casa_enum CasaEnum::type_vars.length != then
             casa_enum CasaEnum::type_vars enum_name build_parameterized_type tc stack_push
         else
-            enum_name tc stack_push
+            enum_name make_named_type tc stack_push_type
         fi
         return
     fi
@@ -1924,7 +1989,7 @@ fn check_enum_variant tc:TypeChecker op:Op {
         for inner_type in inner_types.iter do
             inner_type tc expect_type drop
         done
-        enum_name tc stack_push
+        enum_name make_named_type tc stack_push_type
     fi
 }
 
@@ -1937,12 +2002,12 @@ fn check_is tc:TypeChecker op:Op function_opt:Option[Function] {
     typ resolve_match_type = base
     if base tc.store.enums.get.is_none then
         f"`is` requires an enum type, got `{typ}`" tc raise_type_mismatch
-        "bool" tc stack_push
+        TYPE_BOOL_T tc stack_push_type
         return
     fi
     base tc.store.enums.get.unwrap = casa_enum
     if op.value OpValue::IsCheck(variant) is ! then
-        "bool" tc stack_push
+        TYPE_BOOL_T tc stack_push_type
         return
     fi
     # Validate the variant belongs to the correct enum
@@ -1962,7 +2027,7 @@ fn check_is tc:TypeChecker op:Op function_opt:Option[Function] {
         fi
     fi
     typ variant function_opt tc register_enum_pattern_bindings
-    "bool" tc stack_push
+    TYPE_BOOL_T tc stack_push_type
 }
 
 # ============================================================================
@@ -2156,7 +2221,7 @@ fn check_struct_new tc:TypeChecker op:Op {
     done
     # Construct the result type
     if 0 casa_struct CasaStruct::type_vars.length == then
-        name tc stack_push
+        name make_named_type tc stack_push_type
     else
         bindings casa_struct CasaStruct::type_vars name build_resolved_type tc stack_push
     fi
@@ -2171,7 +2236,7 @@ fn check_struct_literal tc:TypeChecker op:Op {
     literal StructLiteral::struct_name = name
     name tc.store.structs.get = struct_opt
     if struct_opt.is_none then
-        name tc stack_push
+        name make_named_type tc stack_push_type
         return
     fi
     struct_opt.unwrap = casa_struct
@@ -2182,13 +2247,13 @@ fn check_struct_literal tc:TypeChecker op:Op {
         # Find member type
         for member in casa_struct CasaStruct::members.iter do
             if field_name member Member::name == then
-                member Member::typ.format tc expect_type drop
+                member Member::typ tc expect_type_t
                 break
             fi
         done
         index 1 - = index
     done
-    name tc stack_push
+    name make_named_type tc stack_push_type
 }
 
 # ============================================================================
@@ -2417,7 +2482,7 @@ fn check_method_call
                 for trait_method in trait_def DEFAULT_PARSER collect_trait_methods.iter do
                     if method_name trait_method TraitMethod::name == then
                         f"__trait_{receiver}_{method_name}" = hidden_var
-                        tc stack_pop drop
+                        tc stack_pop_drop
                         constraint_subs receiver trait_method TraitMethod::signature resolve_trait_sig apply_type_subs_to_sig = resolved_sig
                         receiver tc stack_push
                         f"{receiver}::{method_name}" resolved_sig tc apply_signature
@@ -2485,19 +2550,19 @@ fn check_fstring_to_str
     function_opt:Option[Function]
 -> int {
     "value with trait `Display`" tc TypeChecker::set_current_expect_ctx
-    tc stack_peek = fstring_type
-    if "str" fstring_type == then
+    if TYPE_STR_T tc stack_peek_type.eq then
         op_index return
     fi
+    tc stack_peek = fstring_type
     if TYPE_MISSING fstring_type == then
-        tc stack_pop drop
-        "str" tc stack_push
+        tc stack_pop_drop
+        TYPE_STR_T tc stack_push_type
         op_index return
     fi
     if function_opt "Display" fstring_type type_satisfies_trait ! then
         op Op::location f"Type `{fstring_type}` cannot be used in f-string: does not satisfy trait `Display`" ErrorKind::MissingTraitMethod add_error
-        tc stack_pop drop
-        "str" tc stack_push
+        tc stack_pop_drop
+        TYPE_STR_T tc stack_push_type
         op_index return
     fi
     "to_str" OpValue::MethodCall op Op::set_value
@@ -2703,11 +2768,11 @@ fn run_type_check_ops checker:TypeChecker ops:List[Op] function_opt:Option[Funct
 
         # Argc / Argv
         if op_value OpValue::Argc is then
-            "int" checker stack_push
+            TYPE_INT_T checker stack_push_type
             continue
         fi
         if op_value OpValue::Argv is then
-            "ptr" checker stack_push
+            TYPE_PTR_T checker stack_push_type
             continue
         fi
 

--- a/compiler/typechecker.casa
+++ b/compiler/typechecker.casa
@@ -2807,9 +2807,9 @@ fn type_check_ops ops:List[Op] function_opt:Option[Function] -> Signature {
     function_opt ops checker run_type_check_ops
 
     # Build inferred signature
-    List::new(List[str]) = inferred_returns
+    List::new(List[Type]) = inferred_returns
     for inferred_type in checker TypeChecker::live TypedStack::types.iter do
-        inferred_type.format inferred_returns.push
+        inferred_type inferred_returns.push
     done
     inferred_returns checker TypeChecker::parameters make_signature = inferred
 

--- a/compiler/typechecker.casa
+++ b/compiler/typechecker.casa
@@ -1015,16 +1015,16 @@ fn check_memory tc:TypeChecker op:Op function_opt:Option[Function] {
 fn unify_variable_assignment op:Op variable:Variable effective_type:str scope:str {
     variable Variable::name = var_name
     if
-    "" variable Variable::typ ==
-    TYPE_UNKNOWN variable Variable::typ == effective_type TYPE_UNKNOWN != && ||
+    "" variable Variable::typ.format ==
+    TYPE_UNKNOWN variable Variable::typ.format == effective_type TYPE_UNKNOWN != && ||
     then
-        effective_type variable Variable::set_typ
+        effective_type parse_type_str variable Variable::set_typ
     fi
-    variable Variable::typ effective_type unify_type = unified
+    variable Variable::typ.format effective_type unify_type = unified
     if "" unified == then
-        op Op::location f"Cannot override {scope} variable `{var_name}` of type `{variable Variable::typ}` with other type `{effective_type}`" ErrorKind::InvalidVariable add_error
+        op Op::location f"Cannot override {scope} variable `{var_name}` of type `{variable Variable::typ.format}` with other type `{effective_type}`" ErrorKind::InvalidVariable add_error
     else
-        unified variable Variable::set_typ
+        unified parse_type_str variable Variable::set_typ
     fi
 }
 
@@ -1106,7 +1106,7 @@ fn check_push_var tc:TypeChecker op:Op function_opt:Option[Function] {
             function_opt.unwrap = function
             capture_name function Function::captures variable_list_index = capture_index
             if 0 capture_index >= then
-                capture_index function Function::captures.get Variable::typ = capture_type
+                capture_index function Function::captures.get Variable::typ.format = capture_type
                 if "" capture_type != then
                     capture_type tc stack_push
                     return
@@ -1126,7 +1126,7 @@ fn check_push_var tc:TypeChecker op:Op function_opt:Option[Function] {
         function_opt.unwrap = function
         var_name function Function::variables variable_list_index = local_index
         if 0 local_index >= then
-            local_index function Function::variables.get Variable::typ = local_type
+            local_index function Function::variables.get Variable::typ.format = local_type
             if "" local_type != then
                 local_type tc stack_push
             else
@@ -1142,7 +1142,7 @@ fn check_push_var tc:TypeChecker op:Op function_opt:Option[Function] {
     # Check global variables
     var_name tc.store.variables.get = global_opt
     if global_opt.is_some then
-        global_opt.unwrap Variable::typ = global_type
+        global_opt.unwrap Variable::typ.format = global_type
         if "" global_type != then
             global_type tc stack_push
         else
@@ -1991,14 +1991,14 @@ fn set_binding_type var_name:str field_type:str function_opt:Option[Function] {
         function_opt.unwrap = function
         for variable in function Function::variables.iter do
             if var_name variable Variable::name == then
-                field_type variable Variable::set_typ
+                field_type parse_type_str variable Variable::set_typ
                 return
             fi
         done
     fi
     var_name DEFAULT_PARSER.store.variables.get = global_opt
     if global_opt.is_some then
-        field_type global_opt.unwrap Variable::set_typ
+        field_type parse_type_str global_opt.unwrap Variable::set_typ
     fi
 }
 
@@ -2151,7 +2151,7 @@ fn check_struct_new tc:TypeChecker op:Op {
     Map::new(Map[str str]) = bindings
     for member in casa_struct CasaStruct::members.iter do
         tc stack_pop = actual
-        member Member::typ = expected
+        member Member::typ.format = expected
         # If expected is a type variable, bind it to the actual type
         for type_var in casa_struct CasaStruct::type_vars.iter do
             if expected type_var == then
@@ -2187,7 +2187,7 @@ fn check_struct_literal tc:TypeChecker op:Op {
         # Find member type
         for member in casa_struct CasaStruct::members.iter do
             if field_name member Member::name == then
-                member Member::typ tc expect_type drop
+                member Member::typ.format tc expect_type drop
                 break
             fi
         done
@@ -2357,7 +2357,7 @@ fn instantiate_default_trait_method
     List::new(List[Variable]) = synth_vars
     for synth_param in resolved_sig Signature::parameters.iter do
         if "" synth_param Parameter::name != then
-            synth_param Parameter::typ.format synth_param Parameter::name Variable synth_vars.push
+            synth_param Parameter::typ synth_param Parameter::name Variable synth_vars.push
             empty_location synth_param Parameter::name OpValue::AssignVar make_op synth_ops.push
         fi
     done

--- a/compiler/typechecker.casa
+++ b/compiler/typechecker.casa
@@ -575,9 +575,9 @@ fn bind_generic_param
     sig:Signature
 -> bool {
     # Bind type vars from a parameterized param like Map[K V].
-    expected Parameter::typ extract_generic_base = base_opt
+    expected Parameter::typ.format extract_generic_base = base_opt
     if base_opt.is_none then false return fi
-    expected Parameter::typ extract_generic_params = expected_params_opt
+    expected Parameter::typ.format extract_generic_params = expected_params_opt
     if expected_params_opt.is_none then false return fi
     expected_params_opt.unwrap = expected_params
     # Check if any param is a type variable
@@ -626,7 +626,7 @@ fn bind_generic_param
 
 fn bind_fn_param tc:TypeChecker bindings:Map[str str] expected:Parameter sig:Signature -> bool {
     # Bind type vars from a fn[sig] param like fn[T -> T].
-    expected Parameter::typ extract_fn_signature_str = fn_sig_opt
+    expected Parameter::typ.format extract_fn_signature_str = fn_sig_opt
     if fn_sig_opt.is_none then false return fi
     fn_sig_opt.unwrap = fn_sig_str
     # Check if any type var appears in the fn signature
@@ -661,9 +661,9 @@ fn bind_fn_param tc:TypeChecker bindings:Map[str str] expected:Parameter sig:Sig
     param_index expected_sig Signature::parameters.length >
     param_index actual_sig Signature::parameters.length > &&
     do
-        param_index expected_sig Signature::parameters.get Parameter::typ = expected_param
+        param_index expected_sig Signature::parameters.get Parameter::typ.format = expected_param
         if expected_param sig Signature::type_vars.has then
-            param_index actual_sig Signature::parameters.get Parameter::typ expected_param bindings tc bind_type_var = bindings
+            param_index actual_sig Signature::parameters.get Parameter::typ.format expected_param bindings tc bind_type_var = bindings
         fi
         1 += param_index
     done
@@ -689,7 +689,7 @@ fn apply_signature tc:TypeChecker sig:Signature name:str {
             if "" name != then
                 f"parameter {index 1 +} of `{name}`" tc TypeChecker::set_current_expect_ctx
             fi
-            index sig Signature::parameters.get Parameter::typ tc expect_type drop
+            index sig Signature::parameters.get Parameter::typ.format tc expect_type drop
             1 += index
         done
         "" tc TypeChecker::set_current_expect_ctx
@@ -704,7 +704,7 @@ fn apply_signature tc:TypeChecker sig:Signature name:str {
     0 = index
     while index sig Signature::parameters.length > do
         index sig Signature::parameters.get = param
-        param Parameter::typ = expected
+        param Parameter::typ.format = expected
 
         if "" name != then
             f"parameter {index 1 +} of `{name}`" tc TypeChecker::set_current_expect_ctx
@@ -1367,8 +1367,8 @@ fn type_satisfies_trait type_name:str trait_name:str function_opt:Option[Functio
         fi
         0 = param_index
         while param_index resolved Signature::parameters.length > do
-            param_index function Function::signature Signature::parameters.get Parameter::typ = actual_param
-            param_index resolved Signature::parameters.get Parameter::typ = expected_param
+            param_index function Function::signature Signature::parameters.get Parameter::typ.format = actual_param
+            param_index resolved Signature::parameters.get Parameter::typ.format = expected_param
             if
             actual_param expected_param !=
             TYPE_UNKNOWN actual_param != &&
@@ -1476,8 +1476,8 @@ fn diff_method_sig
     param_index trait_resolved Signature::parameters.length >
     param_index impl_sig Signature::parameters.length > &&
     do
-        param_index trait_resolved Signature::parameters.get Parameter::typ = expected_param
-        param_index impl_sig Signature::parameters.get Parameter::typ = actual_param
+        param_index trait_resolved Signature::parameters.get Parameter::typ.format = expected_param
+        param_index impl_sig Signature::parameters.get Parameter::typ.format = actual_param
         actual_param expected_param bargs tparams sig bindings bind_from_type_slot = bindings
         1 += param_index
     done
@@ -1559,8 +1559,8 @@ fn inject_trait_fn_ptrs
         if 0 stack_index >= then
             index non_hidden.get = stack_param
             stack_index tc TypeChecker::live TypedStack::types.get = actual
-            if stack_param Parameter::typ sig Signature::type_vars.has then
-                stack_param Parameter::typ = binding_type_var
+            if stack_param Parameter::typ.format sig Signature::type_vars.has then
+                stack_param Parameter::typ.format = binding_type_var
                 binding_type_var bindings.get = existing_binding_opt
                 if existing_binding_opt.is_none then
                     binding_type_var actual bindings.set = bindings
@@ -1568,7 +1568,7 @@ fn inject_trait_fn_ptrs
                     location f"Type variable `{binding_type_var}` bound to `{existing_binding_opt.unwrap}` but got `{actual}`" ErrorKind::TypeMismatch raise_error
                 fi
             else
-                sig Signature::type_vars actual stack_param Parameter::typ bindings bind_generic_params_standalone = bindings
+                sig Signature::type_vars actual stack_param Parameter::typ.format bindings bind_generic_params_standalone = bindings
             fi
         fi
         1 += index
@@ -2357,7 +2357,7 @@ fn instantiate_default_trait_method
     List::new(List[Variable]) = synth_vars
     for synth_param in resolved_sig Signature::parameters.iter do
         if "" synth_param Parameter::name != then
-            synth_param Parameter::typ synth_param Parameter::name Variable synth_vars.push
+            synth_param Parameter::typ.format synth_param Parameter::name Variable synth_vars.push
             empty_location synth_param Parameter::name OpValue::AssignVar make_op synth_ops.push
         fi
     done

--- a/compiler/typechecker.casa
+++ b/compiler/typechecker.casa
@@ -13,20 +13,20 @@ import "pattern"
 # ============================================================================
 
 struct TypedStack {
-    types:   List[str]
+    types:   List[Type]
     origins: List[Location]
 }
 
 impl TypedStack {
     fn new -> TypedStack {
         List::new(List[Location])
-        List::new(List[str])
+        List::new(List[Type])
         TypedStack
     }
 
     # Deep-copy a TypedStack into a new, independent value.
     fn snapshot self:TypedStack -> TypedStack {
-        List::new(List[str]) = new_types
+        List::new(List[Type]) = new_types
         List::new(List[Location]) = new_origins
         0 = snapshot_index
         while snapshot_index self TypedStack::types.length > do
@@ -39,7 +39,7 @@ impl TypedStack {
 
     # Mutate `self` in place so it deep-equals `source`. `source` is unchanged.
     fn restore self:TypedStack source:TypedStack {
-        List::new(List[str]) = new_types
+        List::new(List[Type]) = new_types
         List::new(List[Location]) = new_origins
         0 = restore_index
         while restore_index source TypedStack::types.length > do
@@ -57,7 +57,7 @@ impl TypedStack {
     }
 
     # Produce the unified types list between two TypedStacks, or empty on incompatibility.
-    fn unify_types self:TypedStack candidate:TypedStack -> List[str] {
+    fn unify_types self:TypedStack candidate:TypedStack -> List[Type] {
         self TypedStack::types candidate TypedStack::types stacks_compatible
     }
 }
@@ -175,12 +175,12 @@ fn raise_type_mismatch tc:TypeChecker message:str {
 # ============================================================================
 
 fn stack_push tc:TypeChecker typ:str {
-    typ tc TypeChecker::live TypedStack::types.push
+    typ parse_type_str tc TypeChecker::live TypedStack::types.push
     tc TypeChecker::current_location tc TypeChecker::live TypedStack::origins.push
 }
 
 fn stack_push_origin tc:TypeChecker typ:str origin:Location {
-    typ tc TypeChecker::live TypedStack::types.push
+    typ parse_type_str tc TypeChecker::live TypedStack::types.push
     origin tc TypeChecker::live TypedStack::origins.push
 }
 
@@ -206,7 +206,7 @@ fn stack_peek tc:TypeChecker -> str {
         tc stack_underflow_message tc report_stack_underflow
         TYPE_MISSING return
     fi
-    tc TypeChecker::live TypedStack::types.length 1 - tc TypeChecker::live TypedStack::types.get
+    tc TypeChecker::live TypedStack::types.length 1 - tc TypeChecker::live TypedStack::types.get.format
 }
 
 fn stack_pop tc:TypeChecker -> str {
@@ -219,7 +219,7 @@ fn stack_pop tc:TypeChecker -> str {
         TYPE_MISSING return
     fi
     tc TypeChecker::live TypedStack::origins.pop drop
-    tc TypeChecker::live TypedStack::types.pop
+    tc TypeChecker::live TypedStack::types.pop.format
 }
 
 fn expect_type tc:TypeChecker expected:str -> str {
@@ -232,7 +232,7 @@ fn expect_type tc:TypeChecker expected:str -> str {
         TYPE_MISSING return
     fi
     tc TypeChecker::live TypedStack::origins.pop = et_origin
-    tc TypeChecker::live TypedStack::types.pop = et_actual
+    tc TypeChecker::live TypedStack::types.pop.format = et_actual
     # Check if types are compatible
     if expected et_actual types_match then
         et_actual return
@@ -458,28 +458,28 @@ fn unify_type type_a:str type_b:str -> str {
 # Stack compatibility — unify element-wise, returns empty list on mismatch
 # ============================================================================
 
-fn stacks_compatible stack_a:List[str] stack_b:List[str] -> List[str] {
+fn stacks_compatible stack_a:List[Type] stack_b:List[Type] -> List[Type] {
     if stack_a.length stack_b.length != then
-        List::new(List[str]) return
+        List::new(List[Type]) return
     fi
-    List::new(List[str]) = result
+    List::new(List[Type]) = result
     0 = index
     while index stack_a.length > do
-        index stack_b.get index stack_a.get unify_type = unified
+        index stack_b.get.format index stack_a.get.format unify_type = unified
         if "" unified == then
-            List::new(List[str]) return
+            List::new(List[Type]) return
         fi
-        unified result.push
+        unified parse_type_str result.push
         1 += index
     done
     result
 }
 
-fn stacks_equal stack_a:List[str] stack_b:List[str] -> bool {
+fn stacks_equal stack_a:List[Type] stack_b:List[Type] -> bool {
     if stack_a.length stack_b.length != then false return fi
     0 = index
     while index stack_a.length > do
-        if index stack_a.get index stack_b.get != then false return fi
+        if index stack_a.get.format index stack_b.get.format != then false return fi
         1 += index
     done
     true
@@ -1558,7 +1558,7 @@ fn inject_trait_fn_ptrs
         depth 1 - index - = stack_index
         if 0 stack_index >= then
             index non_hidden.get = stack_param
-            stack_index tc TypeChecker::live TypedStack::types.get = actual
+            stack_index tc TypeChecker::live TypedStack::types.get.format = actual
             if stack_param Parameter::typ.format sig Signature::type_vars.has then
                 stack_param Parameter::typ.format = binding_type_var
                 binding_type_var bindings.get = existing_binding_opt
@@ -2807,7 +2807,11 @@ fn type_check_ops ops:List[Op] function_opt:Option[Function] -> Signature {
     function_opt ops checker run_type_check_ops
 
     # Build inferred signature
-    checker TypeChecker::live TypedStack::types checker TypeChecker::parameters make_signature = inferred
+    List::new(List[str]) = inferred_returns
+    for inferred_type in checker TypeChecker::live TypedStack::types.iter do
+        inferred_type.format inferred_returns.push
+    done
+    inferred_returns checker TypeChecker::parameters make_signature = inferred
 
     # Verify against declared signature if function has one
     ERRORS.length errors_before_ops < = had_type_errors

--- a/compiler/typechecker.casa
+++ b/compiler/typechecker.casa
@@ -415,6 +415,33 @@ fn is_type_variable typ:str -> bool {
     false
 }
 
+fn is_enum_type_var_t typ:Type -> bool {
+    typ.base = base_opt
+    if base_opt.is_some then
+        base_opt.unwrap DEFAULT_PARSER.store.enums.get.is_some
+    else
+        false
+    fi
+}
+
+fn is_type_variable_t typ:Type -> bool {
+    typ match
+        Type::TypeVar(_) => { true }
+        Type::Generic(generic) => {
+            if 0 generic.params.length == then
+                if 1 generic.base.length == then
+                    0 generic.base.at.is_upper
+                else
+                    false
+                fi
+            else
+                generic.base DEFAULT_PARSER.store.enums.get.is_some
+            fi
+        }
+        _ => { false }
+    end
+}
+
 fn types_match_params expected:str actual:str -> bool {
     expected extract_generic_params = expected_params_opt
     actual extract_generic_params = actual_params_opt
@@ -552,59 +579,67 @@ fn stacks_equal stack_a:List[Type] stack_b:List[Type] -> bool {
 # Apply signature — pop params, push returns, with type variable binding
 # ============================================================================
 
-fn resolve_return_type bindings:Map[str str] ret:str -> str {
-    # Direct type variable
-    ret bindings.get = bound_opt
-    if bound_opt.is_some then
-        bound_opt.unwrap return
-    fi
-    # Parameterized type with type vars
-    ret extract_generic_base = base_opt
-    if base_opt.is_some then
-        base_opt.unwrap = base
-        ret extract_generic_params = params_opt
-        if params_opt.is_some then
-            params_opt.unwrap = params
-            List::new(List[str]) = resolved
-            false = changed
-            for param in params.iter do
-                param bindings.get = param_bound_opt
-                if param_bound_opt.is_some then
-                    param_bound_opt.unwrap resolved.push
-                    true = changed
-                else
-                    param resolved.push
-                fi
-            done
-            if changed then
-                resolved base build_parameterized_type return
+fn resolve_return_type_t bindings:Map[str Type] ret:Type -> Type {
+    ret match
+        Type::TypeVar(name) => {
+            if name bindings.get Option::Some(bound) is then
+                bound
+            else
+                name Type::TypeVar
             fi
-        fi
-    fi
-    ret
+        }
+        Type::Generic(generic) => {
+            if 0 generic.params.length == then
+                if generic.base bindings.get Option::Some(bound) is then
+                    bound return
+                fi
+                generic.params generic.base GenericType Type::Generic return
+            fi
+            List::new(List[Type]) = new_params
+            for param in generic.params.iter do
+                param bindings resolve_return_type_t new_params.push
+            done
+            new_params generic.base GenericType Type::Generic
+        }
+        Type::Function(fn_type) => {
+            List::new(List[Type]) = new_params
+            for param in fn_type.parameters.iter do
+                param bindings resolve_return_type_t new_params.push
+            done
+            List::new(List[Type]) = new_returns
+            for ret_inner in fn_type.return_types.iter do
+                ret_inner bindings resolve_return_type_t new_returns.push
+            done
+            new_returns new_params FunctionType Type::Function
+        }
+        Type::Unknown => { Type::Unknown }
+        Type::Builtin(builtin) => { builtin Type::Builtin }
+    end
 }
 
-fn bind_type_var tc:TypeChecker bindings:Map[str str] type_var:str actual:str -> Map[str str] {
+fn bind_type_var tc:TypeChecker bindings:Map[str Type] type_var:str actual:Type -> Map[str Type] {
     type_var bindings.get = existing
     if existing.is_none then
         type_var actual bindings.set return
     fi
     existing.unwrap = bound
+    actual.is_unknown_placeholder = actual_unknown
+    bound.is_unknown_placeholder = bound_unknown
+    bound is_type_variable_t = bound_is_var
     if
-    TYPE_UNKNOWN bound ==
-    bound is_enum_type_var ||
-    bound is_type_variable ||
-    TYPE_UNKNOWN actual != &&
+    bound_unknown
+    bound_is_var ||
+    actual_unknown ! &&
     then
         type_var actual bindings.set return
     fi
     if
-    actual bound !=
-    TYPE_UNKNOWN actual != &&
-    TYPE_UNKNOWN bound != &&
-    actual is_enum_type_var ! &&
+    bound actual.eq !
+    actual_unknown ! &&
+    bound_unknown ! &&
+    actual is_enum_type_var_t ! &&
     then
-        f"Type variable `{type_var}` bound to `{bound}` but got `{actual}`" tc raise_type_mismatch
+        f"Type variable `{type_var}` bound to `{bound.format}` but got `{actual.format}`" tc raise_type_mismatch
     fi
     bindings
 }
@@ -633,65 +668,84 @@ fn type_has_unresolved typ:str -> bool {
 
 fn bind_generic_param
     tc:TypeChecker
-    bindings:Map[str str]
+    bindings:Map[str Type]
     expected:Parameter
     sig:Signature
 -> bool {
     # Bind type vars from a parameterized param like Map[K V].
-    expected Parameter::typ.format extract_generic_base = base_opt
+    expected Parameter::typ.base = base_opt
     if base_opt.is_none then false return fi
-    expected Parameter::typ.format extract_generic_params = expected_params_opt
+    expected Parameter::typ.type_params = expected_params_opt
     if expected_params_opt.is_none then false return fi
     expected_params_opt.unwrap = expected_params
     # Check if any param is a type variable
     false = has_type_var
     for expected_param in expected_params.iter do
-        if expected_param sig Signature::type_vars.has then
-            true = has_type_var
+        if expected_param.type_var_name Option::Some(probe_name) is then
+            if probe_name sig Signature::type_vars.has then
+                true = has_type_var
+            fi
         fi
     done
     if has_type_var ! then false return fi
 
-    tc stack_pop = actual
-    actual extract_generic_base = actual_base
     base_opt.unwrap = base
-    if actual_base.is_some then
-        if base actual_base.unwrap == then
-            actual extract_generic_params = actual_params_opt
-            if actual_params_opt.is_some then
-                actual_params_opt.unwrap = actual_params
-                if actual_params.length expected_params.length == then
-                    0 = bind_index
-                    while bind_index expected_params.length > do
-                        bind_index expected_params.get = expected_param
-                        if expected_param sig Signature::type_vars.has then
-                            bind_index actual_params.get expected_param bindings tc bind_type_var = bindings
-                        fi
-                        1 += bind_index
-                    done
-                    true return
+    tc stack_pop_type match
+        Type::Generic(actual_g) => {
+            if 0 actual_g.params.length == then
+                expected_params bindings sig tc bind_unknowns = bindings
+                true return
+            fi
+            if base actual_g.base != then
+                "Type mismatch" tc raise_type_mismatch
+                true return
+            fi
+            if actual_g.params.length expected_params.length != then
+                "Type mismatch" tc raise_type_mismatch
+                true return
+            fi
+            0 = bind_index
+            while bind_index expected_params.length > do
+                if bind_index expected_params.get.type_var_name Option::Some(bind_name) is then
+                    if bind_name sig Signature::type_vars.has then
+                        bind_index actual_g.params.get bind_name bindings tc bind_type_var = bindings
+                    fi
                 fi
-            fi
+                1 += bind_index
+            done
+            true return
+        }
+        Type::Unknown => {
+            expected_params bindings sig tc bind_unknowns = bindings
+            true return
+        }
+        _ => {
             "Type mismatch" tc raise_type_mismatch
-        fi
-    fi
-    if base actual == TYPE_UNKNOWN actual == || then
-        for expected_param in expected_params.iter do
-            if expected_param sig Signature::type_vars.has then
-                TYPE_UNKNOWN expected_param bindings tc bind_type_var = bindings
-            fi
-        done
-        true return
-    fi
-    "Type mismatch" tc raise_type_mismatch
+        }
+    end
     true
 }
 
-fn bind_fn_param tc:TypeChecker bindings:Map[str str] expected:Parameter sig:Signature -> bool {
+fn bind_unknowns
+    tc:TypeChecker
+    sig:Signature
+    bindings:Map[str Type]
+    expected_params:List[Type]
+-> Map[str Type] {
+    for expected_param in expected_params.iter do
+        if expected_param.type_var_name Option::Some(unk_name) is then
+            if unk_name sig Signature::type_vars.has then
+                TYPE_UNKNOWN_T unk_name bindings tc bind_type_var = bindings
+            fi
+        fi
+    done
+    bindings
+}
+
+fn bind_fn_param tc:TypeChecker bindings:Map[str Type] expected:Parameter sig:Signature -> bool {
     # Bind type vars from a fn[sig] param like fn[T -> T].
-    expected Parameter::typ.format extract_fn_signature_str = fn_sig_opt
-    if fn_sig_opt.is_none then false return fi
-    fn_sig_opt.unwrap = fn_sig_str
+    if expected Parameter::typ.is_fn_type_t ! then false return fi
+    expected Parameter::typ.format = fn_sig_str
     # Check if any type var appears in the fn signature
     false = has_type_var
     sig Signature::type_vars.to_list = type_var_list
@@ -702,45 +756,55 @@ fn bind_fn_param tc:TypeChecker bindings:Map[str str] expected:Parameter sig:Sig
     done
     if has_type_var ! then false return fi
 
-    tc stack_pop = actual
-    if TYPE_UNKNOWN actual == then
+    tc stack_pop_type = actual
+    if actual.is_unknown_placeholder then
         for type_var2 in type_var_list.iter do
             if fn_sig_str type_var2 str::find 0 <= then
-                TYPE_UNKNOWN type_var2 bindings tc bind_type_var = bindings
+                TYPE_UNKNOWN_T type_var2 bindings tc bind_type_var = bindings
             fi
         done
         true return
     fi
-    if actual is_fn_type ! then
+    if actual.is_fn_type_t ! then
         "Type mismatch" tc raise_type_mismatch
         true return
     fi
-    actual extract_fn_signature_str = actual_sig_opt
-    if actual_sig_opt.is_none then true return fi
-    fn_sig_str signature_from_str = expected_sig
-    actual_sig_opt.unwrap signature_from_str = actual_sig
-    0 = param_index
-    while
-    param_index expected_sig Signature::parameters.length >
-    param_index actual_sig Signature::parameters.length > &&
-    do
-        param_index expected_sig Signature::parameters.get Parameter::typ.format = expected_param
-        if expected_param sig Signature::type_vars.has then
-            param_index actual_sig Signature::parameters.get Parameter::typ.format expected_param bindings tc bind_type_var = bindings
-        fi
-        1 += param_index
-    done
-    0 = return_index
-    while
-    return_index expected_sig Signature::return_types.length >
-    return_index actual_sig Signature::return_types.length > &&
-    do
-        return_index expected_sig Signature::return_types.get.format = expected_return
-        if expected_return sig Signature::type_vars.has then
-            return_index actual_sig Signature::return_types.get.format expected_return bindings tc bind_type_var = bindings
-        fi
-        1 += return_index
-    done
+    expected Parameter::typ match
+        Type::Function(expected_fn) => {
+            actual match
+                Type::Function(actual_fn) => {
+                    expected_fn.parameters = expected_fn_params
+                    actual_fn.parameters = actual_fn_params
+                    0 = param_index
+                    while
+                    param_index expected_fn_params.length >
+                    param_index actual_fn_params.length > &&
+                    do
+                        param_index expected_fn_params.get.format = expected_param_name
+                        if expected_param_name sig Signature::type_vars.has then
+                            param_index actual_fn_params.get expected_param_name bindings tc bind_type_var = bindings
+                        fi
+                        1 += param_index
+                    done
+                    expected_fn.return_types = expected_fn_returns
+                    actual_fn.return_types = actual_fn_returns
+                    0 = return_index
+                    while
+                    return_index expected_fn_returns.length >
+                    return_index actual_fn_returns.length > &&
+                    do
+                        return_index expected_fn_returns.get.format = expected_return_name
+                        if expected_return_name sig Signature::type_vars.has then
+                            return_index actual_fn_returns.get expected_return_name bindings tc bind_type_var = bindings
+                        fi
+                        1 += return_index
+                    done
+                }
+                _ => { }
+            end
+        }
+        _ => { }
+    end
     true
 }
 
@@ -763,22 +827,23 @@ fn apply_signature tc:TypeChecker sig:Signature name:str {
     fi
 
     # Generic case: bind type variables
-    Map::new(Map[str str]) = bindings
+    Map::new(Map[str Type]) = bindings
     0 = index
     while index sig Signature::parameters.length > do
         index sig Signature::parameters.get = param
-        param Parameter::typ.format = expected
 
         if "" name != then
             f"parameter {index 1 +} of `{name}`" tc TypeChecker::set_current_expect_ctx
         fi
 
         # Direct type variable (e.g. T)
-        if expected sig Signature::type_vars.has then
-            tc stack_pop = actual_type_var
-            actual_type_var expected bindings tc bind_type_var = bindings
-            1 += index
-            continue
+        if param Parameter::typ.type_var_name Option::Some(direct_tv) is then
+            if direct_tv sig Signature::type_vars.has then
+                tc stack_pop_type = actual_type_var_t
+                actual_type_var_t direct_tv bindings tc bind_type_var = bindings
+                1 += index
+                continue
+            fi
         fi
 
         # Parameterized type with type vars (e.g. Option[T], Map[K V])
@@ -793,14 +858,14 @@ fn apply_signature tc:TypeChecker sig:Signature name:str {
             continue
         fi
 
-        expected tc expect_type drop
+        param Parameter::typ tc expect_type_t
         1 += index
     done
     "" tc TypeChecker::set_current_expect_ctx
 
     # Push resolved return types
     for return_type in sig Signature::return_types.iter do
-        return_type.format bindings resolve_return_type tc stack_push
+        return_type bindings resolve_return_type_t tc stack_push_type
     done
 }
 
@@ -1969,21 +2034,21 @@ fn check_enum_variant tc:TypeChecker op:Op {
     if 0 casa_enum CasaEnum::type_vars.length != then
         # Generic enum variant (e.g. Option::Some with T)
         # Bind type vars from inner values
-        Map::new(Map[str str]) = bindings
+        Map::new(Map[str Type]) = bindings
         Set::new(Set[str]) = type_vars
         for type_var in casa_enum CasaEnum::type_vars.iter do
             type_var type_vars.add = type_vars
         done
         for expected in inner_types.iter do
             if expected type_vars.has then
-                tc stack_pop = actual
-                actual expected bindings tc bind_type_var = bindings
+                tc stack_pop_type = actual_t
+                actual_t expected bindings tc bind_type_var = bindings
             else
                 expected tc expect_type drop
             fi
         done
         # Build resolved type name
-        bindings casa_enum CasaEnum::type_vars enum_name build_resolved_type tc stack_push
+        bindings casa_enum CasaEnum::type_vars enum_name build_resolved_type_t tc stack_push_type
     else
         # Non-generic variant: pop inner values directly
         for inner_type in inner_types.iter do

--- a/compiler/typechecker.casa
+++ b/compiler/typechecker.casa
@@ -179,11 +179,6 @@ fn stack_push tc:TypeChecker typ:str {
     tc TypeChecker::current_location tc TypeChecker::live TypedStack::origins.push
 }
 
-fn stack_push_origin tc:TypeChecker typ:str origin:Location {
-    typ parse_type_str tc TypeChecker::live TypedStack::types.push
-    origin tc TypeChecker::live TypedStack::origins.push
-}
-
 fn report_stack_underflow tc:TypeChecker message:str {
     if tc TypeChecker::underflow_reported_this_op then return fi
     tc TypeChecker::current_location message ErrorKind::StackUnderflow add_error

--- a/compiler/typechecker.casa
+++ b/compiler/typechecker.casa
@@ -672,9 +672,9 @@ fn bind_fn_param tc:TypeChecker bindings:Map[str str] expected:Parameter sig:Sig
     return_index expected_sig Signature::return_types.length >
     return_index actual_sig Signature::return_types.length > &&
     do
-        return_index expected_sig Signature::return_types.get = expected_return
+        return_index expected_sig Signature::return_types.get.format = expected_return
         if expected_return sig Signature::type_vars.has then
-            return_index actual_sig Signature::return_types.get expected_return bindings tc bind_type_var = bindings
+            return_index actual_sig Signature::return_types.get.format expected_return bindings tc bind_type_var = bindings
         fi
         1 += return_index
     done
@@ -694,7 +694,7 @@ fn apply_signature tc:TypeChecker sig:Signature name:str {
         done
         "" tc TypeChecker::set_current_expect_ctx
         for return_type in sig Signature::return_types.iter do
-            return_type tc stack_push
+            return_type.format tc stack_push
         done
         return
     fi
@@ -737,7 +737,7 @@ fn apply_signature tc:TypeChecker sig:Signature name:str {
 
     # Push resolved return types
     for return_type in sig Signature::return_types.iter do
-        return_type bindings resolve_return_type tc stack_push
+        return_type.format bindings resolve_return_type tc stack_push
     done
 }
 
@@ -1380,8 +1380,8 @@ fn type_satisfies_trait type_name:str trait_name:str function_opt:Option[Functio
         done
         0 = return_index
         while return_index resolved Signature::return_types.length > do
-            return_index function Function::signature Signature::return_types.get = actual_return
-            return_index resolved Signature::return_types.get = expected_return
+            return_index function Function::signature Signature::return_types.get.format = actual_return
+            return_index resolved Signature::return_types.get.format = expected_return
             if
             actual_return expected_return !=
             TYPE_UNKNOWN actual_return != &&
@@ -1486,8 +1486,8 @@ fn diff_method_sig
     return_index trait_resolved Signature::return_types.length >
     return_index impl_sig Signature::return_types.length > &&
     do
-        return_index trait_resolved Signature::return_types.get = expected_return
-        return_index impl_sig Signature::return_types.get = actual_return
+        return_index trait_resolved Signature::return_types.get.format = expected_return
+        return_index impl_sig Signature::return_types.get.format = actual_return
         actual_return expected_return bargs tparams sig bindings bind_from_type_slot = bindings
         1 += return_index
     done
@@ -1586,7 +1586,7 @@ fn inject_trait_fn_ptrs
         op_index ops.get = next_op
         if next_op.value OpValue::TypeCast(cast_type) is then
             for return_type in sig Signature::return_types.iter do
-                sig Signature::type_vars cast_type return_type bindings bind_generic_params_standalone = bindings
+                sig Signature::type_vars cast_type return_type.format bindings bind_generic_params_standalone = bindings
             done
         fi
     fi
@@ -2329,7 +2329,7 @@ fn instantiate_default_trait_method
                     receiver infer_method TraitMethod::signature resolve_trait_sig = infer_trait_resolved
                     0 = ret_index
                     while ret_index infer_trait_resolved Signature::return_types.length > ret_index infer_fn Function::signature Signature::return_types.length > && do
-                        type_param_set ret_index infer_fn Function::signature Signature::return_types.get ret_index infer_trait_resolved Signature::return_types.get trait_subs bind_generic_params_standalone = trait_subs
+                        type_param_set ret_index infer_fn Function::signature Signature::return_types.get.format ret_index infer_trait_resolved Signature::return_types.get.format trait_subs bind_generic_params_standalone = trait_subs
                         1 += ret_index
                     done
                 fi

--- a/lsp.casa
+++ b/lsp.casa
@@ -854,16 +854,16 @@ fn resolve_variable_type name:str func:Option[Function] state:DocumentState -> O
         func.unwrap = resolved_func
         for variable in resolved_func Function::variables.iter do
             if variable Variable::name name == then
-                if "" variable Variable::typ != then
-                    variable Variable::typ Option::Some
+                if "" variable Variable::typ.format != then
+                    variable Variable::typ.format Option::Some
                     return
                 fi
             fi
         done
         for capture in resolved_func Function::captures.iter do
             if capture Variable::name name == then
-                if "" capture Variable::typ != then
-                    capture Variable::typ Option::Some
+                if "" capture Variable::typ.format != then
+                    capture Variable::typ.format Option::Some
                     return
                 fi
             fi
@@ -871,7 +871,7 @@ fn resolve_variable_type name:str func:Option[Function] state:DocumentState -> O
     fi
     name state DocumentState::variables.get = global_var_opt
     if global_var_opt.is_some then
-        global_var_opt.unwrap Variable::typ = global_type
+        global_var_opt.unwrap Variable::typ.format = global_type
         if "" global_type != then
             global_type Option::Some
             return
@@ -948,7 +948,7 @@ fn format_hover op:Op state:DocumentState func:Option[Function] -> Option[str] {
             member_index struct_val CasaStruct::members.get = member
             member Member::name struct_builder.append
             ": " struct_builder.append
-            member Member::typ struct_builder.append
+            member Member::typ.format struct_builder.append
             1 += member_index
         done
         " }" struct_builder.append
@@ -1021,7 +1021,7 @@ fn format_struct_hover hover_struct:CasaStruct -> str {
         member_index hover_struct CasaStruct::members.get = member
         member Member::name struct_builder.append
         ": " struct_builder.append
-        member Member::typ struct_builder.append
+        member Member::typ.format struct_builder.append
         1 += member_index
     done
     " }" struct_builder.append
@@ -1379,7 +1379,7 @@ fn compute_completion state:DocumentState line:int col:int trigger:str -> List[C
             member_index struct_val CasaStruct::members.get = member
             member Member::name member_builder.append
             ": " member_builder.append
-            member Member::typ member_builder.append
+            member Member::typ.format member_builder.append
             1 += member_index
         done
         member_builder.build COMPLETION_STRUCT struct_name CompletionItem items.push
@@ -1396,14 +1396,14 @@ fn compute_completion state:DocumentState line:int col:int trigger:str -> List[C
     if containing_func_opt.is_some then
         containing_func_opt.unwrap = containing_func
         for local_var in containing_func Function::variables.iter do
-            local_var Variable::typ COMPLETION_VARIABLE local_var Variable::name CompletionItem items.push
+            local_var Variable::typ.format COMPLETION_VARIABLE local_var Variable::name CompletionItem items.push
         done
     fi
 
     # Global variables
     state DocumentState::variables.keys = global_var_keys
     for global_var_name in global_var_keys.iter do
-        global_var_name state DocumentState::variables.get.unwrap Variable::typ COMPLETION_VARIABLE global_var_name CompletionItem items.push
+        global_var_name state DocumentState::variables.get.unwrap Variable::typ.format COMPLETION_VARIABLE global_var_name CompletionItem items.push
     done
 
     # Keywords

--- a/lsp.casa
+++ b/lsp.casa
@@ -902,7 +902,7 @@ fn format_hover op:Op state:DocumentState func:Option[Function] -> Option[str] {
                         param Parameter::name builder.append
                         ":" builder.append
                     fi
-                    param Parameter::typ builder.append
+                    param Parameter::typ.format builder.append
                     1 += param_index
                 done
             fi

--- a/lsp.casa
+++ b/lsp.casa
@@ -911,7 +911,7 @@ fn format_hover op:Op state:DocumentState func:Option[Function] -> Option[str] {
                 0 = return_index
                 while return_index hover_func Function::signature Signature::return_types.length > do
                     if 0 return_index != then " " builder.append fi
-                    return_index hover_func Function::signature Signature::return_types.get builder.append
+                    return_index hover_func Function::signature Signature::return_types.get.format builder.append
                     1 += return_index
                 done
             else
@@ -1307,7 +1307,7 @@ fn resolve_chain_type parts:List[str] state:DocumentState offset:int -> Option[s
             Option::None(Option[str])
             return
         fi
-        0 func Function::signature Signature::return_types.get = resolved_type
+        0 func Function::signature Signature::return_types.get.format = resolved_type
         1 += part_index
     done
     resolved_type Option::Some

--- a/tests/compiler/test_argv.casa
+++ b/tests/compiler/test_argv.casa
@@ -83,14 +83,14 @@ fn test_typecheck_argc_pushes_int {
     "typecheck_argc_pushes_int" test_start
     "argc" tc_string_argv = sig
     "return count" 1 sig Signature::return_types.length assert_eq
-    "return type" "int" 0 sig Signature::return_types.get assert_str_eq
+    "return type" "int" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_typecheck_argv_pushes_ptr {
     "typecheck_argv_pushes_ptr" test_start
     "argv" tc_string_argv = sig
     "return count" 1 sig Signature::return_types.length assert_eq
-    "return type" "ptr" 0 sig Signature::return_types.get assert_str_eq
+    "return type" "ptr" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_typecheck_argc_no_inputs {
@@ -108,13 +108,13 @@ fn test_typecheck_argv_no_inputs {
 fn test_typecheck_argc_in_arithmetic {
     "typecheck_argc_in_arithmetic" test_start
     "argc 1 +" tc_string_argv = sig
-    "result type" "int" 0 sig Signature::return_types.get assert_str_eq
+    "result type" "int" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_typecheck_argv_with_load {
     "typecheck_argv_with_load" test_start
     "argv load64" tc_string_argv = sig
-    "result type" "int" 0 sig Signature::return_types.get assert_str_eq
+    "result type" "int" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 # ============================================================================

--- a/tests/compiler/test_array_methods.casa
+++ b/tests/compiler/test_array_methods.casa
@@ -103,7 +103,7 @@ fn test_fn_push_type {
 fn test_fn_call_compiles {
     "fn_call_compiles" test_start
     "fn double x:int -> int { x 2 * }\n42 double" tc_am = sig
-    "returns int" "int" 0 sig Signature::return_types.get assert_str_eq
+    "returns int" "int" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 # ============================================================================

--- a/tests/compiler/test_common.casa
+++ b/tests/compiler/test_common.casa
@@ -98,8 +98,8 @@ fn test_signature_from_str {
     "signature_from_str" test_start
     "int str -> bool" signature_from_str = sig
     "two params" 2 sig Signature::parameters.length assert_eq
-    "first param" "int" 0 sig Signature::parameters.get Parameter::typ assert_str_eq
-    "second param" "str" 1 sig Signature::parameters.get Parameter::typ assert_str_eq
+    "first param" "int" 0 sig Signature::parameters.get Parameter::typ.format assert_str_eq
+    "second param" "str" 1 sig Signature::parameters.get Parameter::typ.format assert_str_eq
     "one return" 1 sig Signature::return_types.length assert_eq
     "return type" "bool" 0 sig Signature::return_types.get assert_str_eq
 }

--- a/tests/compiler/test_common.casa
+++ b/tests/compiler/test_common.casa
@@ -101,7 +101,7 @@ fn test_signature_from_str {
     "first param" "int" 0 sig Signature::parameters.get Parameter::typ.format assert_str_eq
     "second param" "str" 1 sig Signature::parameters.get Parameter::typ.format assert_str_eq
     "one return" 1 sig Signature::return_types.length assert_eq
-    "return type" "bool" 0 sig Signature::return_types.get assert_str_eq
+    "return type" "bool" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_signature_matches {

--- a/tests/compiler/test_common.casa
+++ b/tests/compiler/test_common.casa
@@ -87,8 +87,8 @@ fn test_signature_to_str {
     List::new(List[Parameter]) = params
     "int" make_param params.push
     "str" make_param params.push
-    List::new(List[str]) = rets
-    "bool" rets.push
+    List::new(List[Type]) = rets
+    "bool" parse_type_str rets.push
     rets params make_signature = sig
     "sig to str" "int str -> bool" sig signature_to_str assert_str_eq
     "empty sig to str" "None -> None" empty_signature signature_to_str assert_str_eq

--- a/tests/compiler/test_display.casa
+++ b/tests/compiler/test_display.casa
@@ -191,7 +191,7 @@ fn test_trait_exec_pushes_return_type {
     "trait_exec_pushes_return_type" test_start
     DISPLAY_TRAIT "struct Tag { val: int }\nimpl Tag { fn to_str self:Tag -> str { \"tag\" } }\nfn show[T: Display] x:T -> str { x T::to_str }\n1 Tag = t\nt show drop\n" str::concat display_test_typecheck drop
     "show" DEFAULT_PARSER.store.functions.get.unwrap = func
-    "signature has str return type" "str" 0 func Function::signature Signature::return_types.get assert_str_eq
+    "signature has str return type" "str" 0 func Function::signature Signature::return_types.get.format assert_str_eq
     "no errors" assert_no_errors
 }
 

--- a/tests/compiler/test_enum.casa
+++ b/tests/compiler/test_enum.casa
@@ -354,31 +354,31 @@ fn test_resolve_undefined_variant_raises {
 fn test_enum_variant_pushes_enum_type {
     "enum_variant_pushes_enum_type" test_start
     "enum Color { Red Green Blue }\nColor::Red" tc_enum = sig
-    "return type" "Color" 0 sig Signature::return_types.get assert_str_eq
+    "return type" "Color" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_enum_eq_same_type {
     "enum_eq_same_type" test_start
     "enum Color { Red Green Blue }\nColor::Red Color::Green ==" tc_enum = sig
-    "returns bool" "bool" 0 sig Signature::return_types.get assert_str_eq
+    "returns bool" "bool" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_enum_ne_same_type {
     "enum_ne_same_type" test_start
     "enum Color { Red Green Blue }\nColor::Red Color::Blue !=" tc_enum = sig
-    "returns bool" "bool" 0 sig Signature::return_types.get assert_str_eq
+    "returns bool" "bool" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_enum_assign_variable {
     "enum_assign_variable" test_start
     "enum Color { Red Green Blue }\nColor::Red = c c" tc_enum = sig
-    "returns Color" "Color" 0 sig Signature::return_types.get assert_str_eq
+    "returns Color" "Color" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_enum_as_return_type {
     "enum_as_return_type" test_start
     "enum Color { Red Green Blue }\nfn get_color -> Color { Color::Blue }\nget_color\n" tc_enum = sig
-    "returns Color" "Color" 0 sig Signature::return_types.get assert_str_eq
+    "returns Color" "Color" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_enum_print {
@@ -400,19 +400,19 @@ fn test_match_exhaustive_passes {
 fn test_match_as_expression {
     "match_as_expression" test_start
     "enum Color { Red Green Blue }\nColor::Red match\n    Color::Red => 10\n    Color::Green => 20\n    Color::Blue => 30\nend\n" tc_enum = sig
-    "returns int" "int" 0 sig Signature::return_types.get assert_str_eq
+    "returns int" "int" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_match_as_expression_str {
     "match_as_expression_str" test_start
     "enum Color { Red Green Blue }\nColor::Red match\n    Color::Red => \"red\"\n    Color::Green => \"green\"\n    Color::Blue => \"blue\"\nend\n" tc_enum = sig
-    "returns str" "str" 0 sig Signature::return_types.get assert_str_eq
+    "returns str" "str" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_wildcard_only_match {
     "wildcard_only_match" test_start
     "enum Color { Red Green Blue }\nColor::Red match\n    _ => 42\nend\n" tc_enum = sig
-    "returns int" "int" 0 sig Signature::return_types.get assert_str_eq
+    "returns int" "int" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -422,49 +422,49 @@ fn test_wildcard_only_match {
 fn test_data_variant_pops_inner_and_pushes_enum {
     "data_variant_pops_inner_and_pushes_enum" test_start
     "enum Shape { Circle(int) Rectangle(int int) Point }\n10 Shape::Circle" tc_enum = sig
-    "returns Shape" "Shape" 0 sig Signature::return_types.get assert_str_eq
+    "returns Shape" "Shape" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_data_variant_two_inner_values {
     "data_variant_two_inner_values" test_start
     "enum Shape { Circle(int) Rectangle(int int) Point }\n3 4 Shape::Rectangle" tc_enum = sig
-    "returns Shape" "Shape" 0 sig Signature::return_types.get assert_str_eq
+    "returns Shape" "Shape" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_no_data_variant_in_data_enum {
     "no_data_variant_in_data_enum" test_start
     "enum Shape { Circle(int) Rectangle(int int) Point }\nShape::Point" tc_enum = sig
-    "returns Shape" "Shape" 0 sig Signature::return_types.get assert_str_eq
+    "returns Shape" "Shape" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_generic_some_pushes_option_int {
     "generic_some_pushes_option_int" test_start
     "enum Option[T] { None Some(T) }\n42 Option::Some" tc_enum = sig
-    "returns Option[int]" "Option[int]" 0 sig Signature::return_types.get assert_str_eq
+    "returns Option[int]" "Option[int]" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_generic_some_pushes_option_str {
     "generic_some_pushes_option_str" test_start
     "enum Option[T] { None Some(T) }\n\"hello\" Option::Some" tc_enum = sig
-    "returns Option[str]" "Option[str]" 0 sig Signature::return_types.get assert_str_eq
+    "returns Option[str]" "Option[str]" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_generic_none_pushes_option_t {
     "generic_none_pushes_option_t" test_start
     "enum Option[T] { None Some(T) }\nOption::None" tc_enum = sig
-    "returns Option[T]" "Option[T]" 0 sig Signature::return_types.get assert_str_eq
+    "returns Option[T]" "Option[T]" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_data_enum_comparison {
     "data_enum_comparison" test_start
     "enum Shape { Circle(int) Rectangle(int int) Point }\nShape::Point Shape::Point ==" tc_enum = sig
-    "returns bool" "bool" 0 sig Signature::return_types.get assert_str_eq
+    "returns bool" "bool" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_match_destructuring_binding_types {
     "match_destructuring_binding_types" test_start
     "enum Option[T] { None Some(T) }\n42 Option::Some match\n    Option::Some(value) => value\n    Option::None => 0\nend\n" tc_enum = sig
-    "returns int" "int" 0 sig Signature::return_types.get assert_str_eq
+    "returns int" "int" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -474,13 +474,13 @@ fn test_match_destructuring_binding_types {
 fn test_match_inside_function {
     "match_inside_function" test_start
     "enum Color { Red Green Blue }\nfn color_name c:Color -> str {\n    c match\n        Color::Red => \"red\"\n        Color::Green => \"green\"\n        Color::Blue => \"blue\"\n    end\n}\nColor::Blue color_name\n" tc_enum = sig
-    "returns str" "str" 0 sig Signature::return_types.get assert_str_eq
+    "returns str" "str" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_match_result_used_in_function {
     "match_result_used_in_function" test_start
     "enum Color { Red Green Blue }\nfn color_value c:Color -> int {\n    c match\n        Color::Red => 0\n        Color::Green => 1\n        Color::Blue => 2\n    end\n}\nColor::Green color_value\n" tc_enum = sig
-    "returns int" "int" 0 sig Signature::return_types.get assert_str_eq
+    "returns int" "int" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -568,19 +568,19 @@ fn test_parse_empty_braced_arm {
 fn test_bool_match_exhaustive {
     "bool_match_exhaustive" test_start
     "true match\n    true => 1\n    false => 0\nend\n" tc_enum = sig
-    "returns int" "int" 0 sig Signature::return_types.get assert_str_eq
+    "returns int" "int" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_int_match_with_wildcard {
     "int_match_with_wildcard" test_start
     "42 match\n    1 => \"one\"\n    2 => \"two\"\n    _ => \"other\"\nend\n" tc_enum = sig
-    "returns str" "str" 0 sig Signature::return_types.get assert_str_eq
+    "returns str" "str" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_str_match_with_wildcard {
     "str_match_with_wildcard" test_start
     "\"hello\" match\n    \"hello\" => 1\n    \"world\" => 2\n    _ => 0\nend\n" tc_enum = sig
-    "returns int" "int" 0 sig Signature::return_types.get assert_str_eq
+    "returns int" "int" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -694,7 +694,7 @@ fn test_is_type_mismatch_raises {
 fn test_is_plain_enum {
     "is_plain_enum" test_start
     "enum Color { Red Green Blue }\nColor::Red Color::Red is" tc_enum = sig
-    "returns bool" "bool" 0 sig Signature::return_types.get assert_str_eq
+    "returns bool" "bool" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -778,7 +778,7 @@ fn test_wrong_enum_type_in_function_raises {
 fn test_enum_in_function_param {
     "enum_in_function_param" test_start
     "enum Color { Red Green Blue }\nfn is_red c:Color -> bool { c Color::Red == }\nColor::Red is_red\n" tc_enum = sig
-    "returns bool" "bool" 0 sig Signature::return_types.get assert_str_eq
+    "returns bool" "bool" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -788,13 +788,13 @@ fn test_enum_in_function_param {
 fn test_result_ok_pushes_result {
     "result_ok_pushes_result" test_start
     "enum Result[T E] { Error(E) Ok(T) }\n42 Result::Ok" tc_enum = sig
-    "returns Result[int E]" "Result[int E]" 0 sig Signature::return_types.get assert_str_eq
+    "returns Result[int E]" "Result[int E]" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_result_error_pushes_result {
     "result_error_pushes_result" test_start
     "enum Result[T E] { Error(E) Ok(T) }\n\"oops\" Result::Error" tc_enum = sig
-    "returns Result[T str]" "Result[T str]" 0 sig Signature::return_types.get assert_str_eq
+    "returns Result[T str]" "Result[T str]" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_data_enum_wrong_inner_type_raises {
@@ -812,7 +812,7 @@ fn test_data_enum_wrong_inner_type_raises {
 fn test_generic_enum_in_function_return {
     "generic_enum_in_function_return" test_start
     "enum Option[T] { None Some(T) }\nfn wrap x:int -> Option[int] { x Option::Some }\n42 wrap\n" tc_enum = sig
-    "returns Option[int]" "Option[int]" 0 sig Signature::return_types.get assert_str_eq
+    "returns Option[int]" "Option[int]" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -822,7 +822,7 @@ fn test_generic_enum_in_function_return {
 fn test_char_match_with_wildcard {
     "char_match_with_wildcard" test_start
     "'a' match\n    'a' => 1\n    _ => 0\nend\n" tc_enum = sig
-    "returns int" "int" 0 sig Signature::return_types.get assert_str_eq
+    "returns int" "int" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_char_without_wildcard_raises {
@@ -839,7 +839,7 @@ fn test_char_without_wildcard_raises {
 fn test_bool_with_wildcard_passes {
     "bool_with_wildcard_passes" test_start
     "true match\n    true => 1\n    _ => 0\nend\n" tc_enum = sig
-    "returns int" "int" 0 sig Signature::return_types.get assert_str_eq
+    "returns int" "int" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_str_without_wildcard_raises {
@@ -908,7 +908,7 @@ fn test_is_bindings_on_plain_variant_raises {
 fn test_is_generic_enum {
     "is_generic_enum" test_start
     "enum Option[T] { None Some(T) }\n42 Option::Some = m\nm Option::Some is\n" tc_enum = sig
-    "returns bool" "bool" 0 sig Signature::return_types.get assert_str_eq
+    "returns bool" "bool" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_is_generic_with_bindings {
@@ -1018,7 +1018,7 @@ fn test_payload_free_enum_hash_signature {
     "param count" 1 sig Signature::parameters.length assert_eq
     "param type" "Color" 0 sig Signature::parameters.get Parameter::typ.format assert_str_eq
     "return count" 1 sig Signature::return_types.length assert_eq
-    "return type" "int" 0 sig Signature::return_types.get assert_str_eq
+    "return type" "int" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_payload_free_enum_eq_signature {
@@ -1029,7 +1029,7 @@ fn test_payload_free_enum_eq_signature {
     "param count" 2 sig Signature::parameters.length assert_eq
     "param0 type" "Color" 0 sig Signature::parameters.get Parameter::typ.format assert_str_eq
     "param1 type" "Color" 1 sig Signature::parameters.get Parameter::typ.format assert_str_eq
-    "return type" "bool" 0 sig Signature::return_types.get assert_str_eq
+    "return type" "bool" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_payload_bearing_enum_skips_hash_synth {

--- a/tests/compiler/test_enum.casa
+++ b/tests/compiler/test_enum.casa
@@ -922,7 +922,7 @@ fn test_is_binding_propagates_inner_type {
     "enum Foo { Bar(int) Baz(str) }\n42 Foo::Bar = x\nif x Foo::Bar(n) is then\nn drop\nfi\n" tc_enum drop
     "n" DEFAULT_PARSER.store.variables.get = n_opt
     if n_opt Option::Some(n_var) is then
-        "n typed as int" "int" n_var.typ assert_str_eq
+        "n typed as int" "int" n_var.typ.format assert_str_eq
     else
         "n exists" false assert_true
     fi
@@ -933,7 +933,7 @@ fn test_is_binding_propagates_generic_type {
     "enum Option[T] { None Some(T) }\n42 Option::Some = m\nif m Option::Some(v) is then\nv drop\nfi\n" tc_enum drop
     "v" DEFAULT_PARSER.store.variables.get = v_opt
     if v_opt Option::Some(v_var) is then
-        "v typed as int" "int" v_var.typ assert_str_eq
+        "v typed as int" "int" v_var.typ.format assert_str_eq
     else
         "v exists" false assert_true
     fi

--- a/tests/compiler/test_enum.casa
+++ b/tests/compiler/test_enum.casa
@@ -1016,7 +1016,7 @@ fn test_payload_free_enum_hash_signature {
     "Color::hash" DEFAULT_PARSER.store.functions.get.unwrap = hash_fn
     hash_fn Function::signature = sig
     "param count" 1 sig Signature::parameters.length assert_eq
-    "param type" "Color" 0 sig Signature::parameters.get Parameter::typ assert_str_eq
+    "param type" "Color" 0 sig Signature::parameters.get Parameter::typ.format assert_str_eq
     "return count" 1 sig Signature::return_types.length assert_eq
     "return type" "int" 0 sig Signature::return_types.get assert_str_eq
 }
@@ -1027,8 +1027,8 @@ fn test_payload_free_enum_eq_signature {
     "Color::eq" DEFAULT_PARSER.store.functions.get.unwrap = eq_fn
     eq_fn Function::signature = sig
     "param count" 2 sig Signature::parameters.length assert_eq
-    "param0 type" "Color" 0 sig Signature::parameters.get Parameter::typ assert_str_eq
-    "param1 type" "Color" 1 sig Signature::parameters.get Parameter::typ assert_str_eq
+    "param0 type" "Color" 0 sig Signature::parameters.get Parameter::typ.format assert_str_eq
+    "param1 type" "Color" 1 sig Signature::parameters.get Parameter::typ.format assert_str_eq
     "return type" "bool" 0 sig Signature::return_types.get assert_str_eq
 }
 

--- a/tests/compiler/test_generic_structs.casa
+++ b/tests/compiler/test_generic_structs.casa
@@ -94,7 +94,7 @@ fn test_parse_generic_struct_generates_getter {
     "struct Box[T] { value: T }" parse_gs drop
     "getter exists" "Box::value" DEFAULT_PARSER.store.functions.get.is_some assert_true
     "Box::value" DEFAULT_PARSER.store.functions.get.unwrap = getter
-    "getter param type" "Box[T]" 0 getter Function::signature Signature::parameters.get Parameter::typ assert_str_eq
+    "getter param type" "Box[T]" 0 getter Function::signature Signature::parameters.get Parameter::typ.format assert_str_eq
     "getter return type" "T" 0 getter Function::signature Signature::return_types.get assert_str_eq
 }
 
@@ -103,8 +103,8 @@ fn test_parse_generic_struct_generates_setter {
     "struct Box[T] { value: T }" parse_gs drop
     "setter exists" "Box::set_value" DEFAULT_PARSER.store.functions.get.is_some assert_true
     "Box::set_value" DEFAULT_PARSER.store.functions.get.unwrap = setter
-    "setter param 0 type" "Box[T]" 0 setter Function::signature Signature::parameters.get Parameter::typ assert_str_eq
-    "setter param 1 type" "T" 1 setter Function::signature Signature::parameters.get Parameter::typ assert_str_eq
+    "setter param 0 type" "Box[T]" 0 setter Function::signature Signature::parameters.get Parameter::typ.format assert_str_eq
+    "setter param 1 type" "T" 1 setter Function::signature Signature::parameters.get Parameter::typ.format assert_str_eq
 }
 
 fn test_parse_nongeneric_struct_has_empty_type_vars {

--- a/tests/compiler/test_generic_structs.casa
+++ b/tests/compiler/test_generic_structs.casa
@@ -95,7 +95,7 @@ fn test_parse_generic_struct_generates_getter {
     "getter exists" "Box::value" DEFAULT_PARSER.store.functions.get.is_some assert_true
     "Box::value" DEFAULT_PARSER.store.functions.get.unwrap = getter
     "getter param type" "Box[T]" 0 getter Function::signature Signature::parameters.get Parameter::typ.format assert_str_eq
-    "getter return type" "T" 0 getter Function::signature Signature::return_types.get assert_str_eq
+    "getter return type" "T" 0 getter Function::signature Signature::return_types.get.format assert_str_eq
 }
 
 fn test_parse_generic_struct_generates_setter {
@@ -127,25 +127,25 @@ fn test_parse_impl_with_type_params {
 fn test_typecheck_generic_struct_infers_type {
     "typecheck_generic_struct_infers_type" test_start
     "struct Box[T] { value: T }\n42 Box" tc_gs = sig
-    "returns Box[int]" "Box[int]" 0 sig Signature::return_types.get assert_str_eq
+    "returns Box[int]" "Box[int]" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_typecheck_generic_struct_str {
     "typecheck_generic_struct_str" test_start
     "struct Box[T] { value: T }\n\"hello\" Box" tc_gs = sig
-    "returns Box[str]" "Box[str]" 0 sig Signature::return_types.get assert_str_eq
+    "returns Box[str]" "Box[str]" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_typecheck_generic_struct_bool {
     "typecheck_generic_struct_bool" test_start
     "struct Box[T] { value: T }\ntrue Box" tc_gs = sig
-    "returns Box[bool]" "Box[bool]" 0 sig Signature::return_types.get assert_str_eq
+    "returns Box[bool]" "Box[bool]" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_typecheck_generic_struct_getter {
     "typecheck_generic_struct_getter" test_start
     "struct Box[T] { value: T }\n42 Box .value" tc_gs = sig
-    "returns int" "int" 0 sig Signature::return_types.get assert_str_eq
+    "returns int" "int" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_typecheck_generic_struct_setter {
@@ -157,25 +157,25 @@ fn test_typecheck_generic_struct_setter {
 fn test_typecheck_generic_struct_two_fields {
     "typecheck_generic_struct_two_fields" test_start
     "struct Pair[A B] { first: A second: B }\ntrue 42 Pair" tc_gs = sig
-    "returns Pair[int bool]" "Pair[int bool]" 0 sig Signature::return_types.get assert_str_eq
+    "returns Pair[int bool]" "Pair[int bool]" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_typecheck_generic_struct_two_fields_getter {
     "typecheck_generic_struct_two_fields_getter" test_start
     "struct Pair[A B] { first: A second: B }\ntrue 42 Pair .second" tc_gs = sig
-    "returns bool" "bool" 0 sig Signature::return_types.get assert_str_eq
+    "returns bool" "bool" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_typecheck_generic_struct_nested {
     "typecheck_generic_struct_nested" test_start
     "struct Box[T] { value: T }\nstruct Wrapper[U] { inner: U }\n42 Box Wrapper" tc_gs = sig
-    "returns Wrapper[Box[int]]" "Wrapper[Box[int]]" 0 sig Signature::return_types.get assert_str_eq
+    "returns Wrapper[Box[int]]" "Wrapper[Box[int]]" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_typecheck_generic_struct_in_function {
     "typecheck_generic_struct_in_function" test_start
     "struct Box[T] { value: T }\nfn unbox[T] b:Box[T] -> T { b .value }\n42 Box unbox" tc_gs = sig
-    "returns int" "int" 0 sig Signature::return_types.get assert_str_eq
+    "returns int" "int" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 # ============================================================================

--- a/tests/compiler/test_generic_structs.casa
+++ b/tests/compiler/test_generic_structs.casa
@@ -66,7 +66,7 @@ fn test_parse_generic_struct {
     "type vars count" 1 box_struct CasaStruct::type_vars.length assert_eq
     "type var T" "T" 0 box_struct CasaStruct::type_vars.get assert_str_eq
     "member name" "value" 0 box_struct CasaStruct::members.get Member::name assert_str_eq
-    "member type" "T" 0 box_struct CasaStruct::members.get Member::typ assert_str_eq
+    "member type" "T" 0 box_struct CasaStruct::members.get Member::typ.format assert_str_eq
 }
 
 fn test_parse_generic_struct_multiple_type_vars {

--- a/tests/compiler/test_lsp.casa
+++ b/tests/compiler/test_lsp.casa
@@ -985,8 +985,8 @@ fn test_compute_hover_enum_variant_separator_returns_none {
 fn lsp_make_synthetic_method name:str self_type:str ret_type:str -> Function {
     List::new(List[Parameter]) = params
     self_type make_param params.push
-    List::new(List[str]) = returns
-    ret_type returns.push
+    List::new(List[Type]) = returns
+    ret_type parse_type_str returns.push
     returns params make_signature = sig
     sig empty_location List::new(List[Op]) name make_function_with_sig
 }
@@ -994,7 +994,7 @@ fn lsp_make_synthetic_method name:str self_type:str ret_type:str -> Function {
 fn lsp_make_synthetic_void name:str self_type:str -> Function {
     List::new(List[Parameter]) = params
     self_type make_param params.push
-    List::new(List[str]) = returns
+    List::new(List[Type]) = returns
     returns params make_signature = sig
     sig empty_location List::new(List[Op]) name make_function_with_sig
 }

--- a/tests/compiler/test_parser.casa
+++ b/tests/compiler/test_parser.casa
@@ -321,7 +321,7 @@ fn test_parse_struct_def {
     "Point" DEFAULT_PARSER.store.structs.get.unwrap = point_struct
     "member count" 2 point_struct CasaStruct::members.length assert_eq
     "member 0 name" "x" 0 point_struct CasaStruct::members.get Member::name assert_str_eq
-    "member 0 type" "int" 0 point_struct CasaStruct::members.get Member::typ assert_str_eq
+    "member 0 type" "int" 0 point_struct CasaStruct::members.get Member::typ.format assert_str_eq
     "getter registered" "Point::x" DEFAULT_PARSER.store.functions.get.is_some assert_true
     "setter registered" "Point::set_x" DEFAULT_PARSER.store.functions.get.is_some assert_true
 }

--- a/tests/compiler/test_parser.casa
+++ b/tests/compiler/test_parser.casa
@@ -290,7 +290,7 @@ fn test_parse_function_def {
     "fn name" "add" add_fn Function::name assert_str_eq
     "param count" 2 add_fn Function::signature Signature::parameters.length assert_eq
     "return count" 1 add_fn Function::signature Signature::return_types.length assert_eq
-    "return type" "int" 0 add_fn Function::signature Signature::return_types.get assert_str_eq
+    "return type" "int" 0 add_fn Function::signature Signature::return_types.get.format assert_str_eq
 }
 
 # ============================================================================

--- a/tests/compiler/test_struct_literal.casa
+++ b/tests/compiler/test_struct_literal.casa
@@ -254,13 +254,13 @@ fn test_duplicate_field_in_pattern_error {
 fn test_struct_literal_type_correct {
     "struct_literal_type_correct" test_start
     "struct Point { x: int y: int }\nPoint { x: 1 y: 2 }" sl_typecheck = sig
-    "returns Point" "Point" 0 sig Signature::return_types.get assert_str_eq
+    "returns Point" "Point" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_struct_literal_reverse_order_type {
     "struct_literal_reverse_order_type" test_start
     "struct Point { x: int y: int }\nPoint { y: 2 x: 1 }" sl_typecheck = sig
-    "returns Point" "Point" 0 sig Signature::return_types.get assert_str_eq
+    "returns Point" "Point" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_field_type_mismatch_error {
@@ -290,14 +290,14 @@ fn test_struct_match_wildcard_exhaustive {
 fn test_struct_match_binding_types {
     "struct_match_binding_types" test_start
     "struct Person { name: str age: int }\n18 \"Alice\" Person = p\np match\n    Person { name: n age: a } => n a\nend" sl_typecheck = sig
-    "returns str" "str" 0 sig Signature::return_types.get assert_str_eq
-    "returns int" "int" 1 sig Signature::return_types.get assert_str_eq
+    "returns str" "str" 0 sig Signature::return_types.get.format assert_str_eq
+    "returns int" "int" 1 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_struct_match_partial_binding {
     "struct_match_partial_binding" test_start
     "struct Point { x: int y: int }\n1 2 Point = p\np match\n    Point { x: px } => px\nend" sl_typecheck = sig
-    "returns int" "int" 0 sig Signature::return_types.get assert_str_eq
+    "returns int" "int" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_generic_struct_literal {
@@ -306,26 +306,26 @@ fn test_generic_struct_literal {
     # literals (returns "Box" instead of "Box[int]"). Test verifies no crash and
     # that a Box-prefixed type is returned.
     "struct Box[T] { value: T }\nBox { value: 42 }" sl_typecheck = sig
-    "returns Box type" 0 0 sig Signature::return_types.get "Box" str::find >= assert_true
+    "returns Box type" 0 0 sig Signature::return_types.get.format "Box" str::find >= assert_true
 }
 
 fn test_generic_struct_literal_str {
     "generic_struct_literal_str" test_start
     # NOTE: Same limitation as test_generic_struct_literal above.
     "struct Box[T] { value: T }\nBox { value: \"hello\" }" sl_typecheck = sig
-    "returns Box type" 0 0 sig Signature::return_types.get "Box" str::find >= assert_true
+    "returns Box type" 0 0 sig Signature::return_types.get.format "Box" str::find >= assert_true
 }
 
 fn test_stack_based_construction_still_works {
     "stack_based_construction_still_works" test_start
     "struct Point { x: int y: int }\n1 2 Point" sl_typecheck = sig
-    "returns Point" "Point" 0 sig Signature::return_types.get assert_str_eq
+    "returns Point" "Point" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_stack_and_literal_coexist {
     "stack_and_literal_coexist" test_start
     "struct Point { x: int y: int }\n1 2 Point = p1\nPoint { x: 3 y: 4 } = p2\np1.x p2.x +" sl_typecheck = sig
-    "returns int" "int" 0 sig Signature::return_types.get assert_str_eq
+    "returns int" "int" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 # ============================================================================

--- a/tests/compiler/test_traits.casa
+++ b/tests/compiler/test_traits.casa
@@ -71,7 +71,7 @@ fn test_trait_method_sig_params {
     "Hashable" DEFAULT_PARSER.store.traits.get.unwrap CasaTrait::methods = methods
     0 methods.get TraitMethod::signature = hash_sig
     "param count" 1 hash_sig Signature::parameters.length assert_eq
-    "param type" "self" 0 hash_sig Signature::parameters.get Parameter::typ assert_str_eq
+    "param type" "self" 0 hash_sig Signature::parameters.get Parameter::typ.format assert_str_eq
     "param name" "self" 0 hash_sig Signature::parameters.get Parameter::name assert_str_eq
 }
 
@@ -90,8 +90,8 @@ fn test_trait_eq_method_params {
     "Hashable" DEFAULT_PARSER.store.traits.get.unwrap CasaTrait::methods = methods
     1 methods.get TraitMethod::signature = eq_sig
     "param count" 2 eq_sig Signature::parameters.length assert_eq
-    "param0 type" "self" 0 eq_sig Signature::parameters.get Parameter::typ assert_str_eq
-    "param1 type" "self" 1 eq_sig Signature::parameters.get Parameter::typ assert_str_eq
+    "param0 type" "self" 0 eq_sig Signature::parameters.get Parameter::typ.format assert_str_eq
+    "param1 type" "self" 1 eq_sig Signature::parameters.get Parameter::typ.format assert_str_eq
 }
 
 fn test_trait_eq_method_return {
@@ -272,7 +272,7 @@ fn test_trait_hidden_param_type {
     while index func Function::signature Signature::parameters.length > do
         index func Function::signature Signature::parameters.get = param
         if "__trait_K_hash" param Parameter::name == then
-            "type" "fn[K -> int]" param Parameter::typ assert_str_eq
+            "type" "fn[K -> int]" param Parameter::typ.format assert_str_eq
         fi
         1 += index
     done
@@ -308,10 +308,10 @@ fn test_trait_hidden_params_correct_types {
     while index func Function::signature Signature::parameters.length > do
         index func Function::signature Signature::parameters.get = param
         if "__trait_K_hash" param Parameter::name == then
-            "hash type" "fn[K -> int]" param Parameter::typ assert_str_eq
+            "hash type" "fn[K -> int]" param Parameter::typ.format assert_str_eq
         fi
         if "__trait_K_eq" param Parameter::name == then
-            "eq type" "fn[K K -> bool]" param Parameter::typ assert_str_eq
+            "eq type" "fn[K K -> bool]" param Parameter::typ.format assert_str_eq
         fi
         1 += index
     done
@@ -766,7 +766,7 @@ fn test_generic_trait_bound_concrete_hidden_param_type {
         index func Function::signature Signature::parameters.get = param
         if "__trait_I_get" param Parameter::name == then
             true = found
-            "hidden type" "fn[I -> int]" param Parameter::typ assert_str_eq
+            "hidden type" "fn[I -> int]" param Parameter::typ.format assert_str_eq
         fi
         1 += index
     done

--- a/tests/compiler/test_traits.casa
+++ b/tests/compiler/test_traits.casa
@@ -590,7 +590,7 @@ fn test_type_var_with_matching_bound_satisfies {
     Set::new(Set[str]) = type_vars
     "K" type_vars.add = type_vars
     # Construct Signature: parameters, return_types, type_vars, trait_bounds
-    bounds type_vars List::new(List[str]) List::new(List[Parameter]) Signature = sig
+    bounds type_vars List::new(List[Type]) List::new(List[Parameter]) Signature = sig
     sig empty_location List::new(List[Op]) "test_fn" make_function_with_sig = func
     func Option::Some = func_opt
     "satisfies" func_opt "Hashable" "K" type_satisfies_trait assert_true
@@ -602,7 +602,7 @@ fn test_type_var_without_bound_does_not_satisfy {
     # Build a Signature with K but no trait bounds
     Set::new(Set[str]) = type_vars
     "K" type_vars.add = type_vars
-    Map::new(Map[str TraitBound]) type_vars List::new(List[str]) List::new(List[Parameter]) Signature = sig
+    Map::new(Map[str TraitBound]) type_vars List::new(List[Type]) List::new(List[Parameter]) Signature = sig
     sig empty_location List::new(List[Op]) "test_fn" make_function_with_sig = func
     func Option::Some = func_opt
     "does not satisfy" func_opt "Hashable" "K" type_satisfies_trait ! assert_true
@@ -616,7 +616,7 @@ fn test_type_var_with_wrong_bound_does_not_satisfy {
     "K" "Printable" make_simple_trait_bound bounds.set = bounds
     Set::new(Set[str]) = type_vars
     "K" type_vars.add = type_vars
-    bounds type_vars List::new(List[str]) List::new(List[Parameter]) Signature = sig
+    bounds type_vars List::new(List[Type]) List::new(List[Parameter]) Signature = sig
     sig empty_location List::new(List[Op]) "test_fn" make_function_with_sig = func
     func Option::Some = func_opt
     "does not satisfy" func_opt "Hashable" "K" type_satisfies_trait ! assert_true
@@ -638,7 +638,7 @@ fn test_trait_bounds_preserved_in_signature {
     "K" "Hashable" make_simple_trait_bound bounds.set = bounds
     Set::new(Set[str]) = type_vars
     "K" type_vars.add = type_vars
-    bounds type_vars List::new(List[str]) List::new(List[Parameter]) Signature = sig
+    bounds type_vars List::new(List[Type]) List::new(List[Parameter]) Signature = sig
     "preserved" "Hashable" "K" sig Signature::trait_bounds.get.unwrap TraitBound::name assert_str_eq
 }
 

--- a/tests/compiler/test_traits.casa
+++ b/tests/compiler/test_traits.casa
@@ -81,7 +81,7 @@ fn test_trait_method_sig_return {
     "Hashable" DEFAULT_PARSER.store.traits.get.unwrap CasaTrait::methods = methods
     0 methods.get TraitMethod::signature = hash_sig
     "return count" 1 hash_sig Signature::return_types.length assert_eq
-    "return type" "int" 0 hash_sig Signature::return_types.get assert_str_eq
+    "return type" "int" 0 hash_sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_trait_eq_method_params {
@@ -100,7 +100,7 @@ fn test_trait_eq_method_return {
     "Hashable" DEFAULT_PARSER.store.traits.get.unwrap CasaTrait::methods = methods
     1 methods.get TraitMethod::signature = eq_sig
     "return count" 1 eq_sig Signature::return_types.length assert_eq
-    "return type" "bool" 0 eq_sig Signature::return_types.get assert_str_eq
+    "return type" "bool" 0 eq_sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_trait_empty {

--- a/tests/compiler/test_type_annotations.casa
+++ b/tests/compiler/test_type_annotations.casa
@@ -175,43 +175,43 @@ fn test_no_annotation_on_decrement {
 fn test_tc_annotation_int {
     "tc_annotation_int" test_start
     "42 = x:int x" tc_code = sig
-    "return type" "int" 0 sig Signature::return_types.get assert_str_eq
+    "return type" "int" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_tc_annotation_str {
     "tc_annotation_str" test_start
     "\"hello\" = x:str x" tc_code = sig
-    "return type" "str" 0 sig Signature::return_types.get assert_str_eq
+    "return type" "str" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_tc_annotation_bool {
     "tc_annotation_bool" test_start
     "true = x:bool x" tc_code = sig
-    "return type" "bool" 0 sig Signature::return_types.get assert_str_eq
+    "return type" "bool" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_tc_annotation_matches_stack {
     "tc_annotation_matches_stack" test_start
     "42 = x:int x" tc_code = sig
-    "return type" "int" 0 sig Signature::return_types.get assert_str_eq
+    "return type" "int" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_tc_annotation_to_int {
     "tc_annotation_to_int" test_start
     "42 = x:int x" tc_code = sig
-    "return type" "int" 0 sig Signature::return_types.get assert_str_eq
+    "return type" "int" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_tc_annotation_to_str {
     "tc_annotation_to_str" test_start
     "\"hello\" = x:str x" tc_code = sig
-    "return type" "str" 0 sig Signature::return_types.get assert_str_eq
+    "return type" "str" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_tc_annotation_to_option {
     "tc_annotation_to_option" test_start
     OPTION_ENUM "Option::None = x:Option[T] x" str::concat tc_code = sig
-    "return type" "Option[T]" 0 sig Signature::return_types.get assert_str_eq
+    "return type" "Option[T]" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn assert_cast_rejected_as_unknown_type source:str expected_type:str {
@@ -247,37 +247,37 @@ fn test_tc_reject_unknown_generic_param_cast {
 fn test_tc_reassignment_keeps_annotated_type {
     "tc_reassignment_keeps_annotated_type" test_start
     "42 = x:int 99 = x x" tc_code = sig
-    "return type" "int" 0 sig Signature::return_types.get assert_str_eq
+    "return type" "int" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_tc_without_annotation {
     "tc_without_annotation" test_start
     "42 = x x" tc_code = sig
-    "return type" "int" 0 sig Signature::return_types.get assert_str_eq
+    "return type" "int" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_tc_annotation_in_function_body {
     "tc_annotation_in_function_body" test_start
     "fn foo -> int { 42 = x:int x } foo" tc_code = sig
-    "return type" "int" 0 sig Signature::return_types.get assert_str_eq
+    "return type" "int" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_tc_annotation_in_function_explicit {
     "tc_annotation_in_function_explicit" test_start
     "fn foo -> int { 42 = x:int x } foo" tc_code = sig
-    "return type" "int" 0 sig Signature::return_types.get assert_str_eq
+    "return type" "int" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_tc_annotation_with_struct {
     "tc_annotation_with_struct" test_start
     "struct Point { x: int y: int }\n0 0 Point = p:Point\np" tc_code = sig
-    "return type" "Point" 0 sig Signature::return_types.get assert_str_eq
+    "return type" "Point" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_tc_option_int_with_some {
     "tc_option_int_with_some" test_start
     OPTION_ENUM "42 Option::Some = x:Option[int] x" str::concat tc_code = sig
-    "return type" "Option[int]" 0 sig Signature::return_types.get assert_str_eq
+    "return type" "Option[int]" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 # ============================================================================

--- a/tests/compiler/test_type_ast.casa
+++ b/tests/compiler/test_type_ast.casa
@@ -49,9 +49,26 @@ fn test_round_trip_function {
     "fn[int -> int int]" assert_round_trip
     "fn[List[int] -> Option[str]]" assert_round_trip
 }
+
+fn assert_substitute source:str expected:str subs:Map[str str] {
+    subs source parse_type_str.substitute.format = result
+    f"substitute {source}" expected result assert_str_eq
+}
+
+fn test_substitute_function {
+    "Type::substitute on Function" test_start
+    Map::new(Map[str str]) = subs
+    "T" "int" subs.set = subs
+    subs "fn[int]" "fn[T]" assert_substitute
+    subs "fn[int -> str]" "fn[T -> str]" assert_substitute
+    subs "fn[int int -> int]" "fn[T T -> T]" assert_substitute
+    subs "fn[int -> U]" "fn[T -> U]" assert_substitute
+    subs "fn[List[int] -> Option[int]]" "fn[List[T] -> Option[T]]" assert_substitute
+}
 test_round_trip_builtins
 test_round_trip_generics
 test_round_trip_typevar
 test_round_trip_named
 test_round_trip_function
+test_substitute_function
 test_summary

--- a/tests/compiler/test_type_ast.casa
+++ b/tests/compiler/test_type_ast.casa
@@ -1,0 +1,57 @@
+import "../../compiler/common.casa"
+import "../../compiler/error.casa"
+import "../../compiler/lexer.casa"
+import "../../compiler/syntax.casa"
+import "../../lib/test.casa"
+
+fn assert_round_trip source:str {
+    f"round-trip {source}" source source parse_type_str.format assert_str_eq
+}
+
+fn test_round_trip_builtins {
+    "Type round-trip builtins" test_start
+    "int" assert_round_trip
+    "bool" assert_round_trip
+    "char" assert_round_trip
+    "cstr" assert_round_trip
+    "str" assert_round_trip
+    "ptr" assert_round_trip
+}
+
+fn test_round_trip_generics {
+    "Type round-trip generics" test_start
+    "List[int]" assert_round_trip
+    "Option[str]" assert_round_trip
+    "Map[str int]" assert_round_trip
+    "List[List[int]]" assert_round_trip
+    "Map[str List[int]]" assert_round_trip
+}
+
+fn test_round_trip_typevar {
+    "Type round-trip TypeVar" test_start
+    "T" assert_round_trip
+    "K" assert_round_trip
+    "V" assert_round_trip
+}
+
+fn test_round_trip_named {
+    "Type round-trip named (no params)" test_start
+    "Token" assert_round_trip
+    "Function" assert_round_trip
+    "MyStruct" assert_round_trip
+}
+
+fn test_round_trip_function {
+    "Type round-trip Function" test_start
+    "fn" assert_round_trip
+    "fn[int -> int]" assert_round_trip
+    "fn[int int -> int]" assert_round_trip
+    "fn[int -> int int]" assert_round_trip
+    "fn[List[int] -> Option[str]]" assert_round_trip
+}
+test_round_trip_builtins
+test_round_trip_generics
+test_round_trip_typevar
+test_round_trip_named
+test_round_trip_function
+test_summary

--- a/tests/compiler/test_typechecker.casa
+++ b/tests/compiler/test_typechecker.casa
@@ -148,7 +148,7 @@ fn test_push_int_stack {
     empty_location 42 OpValue::PushInt make_op ops.push
     ops tc_check = result_tc
     "stack has one item" 1 result_tc TypeChecker::live TypedStack::types.length assert_eq
-    "type is int" "int" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
+    "type is int" "int" 0 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -163,7 +163,7 @@ fn test_add_stack_effect {
     empty_location OpValue::Add make_op ops.push
     ops tc_check = result_tc
     "stack has one item after add" 1 result_tc TypeChecker::live TypedStack::types.length assert_eq
-    "result type is int" "int" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
+    "result type is int" "int" 0 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -180,7 +180,7 @@ fn test_arithmetic_ops {
     empty_location OpValue::Sub make_op ops_sub.push
     ops_sub tc_check = tc_sub
     "sub result" 1 tc_sub TypeChecker::live TypedStack::types.length assert_eq
-    "sub type" "int" 0 tc_sub TypeChecker::live TypedStack::types.get assert_str_eq
+    "sub type" "int" 0 tc_sub TypeChecker::live TypedStack::types.get.format assert_str_eq
 
     # Mul
     List::new(List[Op]) = ops_mul
@@ -188,7 +188,7 @@ fn test_arithmetic_ops {
     empty_location 3 OpValue::PushInt make_op ops_mul.push
     empty_location OpValue::Mul make_op ops_mul.push
     ops_mul tc_check = tc_mul
-    "mul type" "int" 0 tc_mul TypeChecker::live TypedStack::types.get assert_str_eq
+    "mul type" "int" 0 tc_mul TypeChecker::live TypedStack::types.get.format assert_str_eq
 
     # Div
     List::new(List[Op]) = ops_div
@@ -196,7 +196,7 @@ fn test_arithmetic_ops {
     empty_location 2 OpValue::PushInt make_op ops_div.push
     empty_location OpValue::Div make_op ops_div.push
     ops_div tc_check = tc_div
-    "div type" "int" 0 tc_div TypeChecker::live TypedStack::types.get assert_str_eq
+    "div type" "int" 0 tc_div TypeChecker::live TypedStack::types.get.format assert_str_eq
 
     # Mod
     List::new(List[Op]) = ops_mod
@@ -204,7 +204,7 @@ fn test_arithmetic_ops {
     empty_location 3 OpValue::PushInt make_op ops_mod.push
     empty_location OpValue::Mod make_op ops_mod.push
     ops_mod tc_check = tc_mod
-    "mod type" "int" 0 tc_mod TypeChecker::live TypedStack::types.get assert_str_eq
+    "mod type" "int" 0 tc_mod TypeChecker::live TypedStack::types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -219,7 +219,7 @@ fn test_comparison_produces_bool {
     empty_location OpValue::Lt make_op ops.push
     ops tc_check = result_tc
     "stack after lt" 1 result_tc TypeChecker::live TypedStack::types.length assert_eq
-    "lt result is bool" "bool" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
+    "lt result is bool" "bool" 0 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -234,7 +234,7 @@ fn test_boolean_ops {
     empty_location 0 OpValue::PushBool make_op ops_and.push
     empty_location OpValue::And make_op ops_and.push
     ops_and tc_check = tc_and
-    "and result" "bool" 0 tc_and TypeChecker::live TypedStack::types.get assert_str_eq
+    "and result" "bool" 0 tc_and TypeChecker::live TypedStack::types.get.format assert_str_eq
 
     # OR
     List::new(List[Op]) = ops_or
@@ -242,14 +242,14 @@ fn test_boolean_ops {
     empty_location 0 OpValue::PushBool make_op ops_or.push
     empty_location OpValue::Or make_op ops_or.push
     ops_or tc_check = tc_or
-    "or result" "bool" 0 tc_or TypeChecker::live TypedStack::types.get assert_str_eq
+    "or result" "bool" 0 tc_or TypeChecker::live TypedStack::types.get.format assert_str_eq
 
     # NOT
     List::new(List[Op]) = ops_not
     empty_location 1 OpValue::PushBool make_op ops_not.push
     empty_location OpValue::Not make_op ops_not.push
     ops_not tc_check = tc_not
-    "not result" "bool" 0 tc_not TypeChecker::live TypedStack::types.get assert_str_eq
+    "not result" "bool" 0 tc_not TypeChecker::live TypedStack::types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -263,8 +263,8 @@ fn test_dup_stack_effect {
     empty_location OpValue::Dup make_op ops.push
     ops tc_check = result_tc
     "stack after dup" 2 result_tc TypeChecker::live TypedStack::types.length assert_eq
-    "first is int" "int" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
-    "second is int" "int" 1 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
+    "first is int" "int" 0 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "second is int" "int" 1 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -279,8 +279,8 @@ fn test_swap_stack_effect {
     empty_location OpValue::Swap make_op ops.push
     ops tc_check = result_tc
     "stack after swap" 2 result_tc TypeChecker::live TypedStack::types.length assert_eq
-    "bottom is str" "str" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
-    "top is int" "int" 1 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
+    "bottom is str" "str" 0 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "top is int" "int" 1 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -295,9 +295,9 @@ fn test_over_stack_effect {
     empty_location OpValue::Over make_op ops.push
     ops tc_check = result_tc
     "stack after over" 3 result_tc TypeChecker::live TypedStack::types.length assert_eq
-    "bottom is int" "int" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
-    "middle is str" "str" 1 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
-    "top is int" "int" 2 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
+    "bottom is int" "int" 0 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "middle is str" "str" 1 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "top is int" "int" 2 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -312,7 +312,7 @@ fn test_drop_stack_effect {
     empty_location OpValue::Drop make_op ops.push
     ops tc_check = result_tc
     "stack after drop" 1 result_tc TypeChecker::live TypedStack::types.length assert_eq
-    "remaining is int" "int" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
+    "remaining is int" "int" 0 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -329,9 +329,9 @@ fn test_rot_stack_effect {
     ops tc_check = result_tc
     "stack after rot" 3 result_tc TypeChecker::live TypedStack::types.length assert_eq
     # ROT: pop t1(bool), t2(str), t3(int) -> push t2(str), t1(bool), t3(int)
-    "bottom is str" "str" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
-    "middle is bool" "bool" 1 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
-    "top is int" "int" 2 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
+    "bottom is str" "str" 0 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "middle is bool" "bool" 1 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "top is int" "int" 2 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -345,7 +345,7 @@ fn test_type_cast {
     empty_location "str" OpValue::TypeCast make_op ops.push
     ops tc_check = result_tc
     "stack after cast" 1 result_tc TypeChecker::live TypedStack::types.length assert_eq
-    "cast to str" "str" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
+    "cast to str" "str" 0 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -361,10 +361,10 @@ fn test_push_literals {
     empty_location 65 OpValue::PushChar make_op ops.push
     ops tc_check = result_tc
     "four items on stack" 4 result_tc TypeChecker::live TypedStack::types.length assert_eq
-    "int" "int" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
-    "str" "str" 1 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
-    "bool" "bool" 2 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
-    "char" "char" 3 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
+    "int" "int" 0 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "str" "str" 1 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "bool" "bool" 2 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "char" "char" 3 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -407,7 +407,7 @@ fn test_typeof_effect {
     empty_location OpValue::Typeof make_op ops.push
     ops tc_check = result_tc
     "stack after typeof" 1 result_tc TypeChecker::live TypedStack::types.length assert_eq
-    "typeof result is str" "str" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
+    "typeof result is str" "str" 0 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -422,7 +422,7 @@ fn test_bitwise_ops {
     empty_location 42 OpValue::PushInt make_op ops_bnot.push
     empty_location OpValue::BitNot make_op ops_bnot.push
     ops_bnot tc_check = tc_bnot
-    "bitnot result" "int" 0 tc_bnot TypeChecker::live TypedStack::types.get assert_str_eq
+    "bitnot result" "int" 0 tc_bnot TypeChecker::live TypedStack::types.get.format assert_str_eq
 
     # SHL
     List::new(List[Op]) = ops_shl
@@ -430,7 +430,7 @@ fn test_bitwise_ops {
     empty_location 3 OpValue::PushInt make_op ops_shl.push
     empty_location OpValue::Shl make_op ops_shl.push
     ops_shl tc_check = tc_shl
-    "shl result" "int" 0 tc_shl TypeChecker::live TypedStack::types.get assert_str_eq
+    "shl result" "int" 0 tc_shl TypeChecker::live TypedStack::types.get.format assert_str_eq
 
     # BIT_AND
     List::new(List[Op]) = ops_band
@@ -438,7 +438,7 @@ fn test_bitwise_ops {
     empty_location 1 OpValue::PushInt make_op ops_band.push
     empty_location OpValue::BitAnd make_op ops_band.push
     ops_band tc_check = tc_band
-    "bitand result" "int" 0 tc_band TypeChecker::live TypedStack::types.get assert_str_eq
+    "bitand result" "int" 0 tc_band TypeChecker::live TypedStack::types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -453,7 +453,7 @@ fn test_memory_ops {
     empty_location 100 OpValue::PushInt make_op ops_alloc.push
     empty_location OpValue::HeapAlloc make_op ops_alloc.push
     ops_alloc tc_check = tc_alloc
-    "alloc result is ptr" "ptr" 0 tc_alloc TypeChecker::live TypedStack::types.get assert_str_eq
+    "alloc result is ptr" "ptr" 0 tc_alloc TypeChecker::live TypedStack::types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -467,8 +467,8 @@ fn test_argc_argv {
     empty_location OpValue::Argv make_op ops.push
     ops tc_check = result_tc
     "stack count" 2 result_tc TypeChecker::live TypedStack::types.length assert_eq
-    "argc is int" "int" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
-    "argv is ptr" "ptr" 1 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
+    "argc is int" "int" 0 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "argv is ptr" "ptr" 1 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -503,20 +503,20 @@ fn test_unify_type {
 
 fn test_stacks_compatible {
     "stacks_compatible" test_start
-    List::new(List[str]) = stack_a
-    "int" stack_a.push
-    "str" stack_a.push
-    List::new(List[str]) = stack_b
-    "int" stack_b.push
-    "str" stack_b.push
+    List::new(List[Type]) = stack_a
+    "int" parse_type_str stack_a.push
+    "str" parse_type_str stack_a.push
+    List::new(List[Type]) = stack_b
+    "int" parse_type_str stack_b.push
+    "str" parse_type_str stack_b.push
     stack_b stack_a stacks_compatible = result
     "compatible stacks" 2 result.length assert_eq
 
-    List::new(List[str]) = stack_c
-    "int" stack_c.push
-    List::new(List[str]) = stack_d
-    "int" stack_d.push
-    "str" stack_d.push
+    List::new(List[Type]) = stack_c
+    "int" parse_type_str stack_c.push
+    List::new(List[Type]) = stack_d
+    "int" parse_type_str stack_d.push
+    "str" parse_type_str stack_d.push
     stack_d stack_c stacks_compatible = result2
     "incompatible lengths" 0 result2.length assert_eq
 }
@@ -661,7 +661,7 @@ fn test_typeof_str {
     empty_location "hi" OpValue::PushStr make_op ops.push
     empty_location OpValue::Typeof make_op ops.push
     ops tc_check = result_tc
-    "typeof str result" "str" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
+    "typeof str result" "str" 0 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
 }
 
 fn test_typeof_bool {
@@ -670,7 +670,7 @@ fn test_typeof_bool {
     empty_location 1 OpValue::PushBool make_op ops.push
     empty_location OpValue::Typeof make_op ops.push
     ops tc_check = result_tc
-    "typeof bool result" "str" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
+    "typeof bool result" "str" 0 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -686,7 +686,7 @@ fn test_all_comparison_ops {
     empty_location 1 OpValue::PushInt make_op ops_eq.push
     empty_location OpValue::Eq make_op ops_eq.push
     ops_eq tc_check = tc_eq
-    "eq is bool" "bool" 0 tc_eq TypeChecker::live TypedStack::types.get assert_str_eq
+    "eq is bool" "bool" 0 tc_eq TypeChecker::live TypedStack::types.get.format assert_str_eq
 
     # Ne
     List::new(List[Op]) = ops_ne
@@ -694,7 +694,7 @@ fn test_all_comparison_ops {
     empty_location 2 OpValue::PushInt make_op ops_ne.push
     empty_location OpValue::Ne make_op ops_ne.push
     ops_ne tc_check = tc_ne
-    "ne is bool" "bool" 0 tc_ne TypeChecker::live TypedStack::types.get assert_str_eq
+    "ne is bool" "bool" 0 tc_ne TypeChecker::live TypedStack::types.get.format assert_str_eq
 
     # Le
     List::new(List[Op]) = ops_le
@@ -702,7 +702,7 @@ fn test_all_comparison_ops {
     empty_location 2 OpValue::PushInt make_op ops_le.push
     empty_location OpValue::Le make_op ops_le.push
     ops_le tc_check = tc_le
-    "le is bool" "bool" 0 tc_le TypeChecker::live TypedStack::types.get assert_str_eq
+    "le is bool" "bool" 0 tc_le TypeChecker::live TypedStack::types.get.format assert_str_eq
 
     # Ge
     List::new(List[Op]) = ops_ge
@@ -710,7 +710,7 @@ fn test_all_comparison_ops {
     empty_location 2 OpValue::PushInt make_op ops_ge.push
     empty_location OpValue::Ge make_op ops_ge.push
     ops_ge tc_check = tc_ge
-    "ge is bool" "bool" 0 tc_ge TypeChecker::live TypedStack::types.get assert_str_eq
+    "ge is bool" "bool" 0 tc_ge TypeChecker::live TypedStack::types.get.format assert_str_eq
 
     # Gt
     List::new(List[Op]) = ops_gt
@@ -718,7 +718,7 @@ fn test_all_comparison_ops {
     empty_location 2 OpValue::PushInt make_op ops_gt.push
     empty_location OpValue::Gt make_op ops_gt.push
     ops_gt tc_check = tc_gt
-    "gt is bool" "bool" 0 tc_gt TypeChecker::live TypedStack::types.get assert_str_eq
+    "gt is bool" "bool" 0 tc_gt TypeChecker::live TypedStack::types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -732,7 +732,7 @@ fn test_string_comparison_annotation {
     empty_location "b" OpValue::PushStr make_op ops.push
     empty_location OpValue::Eq make_op ops.push
     ops tc_check = result_tc
-    "str cmp is bool" "bool" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
+    "str cmp is bool" "bool" 0 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
     "annotation is str" "str" 2 ops.get Op::type_annotation assert_str_eq
 }
 
@@ -747,7 +747,7 @@ fn test_bitwise_shr {
     empty_location 2 OpValue::PushInt make_op ops.push
     empty_location OpValue::Shr make_op ops.push
     ops tc_check = result_tc
-    "shr result" "int" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
+    "shr result" "int" 0 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
 }
 
 fn test_bitwise_or {
@@ -757,7 +757,7 @@ fn test_bitwise_or {
     empty_location 3 OpValue::PushInt make_op ops.push
     empty_location OpValue::BitOr make_op ops.push
     ops tc_check = result_tc
-    "bitor result" "int" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
+    "bitor result" "int" 0 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
 }
 
 fn test_bitwise_xor {
@@ -767,7 +767,7 @@ fn test_bitwise_xor {
     empty_location 3 OpValue::PushInt make_op ops.push
     empty_location OpValue::BitXor make_op ops.push
     ops tc_check = result_tc
-    "bitxor result" "int" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
+    "bitxor result" "int" 0 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -783,7 +783,7 @@ fn test_memory_load_sizes {
     empty_location OpValue::HeapAlloc make_op ops8.push
     empty_location OpValue::Load8 make_op ops8.push
     ops8 tc_check = tc8
-    "load8 result" "int" 0 tc8 TypeChecker::live TypedStack::types.get assert_str_eq
+    "load8 result" "int" 0 tc8 TypeChecker::live TypedStack::types.get.format assert_str_eq
 
     # load16
     List::new(List[Op]) = ops16
@@ -791,7 +791,7 @@ fn test_memory_load_sizes {
     empty_location OpValue::HeapAlloc make_op ops16.push
     empty_location OpValue::Load16 make_op ops16.push
     ops16 tc_check = tc16
-    "load16 result" "int" 0 tc16 TypeChecker::live TypedStack::types.get assert_str_eq
+    "load16 result" "int" 0 tc16 TypeChecker::live TypedStack::types.get.format assert_str_eq
 
     # load32
     List::new(List[Op]) = ops32
@@ -799,7 +799,7 @@ fn test_memory_load_sizes {
     empty_location OpValue::HeapAlloc make_op ops32.push
     empty_location OpValue::Load32 make_op ops32.push
     ops32 tc_check = tc32
-    "load32 result" "int" 0 tc32 TypeChecker::live TypedStack::types.get assert_str_eq
+    "load32 result" "int" 0 tc32 TypeChecker::live TypedStack::types.get.format assert_str_eq
 }
 
 fn test_memory_store_sizes {
@@ -1025,18 +1025,18 @@ fn test_types_match_extended {
 
 fn test_stacks_compatible_with_unknown {
     "stacks_compatible_with_unknown" test_start
-    List::new(List[str]) = stack_a
-    "int" stack_a.push
-    List::new(List[str]) = stack_b
-    TYPE_UNKNOWN stack_b.push
+    List::new(List[Type]) = stack_a
+    "int" parse_type_str stack_a.push
+    List::new(List[Type]) = stack_b
+    TYPE_UNKNOWN parse_type_str stack_b.push
     stack_b stack_a stacks_compatible = result
     "TYPE_UNKNOWN matches int" 1 result.length assert_eq
 }
 
 fn test_stacks_compatible_empty {
     "stacks_compatible_empty" test_start
-    List::new(List[str]) = stack_a
-    List::new(List[str]) = stack_b
+    List::new(List[Type]) = stack_a
+    List::new(List[Type]) = stack_b
     stack_b stack_a stacks_compatible = result
     "empty stacks compatible" 0 result.length assert_eq
 }
@@ -1294,7 +1294,7 @@ fn test_syscall_op_level {
     empty_location OpValue::Syscall0 make_op ops0.push
     ops0 tc_check = tc0
     "syscall0 result" 1 tc0 TypeChecker::live TypedStack::types.length assert_eq
-    "syscall0 type" "int" 0 tc0 TypeChecker::live TypedStack::types.get assert_str_eq
+    "syscall0 type" "int" 0 tc0 TypeChecker::live TypedStack::types.get.format assert_str_eq
 
     # syscall1: pops 2 (1 arg + syscall number), pushes int
     List::new(List[Op]) = ops1
@@ -1303,7 +1303,7 @@ fn test_syscall_op_level {
     empty_location OpValue::Syscall1 make_op ops1.push
     ops1 tc_check = tc1
     "syscall1 result" 1 tc1 TypeChecker::live TypedStack::types.length assert_eq
-    "syscall1 type" "int" 0 tc1 TypeChecker::live TypedStack::types.get assert_str_eq
+    "syscall1 type" "int" 0 tc1 TypeChecker::live TypedStack::types.get.format assert_str_eq
 
     # syscall3: pops 4 (3 args + syscall number), pushes int
     List::new(List[Op]) = ops3
@@ -1314,7 +1314,7 @@ fn test_syscall_op_level {
     empty_location OpValue::Syscall3 make_op ops3.push
     ops3 tc_check = tc3
     "syscall3 result" 1 tc3 TypeChecker::live TypedStack::types.length assert_eq
-    "syscall3 type" "int" 0 tc3 TypeChecker::live TypedStack::types.get assert_str_eq
+    "syscall3 type" "int" 0 tc3 TypeChecker::live TypedStack::types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -1327,7 +1327,7 @@ fn test_typeof_char {
     empty_location 65 OpValue::PushChar make_op ops.push
     empty_location OpValue::Typeof make_op ops.push
     ops tc_check = result_tc
-    "typeof char result" "str" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
+    "typeof char result" "str" 0 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
 }
 
 fn test_typeof_ptr {
@@ -1337,7 +1337,7 @@ fn test_typeof_ptr {
     empty_location OpValue::HeapAlloc make_op ops.push
     empty_location OpValue::Typeof make_op ops.push
     ops tc_check = result_tc
-    "typeof ptr result" "str" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
+    "typeof ptr result" "str" 0 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -1351,8 +1351,8 @@ fn test_dup_preserves_str {
     empty_location OpValue::Dup make_op ops.push
     ops tc_check = result_tc
     "dup str count" 2 result_tc TypeChecker::live TypedStack::types.length assert_eq
-    "dup str first" "str" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
-    "dup str second" "str" 1 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
+    "dup str first" "str" 0 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "dup str second" "str" 1 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
 }
 
 fn test_dup_preserves_bool {
@@ -1362,8 +1362,8 @@ fn test_dup_preserves_bool {
     empty_location OpValue::Dup make_op ops.push
     ops tc_check = result_tc
     "dup bool count" 2 result_tc TypeChecker::live TypedStack::types.length assert_eq
-    "dup bool first" "bool" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
-    "dup bool second" "bool" 1 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
+    "dup bool first" "bool" 0 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "dup bool second" "bool" 1 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -1553,10 +1553,10 @@ fn test_tc_pipeline_print_pops {
 
 fn test_stacks_compatible_different_types {
     "stacks_compatible_different_types" test_start
-    List::new(List[str]) = stack_a
-    "int" stack_a.push
-    List::new(List[str]) = stack_b
-    "str" stack_b.push
+    List::new(List[Type]) = stack_a
+    "int" parse_type_str stack_a.push
+    List::new(List[Type]) = stack_b
+    "str" parse_type_str stack_b.push
     stack_b stack_a stacks_compatible = result
     "incompatible types" 0 result.length assert_eq
 }
@@ -1628,7 +1628,7 @@ fn test_type_cast_str_to_int {
     empty_location "int" OpValue::TypeCast make_op ops.push
     ops tc_check = result_tc
     "cast str to int" 1 result_tc TypeChecker::live TypedStack::types.length assert_eq
-    "cast result" "int" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
+    "cast result" "int" 0 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
 }
 
 fn test_type_cast_bool_to_int {
@@ -1637,7 +1637,7 @@ fn test_type_cast_bool_to_int {
     empty_location 1 OpValue::PushBool make_op ops.push
     empty_location "int" OpValue::TypeCast make_op ops.push
     ops tc_check = result_tc
-    "cast bool to int" "int" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
+    "cast bool to int" "int" 0 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -1706,7 +1706,7 @@ fn test_branch_if_else_agree_int {
     empty_location OpValue::IfEnd make_op ops.push
     ops tc_check = result_tc
     "live has one item" 1 result_tc TypeChecker::live TypedStack::types.length assert_eq
-    "unified type is int" "int" 0 result_tc TypeChecker::live TypedStack::types.get assert_str_eq
+    "unified type is int" "int" 0 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
     "frame stack empty" 0 result_tc TypeChecker::branched_stacks.length assert_eq
 }
 # OpIfEnd must pop the BranchFrame from branched_stacks.
@@ -1881,7 +1881,7 @@ fn test_branch_return_inside_if_restores_live {
         ret_if_ctx IfContext::before tc TypeChecker::live.restore
     fi
     "live restored to pre-branch state" 1 tc TypeChecker::live TypedStack::types.length assert_eq
-    "restored type is int" "int" 0 tc TypeChecker::live TypedStack::types.get assert_str_eq
+    "restored type is int" "int" 0 tc TypeChecker::live TypedStack::types.get.format assert_str_eq
     "return_types snapshot captured full state" 2 tc TypeChecker::return_types TypedStack::types.length assert_eq
 }
 

--- a/tests/compiler/test_typechecker.casa
+++ b/tests/compiler/test_typechecker.casa
@@ -532,7 +532,7 @@ fn test_typecheck_simple_expression {
     Option::None(Option[Function]) ops type_check_ops = sig
     "params" 0 sig Signature::parameters.length assert_eq
     "returns" 1 sig Signature::return_types.length assert_eq
-    "return type" "int" 0 sig Signature::return_types.get assert_str_eq
+    "return type" "int" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -555,43 +555,43 @@ fn test_tc_pipeline_literals {
     "tc_pipeline_literals" test_start
     "42" tc_string = sig1
     "int count" 1 sig1 Signature::return_types.length assert_eq
-    "int type" "int" 0 sig1 Signature::return_types.get assert_str_eq
+    "int type" "int" 0 sig1 Signature::return_types.get.format assert_str_eq
     "true" tc_string = sig2
-    "bool" "bool" 0 sig2 Signature::return_types.get assert_str_eq
+    "bool" "bool" 0 sig2 Signature::return_types.get.format assert_str_eq
     "\"hello\"" tc_string = sig3
-    "str" "str" 0 sig3 Signature::return_types.get assert_str_eq
+    "str" "str" 0 sig3 Signature::return_types.get.format assert_str_eq
     "'a'" tc_string = sig4
-    "char" "char" 0 sig4 Signature::return_types.get assert_str_eq
+    "char" "char" 0 sig4 Signature::return_types.get.format assert_str_eq
 }
 
 fn test_tc_pipeline_arithmetic {
     "tc_pipeline_arithmetic" test_start
     "1 2 +" tc_string = sa
-    "add" "int" 0 sa Signature::return_types.get assert_str_eq
+    "add" "int" 0 sa Signature::return_types.get.format assert_str_eq
     "1 2 -" tc_string = ss
-    "sub" "int" 0 ss Signature::return_types.get assert_str_eq
+    "sub" "int" 0 ss Signature::return_types.get.format assert_str_eq
     "1 2 *" tc_string = sm
-    "mul" "int" 0 sm Signature::return_types.get assert_str_eq
+    "mul" "int" 0 sm Signature::return_types.get.format assert_str_eq
 }
 
 fn test_tc_pipeline_comparison {
     "tc_pipeline_comparison" test_start
     "1 2 ==" tc_string = sc
-    "eq" "bool" 0 sc Signature::return_types.get assert_str_eq
+    "eq" "bool" 0 sc Signature::return_types.get.format assert_str_eq
     "1 2 <" tc_string = sl
-    "lt" "bool" 0 sl Signature::return_types.get assert_str_eq
+    "lt" "bool" 0 sl Signature::return_types.get.format assert_str_eq
     "1 2 >=" tc_string = sg
-    "ge" "bool" 0 sg Signature::return_types.get assert_str_eq
+    "ge" "bool" 0 sg Signature::return_types.get.format assert_str_eq
 }
 
 fn test_tc_pipeline_syscalls {
     "tc_pipeline_syscalls" test_start
     "60 syscall0" tc_string = s0
-    "syscall0" "int" 0 s0 Signature::return_types.get assert_str_eq
+    "syscall0" "int" 0 s0 Signature::return_types.get.format assert_str_eq
     "0 60 syscall1" tc_string = s1
-    "syscall1" "int" 0 s1 Signature::return_types.get assert_str_eq
+    "syscall1" "int" 0 s1 Signature::return_types.get.format assert_str_eq
     "0 0 0 0 60 syscall4" tc_string = s4
-    "syscall4" "int" 0 s4 Signature::return_types.get assert_str_eq
+    "syscall4" "int" 0 s4 Signature::return_types.get.format assert_str_eq
 }
 
 fn test_tc_pipeline_stack_ops {
@@ -602,15 +602,15 @@ fn test_tc_pipeline_stack_ops {
     "drop count" 0 sdr Signature::return_types.length assert_eq
     "42 \"hi\" swap" tc_string = sw
     "swap count" 2 sw Signature::return_types.length assert_eq
-    "swap first" "str" 0 sw Signature::return_types.get assert_str_eq
+    "swap first" "str" 0 sw Signature::return_types.get.format assert_str_eq
 }
 
 fn test_tc_pipeline_memory {
     "tc_pipeline_memory" test_start
     "10 alloc" tc_string = sa
-    "alloc" "ptr" 0 sa Signature::return_types.get assert_str_eq
+    "alloc" "ptr" 0 sa Signature::return_types.get.format assert_str_eq
     "10 alloc load64" tc_string = sl
-    "load64" "int" 0 sl Signature::return_types.get assert_str_eq
+    "load64" "int" 0 sl Signature::return_types.get.format assert_str_eq
     "42 10 alloc store64" tc_string = ss
     "store64" 0 ss Signature::return_types.length assert_eq
 }
@@ -841,19 +841,19 @@ fn test_tc_pipeline_variable_assign_and_load {
     "tc_pipeline_variable_assign_and_load" test_start
     "42 = x x" tc_string = sig
     "var returns" 1 sig Signature::return_types.length assert_eq
-    "var type is int" "int" 0 sig Signature::return_types.get assert_str_eq
+    "var type is int" "int" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_tc_pipeline_variable_str {
     "tc_pipeline_variable_str" test_start
     "\"hello\" = s s" tc_string = sig
-    "str var" "str" 0 sig Signature::return_types.get assert_str_eq
+    "str var" "str" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_tc_pipeline_variable_bool {
     "tc_pipeline_variable_bool" test_start
     "true = flag flag" tc_string = sig
-    "bool var" "bool" 0 sig Signature::return_types.get assert_str_eq
+    "bool var" "bool" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_tc_pipeline_assign_pops_stack {
@@ -866,8 +866,8 @@ fn test_tc_pipeline_multiple_vars {
     "tc_pipeline_multiple_vars" test_start
     "42 = x \"hi\" = y x y" tc_string = sig
     "two returns" 2 sig Signature::return_types.length assert_eq
-    "first is int" "int" 0 sig Signature::return_types.get assert_str_eq
-    "second is str" "str" 1 sig Signature::return_types.get assert_str_eq
+    "first is int" "int" 0 sig Signature::return_types.get.format assert_str_eq
+    "second is str" "str" 1 sig Signature::return_types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -878,7 +878,7 @@ fn test_tc_pipeline_fn_call {
     "tc_pipeline_fn_call" test_start
     "fn double a:int -> int { a 2 * } 5 double" tc_string = sig
     "fn call returns" 1 sig Signature::return_types.length assert_eq
-    "fn call type" "int" 0 sig Signature::return_types.get assert_str_eq
+    "fn call type" "int" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_tc_pipeline_fn_no_return {
@@ -890,7 +890,7 @@ fn test_tc_pipeline_fn_no_return {
 fn test_tc_pipeline_fn_multi_param {
     "tc_pipeline_fn_multi_param" test_start
     "fn add a:int b:int -> int { a b + } 3 5 add" tc_string = sig
-    "fn multi param" "int" 0 sig Signature::return_types.get assert_str_eq
+    "fn multi param" "int" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -900,13 +900,13 @@ fn test_tc_pipeline_fn_multi_param {
 fn test_tc_pipeline_type_cast {
     "tc_pipeline_type_cast" test_start
     "42 (str)" tc_string = sig
-    "cast result" "str" 0 sig Signature::return_types.get assert_str_eq
+    "cast result" "str" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_tc_pipeline_type_cast_to_ptr {
     "tc_pipeline_type_cast_to_ptr" test_start
     "42 (ptr)" tc_string = sig
-    "cast to ptr" "ptr" 0 sig Signature::return_types.get assert_str_eq
+    "cast to ptr" "ptr" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -916,19 +916,19 @@ fn test_tc_pipeline_type_cast_to_ptr {
 fn test_tc_pipeline_ne {
     "tc_pipeline_ne" test_start
     "1 2 !=" tc_string = sig
-    "ne" "bool" 0 sig Signature::return_types.get assert_str_eq
+    "ne" "bool" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_tc_pipeline_le {
     "tc_pipeline_le" test_start
     "1 2 <=" tc_string = sig
-    "le" "bool" 0 sig Signature::return_types.get assert_str_eq
+    "le" "bool" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_tc_pipeline_gt {
     "tc_pipeline_gt" test_start
     "5 2 >" tc_string = sig
-    "gt" "bool" 0 sig Signature::return_types.get assert_str_eq
+    "gt" "bool" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -938,19 +938,19 @@ fn test_tc_pipeline_gt {
 fn test_tc_pipeline_boolean_and {
     "tc_pipeline_boolean_and" test_start
     "true false &&" tc_string = sig
-    "and" "bool" 0 sig Signature::return_types.get assert_str_eq
+    "and" "bool" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_tc_pipeline_boolean_or {
     "tc_pipeline_boolean_or" test_start
     "true false ||" tc_string = sig
-    "or" "bool" 0 sig Signature::return_types.get assert_str_eq
+    "or" "bool" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_tc_pipeline_boolean_not {
     "tc_pipeline_boolean_not" test_start
     "true !" tc_string = sig
-    "not" "bool" 0 sig Signature::return_types.get assert_str_eq
+    "not" "bool" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -960,21 +960,21 @@ fn test_tc_pipeline_boolean_not {
 fn test_tc_pipeline_bitwise {
     "tc_pipeline_bitwise" test_start
     "3 5 &" tc_string = sig_and
-    "bitand" "int" 0 sig_and Signature::return_types.get assert_str_eq
+    "bitand" "int" 0 sig_and Signature::return_types.get.format assert_str_eq
     "3 5 |" tc_string = sig_or
-    "bitor" "int" 0 sig_or Signature::return_types.get assert_str_eq
+    "bitor" "int" 0 sig_or Signature::return_types.get.format assert_str_eq
     "3 5 ^" tc_string = sig_xor
-    "bitxor" "int" 0 sig_xor Signature::return_types.get assert_str_eq
+    "bitxor" "int" 0 sig_xor Signature::return_types.get.format assert_str_eq
     "5 ~" tc_string = sig_not
-    "bitnot" "int" 0 sig_not Signature::return_types.get assert_str_eq
+    "bitnot" "int" 0 sig_not Signature::return_types.get.format assert_str_eq
 }
 
 fn test_tc_pipeline_bitshift {
     "tc_pipeline_bitshift" test_start
     "8 2 <<" tc_string = sig_shl
-    "shl" "int" 0 sig_shl Signature::return_types.get assert_str_eq
+    "shl" "int" 0 sig_shl Signature::return_types.get.format assert_str_eq
     "8 2 >>" tc_string = sig_shr
-    "shr" "int" 0 sig_shr Signature::return_types.get assert_str_eq
+    "shr" "int" 0 sig_shr Signature::return_types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -984,13 +984,13 @@ fn test_tc_pipeline_bitshift {
 fn test_tc_pipeline_syscall_remaining {
     "tc_pipeline_syscall_remaining" test_start
     "0 0 60 syscall2" tc_string = s2
-    "syscall2" "int" 0 s2 Signature::return_types.get assert_str_eq
+    "syscall2" "int" 0 s2 Signature::return_types.get.format assert_str_eq
     "0 0 0 60 syscall3" tc_string = s3
-    "syscall3" "int" 0 s3 Signature::return_types.get assert_str_eq
+    "syscall3" "int" 0 s3 Signature::return_types.get.format assert_str_eq
     "0 0 0 0 0 60 syscall5" tc_string = s5
-    "syscall5" "int" 0 s5 Signature::return_types.get assert_str_eq
+    "syscall5" "int" 0 s5 Signature::return_types.get.format assert_str_eq
     "1 2 3 4 5 6 100 syscall6" tc_string = s6
-    "syscall6" "int" 0 s6 Signature::return_types.get assert_str_eq
+    "syscall6" "int" 0 s6 Signature::return_types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -1000,9 +1000,9 @@ fn test_tc_pipeline_syscall_remaining {
 fn test_tc_pipeline_div_mod {
     "tc_pipeline_div_mod" test_start
     "10 3 /" tc_string = sd
-    "div" "int" 0 sd Signature::return_types.get assert_str_eq
+    "div" "int" 0 sd Signature::return_types.get.format assert_str_eq
     "10 3 %" tc_string = sm
-    "mod" "int" 0 sm Signature::return_types.get assert_str_eq
+    "mod" "int" 0 sm Signature::return_types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -1174,7 +1174,7 @@ fn test_memory_store64 {
 fn test_syscall_any_arg_type {
     "syscall_any_arg_type" test_start
     "\"hello\" 42 syscall1" tc_string = sig
-    "syscall with str arg" "int" 0 sig Signature::return_types.get assert_str_eq
+    "syscall with str arg" "int" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -1373,7 +1373,7 @@ fn test_dup_preserves_bool {
 fn test_tc_pipeline_negative_int {
     "tc_pipeline_negative_int" test_start
     "-42" tc_string = sig
-    "negative int type" "int" 0 sig Signature::return_types.get assert_str_eq
+    "negative int type" "int" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -1384,7 +1384,7 @@ fn test_tc_pipeline_if_else_consistent {
     "tc_pipeline_if_else_consistent" test_start
     "if true then 1 else 2 fi" tc_string = sig
     "if else returns" 1 sig Signature::return_types.length assert_eq
-    "if else type" "int" 0 sig Signature::return_types.get assert_str_eq
+    "if else type" "int" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -1430,7 +1430,7 @@ fn test_tc_pipeline_while_loop {
 fn test_tc_pipeline_local_shadows_global {
     "tc_pipeline_local_shadows_global" test_start
     "\"hello\" = x fn foo x:int -> int { x } 42 foo" tc_string = sig
-    "local shadows global" "int" 0 sig Signature::return_types.get assert_str_eq
+    "local shadows global" "int" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -1480,13 +1480,13 @@ fn test_error_unused_fn_type_error {
 fn test_tc_pipeline_type_cast_to_int {
     "tc_pipeline_type_cast_to_int" test_start
     "\"hello\" (int)" tc_string = sig
-    "cast to int" "int" 0 sig Signature::return_types.get assert_str_eq
+    "cast to int" "int" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_tc_pipeline_type_cast_to_bool {
     "tc_pipeline_type_cast_to_bool" test_start
     "42 (bool)" tc_string = sig
-    "cast to bool" "bool" 0 sig Signature::return_types.get assert_str_eq
+    "cast to bool" "bool" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -1497,8 +1497,8 @@ fn test_tc_pipeline_swap_type_order {
     "tc_pipeline_swap_type_order" test_start
     "42 \"hi\" swap" tc_string = sig
     "swap count" 2 sig Signature::return_types.length assert_eq
-    "swap bottom" "str" 0 sig Signature::return_types.get assert_str_eq
-    "swap top" "int" 1 sig Signature::return_types.get assert_str_eq
+    "swap bottom" "str" 0 sig Signature::return_types.get.format assert_str_eq
+    "swap top" "int" 1 sig Signature::return_types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -1509,9 +1509,9 @@ fn test_tc_pipeline_over_type_order {
     "tc_pipeline_over_type_order" test_start
     "42 \"hi\" over" tc_string = sig
     "over count" 3 sig Signature::return_types.length assert_eq
-    "over bottom" "int" 0 sig Signature::return_types.get assert_str_eq
-    "over middle" "str" 1 sig Signature::return_types.get assert_str_eq
-    "over top" "int" 2 sig Signature::return_types.get assert_str_eq
+    "over bottom" "int" 0 sig Signature::return_types.get.format assert_str_eq
+    "over middle" "str" 1 sig Signature::return_types.get.format assert_str_eq
+    "over top" "int" 2 sig Signature::return_types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -1522,9 +1522,9 @@ fn test_tc_pipeline_rot_type_order {
     "tc_pipeline_rot_type_order" test_start
     "1 \"a\" true rot" tc_string = sig
     "rot count" 3 sig Signature::return_types.length assert_eq
-    "rot bottom" "str" 0 sig Signature::return_types.get assert_str_eq
-    "rot middle" "bool" 1 sig Signature::return_types.get assert_str_eq
-    "rot top" "int" 2 sig Signature::return_types.get assert_str_eq
+    "rot bottom" "str" 0 sig Signature::return_types.get.format assert_str_eq
+    "rot middle" "bool" 1 sig Signature::return_types.get.format assert_str_eq
+    "rot top" "int" 2 sig Signature::return_types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -1534,7 +1534,7 @@ fn test_tc_pipeline_rot_type_order {
 fn test_tc_pipeline_typeof {
     "tc_pipeline_typeof" test_start
     "42 typeof" tc_string = sig
-    "typeof returns str" "str" 0 sig Signature::return_types.get assert_str_eq
+    "typeof returns str" "str" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -1659,7 +1659,7 @@ fn test_error_comparison_str_lt_int {
 fn test_tc_pipeline_str_equality {
     "tc_pipeline_str_equality" test_start
     "\"a\" \"b\" ==" tc_string = sig
-    "str eq" "bool" 0 sig Signature::return_types.get assert_str_eq
+    "str eq" "bool" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -1792,37 +1792,37 @@ fn test_array_literal_int_inference {
     "array_literal_int_inference" test_start
     "[1 2 3]" tc_string = sig
     "one return" 1 sig Signature::return_types.length assert_eq
-    "array[int]" "array[int]" 0 sig Signature::return_types.get assert_str_eq
+    "array[int]" "array[int]" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_array_literal_str_inference {
     "array_literal_str_inference" test_start
     "[\"a\" \"b\"]" tc_string = sig
-    "array[str]" "array[str]" 0 sig Signature::return_types.get assert_str_eq
+    "array[str]" "array[str]" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_array_literal_bool_inference {
     "array_literal_bool_inference" test_start
     "[true false]" tc_string = sig
-    "array[bool]" "array[bool]" 0 sig Signature::return_types.get assert_str_eq
+    "array[bool]" "array[bool]" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_array_literal_empty {
     "array_literal_empty" test_start
     "[] (array[int])" tc_string = sig
-    "explicit cast resolves" "array[int]" 0 sig Signature::return_types.get assert_str_eq
+    "explicit cast resolves" "array[int]" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_array_literal_empty_with_annotation {
     "array_literal_empty_with_annotation" test_start
     "[] = xs:array[int] xs" tc_string = sig
-    "annotation resolves" "array[int]" 0 sig Signature::return_types.get assert_str_eq
+    "annotation resolves" "array[int]" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_array_literal_empty_with_cast_then_assign {
     "array_literal_empty_with_cast_then_assign" test_start
     "[] (array[str]) = xs xs" tc_string = sig
-    "cast then assign" "array[str]" 0 sig Signature::return_types.get assert_str_eq
+    "cast then assign" "array[str]" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_error_array_literal_heterogeneous {

--- a/tests/compiler/test_typeof.casa
+++ b/tests/compiler/test_typeof.casa
@@ -99,25 +99,25 @@ fn test_typecheck_typeof_returns_str_for_int {
     "typecheck_typeof_returns_str_for_int" test_start
     "42 typeof" tc_typeof = sig
     "one return" 1 sig Signature::return_types.length assert_eq
-    "returns str" "str" 0 sig Signature::return_types.get assert_str_eq
+    "returns str" "str" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_typecheck_typeof_returns_str_for_bool {
     "typecheck_typeof_returns_str_for_bool" test_start
     "true typeof" tc_typeof = sig
-    "returns str" "str" 0 sig Signature::return_types.get assert_str_eq
+    "returns str" "str" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_typecheck_typeof_returns_str_for_str {
     "typecheck_typeof_returns_str_for_str" test_start
     "\"hello\" typeof" tc_typeof = sig
-    "returns str" "str" 0 sig Signature::return_types.get assert_str_eq
+    "returns str" "str" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_typecheck_typeof_returns_str_for_char {
     "typecheck_typeof_returns_str_for_char" test_start
     "'a' typeof" tc_typeof = sig
-    "returns str" "str" 0 sig Signature::return_types.get assert_str_eq
+    "returns str" "str" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_typecheck_typeof_no_params {
@@ -130,20 +130,20 @@ fn test_typecheck_typeof_chained {
     "typecheck_typeof_chained" test_start
     "42 typeof drop true typeof" tc_typeof = sig
     "one return" 1 sig Signature::return_types.length assert_eq
-    "returns str" "str" 0 sig Signature::return_types.get assert_str_eq
+    "returns str" "str" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_typecheck_typeof_ptr {
     "typecheck_typeof_ptr" test_start
     "10 alloc typeof" tc_typeof = sig
-    "returns str" "str" 0 sig Signature::return_types.get assert_str_eq
+    "returns str" "str" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 fn test_typecheck_typeof_array {
     "typecheck_typeof_array" test_start
     "[1 2 3] typeof" tc_typeof = sig
     "one return" 1 sig Signature::return_types.length assert_eq
-    "returns str" "str" 0 sig Signature::return_types.get assert_str_eq
+    "returns str" "str" 0 sig Signature::return_types.get.format assert_str_eq
 }
 
 # ============================================================================


### PR DESCRIPTION
## Summary

Implements PRD #140. Replaces stringly-typed compiler internals with a structured `Type` enum (`Unknown`, `Builtin`, `Generic`, `Function`, `TypeVar`).

Closes issues #161-#167.

### Per-commit breakdown

- `976a730` Type AST foundation: enum, `parse_type_str`, `Type.format`, round-trip tests
- `e7ef718` Migrate `Parameter.typ: str → Type`
- `a658ef5` Migrate `Variable.typ` and `Member.typ` to `Type`
- `c64f7d1` Migrate `Signature.return_types: List[str] → List[Type]`
- `606f79e` Migrate `TypedStack.types: List[str] → List[Type]`
- `2f59857` Add `Type` methods: `base`, `type_params`, `is_type_var`, `substitute`
- `45f1b12` Fix RPN argument order in `parse_type_str` (str helpers; see below)
- `83de95e` Remove internal string boundaries at `make_named_param` / `make_signature`

### Bug discovered and fixed

`parse_type_str` passed `starts_with`/`ends_with`/`contains`/`find` arguments in the wrong RPN order, so `parse_type_str("fn[T -> U]")` returned a `Generic{base="fn[T -> U]", params=[]}` blob instead of a real `Type::Function`. `Type::format` round-tripped it correctly so the bug was masked, but `Type::substitute` couldn't decompose the blob — broke trait default method synthesis (e.g. `Counter.map` from `Iterable::map`). Direct substitute test added in `test_type_ast.casa` as a regression guard.

### Notes on Casa enum move-semantics

Casa enum values (`Type`, `Option[T]`) are move-semantic: a named variable is consumed on first method call. `resolve_trait_sig` therefore uses a format → check → re-parse pattern when it needs to compare a `Type` against `TRAIT_SELF_TYPE` and reuse it. `signature_matches` similarly stays str-based.

## Test plan

- [x] `tests/test_compiler.sh < /dev/null` — 28/28 pass
- [x] `tests/test_examples.sh` — 40/40 pass
- [x] Self-compilation (compiler builds itself)
- [x] Fixed-point bootstrap