### PR TITLE
docs: reorganize CLAUDE.md into per-workflow agent docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -206,5 +206,4 @@ marimo/_lsp/
 __marimo__/
 
 .claude/
-CLAUDE.md
 roadmap.txt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,73 @@
+# Casa
+
+See [README.md](./README.md) for basic information of the language and the links to documentation and examples.
+
+## Planning
+
+Work back and forth with me, starting with your open questions and outline before writing the plan
+
+## Documentation
+
+When any language feature or standard library function is changed or added, the corresponding documentation must be updated to reflect the change.
+
+## Code conventions
+
+- See [FORMAT.md](./docs/FORMAT.md) for formatting rules
+- See [STYLE.md](./docs/STYLE.md) for naming conventions and idiomatic patterns
+- Files should contain the relevant imports to be self-compilable
+
+### CRITICAL: Reverse polish notation
+
+- The topmost value in the stack is the first argument
+- `a b <` equals to `b < a` in traditional languages
+- `z y x foo` equals to `foo(x, y, z)` in traditional language
+- When troubleshooting, first check if the related function call sites are using the correct argument order
+
+### Import paths
+
+`import` accepts two forms:
+
+- **Path-style** (`import "lib/std.casa"`, `import "/abs/path.casa"`): contains `/` or ends with `.casa`. Resolved relative to the importing file (or used as-is when absolute). No search.
+- **Module-style** (`import "std"`): bare name. Resolved against the importing file's directory first, then each `-L`/`--library-path` directory in CLI order. First existing match wins.
+
+## Git conventions
+
+- Never append any Co-Authored-By messages to commit messages
+- Never mention Claude, AI usage, or other tool usage in commit messages, pull request messages or anywhere else
+- Never commit Claude-related files
+- One commit should only contain changes for one functionality
+- Always sign commits. If signing does not work, ask the user to ssh-add the SSH key.
+- Never make changes to `main` branch
+- Always make commits when a planned changes are finished
+- Always make pull requests when the reviewer agent does not find any more things to fix
+- Keep commit messages brief
+- Never commit binary files unless explicitly asked to do so
+
+## Examples
+
+- Always update examples for new and updated functionality
+- When examples are changed, regenerate the expected output for `tests/test_examples.sh`
+
+## Testing
+
+- Always autoformat changed `.casa` files with `./casafmt` before running tests or creating a pull request (e.g. `./casafmt < file.casa > tmp && mv tmp file.casa`)
+- Always run `tests/test_examples.sh` and `tests/test_compiler.sh` before creating a pull request
+- Both scripts default to the `./casac` binary at the repo root
+
+## Review
+
+- Always use `simplify` and review changes with `feature-dev:code-reviewer` before making a pull request
+
+## Agent skills
+
+### Issue tracker
+
+GitHub Issues at `frendsick/casa`, accessed via `gh`. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Canonical defaults (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`). See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context layout (`CONTEXT.md` + `docs/adr/` at repo root). See `docs/agents/domain.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,20 +1,19 @@
 # Casa
 
-See [README.md](./README.md) for basic information of the language and the links to documentation and examples.
+See [README.md](./README.md) for basic info, language docs, and examples.
 
-## Planning
+## General principles
 
-Work back and forth with me, starting with your open questions and outline before writing the plan
-
-## Documentation
-
-When any language feature or standard library function is changed or added, the corresponding documentation must be updated to reflect the change.
+- The codebase is the source of truth — verify against current code before asserting.
+- Don't web-search Casa specifics; this repo is the only authoritative source.
+- When language features or stdlib functions change, update the corresponding
+  documentation, examples, and tests.
 
 ## Code conventions
 
-- See [FORMAT.md](./docs/FORMAT.md) for formatting rules
-- See [STYLE.md](./docs/STYLE.md) for naming conventions and idiomatic patterns
-- Files should contain the relevant imports to be self-compilable
+- See [FORMAT.md](./docs/FORMAT.md) for formatting rules.
+- See [STYLE.md](./docs/STYLE.md) for naming and idiomatic patterns.
+- Files should contain the relevant imports to be self-compilable.
 
 ### CRITICAL: Reverse polish notation
 
@@ -30,44 +29,15 @@ When any language feature or standard library function is changed or added, the 
 - **Path-style** (`import "lib/std.casa"`, `import "/abs/path.casa"`): contains `/` or ends with `.casa`. Resolved relative to the importing file (or used as-is when absolute). No search.
 - **Module-style** (`import "std"`): bare name. Resolved against the importing file's directory first, then each `-L`/`--library-path` directory in CLI order. First existing match wins.
 
-## Git conventions
-
-- Never append any Co-Authored-By messages to commit messages
-- Never mention Claude, AI usage, or other tool usage in commit messages, pull request messages or anywhere else
-- Never commit Claude-related files
-- One commit should only contain changes for one functionality
-- Always sign commits. If signing does not work, ask the user to ssh-add the SSH key.
-- Never make changes to `main` branch
-- Always make commits when a planned changes are finished
-- Always make pull requests when the reviewer agent does not find any more things to fix
-- Keep commit messages brief
-- Never commit binary files unless explicitly asked to do so
-
-## Examples
-
-- Always update examples for new and updated functionality
-- When examples are changed, regenerate the expected output for `tests/test_examples.sh`
-
-## Testing
-
-- Always autoformat changed `.casa` files with `./casafmt` before running tests or creating a pull request (e.g. `./casafmt < file.casa > tmp && mv tmp file.casa`)
-- Always run `tests/test_examples.sh` and `tests/test_compiler.sh` before creating a pull request
-- Both scripts default to the `./casac` binary at the repo root
-
-## Review
-
-- Always use `simplify` and review changes with `feature-dev:code-reviewer` before making a pull request
-
 ## Agent skills
 
-### Issue tracker
+Load the relevant doc when the matching workflow comes up:
 
-GitHub Issues at `frendsick/casa`, accessed via `gh`. See `docs/agents/issue-tracker.md`.
-
-### Triage labels
-
-Canonical defaults (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`). See `docs/agents/triage-labels.md`.
-
-### Domain docs
-
-Single-context layout (`CONTEXT.md` + `docs/adr/` at repo root). See `docs/agents/domain.md`.
+- **Git** — `docs/agents/git.md`
+- **Testing** — `docs/agents/testing.md`
+- **Review** — `docs/agents/review.md`
+- **Examples** — `docs/agents/examples.md`
+- **Pitfalls** — `docs/agents/pitfalls.md` (known Casa gotchas with workarounds)
+- **Issue tracker** — `docs/agents/issue-tracker.md`
+- **Triage labels** — `docs/agents/triage-labels.md`
+- **Domain docs** — `docs/agents/domain.md`

--- a/docs/STYLE.md
+++ b/docs/STYLE.md
@@ -174,6 +174,44 @@ without a type-name prefix is acceptable.
 
 ---
 
+## Function parameters
+
+### Order: primary data first, config flags last
+
+- **MUST** put primary data parameters first and config/flag/mode parameters last.
+- Casa's RPN means param 1 is the topmost stack slot — the first argument pushed last.
+  That position belongs to the primary data being operated on. A config flag in param 1
+  forces every call site to push the flag immediately before the function name, burying
+  the important argument under a trailing literal.
+
+  ```casa
+  # MUST — primary data first, flag last
+  fn find_matching_label
+      ops:List[Op]
+      op_index:int
+      boundary:int
+      target:OpKind
+      backward:bool
+  -> int { ... }
+
+  # MUST NOT — flag in first position
+  fn find_matching_label
+      backward:bool
+      ops:List[Op]
+      ...
+  -> int { ... }
+  ```
+
+### Flag types match the value range
+
+- **MUST** pick the parameter type matching the actual value set. Two states = `bool`.
+  Arbitrary integer = `int`. Don't use `int` as a stand-in for "one of two values".
+- `int` tells the reader "any integer" and invites misuse. If only `1` and `-1` are
+  ever valid, the type lies about the domain. Use `bool` and derive the integer
+  internally (`if backward then -1 else 1 fi = step`).
+
+---
+
 ## Option and Result
 
 - **MUST** use `Option[T]` for values that may be absent. Never return a sentinel

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/examples.md
+++ b/docs/agents/examples.md
@@ -1,0 +1,9 @@
+# Examples
+
+Rules for updating examples when language features or standard library functions change.
+
+- **MUST** update the relevant examples for any new or changed functionality.
+- **MUST** regenerate the expected-output files used by `tests/test_examples.sh` after
+  the example output changes. The test script will tell you which file to refresh.
+
+Then run the tests as described in [testing.md](./testing.md).

--- a/docs/agents/git.md
+++ b/docs/agents/git.md
@@ -1,0 +1,24 @@
+# Git conventions
+
+Rules for commits, branches, and pull requests in this repo.
+
+## Commits
+
+- **MUST** sign every commit. Never bypass signing with `-c commit.gpgsign=false` or
+  `--no-gpg-sign`. If signing fails, stop and ask the user to `ssh-add` their SSH key.
+- **MUST NOT** append `Co-Authored-By` lines, mentions of Claude or AI usage, or any
+  other tooling references to commit messages, PR descriptions, or branch names.
+- **MUST NOT** commit Claude-related files (`.claude/`, agent memory, transcripts).
+- **MUST NOT** commit binary files unless the user explicitly asks for it.
+- **MUST** keep one commit per functionality. Don't mix unrelated changes.
+- **MUST** keep commit messages brief.
+
+## Branches
+
+- **MUST NOT** modify `main` directly. All work happens on a feature branch.
+
+## Workflow
+
+- **MUST** make a commit once a planned change is finished.
+- **MUST** open a pull request once `feature-dev:code-reviewer` finds no more issues to
+  fix. See [review.md](./review.md) for the review loop.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/pitfalls.md
+++ b/docs/agents/pitfalls.md
@@ -1,0 +1,40 @@
+# Pitfalls
+
+Known Casa gotchas that aren't yet captured as fixes. Each entry has a one-line
+description, a workaround, and a link to the tracking issue. Remove an entry when its
+issue closes.
+
+## `test_lsp` blocks on stdin
+
+`tests/test_compiler.sh` includes a `test_lsp` unit that reads from stdin and waits
+for Enter. When the script is run non-interactively the suite hangs forever.
+
+- **Workaround:** redirect stdin — `tests/test_compiler.sh < /dev/null`.
+- **Tracking:** [#170](https://github.com/frendsick/casa/issues/170).
+
+## Locals in `lib/*.casa` impl methods leak to global scope
+
+Variables declared inside `impl` methods in `lib/*.casa` create global bindings that
+clash with user code. Renaming `ai_value` / `li_value` / `sc_value` in `lib/std.casa`
+to plain `value` breaks any user code that does `for value in ... do`.
+
+- **Workaround:** keep distinct prefixed names (`ai_value`, `li_value`, `sc_value`)
+  inside lib impl methods. Don't "simplify" them to generic names like `value`,
+  `index`, or `item` that user code is likely to reuse.
+- **Tracking:** [#171](https://github.com/frendsick/casa/issues/171).
+
+## Type enum methods may consume the value (context-dependent)
+
+Casa enum values (`Type`, `Option[T]`) are usually safe to call methods on multiple
+times — `t.format` twice on a named `Type` var works in isolation, for-loop iteration
+works, list re-iteration works. But there are reported patterns that crash stage2 with
+"unwrap on None" after an enum method call, especially when chained `.get.typ`
+extractions feed into multiple methods.
+
+- **Default:** write the cleaner reuse-the-value code.
+- **If you hit a stage2 crash** after an enum method call: bind the intermediate
+  result to a fresh variable, or fall back to formatting once and threading the
+  string through. Then verify with `tests/test_compiler.sh < /dev/null` and
+  `tests/test_examples.sh`.
+- No tracking issue yet — root cause unconfirmed. File one if you reproduce a
+  specific crash pattern.

--- a/docs/agents/review.md
+++ b/docs/agents/review.md
@@ -1,0 +1,22 @@
+# Review
+
+Rules for the pre-PR review loop.
+
+## Review loop
+
+Before opening a pull request:
+
+1. Run the `simplify` skill on the diff. Apply any reuse, quality, or efficiency fixes
+   it finds.
+2. Review the changes with the `feature-dev:code-reviewer` agent.
+3. **MUST** fix every issue the reviewer reports — must-fix, should-fix, and consider
+   alike — without pausing, asking, or surfacing the review output to the user as a
+   stopping point. Treat reviewer output as an internal todo list.
+4. Re-run the reviewer on the fixed diff.
+5. Loop steps 3–4 until the reviewer reports no must-fix or should-fix issues.
+6. Only then open the PR. See [git.md](./git.md).
+
+## Why no pausing
+
+Stopping mid-loop wastes a round-trip and frustrates the user. The review is the work
+of finishing the change; treat it as part of the change, not a separate sign-off.

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -1,0 +1,33 @@
+# Testing
+
+Rules for running and updating tests.
+
+## Before running tests or opening a PR
+
+- **MUST** autoformat every changed `.casa` file with `./casafmt`:
+
+  ```
+  ./casafmt < file.casa > tmp && mv tmp file.casa
+  ```
+
+- **MUST** run both test scripts:
+
+  ```
+  tests/test_examples.sh
+  tests/test_compiler.sh < /dev/null
+  ```
+
+  The stdin redirect on `test_compiler.sh` is required to avoid hanging in the
+  `test_lsp` unit when run non-interactively. Tracked in
+  [issue #170](https://github.com/frendsick/casa/issues/170).
+
+- Both scripts default to the `./casac` binary at the repo root. Rebuild casac before
+  testing if compiler sources changed:
+
+  ```
+  ./casac -L lib casa.casa -o casac
+  ```
+
+## When examples change
+
+See [examples.md](./examples.md).

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.


### PR DESCRIPTION
## Summary

- Splits CLAUDE.md from a single rules file into always-loaded principles plus per-workflow pointers
- Adds five new docs under `docs/agents/` (git, testing, review, examples, pitfalls) so workflow rules load only when relevant
- Adds two function-parameter style rules to STYLE.md (primary-data-first ordering, `bool` vs `int` for flag types)
- Files referenced issues for two known Casa gotchas: #170 (`test_lsp` stdin hang), #171 (lib impl-method locals leaking to globals)

## Test plan

- [x] Verified all cross-references between CLAUDE.md, STYLE.md, and `docs/agents/*.md` resolve
- N/A: docs-only change — no `.casa` or compiler sources touched, so `tests/test_examples.sh` and `tests/test_compiler.sh` are unaffected