### PR TITLE
perf(typechecker): migrate trait dispatch bindings to Map[str Type]

### DIFF
--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -1017,6 +1017,45 @@ impl Type {
         end
     }
 
+    fn substitute_t self:Type bindings:Map[str Type] -> Type {
+        self match
+            Type::Unknown => { Type::Unknown }
+            Type::Builtin(builtin) => { builtin Type::Builtin }
+            Type::TypeVar(name) => {
+                if name bindings.get Option::Some(bound) is then
+                    bound
+                else
+                    name Type::TypeVar
+                fi
+            }
+            Type::Generic(generic) => {
+                generic.base = base
+                if 0 generic.params.length == then
+                    if base bindings.get Option::Some(bound) is then
+                        bound return
+                    fi
+                    generic.params base GenericType Type::Generic return
+                fi
+                List::new(List[Type]) = new_params
+                for param in generic.params.iter do
+                    bindings param.substitute_t new_params.push
+                done
+                new_params base GenericType Type::Generic
+            }
+            Type::Function(fn_type) => {
+                List::new(List[Type]) = new_params
+                for param in fn_type.parameters.iter do
+                    bindings param.substitute_t new_params.push
+                done
+                List::new(List[Type]) = new_returns
+                for ret in fn_type.return_types.iter do
+                    bindings ret.substitute_t new_returns.push
+                done
+                new_returns new_params FunctionType Type::Function
+            }
+        end
+    }
+
     fn is_unknown self:Type -> bool {
         self match
             Type::Unknown => { true }
@@ -1043,6 +1082,31 @@ impl Type {
             Type::Unknown => { true }
             Type::Generic(generic) => {
                 0 generic.params.length == TYPE_UNKNOWN generic.base == &&
+            }
+            _ => { false }
+        end
+    }
+
+    fn type_contains_var self:Type type_var:str -> bool {
+        self match
+            Type::TypeVar(name) => { name type_var == }
+            Type::Generic(generic) => {
+                if 0 generic.params.length == then
+                    generic.base type_var == return
+                fi
+                for param in generic.params.iter do
+                    if type_var param.type_contains_var then true return fi
+                done
+                false
+            }
+            Type::Function(fn_type) => {
+                for param in fn_type.parameters.iter do
+                    if type_var param.type_contains_var then true return fi
+                done
+                for ret in fn_type.return_types.iter do
+                    if type_var ret.type_contains_var then true return fi
+                done
+                false
             }
             _ => { false }
         end
@@ -1572,6 +1636,22 @@ fn apply_type_subs_to_sig sig:Signature subs:Map[str str] -> Signature {
     List::new(List[Type]) = returns
     for return_type in sig Signature::return_types.iter do
         subs return_type.substitute returns.push
+    done
+    returns params make_signature
+}
+
+fn apply_type_subs_to_sig_t sig:Signature subs:Map[str Type] -> Signature {
+    if 0 subs.length == then
+        sig return
+    fi
+    List::new(List[Parameter]) = params
+    for param in sig Signature::parameters.iter do
+        subs param Parameter::typ.substitute_t = new_typ
+        param Parameter::name new_typ make_named_param params.push
+    done
+    List::new(List[Type]) = returns
+    for return_type in sig Signature::return_types.iter do
+        subs return_type.substitute_t returns.push
     done
     returns params make_signature
 }

--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -978,6 +978,19 @@ impl Type {
         end
     }
 
+    fn as_generic self:Type -> Option[GenericType] {
+        self match
+            Type::Generic(generic) => {
+                if 0 generic.params.length == then
+                    Option::None
+                else
+                    generic Option::Some
+                fi
+            }
+            _ => { Option::None }
+        end
+    }
+
     fn substitute self:Type subs:Map[str str] -> Type {
         self match
             Type::Unknown => { Type::Unknown }

--- a/compiler/typechecker.casa
+++ b/compiler/typechecker.casa
@@ -1400,34 +1400,24 @@ fn bind_generic_params_standalone
     actual_type:Type
     type_vars:Set[str]
 -> Map[str Type] {
-    expected_type match
-        Type::Generic(expected_g) => {
-            if 0 expected_g.params.length == then bindings return fi
-            actual_type match
-                Type::Generic(actual_g) => {
-                    if 0 actual_g.params.length == then bindings return fi
-                    if expected_g.base actual_g.base != then bindings return fi
-                    0 = index
-                    while
-                    index expected_g.params.length >
-                    index actual_g.params.length > &&
-                    do
-                        if index expected_g.params.get.type_var_name Option::Some(tv_name) is then
-                            if
-                            tv_name type_vars.has
-                            tv_name bindings.get.is_none &&
-                            then
-                                tv_name index actual_g.params.get bindings.set = bindings
-                            fi
-                        fi
-                        1 += index
-                    done
-                }
-                _ => { }
-            end
-        }
-        _ => { }
-    end
+    if expected_type.as_generic Option::Some(expected_g) is ! then bindings return fi
+    if actual_type.as_generic Option::Some(actual_g) is ! then bindings return fi
+    if expected_g.base actual_g.base != then bindings return fi
+    0 = index
+    while
+    index expected_g.params.length >
+    index actual_g.params.length > &&
+    do
+        if index expected_g.params.get.type_var_name Option::Some(tv_name) is then
+            if
+            tv_name type_vars.has
+            tv_name bindings.get.is_none &&
+            then
+                tv_name index actual_g.params.get bindings.set = bindings
+            fi
+        fi
+        1 += index
+    done
     bindings
 }
 
@@ -1569,34 +1559,25 @@ fn bind_from_type_slot
             direct_tp_idx bargs.get = direct_caller_ref
             actual direct_caller_ref sig bindings try_bind_caller_tvar return
         fi
+        bindings return
     fi
-    expected match
-        Type::Generic(expected_g) => {
-            if 0 expected_g.params.length == then bindings return fi
-            actual match
-                Type::Generic(actual_g) => {
-                    if 0 actual_g.params.length == then bindings return fi
-                    if expected_g.base actual_g.base != then bindings return fi
-                    0 = slot_index
-                    while
-                    slot_index expected_g.params.length >
-                    slot_index actual_g.params.length > &&
-                    do
-                        if slot_index expected_g.params.get.type_var_name Option::Some(nested_name) is then
-                            nested_name tparams find_tparam_index = nested_tp_idx
-                            if 0 nested_tp_idx >= then
-                                nested_tp_idx bargs.get = nested_caller_ref
-                                slot_index actual_g.params.get nested_caller_ref sig bindings try_bind_caller_tvar = bindings
-                            fi
-                        fi
-                        1 += slot_index
-                    done
-                }
-                _ => { }
-            end
-        }
-        _ => { }
-    end
+    if expected.as_generic Option::Some(expected_g) is ! then bindings return fi
+    if actual.as_generic Option::Some(actual_g) is ! then bindings return fi
+    if expected_g.base actual_g.base != then bindings return fi
+    0 = slot_index
+    while
+    slot_index expected_g.params.length >
+    slot_index actual_g.params.length > &&
+    do
+        if slot_index expected_g.params.get.type_var_name Option::Some(nested_name) is then
+            nested_name tparams find_tparam_index = nested_tp_idx
+            if 0 nested_tp_idx >= then
+                nested_tp_idx bargs.get = nested_caller_ref
+                slot_index actual_g.params.get nested_caller_ref sig bindings try_bind_caller_tvar = bindings
+            fi
+        fi
+        1 += slot_index
+    done
     bindings
 }
 

--- a/compiler/typechecker.casa
+++ b/compiler/typechecker.casa
@@ -745,12 +745,11 @@ fn bind_unknowns
 fn bind_fn_param tc:TypeChecker bindings:Map[str Type] expected:Parameter sig:Signature -> bool {
     # Bind type vars from a fn[sig] param like fn[T -> T].
     if expected Parameter::typ.is_fn_type_t ! then false return fi
-    expected Parameter::typ.format = fn_sig_str
     # Check if any type var appears in the fn signature
     false = has_type_var
     sig Signature::type_vars.to_list = type_var_list
     for type_var in type_var_list.iter do
-        if fn_sig_str type_var str::find 0 <= then
+        if type_var expected Parameter::typ.type_contains_var then
             true = has_type_var
         fi
     done
@@ -759,7 +758,7 @@ fn bind_fn_param tc:TypeChecker bindings:Map[str Type] expected:Parameter sig:Si
     tc stack_pop_type = actual
     if actual.is_unknown_placeholder then
         for type_var2 in type_var_list.iter do
-            if fn_sig_str type_var2 str::find 0 <= then
+            if type_var2 expected Parameter::typ.type_contains_var then
                 TYPE_UNKNOWN_T type_var2 bindings tc bind_type_var = bindings
             fi
         done
@@ -1396,30 +1395,39 @@ fn check_while_block tc:TypeChecker op:Op {
 # ============================================================================
 
 fn bind_generic_params_standalone
-    bindings:Map[str str]
-    expected_type:str
-    actual_type:str
+    bindings:Map[str Type]
+    expected_type:Type
+    actual_type:Type
     type_vars:Set[str]
--> Map[str str] {
-    expected_type extract_generic_base = expected_base
-    if expected_base.is_none then bindings return fi
-    actual_type extract_generic_base = actual_base
-    if actual_base.is_none then bindings return fi
-    if expected_base.unwrap actual_base.unwrap != then bindings return fi
-    expected_type extract_generic_params = expected_params_opt
-    actual_type extract_generic_params = actual_params_opt
-    if expected_params_opt.is_none then bindings return fi
-    if actual_params_opt.is_none then bindings return fi
-    expected_params_opt.unwrap = expected_params
-    actual_params_opt.unwrap = actual_params
-    0 = index
-    while index expected_params.length > index actual_params.length > && do
-        index expected_params.get = expected_param
-        if expected_param type_vars.has expected_param bindings.get.is_none && then
-            expected_param index actual_params.get bindings.set = bindings
-        fi
-        1 += index
-    done
+-> Map[str Type] {
+    expected_type match
+        Type::Generic(expected_g) => {
+            if 0 expected_g.params.length == then bindings return fi
+            actual_type match
+                Type::Generic(actual_g) => {
+                    if 0 actual_g.params.length == then bindings return fi
+                    if expected_g.base actual_g.base != then bindings return fi
+                    0 = index
+                    while
+                    index expected_g.params.length >
+                    index actual_g.params.length > &&
+                    do
+                        if index expected_g.params.get.type_var_name Option::Some(tv_name) is then
+                            if
+                            tv_name type_vars.has
+                            tv_name bindings.get.is_none &&
+                            then
+                                tv_name index actual_g.params.get bindings.set = bindings
+                            fi
+                        fi
+                        1 += index
+                    done
+                }
+                _ => { }
+            end
+        }
+        _ => { }
+    end
     bindings
 }
 
@@ -1532,11 +1540,11 @@ fn find_tparam_index tparams:List[str] name:str -> int {
 }
 
 fn try_bind_caller_tvar
-    bindings:Map[str str]
+    bindings:Map[str Type]
     sig:Signature
     caller_ref:str
-    concrete:str
--> Map[str str] {
+    concrete:Type
+-> Map[str Type] {
     if caller_ref sig Signature::type_vars.has ! then bindings return fi
     if caller_ref bindings.get.is_some then bindings return fi
     caller_ref concrete bindings.set return
@@ -1548,60 +1556,65 @@ fn try_bind_caller_tvar
 # references (`T`) and one-level nested generics (`Option[T]` vs `Option[int]`).
 
 fn bind_from_type_slot
-    bindings:Map[str str]
+    bindings:Map[str Type]
     sig:Signature
     tparams:List[str]
     bargs:List[str]
-    expected:str
-    actual:str
--> Map[str str] {
-    expected tparams find_tparam_index = direct_tp_idx
-    if 0 direct_tp_idx >= then
-        direct_tp_idx bargs.get = direct_caller_ref
-        actual direct_caller_ref sig bindings try_bind_caller_tvar return
-    fi
-    expected extract_generic_base = expected_base_opt
-    actual extract_generic_base = actual_base_opt
-    if expected_base_opt.is_none then bindings return fi
-    if actual_base_opt.is_none then bindings return fi
-    if expected_base_opt.unwrap actual_base_opt.unwrap != then bindings return fi
-    expected extract_generic_params = expected_params_opt
-    actual extract_generic_params = actual_params_opt
-    if expected_params_opt.is_none then bindings return fi
-    if actual_params_opt.is_none then bindings return fi
-    expected_params_opt.unwrap = expected_params
-    actual_params_opt.unwrap = actual_params
-    0 = slot_index
-    while
-    slot_index expected_params.length >
-    slot_index actual_params.length > &&
-    do
-        slot_index expected_params.get = nested_expected
-        nested_expected tparams find_tparam_index = nested_tp_idx
-        if 0 nested_tp_idx >= then
-            nested_tp_idx bargs.get = nested_caller_ref
-            slot_index actual_params.get nested_caller_ref sig bindings try_bind_caller_tvar = bindings
+    expected:Type
+    actual:Type
+-> Map[str Type] {
+    if expected.type_var_name Option::Some(direct_tv_name) is then
+        direct_tv_name tparams find_tparam_index = direct_tp_idx
+        if 0 direct_tp_idx >= then
+            direct_tp_idx bargs.get = direct_caller_ref
+            actual direct_caller_ref sig bindings try_bind_caller_tvar return
         fi
-        1 += slot_index
-    done
+    fi
+    expected match
+        Type::Generic(expected_g) => {
+            if 0 expected_g.params.length == then bindings return fi
+            actual match
+                Type::Generic(actual_g) => {
+                    if 0 actual_g.params.length == then bindings return fi
+                    if expected_g.base actual_g.base != then bindings return fi
+                    0 = slot_index
+                    while
+                    slot_index expected_g.params.length >
+                    slot_index actual_g.params.length > &&
+                    do
+                        if slot_index expected_g.params.get.type_var_name Option::Some(nested_name) is then
+                            nested_name tparams find_tparam_index = nested_tp_idx
+                            if 0 nested_tp_idx >= then
+                                nested_tp_idx bargs.get = nested_caller_ref
+                                slot_index actual_g.params.get nested_caller_ref sig bindings try_bind_caller_tvar = bindings
+                            fi
+                        fi
+                        1 += slot_index
+                    done
+                }
+                _ => { }
+            end
+        }
+        _ => { }
+    end
     bindings
 }
 
 fn diff_method_sig
-    bindings:Map[str str]
+    bindings:Map[str Type]
     sig:Signature
     tparams:List[str]
     bargs:List[str]
     trait_resolved:Signature
     impl_sig:Signature
--> Map[str str] {
+-> Map[str Type] {
     0 = param_index
     while
     param_index trait_resolved Signature::parameters.length >
     param_index impl_sig Signature::parameters.length > &&
     do
-        param_index trait_resolved Signature::parameters.get Parameter::typ.format = expected_param
-        param_index impl_sig Signature::parameters.get Parameter::typ.format = actual_param
+        param_index trait_resolved Signature::parameters.get Parameter::typ = expected_param
+        param_index impl_sig Signature::parameters.get Parameter::typ = actual_param
         actual_param expected_param bargs tparams sig bindings bind_from_type_slot = bindings
         1 += param_index
     done
@@ -1610,8 +1623,8 @@ fn diff_method_sig
     return_index trait_resolved Signature::return_types.length >
     return_index impl_sig Signature::return_types.length > &&
     do
-        return_index trait_resolved Signature::return_types.get.format = expected_return
-        return_index impl_sig Signature::return_types.get.format = actual_return
+        return_index trait_resolved Signature::return_types.get = expected_return
+        return_index impl_sig Signature::return_types.get = actual_return
         actual_return expected_return bargs tparams sig bindings bind_from_type_slot = bindings
         1 += return_index
     done
@@ -1619,11 +1632,11 @@ fn diff_method_sig
 }
 
 fn method_diff_bind_for_bound
-    bindings:Map[str str]
+    bindings:Map[str Type]
     sig:Signature
     bound:TraitBound
     concrete:str
--> Map[str str] {
+-> Map[str Type] {
     bound TraitBound::name DEFAULT_PARSER.store.traits.get = trait_opt
     if trait_opt.is_none then bindings return fi
     trait_opt.unwrap = trait_def
@@ -1643,14 +1656,14 @@ fn method_diff_bind_for_bound
 fn method_diff_bind_all
     sig:Signature
     function_opt:Option[Function]
-    bindings:Map[str str]
--> Map[str str] {
+    bindings:Map[str Type]
+-> Map[str Type] {
     sig Signature::trait_bounds.keys = bound_keys
     for bound_type_var in bound_keys.iter do
         bound_type_var sig Signature::trait_bounds.get.unwrap = bound_constraint
         bound_type_var bindings.get = concrete_opt
         if concrete_opt.is_some then
-            concrete_opt.unwrap bound_constraint sig bindings method_diff_bind_for_bound = bindings
+            concrete_opt.unwrap.format bound_constraint sig bindings method_diff_bind_for_bound = bindings
         fi
     done
     bindings
@@ -1665,7 +1678,7 @@ fn inject_trait_fn_ptrs
     function_opt:Option[Function]
 -> int {
     # Bind type variables from the stack (peek at positions)
-    Map::new(Map[str str]) = bindings
+    Map::new(Map[str Type]) = bindings
 
     # Collect non-hidden parameters
     List::new(List[Parameter]) = non_hidden
@@ -1682,17 +1695,23 @@ fn inject_trait_fn_ptrs
         depth 1 - index - = stack_index
         if 0 stack_index >= then
             index non_hidden.get = stack_param
-            stack_index tc TypeChecker::live TypedStack::types.get.format = actual
-            if stack_param Parameter::typ.format sig Signature::type_vars.has then
-                stack_param Parameter::typ.format = binding_type_var
-                binding_type_var bindings.get = existing_binding_opt
-                if existing_binding_opt.is_none then
-                    binding_type_var actual bindings.set = bindings
-                elif actual existing_binding_opt.unwrap != then
-                    location f"Type variable `{binding_type_var}` bound to `{existing_binding_opt.unwrap}` but got `{actual}`" ErrorKind::TypeMismatch raise_error
+            stack_index tc TypeChecker::live TypedStack::types.get = actual
+            if stack_param Parameter::typ.type_var_name Option::Some(binding_type_var) is then
+                if binding_type_var sig Signature::type_vars.has then
+                    binding_type_var bindings.get = existing_binding_opt
+                    if existing_binding_opt.is_none then
+                        binding_type_var actual bindings.set = bindings
+                    else
+                        existing_binding_opt.unwrap = existing_binding
+                        if existing_binding actual.eq ! then
+                            location f"Type variable `{binding_type_var}` bound to `{existing_binding.format}` but got `{actual.format}`" ErrorKind::TypeMismatch raise_error
+                        fi
+                    fi
+                else
+                    sig Signature::type_vars actual stack_param Parameter::typ bindings bind_generic_params_standalone = bindings
                 fi
             else
-                sig Signature::type_vars actual stack_param Parameter::typ.format bindings bind_generic_params_standalone = bindings
+                sig Signature::type_vars actual stack_param Parameter::typ bindings bind_generic_params_standalone = bindings
             fi
         fi
         1 += index
@@ -1710,10 +1729,17 @@ fn inject_trait_fn_ptrs
         op_index ops.get = next_op
         if next_op.value OpValue::TypeCast(cast_type) is then
             for return_type in sig Signature::return_types.iter do
-                sig Signature::type_vars cast_type return_type.format bindings bind_generic_params_standalone = bindings
+                sig Signature::type_vars cast_type parse_type_str return_type bindings bind_generic_params_standalone = bindings
             done
         fi
     fi
+
+    # Build str-view of bindings for the per-bound substitute_type_params call.
+    Map::new(Map[str str]) = bindings_str
+    for binding_key in bindings.keys.iter do
+        binding_key bindings.get.unwrap.format = binding_value
+        binding_key binding_value bindings_str.set = bindings_str
+    done
 
     # Inject FN_PUSH ops for each trait bound.
     # Iterate type vars in reverse so the first param in the signature (which
@@ -1728,14 +1754,14 @@ fn inject_trait_fn_ptrs
         type_var sig Signature::trait_bounds.get.unwrap = trait_bound
         # Resolve trait type args against current bindings so that
         # `Carrier[T]` becomes `Carrier[int]` once T has been bound.
-        bindings trait_bound trait_bound_to_str substitute_type_params = trait_name
+        bindings_str trait_bound trait_bound_to_str substitute_type_params = trait_name
         type_var bindings.get = concrete_opt
         if concrete_opt.is_none then
             location f"Cannot determine concrete type for type variable `{type_var}`" ErrorKind::TypeMismatch raise_error
             type_index 1 - = type_index
             continue
         fi
-        concrete_opt.unwrap = concrete
+        concrete_opt.unwrap.format = concrete
         trait_bound TraitBound::name tc.store.traits.get.unwrap = trait_def
 
         # Check if forwarding (type var has same trait bound in calling function)
@@ -2420,7 +2446,7 @@ fn instantiate_default_trait_method
 
     # For generic receivers, keep trait type params as function type vars.
     # For non-generic receivers, substitute trait type params with concrete types.
-    Map::new(Map[str str]) = trait_subs
+    Map::new(Map[str Type]) = trait_subs
     if fn_base_opt.is_some then
         fn_base_opt.unwrap = base_name
         if 0 type_params.length != then
@@ -2454,13 +2480,13 @@ fn instantiate_default_trait_method
                     receiver infer_method TraitMethod::signature resolve_trait_sig = infer_trait_resolved
                     0 = ret_index
                     while ret_index infer_trait_resolved Signature::return_types.length > ret_index infer_fn Function::signature Signature::return_types.length > && do
-                        type_param_set ret_index infer_fn Function::signature Signature::return_types.get.format ret_index infer_trait_resolved Signature::return_types.get.format trait_subs bind_generic_params_standalone = trait_subs
+                        type_param_set ret_index infer_fn Function::signature Signature::return_types.get ret_index infer_trait_resolved Signature::return_types.get trait_subs bind_generic_params_standalone = trait_subs
                         1 += ret_index
                     done
                 fi
             fi
         done
-        trait_subs receiver default_method TraitMethod::signature resolve_trait_sig apply_type_subs_to_sig = resolved_sig
+        trait_subs receiver default_method TraitMethod::signature resolve_trait_sig apply_type_subs_to_sig_t = resolved_sig
     fi
 
     # Add trait type params as function type vars for generic receivers
@@ -2489,7 +2515,12 @@ fn instantiate_default_trait_method
 
     default_method TraitMethod::default_ops clone_ops = cloned_body
     if 0 trait_subs.length != then
-        trait_subs cloned_body substitute_ops_types
+        Map::new(Map[str str]) = trait_subs_str
+        for sub_key in trait_subs.keys.iter do
+            sub_key trait_subs.get.unwrap.format = sub_value
+            sub_key sub_value trait_subs_str.set = trait_subs_str
+        done
+        trait_subs_str cloned_body substitute_ops_types
     fi
     for body_op in cloned_body.iter do
         body_op synth_ops.push


### PR DESCRIPTION
## Summary
- Migrate trait dispatch binding maps in typechecker from `Map[str str]` to `Map[str Type]`, removing Type/str round-trips on the hot trait-dispatch path
- Replace string-based generic param extraction (`extract_generic_base`/`extract_generic_params`) with native `Type` matching in `bind_generic_params_standalone` and `bind_from_type_slot`
- Add `Type::substitute_t`, `Type::type_contains_var`, and `apply_type_subs_to_sig_t` helpers operating directly on `Type`

## Test plan
- [x] `tests/test_compiler.sh` (28 passed)
- [x] `tests/test_examples.sh` (40 passed)