### PR TITLE
Complete Type AST cleanup

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -4,6 +4,14 @@ Casa is a self-hosted programming language and compiler. Its CI vocabulary descr
 
 ## Language
 
+**Type AST**:
+The compiler-owned structural representation of a Casa type after parsing.
+_Avoid_: Type string, source type text
+
+**Source type syntax**:
+The user-written type expression before the parser converts it into the **Type AST**.
+_Avoid_: Type annotation metadata, internal type string
+
 **Bootstrap compiler**:
 The latest stable released `casac` binary used to compile the compiler source on a branch.
 _Avoid_: Temporary compiler, release compiler
@@ -42,6 +50,8 @@ _Avoid_: Release lint, tag lint
 
 ## Relationships
 
+- **Source type syntax** is parsed into the **Type AST** before compiler analysis.
+- Compiler analysis should operate on the **Type AST**, not reparsed or reformatted type strings.
 - A **Bootstrap compiler** builds exactly one **Branch compiler** at the start of CI.
 - A **Branch compiler** must self-compile and reach a **Fixed point** before the branch is considered releasable.
 - A **Temporary compiler release** must not replace the **Bootstrap compiler** as the normal PR CI input.
@@ -58,5 +68,6 @@ _Avoid_: Release lint, tag lint
 
 ## Flagged Ambiguities
 
+- "`Op.type_annotation` / `Op.deferred_return_type` as source text" was used to justify keeping parsed type metadata as strings. Resolved: user-written type expressions are **Source type syntax** only before parsing; after parsing, compiler-owned metadata should use the **Type AST**.
 - "release compiler" was used to mean both the stable compiler downloaded by CI and an ad hoc temporary compiler. Resolved: use **Bootstrap compiler** for the stable CI input; temporary releases are exceptional escape hatches.
 - "temporary release" was considered as a normal CI mechanism. Resolved: use **Temporary compiler release** only as an exception, not as the default bootstrap path.

--- a/compiler/bytecode.casa
+++ b/compiler/bytecode.casa
@@ -908,6 +908,12 @@ fn compile_enum_comparison
 fn compile_op compiler:BytecodeCompiler op:Op op_index:int bytecode:List[InstValue] {
     op.value = op_value
     op_value direct_op_to_inst = direct_inst_opt
+    false = has_type_hint
+    "" = type_hint_name
+    if op Op::type_hint Option::Some(type_hint) is then
+        true = has_type_hint
+        type_hint.format = type_hint_name
+    fi
 
     # Check direct op-to-inst mapping first
     if direct_inst_opt.is_some then
@@ -919,8 +925,8 @@ fn compile_op compiler:BytecodeCompiler op:Op op_index:int bytecode:List[InstVal
         op_value OpValue::Le is ||
         op_value OpValue::Gt is ||
         op_value OpValue::Ge is ||
-        "" op Op::type_annotation != &&
-        op Op::type_annotation compiler.store.enums.has &&
+        has_type_hint &&
+        type_hint_name compiler.store.enums.has &&
         then
             bytecode direct_inst_opt.unwrap compiler compile_enum_comparison
             return
@@ -929,7 +935,7 @@ fn compile_op compiler:BytecodeCompiler op:Op op_index:int bytecode:List[InstVal
         if
         op_value OpValue::Eq is
         op_value OpValue::Ne is ||
-        "str" op Op::type_annotation == &&
+        "str" type_hint_name == &&
         then
             InstValue::StrEq bytecode.push
             if op_value OpValue::Ne is then
@@ -938,7 +944,7 @@ fn compile_op compiler:BytecodeCompiler op:Op op_index:int bytecode:List[InstVal
             return
         fi
         # Data-carrying enum print
-        if op_value OpValue::PrintInt is "" op Op::type_annotation != && then
+        if op_value OpValue::PrintInt is has_type_hint && then
             InstValue::Load64 bytecode.push
             InstValue::PrintInt bytecode.push
             return
@@ -1002,11 +1008,15 @@ fn compile_op compiler:BytecodeCompiler op:Op op_index:int bytecode:List[InstVal
     elif op_value OpValue::MethodCall is then
         "Method call should be transpiled to function call during type checking\n" eprint
         1 exit
+    elif op_value OpValue::TraitMethodCall(trait_hidden_var) is then
+        trait_hidden_var compiler resolve_variable = trait_resolved
+        bytecode trait_resolved.emit_get
+        InstValue::FnExec bytecode.push
     elif op_value OpValue::Print is then
         "PRINT should be resolved by type checker\n" eprint
         1 exit
     elif op_value OpValue::Typeof is then
-        op Op::type_annotation = type_name
+        type_hint_name = type_name
         type_name compiler intern_string = typeof_index
         InstValue::Drop bytecode.push
         typeof_index InstValue::PushStr bytecode.push
@@ -1030,10 +1040,6 @@ fn compile_op compiler:BytecodeCompiler op:Op op_index:int bytecode:List[InstVal
     elif op_value OpValue::PushVar(var_name) is then
         var_name compiler resolve_variable = var_resolved
         bytecode var_resolved.emit_get
-        # Emit FN_EXEC after trait-bound variable push
-        if "trait_exec" op Op::type_annotation == then
-            InstValue::FnExec bytecode.push
-        fi
     elif op_value OpValue::StructNew is then
         bytecode op compiler compile_struct_new
     elif op_value OpValue::StructLiteral is then

--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -312,17 +312,17 @@ fn make_token value:str kind:TokenKind location:Location -> Token {
 
 struct Op {
     location:             Location
-    type_annotation:      str
-    deferred_return_type: str
+    type_hint:            Option[Type]
+    deferred_return_hint: Option[Type]
     value:                OpValue
 }
 
 fn make_op value:OpValue location:Location -> Op {
-    value "" "" location Op
+    value Option::None(Option[Type]) Option::None(Option[Type]) location Op
 }
 
-fn make_op_annotated value:OpValue location:Location annotation:str -> Op {
-    value "" annotation location Op
+fn make_op_with_type_hint value:OpValue location:Location type_hint:Type -> Op {
+    value Option::None(Option[Type]) type_hint Option::Some location Op
 }
 # Op identity is its heap address: two Op values compare equal iff the same
 # allocation. Required so labels map by Op identity (Map[Op int]), not by an
@@ -336,23 +336,21 @@ impl Op {
 fn clone_ops ops:List[Op] -> List[Op] {
     List::new(List[Op]) = result
     for source_op in ops.iter do
-        source_op.value source_op.deferred_return_type source_op.type_annotation source_op.location Op result.push
+        source_op.value source_op.deferred_return_hint source_op.type_hint source_op.location Op result.push
     done
     result
 }
 
-fn substitute_ops_types ops:List[Op] subs:Map[str str] {
+fn substitute_ops_types ops:List[Op] subs:Map[str Type] {
     for sub_op in ops.iter do
         if sub_op.value OpValue::TypeCast(cast_type) is then
-            subs cast_type substitute_type_params OpValue::TypeCast sub_op Op::set_value
+            subs cast_type.substitute_t OpValue::TypeCast sub_op Op::set_value
         fi
-        if "" sub_op Op::type_annotation != then
-            subs sub_op Op::type_annotation substitute_type_params = new_annot
-            new_annot sub_op Op::set_type_annotation
+        if sub_op Op::type_hint Option::Some(hint) is then
+            subs hint.substitute_t Option::Some sub_op Op::set_type_hint
         fi
-        if "" sub_op Op::deferred_return_type != then
-            subs sub_op Op::deferred_return_type substitute_type_params = new_deferred
-            new_deferred sub_op Op::set_deferred_return_type
+        if sub_op Op::deferred_return_hint Option::Some(deferred_hint) is then
+            subs deferred_hint.substitute_t Option::Some sub_op Op::set_deferred_return_hint
         fi
     done
 }
@@ -565,6 +563,7 @@ enum OpValue {
     FnPush (str)
     FnReturn
     MethodCall (str)
+    TraitMethodCall (str)
     # Loops
     WhileStart
     WhileCondition
@@ -595,7 +594,7 @@ enum OpValue {
     StructNew (CasaStruct)
     StructLiteral (StructLiteral)
     # Types
-    TypeCast (str)
+    TypeCast (Type)
     # Import
     ImportFile (str)
     # F-strings
@@ -616,13 +615,13 @@ fn op_str_value op:Op -> str {
     if op.value OpValue::FnCall(value) is then value return fi
     if op.value OpValue::FnPush(value) is then value return fi
     if op.value OpValue::MethodCall(value) is then value return fi
+    if op.value OpValue::TraitMethodCall(value) is then value return fi
     if op.value OpValue::PushStr(value) is then value return fi
     if op.value OpValue::PushVar(value) is then value return fi
     if op.value OpValue::PushCapture(value) is then value return fi
     if op.value OpValue::AssignVar(value) is then value return fi
     if op.value OpValue::AssignDec(value) is then value return fi
     if op.value OpValue::AssignInc(value) is then value return fi
-    if op.value OpValue::TypeCast(value) is then value return fi
     if op.value OpValue::ImportFile(value) is then value return fi
     if op.value OpValue::Identifier(value) is then value return fi
     "Internal error: op_str_value called on non-str op\n" eprint
@@ -769,6 +768,14 @@ fn trait_bound_to_str bound:TraitBound -> str {
     done
     "]" builder.append
     builder.build
+}
+
+fn trait_bound_to_type bound:TraitBound -> Type {
+    List::new(List[Type]) = type_args
+    for type_arg in bound TraitBound::type_args.iter do
+        type_arg parse_type_str type_args.push
+    done
+    type_args bound TraitBound::name GenericType Type::Generic
 }
 
 fn trait_bound_eq a:TraitBound b:TraitBound -> bool {
@@ -994,45 +1001,6 @@ impl Type {
         end
     }
 
-    fn substitute self:Type subs:Map[str str] -> Type {
-        self match
-            Type::Unknown => { Type::Unknown }
-            Type::Builtin(builtin) => { builtin Type::Builtin }
-            Type::TypeVar(name) => {
-                if name subs.get Option::Some(bound) is then
-                    bound parse_type_str
-                else
-                    name Type::TypeVar
-                fi
-            }
-            Type::Generic(generic) => {
-                generic.base = base
-                if 0 generic.params.length == then
-                    if base subs.get Option::Some(bound) is then
-                        bound parse_type_str return
-                    fi
-                    generic.params base GenericType Type::Generic return
-                fi
-                List::new(List[Type]) = new_params
-                for param in generic.params.iter do
-                    subs param.substitute new_params.push
-                done
-                new_params base GenericType Type::Generic
-            }
-            Type::Function(fn_type) => {
-                List::new(List[Type]) = new_params
-                for param in fn_type.parameters.iter do
-                    subs param.substitute new_params.push
-                done
-                List::new(List[Type]) = new_returns
-                for ret in fn_type.return_types.iter do
-                    subs ret.substitute new_returns.push
-                done
-                new_returns new_params FunctionType Type::Function
-            }
-        end
-    }
-
     fn substitute_t self:Type bindings:Map[str Type] -> Type {
         self match
             Type::Unknown => { Type::Unknown }
@@ -1132,6 +1100,97 @@ impl Type {
         self match
             Type::Function(_) => { true }
             _ => { false }
+        end
+    }
+
+    fn is_builtin_type_t self:Type -> bool {
+        self match
+            Type::Builtin(_) => { true }
+            Type::Generic(generic) => {
+                0 generic.params.length == "array" generic.base == &&
+            }
+            _ => { false }
+        end
+    }
+
+    fn is_primitive_compare_type_t self:Type -> bool {
+        self match
+            Type::Builtin(builtin) => {
+                builtin BuiltinType::Int ==
+                builtin BuiltinType::Bool == ||
+                builtin BuiltinType::Char == ||
+                builtin BuiltinType::Cstr == ||
+                builtin BuiltinType::Ptr == ||
+            }
+            _ => { false }
+        end
+    }
+
+    fn match_base self:Type -> str {
+        self match
+            Type::Generic(generic) => { generic.base }
+            _ => { self.format }
+        end
+    }
+
+    fn has_unresolved self:Type -> bool {
+        self match
+            Type::Generic(generic) => {
+                if 0 generic.params.length == then
+                    false
+                else
+                    for param in generic.params.iter do
+                        if param.is_unknown_placeholder then true return fi
+                        if param.has_unresolved then true return fi
+                    done
+                    false
+                fi
+            }
+            Type::Function(fn_type) => {
+                for param in fn_type.parameters.iter do
+                    if param.has_unresolved then true return fi
+                done
+                for ret in fn_type.return_types.iter do
+                    if ret.has_unresolved then true return fi
+                done
+                false
+            }
+            Type::Unknown => { false }
+            _ => { false }
+        end
+    }
+
+    fn exists_recursive self:Type function_opt:Option[Function] -> bool {
+        self match
+            Type::Unknown => { false }
+            Type::Builtin(_) => { true }
+            Type::TypeVar(name) => {
+                if function_opt Option::Some(check_fn) is then
+                    name check_fn Function::signature Signature::type_vars.has return
+                fi
+                false
+            }
+            Type::Generic(generic) => {
+                for param in generic.params.iter do
+                    if function_opt param.exists_recursive ! then false return fi
+                done
+                if generic.base DEFAULT_PARSER.store.structs.get.is_some then true return fi
+                if generic.base DEFAULT_PARSER.store.enums.get.is_some then true return fi
+                if "array" generic.base == then true return fi
+                if function_opt Option::Some(check_fn) is then
+                    if generic.base check_fn Function::signature Signature::type_vars.has then true return fi
+                fi
+                false
+            }
+            Type::Function(fn_type) => {
+                for param in fn_type.parameters.iter do
+                    if function_opt param.exists_recursive ! then false return fi
+                done
+                for ret in fn_type.return_types.iter do
+                    if function_opt ret.exists_recursive ! then false return fi
+                done
+                true
+            }
         end
     }
 
@@ -1290,38 +1349,6 @@ fn parse_type_str source:str -> Type {
 # Type utility functions
 # ============================================================================
 
-fn extract_generic_base typ:str -> Option[str] {
-    # For 'array[int]' returns 'array', for 'List[int]' returns 'List'.
-    # Returns None for fn types and non-parameterized types.
-    typ "[" str::find = bracket
-    if 0 bracket <= then
-        Option::None
-        return
-    fi
-    if typ "]" str::ends_with ! then
-        Option::None
-        return
-    fi
-    typ 0 bracket str::substring = base
-    if "fn" base == then
-        Option::None
-    else
-        base Option::Some
-    fi
-}
-
-fn extract_generic_inner typ:str -> Option[str] {
-    # For 'array[int]' returns 'int'.
-    typ extract_generic_base = base_opt
-    if base_opt.is_none then
-        Option::None
-        return
-    fi
-    base_opt.unwrap = base
-    typ.length base.length - 2 - = inner_length
-    typ base.length 1 + inner_length str::substring Option::Some
-}
-
 fn split_type_tokens s:str -> List[str] {
     # Split a space-separated type string into tokens, respecting brackets.
     List::new(List[str]) = tokens
@@ -1347,37 +1374,6 @@ fn split_type_tokens s:str -> List[str] {
         current.build tokens.push
     fi
     tokens
-}
-
-fn extract_generic_params typ:str -> Option[List[str]] {
-    # For 'Map[str int]' returns ['str', 'int'].
-    typ extract_generic_base = base_opt
-    if base_opt.is_none then
-        Option::None
-        return
-    fi
-    base_opt.unwrap = base
-    typ.length base.length - 2 - = inner_length
-    typ base.length 1 + inner_length str::substring split_type_tokens Option::Some
-}
-
-fn is_fn_type typ:str -> bool {
-    "fn" typ == typ "fn[" str::starts_with ||
-}
-
-fn extract_fn_signature_str typ:str -> Option[str] {
-    # Returns None for bare 'fn' or non-fn types.
-    if typ "fn[" str::starts_with ! then
-        Option::None
-        return
-    fi
-    if typ "]" str::ends_with ! then
-        Option::None
-        return
-    fi
-    # Extract between fn[ and ]
-    typ.length 4 - = length
-    typ 3 length str::substring Option::Some
 }
 
 fn build_parameterized_type base:str params:List[str] -> str {
@@ -1418,16 +1414,6 @@ fn build_resolved_type_t base:str type_vars:List[str] bindings:Map[str Type] -> 
         fi
     done
     params base GenericType Type::Generic
-}
-
-fn is_builtin_type typ:str -> bool {
-    "int" typ ==
-    "bool" typ == ||
-    "char" typ == ||
-    "cstr" typ == ||
-    "str" typ == ||
-    "ptr" typ == ||
-    "array" typ == ||
 }
 
 # ============================================================================
@@ -1476,6 +1462,14 @@ fn signature_to_function_type sig:Signature -> Type {
     fn_returns fn_params FunctionType Type::Function
 }
 
+fn function_type_to_signature fn_type:FunctionType -> Signature {
+    List::new(List[Parameter]) = params
+    for param_type in fn_type FunctionType::parameters.iter do
+        "" param_type Parameter params.push
+    done
+    fn_type FunctionType::return_types params make_signature
+}
+
 fn signature_from_str sig_str:str -> Signature {
     # Parse "param1 param2 -> ret1 ret2" into Signature
     sig_str split_type_tokens = tokens
@@ -1517,6 +1511,126 @@ fn signature_from_str sig_str:str -> Signature {
     returns params make_signature
 }
 
+fn signature_type_param_matches expected:Type actual:Type type_vars:Set[str] -> bool {
+    if expected actual.eq then true return fi
+    if expected.is_unknown_placeholder then true return fi
+    if actual.is_unknown_placeholder then true return fi
+    if expected.type_var_name Option::Some(expected_name) is then
+        if expected_name type_vars.has then true return fi
+    fi
+    if actual.type_var_name Option::Some(actual_name) is then
+        if actual_name type_vars.has then true return fi
+    fi
+    false
+}
+
+fn signature_type_matches expected:Type actual:Type -> bool {
+    if expected actual.eq then true return fi
+    if expected.is_unknown_placeholder then true return fi
+    if actual.is_unknown_placeholder then true return fi
+    expected match
+        Type::Function(_) => { }
+        Type::Generic(expected_generic) => {
+            if 0 expected_generic.params.length == then
+                actual match
+                    Type::Generic(actual_generic) => {
+                        if 0 actual_generic.params.length != expected_generic.base actual_generic.base == && then
+                            true return
+                        fi
+                    }
+                    _ => { }
+                end
+            fi
+        }
+        _ => { }
+    end
+    actual match
+        Type::Function(_) => { }
+        Type::Generic(actual_generic) => {
+            if 0 actual_generic.params.length == then
+                expected match
+                    Type::Generic(expected_generic) => {
+                        if 0 expected_generic.params.length != actual_generic.base expected_generic.base == && then
+                            true return
+                        fi
+                    }
+                    _ => { }
+                end
+            fi
+        }
+        _ => { }
+    end
+    expected match
+        Type::Function(expected_fn) => {
+            actual match
+                Type::Function(actual_fn) => {
+                    if 0 expected_fn.parameters.length == 0 expected_fn.return_types.length == && then
+                        true return
+                    fi
+                    if 0 actual_fn.parameters.length == 0 actual_fn.return_types.length == && then
+                        true return
+                    fi
+                    if expected_fn.parameters.length actual_fn.parameters.length != then false return fi
+                    if expected_fn.return_types.length actual_fn.return_types.length != then false return fi
+                    0 = fn_index
+                    while fn_index expected_fn.parameters.length > do
+                        if fn_index actual_fn.parameters.get fn_index expected_fn.parameters.get signature_type_matches ! then
+                            false return
+                        fi
+                        1 += fn_index
+                    done
+                    0 = fn_index
+                    while fn_index expected_fn.return_types.length > do
+                        if fn_index actual_fn.return_types.get fn_index expected_fn.return_types.get signature_type_matches ! then
+                            false return
+                        fi
+                        1 += fn_index
+                    done
+                    true return
+                }
+                _ => { }
+            end
+        }
+        Type::Generic(expected_generic) => {
+            actual match
+                Type::Generic(actual_generic) => {
+                    if expected_generic.base actual_generic.base != then false return fi
+                    if expected_generic.params.length actual_generic.params.length != then false return fi
+                    Set::new(Set[str]) = type_vars
+                    expected_generic.base DEFAULT_PARSER.store.enums.get = enum_opt
+                    if enum_opt.is_some then
+                        for type_var in enum_opt.unwrap CasaEnum::type_vars.iter do
+                            type_var type_vars.add = type_vars
+                        done
+                    fi
+                    expected_generic.base DEFAULT_PARSER.store.structs.get = struct_opt
+                    if struct_opt.is_some then
+                        for type_var in struct_opt.unwrap CasaStruct::type_vars.iter do
+                            type_var type_vars.add = type_vars
+                        done
+                    fi
+                    0 = param_index
+                    while param_index expected_generic.params.length > do
+                        if
+                        type_vars
+                        param_index actual_generic.params.get
+                        param_index expected_generic.params.get
+                        signature_type_param_matches !
+                        then
+                            false return
+                        fi
+                        1 += param_index
+                    done
+                    true return
+                }
+                _ => { }
+            end
+        }
+        _ => { }
+    end
+    false
+}
+
 fn signature_matches sig_a:Signature sig_b:Signature -> bool {
     # Check if two signatures are compatible, respecting any types.
     if sig_a Signature::parameters.length sig_b Signature::parameters.length != then
@@ -1528,132 +1642,25 @@ fn signature_matches sig_a:Signature sig_b:Signature -> bool {
 
     0 = index
     while index sig_a Signature::parameters.length > do
-        index sig_a Signature::parameters.get Parameter::typ.format = type_a
-        index sig_b Signature::parameters.get Parameter::typ.format = type_b
-        if type_a type_b != TYPE_UNKNOWN type_a != && TYPE_UNKNOWN type_b != && then
-            type_b extract_generic_base = base_b
-            type_a extract_generic_base = base_a
-            if base_b.is_some type_a base_b.unwrap_or "" == && ! then
-                if base_a.is_some type_b base_a.unwrap_or "" == && ! then
-                    false return
-                fi
-            fi
+        index sig_a Signature::parameters.get Parameter::typ = type_a
+        index sig_b Signature::parameters.get Parameter::typ = type_b
+        if type_b type_a signature_type_matches ! then
+            false return
         fi
         1 += index
     done
 
     0 = index
     while index sig_a Signature::return_types.length > do
-        index sig_a Signature::return_types.get.format = return_a
-        index sig_b Signature::return_types.get.format = return_b
-        if return_a return_b != TYPE_UNKNOWN return_a != && TYPE_UNKNOWN return_b != && then
-            return_b extract_generic_base = return_base_b
-            return_a extract_generic_base = return_base_a
-            if return_base_b.is_some return_base_a.is_some && return_base_b.unwrap return_base_a.unwrap == && then
-                # Same base — check params are compatible (allow type vars)
-                return_a extract_generic_params = params_a_opt
-                return_b extract_generic_params = params_b_opt
-                if params_a_opt.is_some params_b_opt.is_some && then
-                    params_a_opt.unwrap = params_a
-                    params_b_opt.unwrap = params_b
-                    if params_a.length params_b.length == then
-                        0 = param_index
-                        while param_index params_a.length > do
-                            param_index params_a.get = param_a
-                            param_index params_b.get = param_b
-                            if
-                            param_a param_b !=
-                            TYPE_UNKNOWN param_a != &&
-                            TYPE_UNKNOWN param_b != &&
-                            param_a.length 1 != &&
-                            param_b.length 1 != &&
-                            then
-                                false return
-                            fi
-                            1 += param_index
-                        done
-                    fi
-                fi
-            elif return_base_b.is_some return_a return_base_b.unwrap_or "" == && ! then
-                if return_base_a.is_some return_b return_base_a.unwrap_or "" == && ! then
-                    false return
-                fi
-            fi
+        index sig_a Signature::return_types.get = return_a
+        index sig_b Signature::return_types.get = return_b
+        if return_b return_a signature_type_matches ! then
+            false return
         fi
         1 += index
     done
 
     true
-}
-
-fn substitute_type_params typ:str subs:Map[str str] -> str {
-    # Replace any occurrence of a substitution key within a type expression.
-    # E.g. with subs {T: int}, "T" -> "int", "Option[T]" -> "Option[int]".
-    if typ subs.get Option::Some(substituted) is then
-        substituted return
-    fi
-    # Handle function types: fn[T -> U] -> fn[int -> U]
-    if typ "fn[" str::starts_with typ "]" str::ends_with && then
-        typ.length 4 - = fn_inner_len
-        typ 3 fn_inner_len str::substring = fn_inner
-        fn_inner split_type_tokens = fn_tokens
-        StringBuilder::new = fn_builder
-        "fn[" fn_builder.append
-        0 = fn_tok_index
-        while fn_tok_index fn_tokens.length > do
-            if 0 fn_tok_index != then
-                " " fn_builder.append
-            fi
-            fn_tok_index fn_tokens.get = fn_tok
-            if "->" fn_tok == then
-                "->" fn_builder.append
-            else
-                subs fn_tok substitute_type_params fn_builder.append
-            fi
-            1 += fn_tok_index
-        done
-        "]" fn_builder.append
-        fn_builder.build return
-    fi
-    typ extract_generic_base = base_opt
-    if base_opt.is_none then
-        typ return
-    fi
-    base_opt.unwrap = base
-    typ extract_generic_params = params_opt
-    if params_opt.is_none then
-        typ return
-    fi
-    params_opt.unwrap = params
-    StringBuilder::new = builder
-    base builder.append
-    "[" builder.append
-    0 = index
-    while index params.length > do
-        if 0 index != then
-            " " builder.append
-        fi
-        subs index params.get substitute_type_params builder.append
-        1 += index
-    done
-    "]" builder.append
-    builder.build
-}
-
-fn apply_type_subs_to_sig sig:Signature subs:Map[str str] -> Signature {
-    if 0 subs.length == then
-        sig return
-    fi
-    List::new(List[Parameter]) = params
-    for param in sig Signature::parameters.iter do
-        subs param Parameter::typ.substitute = new_typ
-        param Parameter::name new_typ make_named_param params.push
-    done
-    List::new(List[Type]) = returns
-    for return_type in sig Signature::return_types.iter do
-        subs return_type.substitute returns.push
-    done
-    returns params make_signature
 }
 
 fn apply_type_subs_to_sig_t sig:Signature subs:Map[str Type] -> Signature {

--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -324,6 +324,7 @@ fn make_op value:OpValue location:Location -> Op {
 fn make_op_with_type_hint value:OpValue location:Location type_hint:Type -> Op {
     value Option::None(Option[Type]) type_hint Option::Some location Op
 }
+
 # Op identity is its heap address: two Op values compare equal iff the same
 # allocation. Required so labels map by Op identity (Map[Op int]), not by an
 # int reinterpretation of an Op pointer at every read site.
@@ -683,7 +684,7 @@ struct CasaEnum {
     name:              str
     variants:          List[str]
     location:          Location
-    variant_types:     Map[str List[str]]
+    variant_types:     Map[str List[Type]]
     type_vars:         List[str]
     variant_locations: Map[str Location]
 }

--- a/compiler/pattern.casa
+++ b/compiler/pattern.casa
@@ -147,7 +147,7 @@ fn assign_struct_binding_type
 {
     for member in matched_struct CasaStruct::members.iter do
         if field_name member Member::name == then
-            function_opt member Member::typ.format bound_var set_binding_type
+            function_opt member Member::typ bound_var set_binding_type
         fi
     done
 }
@@ -185,8 +185,8 @@ fn register_enum_pattern_bindings
     fi
 }
 
-fn build_enum_type_bindings casa_enum:CasaEnum match_subject_type:str -> Map[str str] {
-    Map::new(Map[str str]) = type_bindings
+fn build_enum_type_bindings casa_enum:CasaEnum match_subject_type:str -> Map[str Type] {
+    Map::new(Map[str Type]) = type_bindings
     if 0 casa_enum CasaEnum::type_vars.length == then type_bindings return fi
     if match_subject_type parse_type_str.type_params Option::Some(raw_params) is then
         raw_params = type_params
@@ -195,7 +195,7 @@ fn build_enum_type_bindings casa_enum:CasaEnum match_subject_type:str -> Map[str
         type_var_index casa_enum CasaEnum::type_vars.length >
         type_var_index type_params.length > &&
         do
-            type_var_index casa_enum CasaEnum::type_vars.get type_var_index type_params.get.format type_bindings.set = type_bindings
+            type_var_index casa_enum CasaEnum::type_vars.get type_var_index type_params.get type_bindings.set = type_bindings
             1 += type_var_index
         done
     fi
@@ -205,8 +205,8 @@ fn build_enum_type_bindings casa_enum:CasaEnum match_subject_type:str -> Map[str
 fn apply_enum_bindings
     tc:TypeChecker
     function_opt:Option[Function]
-    inner_types:List[str]
-    type_bindings:Map[str str]
+    inner_types:List[Type]
+    type_bindings:Map[str Type]
     variant:EnumVariant
 {
     0 = bind_index
@@ -216,7 +216,7 @@ fn apply_enum_bindings
     do
         bind_index variant EnumVariant::bindings.get = binding_var
         bind_index inner_types.get = binding_type
-        if binding_type type_bindings.get Option::Some(resolved) is then
+        if binding_type.format type_bindings.get Option::Some(resolved) is then
             resolved = binding_type
         fi
         function_opt binding_type binding_var set_binding_type

--- a/compiler/pattern.casa
+++ b/compiler/pattern.casa
@@ -2,7 +2,7 @@
 #
 # Introspection primitives and per-phase entry points every compiler phase
 # (parser-resolve, typechecker, bytecode) uses to handle match patterns
-# without re-reading the legacy Op.type_annotation tag string.
+# without re-reading op-level type metadata.
 import "std"
 import "common"
 import "error"
@@ -176,7 +176,7 @@ fn register_enum_pattern_bindings
     match_subject_type:str
 {
     if 0 variant EnumVariant::bindings.length == then return fi
-    match_subject_type resolve_match_type = base_enum_name
+    match_subject_type parse_type_str.match_base = base_enum_name
     if base_enum_name tc.store.enums.get Option::Some(casa_enum) is then
         if variant EnumVariant::variant_name casa_enum CasaEnum::variant_types.get Option::Some(inner_types) is then
             match_subject_type casa_enum build_enum_type_bindings = type_bindings
@@ -188,14 +188,14 @@ fn register_enum_pattern_bindings
 fn build_enum_type_bindings casa_enum:CasaEnum match_subject_type:str -> Map[str str] {
     Map::new(Map[str str]) = type_bindings
     if 0 casa_enum CasaEnum::type_vars.length == then type_bindings return fi
-    if match_subject_type extract_generic_params Option::Some(raw_params) is then
-        raw_params (List[str]) = type_params
+    if match_subject_type parse_type_str.type_params Option::Some(raw_params) is then
+        raw_params = type_params
         0 = type_var_index
         while
         type_var_index casa_enum CasaEnum::type_vars.length >
         type_var_index type_params.length > &&
         do
-            type_var_index casa_enum CasaEnum::type_vars.get type_var_index type_params.get type_bindings.set = type_bindings
+            type_var_index casa_enum CasaEnum::type_vars.get type_var_index type_params.get.format type_bindings.set = type_bindings
             1 += type_var_index
         done
     fi
@@ -259,7 +259,7 @@ fn typecheck_match_op tc:TypeChecker function_opt:Option[Function] op:Op {
     if top_frame BranchFrame::BranchMatch(match_ctx) is then
         match_ctx MatchContext::match_type = match_subject_type
         op pattern_covered_key = covered_key
-        match_subject_type resolve_match_type = arm_base
+        match_subject_type parse_type_str.match_base = arm_base
 
         if op pattern_value_of PatternValue::EnumVariant(variant) is then
             if op pattern_is_wildcard ! then

--- a/compiler/syntax.casa
+++ b/compiler/syntax.casa
@@ -266,7 +266,7 @@ fn parse_type cursor:TokenCursor -> str {
 
 fn get_op_type_cast cursor:TokenCursor -> Op {
     "(" cursor expect_token_value = open_token
-    cursor parse_type = cast_type
+    cursor parse_type_ast = cast_type
     ")" cursor expect_token_value = close_token
 
     open_token Token::location Location::span Span::offset = open_offset
@@ -347,17 +347,17 @@ fn get_op_operator token:Token cursor:TokenCursor function_name:str -> Op {
         name_token Token::value = var_name
 
         # Optional type annotation: = varname : type
-        "" = type_annotation
+        Option::None(Option[Type]) = type_hint
         cursor.peek = colon_opt
         if colon_opt.is_some then
             if ":" colon_opt.unwrap Token::value == then
                 cursor.advance
-                cursor parse_type = type_annotation
+                cursor parse_type_ast Option::Some = type_hint
             fi
         fi
         name_token Token::location var_name OpValue::AssignVar make_op = assign_op
-        if "" type_annotation != then
-            type_annotation assign_op->type_annotation
+        if type_hint Option::Some(hint) is then
+            hint Option::Some assign_op->type_hint
         fi
         assign_op
         return
@@ -902,13 +902,13 @@ fn build_hidden_trait_methods
             bound_trait_opt.unwrap = bound_trait
             # Build substitution map from trait's declared type_params to the
             # concrete type_args carried on the bound.
-            Map::new(Map[str str]) = bound_subs
+            Map::new(Map[str Type]) = bound_subs
             bound_trait CasaTrait::type_params = bhtm_params
             bound TraitBound::type_args = bhtm_args
             if bhtm_params.length bhtm_args.length == then
                 0 = bhtm_sub_index
                 while bhtm_sub_index bhtm_params.length > do
-                    bhtm_sub_index bhtm_params.get bhtm_sub_index bhtm_args.get bound_subs.set = bound_subs
+                    bhtm_sub_index bhtm_params.get bhtm_sub_index bhtm_args.get parse_type_str bound_subs.set = bound_subs
                     1 += bhtm_sub_index
                 done
             fi
@@ -916,7 +916,7 @@ fn build_hidden_trait_methods
                 # Skip default methods — only abstract methods need hidden fn ptrs
                 if 0 bound_method TraitMethod::default_ops.length == then
                     f"__trait_{bound_type_var}_{bound_method TraitMethod::name}" = hidden_name
-                    bound_subs bound_type_var bound_method TraitMethod::signature resolve_trait_sig apply_type_subs_to_sig = hidden_sig
+                    bound_subs bound_type_var bound_method TraitMethod::signature resolve_trait_sig apply_type_subs_to_sig_t = hidden_sig
                     hidden_sig signature_to_function_type = hidden_type
                     hidden_type hidden_name HiddenTraitMethod result.push
                 fi
@@ -966,7 +966,9 @@ fn parse_function parser:Parser cursor:TokenCursor -> Function {
             hidden HiddenTraitMethod::fn_type = hidden_type
             hidden_name hidden_type make_named_param hidden_params.push
             hidden_type hidden_name Variable variables.push
-            name_token Token::location hidden_name OpValue::AssignVar make_op ops.push
+            name_token Token::location hidden_name OpValue::AssignVar make_op = hidden_assign
+            hidden_type Option::Some hidden_assign Op::set_type_hint
+            hidden_assign ops.push
         done
         # Prepend hidden params to signature parameters
         for sig_parameter in sig Signature::parameters.iter do
@@ -1074,7 +1076,7 @@ fn synthesize_hashable_for_enum parser:Parser casa_enum:CasaEnum {
     f"{enum_name}::hash" = hash_name
     if hash_name parser.store.functions.get.is_none then
         List::new(List[Op]) = hash_ops
-        location "int" OpValue::TypeCast make_op hash_ops.push
+        location TYPE_INT_T OpValue::TypeCast make_op hash_ops.push
         List::new(List[Parameter]) = hash_params
         enum_name make_param hash_params.push
         List::new(List[Type]) = hash_returns
@@ -1133,11 +1135,11 @@ fn create_member_accessor
     # Getter
     f"{struct_name}::{member_name}" = getter_name
     List::new(List[Op]) = getter_ops
-    location "ptr" OpValue::TypeCast make_op getter_ops.push
+    location TYPE_PTR_T OpValue::TypeCast make_op getter_ops.push
     location offset OpValue::PushInt make_op getter_ops.push
     location OpValue::Add make_op getter_ops.push
     location OpValue::Load64 make_op getter_ops.push
-    location member_type OpValue::TypeCast make_op getter_ops.push
+    location member_type parse_type_str OpValue::TypeCast make_op getter_ops.push
 
     List::new(List[Parameter]) = getter_params
     param_type make_param getter_params.push
@@ -1155,7 +1157,7 @@ fn create_member_accessor
     # Setter
     f"{struct_name}::set_{member_name}" = setter_name
     List::new(List[Op]) = setter_ops
-    location "ptr" OpValue::TypeCast make_op setter_ops.push
+    location TYPE_PTR_T OpValue::TypeCast make_op setter_ops.push
     location offset OpValue::PushInt make_op setter_ops.push
     location OpValue::Add make_op setter_ops.push
     location OpValue::Store64 make_op setter_ops.push
@@ -1419,6 +1421,7 @@ fn inject_impl_trait_params
         hidden_name hidden_type make_named_param hidden_params.push
         hidden_name make_variable function Function::variables.push
         function Function::location hidden_name OpValue::AssignVar make_op = assign_op
+        hidden_type Option::Some assign_op Op::set_type_hint
         insert_pos assign_op function Function::ops.insert
         1 += insert_pos
     done
@@ -2481,8 +2484,7 @@ fn try_resolve_trait_method_call parser:Parser function:Function op:Op ident:str
     if hidden_var function Function::variables variable_list_contains ! then
         hidden_var make_variable function Function::variables.push
     fi
-    hidden_var OpValue::PushVar op Op::set_value
-    "trait_exec" op Op::set_type_annotation
+    hidden_var OpValue::TraitMethodCall op Op::set_value
     true
 }
 # Resolve a bare identifier after `&`-ref, enum-variant, and trait-method

--- a/compiler/syntax.casa
+++ b/compiler/syntax.casa
@@ -1016,7 +1016,7 @@ fn parse_enum parser:Parser cursor:TokenCursor -> CasaEnum {
 
     "{" cursor expect_token_value drop
     List::new(List[str]) = variants
-    Map::new(Map[str List[str]]) = variant_types
+    Map::new(Map[str List[Type]]) = variant_types
     Map::new(Map[str Location]) = variant_locations
 
     while true do
@@ -1032,7 +1032,7 @@ fn parse_enum parser:Parser cursor:TokenCursor -> CasaEnum {
         variant_token Token::value variant_token Token::location variant_locations.set = variant_locations
 
         # Parse optional inner types: Variant(type1 type2)
-        List::new(List[str]) = inner_types
+        List::new(List[Type]) = inner_types
         cursor.peek = paren_opt
         if paren_opt.is_some then
             if "(" paren_opt.unwrap Token::value == then
@@ -1046,7 +1046,7 @@ fn parse_enum parser:Parser cursor:TokenCursor -> CasaEnum {
                         cursor.pop drop # consume )
                         break
                     fi
-                    cursor parse_type inner_types.push
+                    cursor parse_type_ast inner_types.push
                 done
                 if 0 inner_types.length == then
                     variant_token Token::location "Variant inner types cannot be empty" ErrorKind::Syntax raise_error

--- a/compiler/typechecker.casa
+++ b/compiler/typechecker.casa
@@ -297,10 +297,10 @@ fn expect_type_t tc:TypeChecker expected:Type {
     tc TypeChecker::live TypedStack::origins.pop drop
     tc TypeChecker::live TypedStack::types.pop = et_actual_t
     if expected et_actual_t.eq then return fi
+    if et_actual_t expected types_match_t then return fi
+    if expected et_actual_t types_match_t then return fi
     et_actual_t.format = et_actual
     expected.format = et_expected
-    if et_expected et_actual types_match then return fi
-    if et_actual et_expected types_match then return fi
     "Type mismatch" = et_message
     if "" tc TypeChecker::current_op_context != then
         f"Type mismatch in {tc TypeChecker::current_op_context}" = et_message
@@ -313,106 +313,7 @@ fn expect_type_t tc:TypeChecker expected:Type {
 # ============================================================================
 
 fn types_match expected:str actual:str -> bool {
-    if expected actual == then true return fi
-    if TYPE_UNKNOWN expected == then true return fi
-    if TYPE_UNKNOWN actual == then true return fi
-    if TYPE_MISSING expected == then true return fi
-    if TYPE_MISSING actual == then true return fi
-    # Check fn type matching
-    if "fn" expected == then
-        if actual is_fn_type then true return fi
-    fi
-    if "fn" actual == then
-        if expected is_fn_type then true return fi
-    fi
-    # Check generic base matching: expected is base, actual is parameterized
-    actual extract_generic_base = actual_base
-    if actual_base.is_some then
-        if expected actual_base.unwrap == then true return fi
-    fi
-    expected extract_generic_base = expected_base
-    if expected_base.is_some then
-        if actual expected_base.unwrap == then true return fi
-    fi
-    # Check parameterized generics with same base
-    if expected_base.is_some then
-        if actual_base.is_some then
-            if expected_base.unwrap actual_base.unwrap == then
-                expected actual types_match_params = params_ok
-                if params_ok then true return fi
-            fi
-        fi
-    fi
-    # Check fn signature matching
-    expected extract_fn_signature_str = expected_fn_opt
-    if expected_fn_opt.is_some then
-        actual extract_fn_signature_str = actual_fn_opt
-        if actual_fn_opt.is_some then
-            actual_fn_opt.unwrap signature_from_str expected_fn_opt.unwrap signature_from_str signature_matches = sig_ok
-            if sig_ok then true return fi
-        fi
-    fi
-    false
-}
-
-fn base_type_exists base:str function_opt:Option[Function] -> bool {
-    if base is_builtin_type then true return fi
-    if base DEFAULT_PARSER.store.structs.get.is_some then true return fi
-    if base DEFAULT_PARSER.store.enums.get.is_some then true return fi
-    if function_opt Option::Some(check_fn) is then
-        if base check_fn Function::signature Signature::type_vars.has then true return fi
-    fi
-    false
-}
-
-fn type_exists_recursive typ:str function_opt:Option[Function] -> bool {
-    if typ.length 0 == then false return fi
-
-    if typ is_fn_type then
-        typ extract_fn_signature_str = function_inner_opt
-        if function_inner_opt Option::Some(function_inner) is then
-            for function_token in function_inner split_type_tokens.iter do
-                if "->" function_token != then
-                    if function_opt function_token type_exists_recursive ! then false return fi
-                fi
-            done
-        fi
-        true return
-    fi
-
-    typ extract_generic_base = base_opt
-    if base_opt Option::Some(generic_base) is then
-        generic_base.length = base_length
-        typ.length base_length - 2 - = inner_length
-        typ base_length 1 + inner_length str::substring split_type_tokens = generic_params
-        for generic_param in generic_params.iter do
-            if function_opt generic_param type_exists_recursive ! then false return fi
-        done
-        function_opt generic_base base_type_exists return
-    fi
-
-    function_opt typ base_type_exists
-}
-
-fn validate_type_exists typ:str function_opt:Option[Function] location:Location {
-    if function_opt typ type_exists_recursive then return fi
-    location f"type `{typ}` does not exist" ErrorKind::Syntax raise_error
-}
-
-fn is_type_variable typ:str -> bool {
-    # Check if the type is a type variable (single uppercase letter or
-    # registered as a type var in a generic enum/struct)
-    if typ.length 0 == then false return fi
-    # Single uppercase letter is a type variable
-    if typ.length 1 == then
-        0 typ.at.is_upper return
-    fi
-    # Check if it's a known type variable in enums
-    typ extract_generic_base = itv_base
-    if itv_base.is_some then
-        itv_base.unwrap DEFAULT_PARSER.store.enums.get.is_some return
-    fi
-    false
+    actual parse_type_str expected parse_type_str types_match_t
 }
 
 fn is_enum_type_var_t typ:Type -> bool {
@@ -442,102 +343,69 @@ fn is_type_variable_t typ:Type -> bool {
     end
 }
 
-fn types_match_params expected:str actual:str -> bool {
-    expected extract_generic_params = expected_params_opt
-    actual extract_generic_params = actual_params_opt
-    if expected_params_opt.is_none then false return fi
-    if actual_params_opt.is_none then false return fi
-    expected_params_opt.unwrap = expected_params
-    actual_params_opt.unwrap = actual_params
-    if expected_params.length actual_params.length != then false return fi
+fn types_match_t expected:Type actual:Type -> bool {
+    actual expected signature_type_matches
+}
 
-    # Collect type variables from the expected type's base (if it's a generic struct/enum)
-    expected extract_generic_base = base_opt
-    Set::new(Set[str]) = type_vars
-    if base_opt.is_some then
-        base_opt.unwrap DEFAULT_PARSER.store.enums.get = enum_opt
-        if enum_opt.is_some then
-            for type_var in enum_opt.unwrap CasaEnum::type_vars.iter do
-                type_var type_vars.add = type_vars
-            done
-        fi
-        base_opt.unwrap DEFAULT_PARSER.store.structs.get = struct_opt
-        if struct_opt.is_some then
-            for type_var in struct_opt.unwrap CasaStruct::type_vars.iter do
-                type_var type_vars.add = type_vars
-            done
-        fi
-    fi
-
-    0 = index
-    while index expected_params.length > do
-        index expected_params.get = expected_param
-        index actual_params.get = actual_param
-        if expected_param actual_param != then
-            if
-            TYPE_UNKNOWN expected_param !=
-            TYPE_UNKNOWN actual_param != &&
-            expected_param type_vars.has ! &&
-            actual_param type_vars.has ! &&
-            expected_param is_type_variable ! &&
-            actual_param is_type_variable ! &&
-            then
-                false return
-            fi
-        fi
-        1 += index
-    done
-    true
+fn validate_type_exists typ:Type function_opt:Option[Function] location:Location {
+    if function_opt typ.exists_recursive then return fi
+    location f"type `{typ.format}` does not exist" ErrorKind::Syntax raise_error
 }
 
 # ============================================================================
 # Unify types — returns the more specific type, or "" on incompatibility
 # ============================================================================
 
-fn unify_generic_params type_a:str type_b:str -> str {
-    type_a extract_generic_params = params_a_opt
-    type_b extract_generic_params = params_b_opt
-    if params_a_opt.is_none then type_b return fi
-    if params_b_opt.is_none then type_a return fi
+fn unify_generic_params_t type_a:Type type_b:Type -> Option[Type] {
+    type_a.type_params = params_a_opt
+    type_b.type_params = params_b_opt
+    if params_a_opt.is_none then type_b Option::Some return fi
+    if params_b_opt.is_none then type_a Option::Some return fi
     params_a_opt.unwrap = params_a
     params_b_opt.unwrap = params_b
-    if params_a.length params_b.length != then "" return fi
-    List::new(List[str]) = unified
+    if params_a.length params_b.length != then Option::None(Option[Type]) return fi
+    List::new(List[Type]) = unified
     0 = index
     while index params_a.length > do
-        index params_b.get index params_a.get unify_type = unified_type
-        if "" unified_type == then "" return fi
-        unified_type unified.push
+        index params_b.get index params_a.get unify_type_t = unified_opt
+        if unified_opt.is_none then Option::None(Option[Type]) return fi
+        unified_opt.unwrap unified.push
         1 += index
     done
-    type_a extract_generic_base.unwrap = base
-    unified base build_parameterized_type
+    type_a.base.unwrap = base
+    unified base GenericType Type::Generic Option::Some
 }
 
 fn unify_type type_a:str type_b:str -> str {
-    if type_a type_b == then type_a return fi
-    if TYPE_UNKNOWN type_a == then type_b return fi
-    if TYPE_UNKNOWN type_b == then type_a return fi
-    # Enum type variables unify with concrete types
-    if type_a is_enum_type_var then type_b return fi
-    if type_b is_enum_type_var then type_a return fi
-    type_a extract_generic_base = base_a
-    type_b extract_generic_base = base_b
+    type_b parse_type_str type_a parse_type_str unify_type_t = unified_opt
+    if unified_opt.is_none then "" return fi
+    unified_opt.unwrap.format
+}
+
+fn unify_type_t type_a:Type type_b:Type -> Option[Type] {
+    if type_a type_b.eq then type_a Option::Some return fi
+    if type_a.is_unknown_placeholder then type_b Option::Some return fi
+    if type_b.is_unknown_placeholder then type_a Option::Some return fi
+    # Enum type variables unify with concrete types.
+    if type_a is_enum_type_var_t then type_b Option::Some return fi
+    if type_b is_enum_type_var_t then type_a Option::Some return fi
+    type_a.base = base_a
+    type_b.base = base_b
     if base_a.is_some then
         if base_b.is_some then
             if base_a.unwrap base_b.unwrap == then
-                type_b type_a unify_generic_params = generic_result
-                if "" generic_result != then generic_result return fi
+                type_b type_a unify_generic_params_t = generic_result
+                if generic_result.is_some then generic_result return fi
             fi
         fi
     fi
     if base_a.is_some then
-        if base_a.unwrap type_b == then type_a return fi
+        if base_a.unwrap type_b.format == then type_a Option::Some return fi
     fi
     if base_b.is_some then
-        if base_b.unwrap type_a == then type_b return fi
+        if base_b.unwrap type_a.format == then type_b Option::Some return fi
     fi
-    ""
+    Option::None(Option[Type])
 }
 
 # ============================================================================
@@ -554,11 +422,11 @@ fn stacks_compatible stack_a:List[Type] stack_b:List[Type] -> List[Type] {
         if index stack_b.get index stack_a.get.eq then
             index stack_a.get result.push
         else
-            index stack_b.get.format index stack_a.get.format unify_type = unified
-            if "" unified == then
+            index stack_b.get index stack_a.get unify_type_t = unified
+            if unified.is_none then
                 List::new(List[Type]) return
             fi
-            unified parse_type_str result.push
+            unified.unwrap result.push
         fi
         1 += index
     done
@@ -642,28 +510,6 @@ fn bind_type_var tc:TypeChecker bindings:Map[str Type] type_var:str actual:Type 
         f"Type variable `{type_var}` bound to `{bound.format}` but got `{actual.format}`" tc raise_type_mismatch
     fi
     bindings
-}
-
-fn is_enum_type_var typ:str -> bool {
-    typ extract_generic_base = base
-    if base.is_some then
-        base.unwrap DEFAULT_PARSER.store.enums.get.is_some
-    else
-        false
-    fi
-}
-# True when typ has TYPE_UNKNOWN inside any parametric position. Used to
-# detect empty array literals whose element type was never constrained by an
-# annotation, cast, or surrounding use.
-
-fn type_has_unresolved typ:str -> bool {
-    typ extract_generic_params = params_opt
-    if params_opt.is_none then false return fi
-    for param in params_opt.unwrap.iter do
-        if TYPE_UNKNOWN param == then true return fi
-        if param type_has_unresolved then true return fi
-    done
-    false
 }
 
 fn bind_generic_param
@@ -890,17 +736,8 @@ fn check_arithmetic tc:TypeChecker op:Op {
 # ============================================================================
 # Check comparison operations
 # ============================================================================
-# Primitive types whose `==`/`<` etc. are emitted as direct bytecode rather
-# than dispatched through Eq/Ord trait methods. `str` is handled separately
-# because it only supports `==`/`!=` and carries a type annotation.
-
-fn is_primitive_compare_type typ:str -> bool {
-    "int" typ ==
-    "bool" typ == ||
-    "char" typ == ||
-    "cstr" typ == ||
-    "ptr" typ == ||
-}
+# Primitive comparisons are emitted as direct bytecode. `str` is handled
+# separately because it only supports `==`/`!=` and carries a type hint.
 
 fn comparison_method_name cmp_value:OpValue -> str {
     if cmp_value OpValue::Eq is then "eq" return fi
@@ -931,8 +768,10 @@ fn check_comparison
     cmp_value OpValue::Eq is cmp_value OpValue::Ne is || = is_eq_op
     if is_eq_op then "Eq" else "Ord" fi = trait_name
     f"value with trait `{trait_name}`" tc TypeChecker::set_current_expect_ctx
-    tc stack_pop = type1
-    tc stack_pop = type2
+    tc stack_pop_type = type1_t
+    tc stack_pop_type = type2_t
+    type1_t.format = type1
+    type2_t.format = type2
     # Stack-underflow placeholder on either side: defer to caller-level
     # inference (lambda param synthesis, generic body deferral). Skip both
     # the same-type rule and the trait-bound check.
@@ -945,12 +784,12 @@ fn check_comparison
         TYPE_BOOL_T tc stack_push_type
         op_index return
     fi
-    type1 resolve_match_type = base1
-    type2 resolve_match_type = base2
+    type1_t.match_base = base1
+    type2_t.match_base = base2
     base1 tc.store.enums.get.is_some = is_enum1
     base2 tc.store.enums.get.is_some = is_enum2
     # Same-type rule applies before any specialization.
-    if type1 type2 != then
+    if type1_t type2_t.eq ! then
         f"Cannot compare `{type2}` with `{type1}`" tc raise_type_mismatch
         TYPE_BOOL_T tc stack_push_type
         op_index return
@@ -960,7 +799,7 @@ fn check_comparison
         if is_enum1 then
             base1 tc.store.enums.get.unwrap = casa_enum
             if casa_enum has_inner_values then
-                base1 op Op::set_type_annotation
+                base1 make_named_type Option::Some op Op::set_type_hint
             fi
         fi
         TYPE_BOOL_T tc stack_push_type
@@ -971,12 +810,12 @@ fn check_comparison
         if is_eq_op ! then
             "Type `str` only supports `==` and `!=` comparison" tc raise_type_mismatch
         fi
-        "str" op Op::set_type_annotation
+        TYPE_STR_T Option::Some op Op::set_type_hint
         TYPE_BOOL_T tc stack_push_type
         op_index return
     fi
     # Other primitives: bytecode handles the comparison directly.
-    if type1 is_primitive_compare_type then
+    if type1_t.is_primitive_compare_type_t then
         TYPE_BOOL_T tc stack_push_type
         op_index return
     fi
@@ -989,8 +828,8 @@ fn check_comparison
     fi
     # Lower the operator to the corresponding trait method call.
     cmp_value comparison_method_name = method_name
-    type2 tc stack_push
-    type1 tc stack_push
+    type2_t tc stack_push_type
+    type1_t tc stack_push_type
     method_name OpValue::MethodCall op Op::set_value
     function_opt op_index ops op tc check_method_call
 }
@@ -1137,20 +976,18 @@ fn check_memory tc:TypeChecker op:Op function_opt:Option[Function] {
 # Unify the stored type of `variable` with the type being assigned to it.
 # `scope` ("local" / "global") is only used in the error message.
 
-fn unify_variable_assignment op:Op variable:Variable effective_type:str scope:str {
+fn unify_variable_assignment op:Op variable:Variable effective_type:Type scope:str {
     variable Variable::name = var_name
-    variable Variable::typ.format = pre_str
-    if
-    "" pre_str ==
-    TYPE_UNKNOWN pre_str == effective_type TYPE_UNKNOWN != && ||
-    then
-        effective_type parse_type_str variable Variable::set_typ
+    variable Variable::typ = pre_type
+    pre_type.is_unknown pre_type.is_unknown_placeholder || = pre_unknown
+    if pre_unknown effective_type.is_unknown_placeholder ! && then
+        effective_type variable Variable::set_typ
     fi
-    variable Variable::typ.format effective_type unify_type = unified
-    if "" unified == then
-        op Op::location f"Cannot override {scope} variable `{var_name}` of type `{variable Variable::typ.format}` with other type `{effective_type}`" ErrorKind::InvalidVariable add_error
+    effective_type variable Variable::typ unify_type_t = unified
+    if unified.is_none then
+        op Op::location f"Cannot override {scope} variable `{var_name}` of type `{variable Variable::typ.format}` with other type `{effective_type.format}`" ErrorKind::InvalidVariable add_error
     else
-        unified parse_type_str variable Variable::set_typ
+        unified.unwrap variable Variable::set_typ
     fi
 }
 
@@ -1163,13 +1000,13 @@ fn check_assignment tc:TypeChecker op:Op function_opt:Option[Function] {
         return
     fi
     if op.value OpValue::AssignVar(var_name) is ! then return fi
-    tc stack_peek = stack_type
-    "" op Op::type_annotation != = has_annotation
-    stack_type = effective_type
+    tc stack_peek_type = stack_type_t
+    op Op::type_hint.is_some = has_annotation
+    stack_type_t = effective_type_t
     if has_annotation then
-        op Op::type_annotation = effective_type
+        op Op::type_hint.unwrap = effective_type_t
     fi
-    if has_annotation ! stack_type type_has_unresolved && then
+    if has_annotation ! stack_type_t.has_unresolved && then
         op Op::location f"Cannot infer element type of empty array literal assigned to `{var_name}`; add a type annotation (e.g. `= {var_name}:array[int]`) or an explicit cast (e.g. `[] (array[int])`)." ErrorKind::TypeMismatch raise_error
     fi
 
@@ -1179,8 +1016,8 @@ fn check_assignment tc:TypeChecker op:Op function_opt:Option[Function] {
         var_name function Function::variables variable_list_index = local_index
         if 0 local_index >= then
             local_index function Function::variables.get = local_var
-            "local" effective_type local_var op unify_variable_assignment
-            effective_type tc expect_type drop
+            "local" effective_type_t local_var op unify_variable_assignment
+            effective_type_t tc expect_type_t
             return
         fi
     fi
@@ -1189,11 +1026,11 @@ fn check_assignment tc:TypeChecker op:Op function_opt:Option[Function] {
     var_name tc.store.variables.get = global_opt
     if global_opt.is_some then
         global_opt.unwrap = global_var
-        "global" effective_type global_var op unify_variable_assignment
-        effective_type tc expect_type drop
+        "global" effective_type_t global_var op unify_variable_assignment
+        effective_type_t tc expect_type_t
         return
     fi
-    effective_type tc expect_type drop
+    effective_type_t tc expect_type_t
 }
 
 # ============================================================================
@@ -1201,11 +1038,11 @@ fn check_assignment tc:TypeChecker op:Op function_opt:Option[Function] {
 # ============================================================================
 # Simulate the FnExec emitted by the bytecode pass for trait-bound namespace calls
 # like `K::hash`. The parser rewrites these to an OpPushVar of the hidden
-# `__trait_{type_var}_{method}` variable, annotated as "trait_exec". At typecheck
-# time we pop the fn-pointer type we just pushed and apply the resolved trait
-# method signature so the correct return type lands on the stack.
+# `__trait_{type_var}_{method}` variable. At typecheck time we pop the
+# fn-pointer type we just pushed and apply the resolved trait method signature
+# so the correct return type lands on the stack.
 
-fn simulate_trait_exec tc:TypeChecker function:Function var_name:str {
+fn simulate_trait_method_call tc:TypeChecker function:Function var_name:str {
     var_name 8 var_name.length 8 - str::substring = trait_suffix
     trait_suffix "_" str::find = trait_sep
     if trait_sep 0 >= then return fi
@@ -1242,9 +1079,25 @@ fn check_push_var tc:TypeChecker op:Op function_opt:Option[Function] {
         return
     fi
 
+    if op.value OpValue::TraitMethodCall(trait_var_name) is then
+        if function_opt Option::Some(function) is then
+            trait_var_name function Function::variables variable_list_index = trait_index
+            if 0 trait_index >= then
+                if trait_index function Function::variables.get Variable::typ.is_unknown ! then
+                    trait_index function Function::variables.get Variable::typ tc stack_push_type
+                else
+                    TYPE_UNKNOWN_T tc stack_push_type
+                fi
+            else
+                TYPE_UNKNOWN_T tc stack_push_type
+            fi
+            trait_var_name function tc simulate_trait_method_call
+        fi
+        return
+    fi
+
     # PUSH_VARIABLE
     if op.value OpValue::PushVar(var_name) is ! then return fi
-    "trait_exec" op Op::type_annotation == = is_trait_exec
 
     # Check local variables first
     if function_opt.is_some then
@@ -1255,9 +1108,6 @@ fn check_push_var tc:TypeChecker op:Op function_opt:Option[Function] {
                 local_index function Function::variables.get Variable::typ tc stack_push_type
             else
                 TYPE_UNKNOWN_T tc stack_push_type
-            fi
-            if is_trait_exec then
-                var_name function tc simulate_trait_exec
             fi
             return
         fi
@@ -1423,15 +1273,16 @@ fn bind_generic_params_standalone
 
 fn type_satisfies_trait type_name:str trait_name:str function_opt:Option[Function] -> bool {
     # Accept both bare ("Iterable") and concrete generic ("Iterable[int]") trait names.
-    trait_name extract_generic_base = trait_base_opt
+    trait_name parse_type_str = trait_type
+    trait_type.base = trait_base_opt
     if trait_base_opt.is_some then trait_base_opt.unwrap else trait_name fi = trait_lookup_name
     trait_lookup_name DEFAULT_PARSER.store.traits.get = trait_opt
     if trait_opt.is_none then false return fi
     trait_opt.unwrap = trait_def
     # Build substitution map from trait's type_params to concrete args from trait_name.
-    Map::new(Map[str str]) = trait_subs
+    Map::new(Map[str Type]) = trait_subs
     if trait_base_opt.is_some then
-        trait_name extract_generic_params = trait_args_opt
+        trait_type.type_params = trait_args_opt
         if trait_args_opt.is_some then
             trait_args_opt.unwrap = trait_args
             trait_def CasaTrait::type_params = tparams
@@ -1458,7 +1309,7 @@ fn type_satisfies_trait type_name:str trait_name:str function_opt:Option[Functio
         false = via_generic_base
         # Fall back to the generic base type (e.g. `Option::to_str` for `Option[int]`)
         if fn_opt.is_none then
-            type_name extract_generic_base = base_opt
+            type_name parse_type_str.base = base_opt
             if base_opt.is_some then
                 f"{base_opt.unwrap}::{method TraitMethod::name}" = fn_name
                 fn_name DEFAULT_PARSER.store.functions.get = fn_opt
@@ -1480,7 +1331,7 @@ fn type_satisfies_trait type_name:str trait_name:str function_opt:Option[Functio
         if via_generic_base then
             continue
         fi
-        trait_subs type_name method TraitMethod::signature resolve_trait_sig apply_type_subs_to_sig = resolved
+        trait_subs type_name method TraitMethod::signature resolve_trait_sig apply_type_subs_to_sig_t = resolved
         if function Function::signature Signature::parameters.length resolved Signature::parameters.length != then
             false return
         fi
@@ -1489,26 +1340,18 @@ fn type_satisfies_trait type_name:str trait_name:str function_opt:Option[Functio
         fi
         0 = param_index
         while param_index resolved Signature::parameters.length > do
-            param_index function Function::signature Signature::parameters.get Parameter::typ.format = actual_param
-            param_index resolved Signature::parameters.get Parameter::typ.format = expected_param
-            if
-            actual_param expected_param !=
-            TYPE_UNKNOWN actual_param != &&
-            TYPE_UNKNOWN expected_param != &&
-            then
+            param_index function Function::signature Signature::parameters.get Parameter::typ = actual_param
+            param_index resolved Signature::parameters.get Parameter::typ = expected_param
+            if expected_param actual_param types_match_t ! then
                 false return
             fi
             1 += param_index
         done
         0 = return_index
         while return_index resolved Signature::return_types.length > do
-            return_index function Function::signature Signature::return_types.get.format = actual_return
-            return_index resolved Signature::return_types.get.format = expected_return
-            if
-            actual_return expected_return !=
-            TYPE_UNKNOWN actual_return != &&
-            TYPE_UNKNOWN expected_return != &&
-            then
+            return_index function Function::signature Signature::return_types.get = actual_return
+            return_index resolved Signature::return_types.get = expected_return
+            if expected_return actual_return types_match_t ! then
                 false return
             fi
             1 += return_index
@@ -1710,17 +1553,10 @@ fn inject_trait_fn_ptrs
         op_index ops.get = next_op
         if next_op.value OpValue::TypeCast(cast_type) is then
             for return_type in sig Signature::return_types.iter do
-                sig Signature::type_vars cast_type parse_type_str return_type bindings bind_generic_params_standalone = bindings
+                sig Signature::type_vars cast_type return_type bindings bind_generic_params_standalone = bindings
             done
         fi
     fi
-
-    # Build str-view of bindings for the per-bound substitute_type_params call.
-    Map::new(Map[str str]) = bindings_str
-    for binding_key in bindings.keys.iter do
-        binding_key bindings.get.unwrap.format = binding_value
-        binding_key binding_value bindings_str.set = bindings_str
-    done
 
     # Inject FN_PUSH ops for each trait bound.
     # Iterate type vars in reverse so the first param in the signature (which
@@ -1735,7 +1571,8 @@ fn inject_trait_fn_ptrs
         type_var sig Signature::trait_bounds.get.unwrap = trait_bound
         # Resolve trait type args against current bindings so that
         # `Carrier[T]` becomes `Carrier[int]` once T has been bound.
-        bindings_str trait_bound trait_bound_to_str substitute_type_params = trait_name
+        trait_bound trait_bound_to_type = trait_bound_type
+        bindings trait_bound_type.substitute_t.format = trait_name
         type_var bindings.get = concrete_opt
         if concrete_opt.is_none then
             location f"Cannot determine concrete type for type variable `{type_var}`" ErrorKind::TypeMismatch raise_error
@@ -1836,13 +1673,15 @@ fn check_function_ops
             fn_name sig tc apply_signature
         fi
     elif fn_value OpValue::FnExec is then
-        tc stack_peek = fn_ptr_type
-        if TYPE_UNKNOWN fn_ptr_type == then "fn" = fn_ptr_type fi
-        fn_ptr_type tc expect_type drop
-        if "fn" fn_ptr_type != then
-            fn_ptr_type extract_fn_signature_str = sig_str_opt
-            if sig_str_opt.is_some then
-                "exec" sig_str_opt.unwrap signature_from_str tc apply_signature
+        tc stack_peek_type = fn_ptr_type
+        if fn_ptr_type.is_unknown_placeholder then
+            TYPE_UNKNOWN_T tc expect_type_t
+        else
+            fn_ptr_type tc expect_type_t
+            if fn_ptr_type Type::Function(fn_type) is then
+                if 0 fn_type FunctionType::parameters.length != 0 fn_type FunctionType::return_types.length != || then
+                    "exec" fn_type function_type_to_signature tc apply_signature
+                fi
             fi
         fi
     elif fn_value OpValue::FnPush(push_name) is then
@@ -1975,7 +1814,7 @@ fn check_io tc:TypeChecker op:Op ops:List[Op] op_index:int function_opt:Option[F
 
 fn check_typeof tc:TypeChecker op:Op {
     tc stack_pop = typ
-    typ op Op::set_type_annotation
+    typ parse_type_str Option::Some op Op::set_type_hint
     TYPE_STR_T tc stack_push_type
 }
 
@@ -2070,10 +1909,10 @@ fn check_enum_variant tc:TypeChecker op:Op {
 # ============================================================================
 
 fn check_is tc:TypeChecker op:Op function_opt:Option[Function] {
-    tc stack_pop = typ
-    typ resolve_match_type = base
+    tc stack_pop_type = typ
+    typ.match_base = base
     if base tc.store.enums.get.is_none then
-        f"`is` requires an enum type, got `{typ}`" tc raise_type_mismatch
+        f"`is` requires an enum type, got `{typ.format}`" tc raise_type_mismatch
         TYPE_BOOL_T tc stack_push_type
         return
     fi
@@ -2085,7 +1924,7 @@ fn check_is tc:TypeChecker op:Op function_opt:Option[Function] {
     # Validate the variant belongs to the correct enum
     if "" variant EnumVariant::enum_name != then
         if variant EnumVariant::enum_name casa_enum CasaEnum::name != then
-            f"Cannot check `{variant EnumVariant::enum_name}::{variant EnumVariant::variant_name}` on value of type `{typ}`" tc raise_type_mismatch
+            f"Cannot check `{variant EnumVariant::enum_name}::{variant EnumVariant::variant_name}` on value of type `{typ.format}`" tc raise_type_mismatch
         fi
     fi
     # Validate binding count for data-carrying variants
@@ -2098,25 +1937,13 @@ fn check_is tc:TypeChecker op:Op function_opt:Option[Function] {
             fi
         fi
     fi
-    typ variant function_opt tc register_enum_pattern_bindings
+    typ.format variant function_opt tc register_enum_pattern_bindings
     TYPE_BOOL_T tc stack_push_type
 }
 
 # ============================================================================
 # Check match blocks
 # ============================================================================
-
-fn resolve_match_type typ:str -> str {
-    if typ DEFAULT_PARSER.store.enums.get.is_some then typ return fi
-    if typ DEFAULT_PARSER.store.structs.get.is_some then typ return fi
-    typ extract_generic_base = base
-    if base.is_some then
-        if base.unwrap DEFAULT_PARSER.store.enums.get.is_some then
-            base.unwrap return
-        fi
-    fi
-    typ
-}
 
 fn set_binding_type var_name:str field_type:str function_opt:Option[Function] {
     if function_opt.is_some then
@@ -2191,7 +2018,7 @@ fn check_match tc:TypeChecker op:Op function_opt:Option[Function] {
             fi
 
             match_ctx MatchContext::match_type = end_match_type
-            end_match_type resolve_match_type = end_base
+            end_match_type parse_type_str.match_base = end_base
 
             # Build covered set
             Set::new(Set[str]) = covered_set
@@ -2363,7 +2190,7 @@ fn check_abstract_methods_present receiver:str trait_def:CasaTrait -> bool {
         if 0 cam_method TraitMethod::default_ops.length == then
             f"{receiver}::{cam_method TraitMethod::name}" DEFAULT_PARSER.store.functions.get = cam_fn_opt
             if cam_fn_opt.is_none then
-                receiver extract_generic_base = cam_base_opt
+                receiver parse_type_str.base = cam_base_opt
                 if cam_base_opt.is_some then
                     f"{cam_base_opt.unwrap}::{cam_method TraitMethod::name}" DEFAULT_PARSER.store.functions.get = cam_fn_opt
                 fi
@@ -2388,7 +2215,7 @@ fn instantiate_default_trait_method
         f"{receiver}::{method_name}" Option::Some return
     fi
     # Also check generic base
-    receiver extract_generic_base = already_base_opt
+    receiver parse_type_str.base = already_base_opt
     if already_base_opt.is_some then
         f"{already_base_opt.unwrap}::{method_name}" DEFAULT_PARSER.store.functions.get = already_base_fn_opt
         if already_base_fn_opt.is_some then
@@ -2422,7 +2249,7 @@ fn instantiate_default_trait_method
     trait_def CasaTrait::type_params = type_params
 
     # Determine function name and whether to use generic or concrete form
-    receiver extract_generic_base = fn_base_opt
+    receiver parse_type_str.base = fn_base_opt
     if fn_base_opt.is_some then fn_base_opt.unwrap else receiver fi = fn_type_name
     f"{fn_type_name}::{method_name}" = synth_fn_name
 
@@ -2497,12 +2324,7 @@ fn instantiate_default_trait_method
 
     default_method TraitMethod::default_ops clone_ops = cloned_body
     if 0 trait_subs.length != then
-        Map::new(Map[str str]) = trait_subs_str
-        for sub_key in trait_subs.keys.iter do
-            sub_key trait_subs.get.unwrap.format = sub_value
-            sub_key sub_value trait_subs_str.set = trait_subs_str
-        done
-        trait_subs_str cloned_body substitute_ops_types
+        trait_subs cloned_body substitute_ops_types
     fi
     for body_op in cloned_body.iter do
         body_op synth_ops.push
@@ -2547,13 +2369,13 @@ fn check_method_call
                 # bound's concrete type_args, so that a trait method like
                 # `next self:self -> Option[T]` with bound `I: Iterable[int]`
                 # resolves to `next self:I -> Option[int]` at the call site.
-                Map::new(Map[str str]) = constraint_subs
+                Map::new(Map[str Type]) = constraint_subs
                 trait_def CasaTrait::type_params = constraint_params
                 bound TraitBound::type_args = constraint_args
                 if constraint_params.length constraint_args.length == then
                     0 = constraint_index
                     while constraint_index constraint_params.length > do
-                        constraint_index constraint_params.get constraint_index constraint_args.get constraint_subs.set = constraint_subs
+                        constraint_index constraint_params.get constraint_index constraint_args.get parse_type_str constraint_subs.set = constraint_subs
                         1 += constraint_index
                     done
                 fi
@@ -2561,7 +2383,7 @@ fn check_method_call
                     if method_name trait_method TraitMethod::name == then
                         f"__trait_{receiver}_{method_name}" = hidden_var
                         tc stack_pop_drop
-                        constraint_subs receiver trait_method TraitMethod::signature resolve_trait_sig apply_type_subs_to_sig = resolved_sig
+                        constraint_subs receiver trait_method TraitMethod::signature resolve_trait_sig apply_type_subs_to_sig_t = resolved_sig
                         receiver tc stack_push
                         f"{receiver}::{method_name}" resolved_sig tc apply_signature
                         hidden_var OpValue::PushVar op Op::set_value
@@ -2581,7 +2403,7 @@ fn check_method_call
 
     # Try generic base type
     if fn_opt.is_none then
-        receiver extract_generic_base = base_opt
+        receiver parse_type_str.base = base_opt
         if base_opt.is_some then
             f"{base_opt.unwrap}::{method_name}" = fn_name
             fn_name tc.store.functions.get = fn_opt
@@ -2894,6 +2716,12 @@ fn run_type_check_ops checker:TypeChecker ops:List[Op] function_opt:Option[Funct
             continue
         fi
 
+        # Trait-bound method call
+        if op_value OpValue::TraitMethodCall is then
+            function_opt current_op checker check_push_var
+            continue
+        fi
+
         # F-string expression -> str conversion (Display trait)
         if op_value OpValue::FstringToStr is then
             function_opt op_index ops current_op checker check_fstring_to_str = op_index
@@ -2904,7 +2732,7 @@ fn run_type_check_ops checker:TypeChecker ops:List[Op] function_opt:Option[Funct
         if op_value OpValue::TypeCast(cast_type) is then
             current_op Op::location function_opt cast_type validate_type_exists
             checker stack_pop drop
-            cast_type checker stack_push
+            cast_type checker stack_push_type
             continue
         fi
 

--- a/compiler/typechecker.casa
+++ b/compiler/typechecker.casa
@@ -258,32 +258,6 @@ fn stack_pop_drop tc:TypeChecker {
     tc TypeChecker::live TypedStack::types.pop drop
 }
 
-fn expect_type tc:TypeChecker expected:str -> str {
-    if 0 tc TypeChecker::live TypedStack::types.length == then
-        if tc within_param_cap then
-            expected make_param tc TypeChecker::parameters.push
-            expected return
-        fi
-        f"Stack underflow: expected `{expected}` but stack is empty" tc report_stack_underflow
-        TYPE_MISSING return
-    fi
-    tc TypeChecker::live TypedStack::origins.pop = et_origin
-    tc TypeChecker::live TypedStack::types.pop.format = et_actual
-    # Check if types are compatible
-    if expected et_actual types_match then
-        et_actual return
-    fi
-    if et_actual expected types_match then
-        expected return
-    fi
-    # Build error message
-    "Type mismatch" = et_message
-    if "" tc TypeChecker::current_op_context != then
-        f"Type mismatch in {tc TypeChecker::current_op_context}" = et_message
-    fi
-    et_actual expected tc TypeChecker::current_location et_message ErrorKind::TypeMismatch add_error_expected
-    expected
-}
 
 fn expect_type_t tc:TypeChecker expected:Type {
     if 0 tc TypeChecker::live TypedStack::types.length == then
@@ -311,10 +285,6 @@ fn expect_type_t tc:TypeChecker expected:Type {
 # ============================================================================
 # Type compatibility
 # ============================================================================
-
-fn types_match expected:str actual:str -> bool {
-    actual parse_type_str expected parse_type_str types_match_t
-}
 
 fn is_enum_type_var_t typ:Type -> bool {
     typ.base = base_opt
@@ -374,12 +344,6 @@ fn unify_generic_params_t type_a:Type type_b:Type -> Option[Type] {
     done
     type_a.base.unwrap = base
     unified base GenericType Type::Generic Option::Some
-}
-
-fn unify_type type_a:str type_b:str -> str {
-    type_b parse_type_str type_a parse_type_str unify_type_t = unified_opt
-    if unified_opt.is_none then "" return fi
-    unified_opt.unwrap.format
 }
 
 fn unify_type_t type_a:Type type_b:Type -> Option[Type] {
@@ -820,7 +784,7 @@ fn check_comparison
         op_index return
     fi
     # User-defined types must satisfy Eq (or Ord) explicitly.
-    if function_opt trait_name type1 type_satisfies_trait ! then
+    if function_opt trait_name type1_t type_satisfies_trait ! then
         cmp_value comparison_op_str = cmp_str
         op Op::location f"Type `{type1}` cannot be compared with `{cmp_str}`: does not satisfy trait `{trait_name}`" ErrorKind::MissingTraitMethod add_error
         TYPE_BOOL_T tc stack_push_type
@@ -1271,7 +1235,8 @@ fn bind_generic_params_standalone
     bindings
 }
 
-fn type_satisfies_trait type_name:str trait_name:str function_opt:Option[Function] -> bool {
+fn type_satisfies_trait type_name:Type trait_name:str function_opt:Option[Function] -> bool {
+    type_name.format = type_name_str
     # Accept both bare ("Iterable") and concrete generic ("Iterable[int]") trait names.
     trait_name parse_type_str = trait_type
     trait_type.base = trait_base_opt
@@ -1298,18 +1263,18 @@ fn type_satisfies_trait type_name:str trait_name:str function_opt:Option[Functio
     # Type variable with matching bound satisfies the trait
     if function_opt.is_some then
         function_opt.unwrap Function::signature Signature::trait_bounds = bounds
-        type_name bounds.get = bound_opt
+        type_name_str bounds.get = bound_opt
         if bound_opt.is_some then
             if trait_name bound_opt.unwrap trait_bound_to_str == then true return fi
         fi
     fi
     for method in trait_def DEFAULT_PARSER collect_trait_methods.iter do
-        f"{type_name}::{method TraitMethod::name}" = fn_name
+        f"{type_name_str}::{method TraitMethod::name}" = fn_name
         fn_name DEFAULT_PARSER.store.functions.get = fn_opt
         false = via_generic_base
         # Fall back to the generic base type (e.g. `Option::to_str` for `Option[int]`)
         if fn_opt.is_none then
-            type_name parse_type_str.base = base_opt
+            type_name.base = base_opt
             if base_opt.is_some then
                 f"{base_opt.unwrap}::{method TraitMethod::name}" = fn_name
                 fn_name DEFAULT_PARSER.store.functions.get = fn_opt
@@ -1331,7 +1296,7 @@ fn type_satisfies_trait type_name:str trait_name:str function_opt:Option[Functio
         if via_generic_base then
             continue
         fi
-        trait_subs type_name method TraitMethod::signature resolve_trait_sig apply_type_subs_to_sig_t = resolved
+        trait_subs type_name_str method TraitMethod::signature resolve_trait_sig apply_type_subs_to_sig_t = resolved
         if function Function::signature Signature::parameters.length resolved Signature::parameters.length != then
             false return
         fi
@@ -1579,7 +1544,8 @@ fn inject_trait_fn_ptrs
             type_index 1 - = type_index
             continue
         fi
-        concrete_opt.unwrap.format = concrete
+        concrete_opt.unwrap = concrete_t
+        concrete_t.format = concrete
         trait_bound TraitBound::name tc.store.traits.get.unwrap = trait_def
 
         # Check if forwarding (type var has same trait bound in calling function)
@@ -1613,7 +1579,7 @@ fn inject_trait_fn_ptrs
             done
         else
             # Verify structural satisfaction
-            if function_opt trait_name concrete type_satisfies_trait ! then
+            if function_opt trait_name concrete_t type_satisfies_trait ! then
                 location f"Type `{concrete}` does not satisfy trait `{trait_name}`" ErrorKind::TypeMismatch raise_error
             fi
             # Inject FN_PUSH for each abstract method (reversed)
@@ -1728,26 +1694,26 @@ fn check_literals tc:TypeChecker op:Op function_opt:Option[Function] {
         TYPE_CHAR_T tc stack_push_type
     elif literal_value OpValue::PushArray(items) is then
         if 0 items.length == then
-            List::new(List[str]) = empty_params
-            TYPE_UNKNOWN empty_params.push
-            empty_params "array" build_parameterized_type tc stack_push
+            List::new(List[Type]) = empty_params
+            TYPE_UNKNOWN_T empty_params.push
+            empty_params "array" GenericType Type::Generic tc stack_push_type
         else
             function_opt items tc run_type_check_ops
-            TYPE_UNKNOWN = elem_type
+            TYPE_UNKNOWN_T = elem_type_t
             0 = items_idx
             while items_idx items.length > do
-                tc stack_pop = item_type
-                elem_type item_type unify_type = unified
-                if "" unified == then
-                    op Op::location f"Heterogeneous array literal: cannot unify `{elem_type}` and `{item_type}`" ErrorKind::TypeMismatch raise_error
+                tc stack_pop_type = item_type_t
+                item_type_t elem_type_t unify_type_t = unified_opt
+                if unified_opt.is_none then
+                    op Op::location f"Heterogeneous array literal: cannot unify `{elem_type_t.format}` and `{item_type_t.format}`" ErrorKind::TypeMismatch raise_error
                 else
-                    unified = elem_type
+                    unified_opt.unwrap = elem_type_t
                 fi
                 1 += items_idx
             done
-            List::new(List[str]) = item_params
-            elem_type item_params.push
-            item_params "array" build_parameterized_type tc stack_push
+            List::new(List[Type]) = item_params
+            elem_type_t item_params.push
+            item_params "array" GenericType Type::Generic tc stack_push_type
         fi
     elif literal_value OpValue::FstringConcat(count) is then
         0 = index
@@ -1796,7 +1762,7 @@ fn check_io tc:TypeChecker op:Op ops:List[Op] op_index:int function_opt:Option[F
         tc stack_pop_drop
         op_index return
     fi
-    if function_opt "Display" typ type_satisfies_trait ! then
+    if function_opt "Display" peek_t type_satisfies_trait ! then
         op Op::location f"Type `{typ}` cannot be printed: does not satisfy trait `Display`" ErrorKind::MissingTraitMethod add_error
         tc stack_pop_drop
         op_index return
@@ -1886,11 +1852,11 @@ fn check_enum_variant tc:TypeChecker op:Op {
             type_var type_vars.add = type_vars
         done
         for expected in inner_types.iter do
-            if expected type_vars.has then
+            if expected.type_var_name Option::Some(tv_name) is tv_name type_vars.has && then
                 tc stack_pop_type = actual_t
-                actual_t expected bindings tc bind_type_var = bindings
+                actual_t tv_name bindings tc bind_type_var = bindings
             else
-                expected tc expect_type drop
+                expected tc expect_type_t
             fi
         done
         # Build resolved type name
@@ -1898,7 +1864,7 @@ fn check_enum_variant tc:TypeChecker op:Op {
     else
         # Non-generic variant: pop inner values directly
         for inner_type in inner_types.iter do
-            inner_type tc expect_type drop
+            inner_type tc expect_type_t
         done
         enum_name make_named_type tc stack_push_type
     fi
@@ -1945,19 +1911,19 @@ fn check_is tc:TypeChecker op:Op function_opt:Option[Function] {
 # Check match blocks
 # ============================================================================
 
-fn set_binding_type var_name:str field_type:str function_opt:Option[Function] {
+fn set_binding_type var_name:str field_type:Type function_opt:Option[Function] {
     if function_opt.is_some then
         function_opt.unwrap = function
         for variable in function Function::variables.iter do
             if var_name variable Variable::name == then
-                field_type parse_type_str variable Variable::set_typ
+                field_type variable Variable::set_typ
                 return
             fi
         done
     fi
     var_name DEFAULT_PARSER.store.variables.get = global_opt
     if global_opt.is_some then
-        field_type parse_type_str global_opt.unwrap Variable::set_typ
+        field_type global_opt.unwrap Variable::set_typ
     fi
 }
 
@@ -2453,13 +2419,14 @@ fn check_fstring_to_str
     if TYPE_STR_T tc stack_peek_type.eq then
         op_index return
     fi
-    tc stack_peek = fstring_type
+    tc stack_peek_type = fstring_type_t
+    fstring_type_t.format = fstring_type
     if TYPE_MISSING fstring_type == then
         tc stack_pop_drop
         TYPE_STR_T tc stack_push_type
         op_index return
     fi
-    if function_opt "Display" fstring_type type_satisfies_trait ! then
+    if function_opt "Display" fstring_type_t type_satisfies_trait ! then
         op Op::location f"Type `{fstring_type}` cannot be used in f-string: does not satisfy trait `Display`" ErrorKind::MissingTraitMethod add_error
         tc stack_pop_drop
         TYPE_STR_T tc stack_push_type

--- a/lsp.casa
+++ b/lsp.casa
@@ -817,12 +817,13 @@ fn compute_definition state:DocumentState line:int col:int -> Option[LspLocation
 
     # TYPE_CAST
     if op_value OpValue::TypeCast(cast_type) is then
-        if cast_type state DocumentState::structs.has then
-            cast_type state DocumentState::structs.get.unwrap CasaStruct::location casa_location_to_lsp Option::Some
+        cast_type.format = cast_name
+        if cast_name state DocumentState::structs.has then
+            cast_name state DocumentState::structs.get.unwrap CasaStruct::location casa_location_to_lsp Option::Some
             return
         fi
-        if cast_type state DocumentState::enums.has then
-            cast_type state DocumentState::enums.get.unwrap CasaEnum::location casa_location_to_lsp Option::Some
+        if cast_name state DocumentState::enums.has then
+            cast_name state DocumentState::enums.get.unwrap CasaEnum::location casa_location_to_lsp Option::Some
             return
         fi
     fi
@@ -1182,7 +1183,7 @@ fn handle_hover message:JsonValue {
 # ============================================================================
 
 fn methods_for_type receiver_type:str state:DocumentState -> List[CompletionItem] {
-    receiver_type extract_generic_base = base_opt
+    receiver_type parse_type_str.base = base_opt
     if base_opt.is_some then
         base_opt.unwrap
     else
@@ -1299,7 +1300,7 @@ fn resolve_chain_type parts:List[str] state:DocumentState offset:int -> Option[s
     current_type.unwrap = resolved_type
     1 = part_index
     while part_index parts.length > do
-        resolved_type extract_generic_base = base_opt
+        resolved_type parse_type_str.base = base_opt
         if base_opt.is_some then base_opt.unwrap else resolved_type fi = base_type
         part_index parts.get = method_name
         f"{base_type}::{method_name}" state DocumentState::functions.get = fn_opt
@@ -1515,7 +1516,7 @@ fn collect_struct_refs ops:List[Op] name:str results:List[LspLocation] {
                 op Op::location casa_location_to_lsp results.push
             fi
         elif op.value OpValue::TypeCast(cast_type) is then
-            if cast_type name == then
+            if cast_type.format name == then
                 op Op::location casa_location_to_lsp results.push
             fi
         fi
@@ -1811,6 +1812,7 @@ fn op_value_token_type op_value:OpValue -> Option[int] {
         OpValue::FnCall(_) => TOKEN_FUNCTION Option::Some
         OpValue::FnPush(_) => TOKEN_FUNCTION Option::Some
         OpValue::MethodCall(_) => TOKEN_FUNCTION Option::Some
+        OpValue::TraitMethodCall(_) => TOKEN_FUNCTION Option::Some
         OpValue::PushVar(_) => TOKEN_VARIABLE Option::Some
         OpValue::PushCapture(_) => TOKEN_VARIABLE Option::Some
         OpValue::AssignVar(_) => TOKEN_VARIABLE Option::Some

--- a/tests/compiler/test_bytecode.casa
+++ b/tests/compiler/test_bytecode.casa
@@ -23,8 +23,8 @@ fn test_make_op value:OpValue -> Op {
     make_test_location value make_op
 }
 
-fn test_make_op_annotated value:OpValue annotation:str -> Op {
-    annotation make_test_location value make_op_annotated
+fn test_make_op_with_type_hint value:OpValue type_hint:Type -> Op {
+    type_hint make_test_location value make_op_with_type_hint
 }
 
 # ============================================================================
@@ -234,7 +234,7 @@ fn test_compile_type_cast_no_output {
     "compile_type_cast_no_output" test_start
     reset_labels
     List::new(List[Op]) = ops
-    "" OpValue::TypeCast test_make_op ops.push
+    TYPE_UNKNOWN_T OpValue::TypeCast test_make_op ops.push
 
     ops TEST_STORE make_compiler = compiler
     List::new(List[InstValue]) = bytecode
@@ -317,7 +317,7 @@ fn test_compile_string_eq {
     "compile_string_eq" test_start
     reset_labels
     List::new(List[Op]) = ops
-    "str" OpValue::Eq test_make_op_annotated ops.push
+    TYPE_STR_T OpValue::Eq test_make_op_with_type_hint ops.push
 
     ops TEST_STORE make_compiler = compiler
     List::new(List[InstValue]) = bytecode
@@ -330,7 +330,7 @@ fn test_compile_string_ne {
     "compile_string_ne" test_start
     reset_labels
     List::new(List[Op]) = ops
-    "str" OpValue::Ne test_make_op_annotated ops.push
+    TYPE_STR_T OpValue::Ne test_make_op_with_type_hint ops.push
 
     ops TEST_STORE make_compiler = compiler
     List::new(List[InstValue]) = bytecode

--- a/tests/compiler/test_common.casa
+++ b/tests/compiler/test_common.casa
@@ -4,20 +4,20 @@ import "../../compiler/lexer.casa"
 import "../../compiler/syntax.casa"
 import "../../lib/test.casa"
 
-fn test_extract_generic_base {
-    "extract_generic_base" test_start
-    "array[int] has base" "array[int]" extract_generic_base.is_some assert_true
-    "array[int] base is array" "array" "array[int]" extract_generic_base.unwrap assert_str_eq
-    "List[str] base is List" "List" "List[str]" extract_generic_base.unwrap assert_str_eq
-    "Map base" "Map" "Map[str int]" extract_generic_base.unwrap assert_str_eq
-    "fn type has no base" "fn[int -> int]" extract_generic_base.is_none assert_true
-    "int has no base" "int" extract_generic_base.is_none assert_true
+fn test_type_base {
+    "type_base" test_start
+    "array[int] has base" "array[int]" parse_type_str.base.is_some assert_true
+    "array[int] base is array" "array" "array[int]" parse_type_str.base.unwrap assert_str_eq
+    "List[str] base is List" "List" "List[str]" parse_type_str.base.unwrap assert_str_eq
+    "Map base" "Map" "Map[str int]" parse_type_str.base.unwrap assert_str_eq
+    "fn type has no base" "fn[int -> int]" parse_type_str.base.is_none assert_true
+    "int has no base" "int" parse_type_str.base.is_none assert_true
 }
 
-fn test_extract_generic_inner {
-    "extract_generic_inner" test_start
-    "array[int] inner" "int" "array[int]" extract_generic_inner.unwrap assert_str_eq
-    "List[str] inner" "str" "List[str]" extract_generic_inner.unwrap assert_str_eq
+fn test_type_params {
+    "type_params" test_start
+    "array[int] inner" "int" 0 "array[int]" parse_type_str.type_params.unwrap.get.format assert_str_eq
+    "List[str] inner" "str" 0 "List[str]" parse_type_str.type_params.unwrap.get.format assert_str_eq
 }
 
 fn test_split_type_tokens {
@@ -36,17 +36,29 @@ fn test_split_type_tokens {
     "arrow token" "->" 1 tokens_with_arrow.get assert_str_eq
 }
 
-fn test_is_fn_type {
-    "is_fn_type" test_start
-    "bare fn" "fn" is_fn_type assert_true
-    "parameterized fn" "fn[int -> int]" is_fn_type assert_true
-    "int is not fn" "int" is_fn_type ! assert_true
+fn test_type_is_fn {
+    "type_is_fn" test_start
+    "bare fn" "fn" parse_type_str.is_fn_type_t assert_true
+    "parameterized fn" "fn[int -> int]" parse_type_str.is_fn_type_t assert_true
+    "int is not fn" "int" parse_type_str.is_fn_type_t ! assert_true
 }
 
-fn test_extract_fn_signature_str {
-    "extract_fn_signature_str" test_start
-    "fn sig" "int -> int" "fn[int -> int]" extract_fn_signature_str.unwrap assert_str_eq
-    "bare fn has no sig" "fn" extract_fn_signature_str.is_none assert_true
+fn test_function_type_signature {
+    "function_type_signature" test_start
+    if "fn[int -> int]" parse_type_str Type::Function(fn_type) is then
+        "param count" 1 fn_type FunctionType::parameters.length assert_eq
+        "return count" 1 fn_type FunctionType::return_types.length assert_eq
+        "param" "int" 0 fn_type FunctionType::parameters.get.format assert_str_eq
+        "return" "int" 0 fn_type FunctionType::return_types.get.format assert_str_eq
+    else
+        "fn type parsed" false assert_true
+    fi
+    if "fn" parse_type_str Type::Function(bare_fn) is then
+        "bare params" 0 bare_fn FunctionType::parameters.length assert_eq
+        "bare returns" 0 bare_fn FunctionType::return_types.length assert_eq
+    else
+        "bare fn parsed" false assert_true
+    fi
 }
 
 fn test_keyword_lookup {
@@ -119,11 +131,11 @@ fn test_signature_matches {
     "TYPE_UNKNOWN matches int" sig6 sig5 signature_matches assert_true
 }
 
-fn test_is_builtin_type {
-    "is_builtin_type" test_start
-    "int is builtin" "int" is_builtin_type assert_true
-    "str is builtin" "str" is_builtin_type assert_true
-    "MyStruct not builtin" "MyStruct" is_builtin_type ! assert_true
+fn test_type_is_builtin {
+    "type_is_builtin" test_start
+    "int is builtin" "int" parse_type_str.is_builtin_type_t assert_true
+    "str is builtin" "str" parse_type_str.is_builtin_type_t assert_true
+    "MyStruct not builtin" "MyStruct" parse_type_str.is_builtin_type_t ! assert_true
 }
 
 fn test_variable_list_helpers {
@@ -165,11 +177,11 @@ fn test_build_resolved_type {
     "K" "str" bindings2.set = bindings2
     "partial" "Map[str V]" bindings2 type_vars2 "Map" build_resolved_type assert_str_eq
 }
-test_extract_generic_base
-test_extract_generic_inner
+test_type_base
+test_type_params
 test_split_type_tokens
-test_is_fn_type
-test_extract_fn_signature_str
+test_type_is_fn
+test_function_type_signature
 test_keyword_lookup
 test_operator_lookup
 test_intrinsic_lookup
@@ -177,7 +189,7 @@ test_delimiter_lookup
 test_signature_to_str
 test_signature_from_str
 test_signature_matches
-test_is_builtin_type
+test_type_is_builtin
 test_variable_list_helpers
 test_build_parameterized_type
 test_build_resolved_type

--- a/tests/compiler/test_display.casa
+++ b/tests/compiler/test_display.casa
@@ -184,11 +184,11 @@ fn test_type_satisfies_trait_no_fallback_method {
 }
 
 # ============================================================================
-# check_push_var: trait_exec annotation simulates the exec
+# check_push_var: trait method calls simulate the exec
 # ============================================================================
 
-fn test_trait_exec_pushes_return_type {
-    "trait_exec_pushes_return_type" test_start
+fn test_trait_method_call_pushes_return_type {
+    "trait_method_call_pushes_return_type" test_start
     DISPLAY_TRAIT "struct Tag { val: int }\nimpl Tag { fn to_str self:Tag -> str { \"tag\" } }\nfn show[T: Display] x:T -> str { x T::to_str }\n1 Tag = t\nt show drop\n" str::concat display_test_typecheck drop
     "show" DEFAULT_PARSER.store.functions.get.unwrap = func
     "signature has str return type" "str" 0 func Function::signature Signature::return_types.get.format assert_str_eq
@@ -303,8 +303,8 @@ test_fstring_missing_display_without_trait_raises
 # type_satisfies_trait
 test_type_satisfies_trait_generic_base_fallback
 test_type_satisfies_trait_no_fallback_method
-# check_push_var trait_exec simulation
-test_trait_exec_pushes_return_type
+# check_push_var trait method simulation
+test_trait_method_call_pushes_return_type
 # Multi-type-parameter trait bound ordering
 test_multi_trait_bound_ordering
 # print dispatch

--- a/tests/compiler/test_display.casa
+++ b/tests/compiler/test_display.casa
@@ -172,15 +172,15 @@ fn test_type_satisfies_trait_generic_base_fallback {
     "type_satisfies_trait_generic_base_fallback" test_start
     DISPLAY_TRAIT "enum Box[T] { Boxed(T) }\nimpl Box { fn to_str self:Box -> str { \"boxed\" } }\n" str::concat display_test_resolve drop
     Option::None(Option[Function]) = no_fn
-    "Box[int] satisfies Display via base" no_fn "Display" "Box[int]" type_satisfies_trait assert_true
-    "Box[str] satisfies Display via base" no_fn "Display" "Box[str]" type_satisfies_trait assert_true
+    "Box[int] satisfies Display via base" no_fn "Display" "Box[int]" parse_type_str type_satisfies_trait assert_true
+    "Box[str] satisfies Display via base" no_fn "Display" "Box[str]" parse_type_str type_satisfies_trait assert_true
 }
 
 fn test_type_satisfies_trait_no_fallback_method {
     "type_satisfies_trait_no_fallback_method" test_start
     DISPLAY_TRAIT "enum Bag[T] { Empty Full(T) }\n" str::concat display_test_resolve drop
     Option::None(Option[Function]) = no_fn
-    "Bag[int] does not satisfy without to_str" no_fn "Display" "Bag[int]" type_satisfies_trait ! assert_true
+    "Bag[int] does not satisfy without to_str" no_fn "Display" "Bag[int]" parse_type_str type_satisfies_trait ! assert_true
 }
 
 # ============================================================================

--- a/tests/compiler/test_enum.casa
+++ b/tests/compiler/test_enum.casa
@@ -172,7 +172,7 @@ fn test_test_parse_code_with_inner_types {
     SHAPE_ENUM test_parse_code drop
     "Shape" DEFAULT_PARSER.store.enums.get.unwrap = shape
     "Circle types" 1 "Circle" shape CasaEnum::variant_types.get.unwrap.length assert_eq
-    "Circle type" "int" 0 "Circle" shape CasaEnum::variant_types.get.unwrap.get assert_str_eq
+    "Circle type" "int" 0 "Circle" shape CasaEnum::variant_types.get.unwrap.get.format assert_str_eq
     "Rectangle types" 2 "Rectangle" shape CasaEnum::variant_types.get.unwrap.length assert_eq
     "Point types" 0 "Point" shape CasaEnum::variant_types.get.unwrap.length assert_eq
 }

--- a/tests/compiler/test_parser.casa
+++ b/tests/compiler/test_parser.casa
@@ -210,7 +210,9 @@ fn test_parse_type_cast {
     tokens DEFAULT_PARSER parse_ops = ops
     "count" 1 ops.length assert_eq
     "kind" 0 ops.get.value OpValue::TypeCast is assert_true
-    "value" "int" 0 ops.get op_str_value assert_str_eq
+    if 0 ops.get.value OpValue::TypeCast(cast_type) is then
+        "value" "int" parse_type_str cast_type.eq assert_true
+    fi
 }
 
 fn test_parse_type_cast_str {
@@ -218,7 +220,9 @@ fn test_parse_type_cast_str {
     "test" "(str)" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
     "kind" 0 ops.get.value OpValue::TypeCast is assert_true
-    "value" "str" 0 ops.get op_str_value assert_str_eq
+    if 0 ops.get.value OpValue::TypeCast(cast_type) is then
+        "value" "str" parse_type_str cast_type.eq assert_true
+    fi
 }
 
 # ============================================================================

--- a/tests/compiler/test_traits.casa
+++ b/tests/compiler/test_traits.casa
@@ -358,57 +358,57 @@ fn test_trait_hidden_params_creates_assign_ops {
 fn test_struct_with_impl_satisfies {
     "struct_with_impl_satisfies" test_start
     HASHABLE_TRAIT "struct Foo { val: int }\nimpl Foo { fn hash self:Foo -> int { self Foo::val } fn eq self:Foo other:Foo -> bool { self Foo::val other Foo::val == } }\n" str::concat trait_test_resolve drop
-    "satisfies" Option::None(Option[Function]) "Hashable" "Foo" type_satisfies_trait assert_true
+    "satisfies" Option::None(Option[Function]) "Hashable" "Foo" parse_type_str type_satisfies_trait assert_true
 }
 
 fn test_struct_without_impl_does_not_satisfy {
     "struct_without_impl_does_not_satisfy" test_start
     HASHABLE_TRAIT "struct Bar { val: int }\n" str::concat trait_test_resolve drop
-    "does not satisfy" Option::None(Option[Function]) "Hashable" "Bar" type_satisfies_trait ! assert_true
+    "does not satisfy" Option::None(Option[Function]) "Hashable" "Bar" parse_type_str type_satisfies_trait ! assert_true
 }
 
 fn test_partial_impl_does_not_satisfy {
     "partial_impl_does_not_satisfy" test_start
     HASHABLE_TRAIT "struct Baz { val: int }\nimpl Baz { fn hash self:Baz -> int { self Baz::val } }\n" str::concat trait_test_resolve drop
-    "does not satisfy" Option::None(Option[Function]) "Hashable" "Baz" type_satisfies_trait ! assert_true
+    "does not satisfy" Option::None(Option[Function]) "Hashable" "Baz" parse_type_str type_satisfies_trait ! assert_true
 }
 
 fn test_struct_satisfies_generic_trait_concrete_int {
     "struct_satisfies_generic_trait_concrete_int" test_start
     "trait Carrier[T] { fn get self:self -> T }\nstruct Counter { val: int }\nimpl Counter { fn get self:Counter -> int { self Counter::val } }\n" trait_test_resolve drop
-    "satisfies" Option::None(Option[Function]) "Carrier[int]" "Counter" type_satisfies_trait assert_true
+    "satisfies" Option::None(Option[Function]) "Carrier[int]" "Counter" parse_type_str type_satisfies_trait assert_true
 }
 
 fn test_struct_does_not_satisfy_generic_trait_wrong_inner {
     "struct_does_not_satisfy_generic_trait_wrong_inner" test_start
     "trait Carrier[T] { fn get self:self -> T }\nstruct Counter { val: int }\nimpl Counter { fn get self:Counter -> int { self Counter::val } }\n" trait_test_resolve drop
-    "does not satisfy str" Option::None(Option[Function]) "Carrier[str]" "Counter" type_satisfies_trait ! assert_true
+    "does not satisfy str" Option::None(Option[Function]) "Carrier[str]" "Counter" parse_type_str type_satisfies_trait ! assert_true
 }
 
 fn test_undefined_trait_returns_false {
     "undefined_trait_returns_false" test_start
     clear_global_state
-    "does not satisfy" Option::None(Option[Function]) "Nonexistent" "int" type_satisfies_trait ! assert_true
+    "does not satisfy" Option::None(Option[Function]) "Nonexistent" "int" parse_type_str type_satisfies_trait ! assert_true
 }
 # Primitive Eq impls must satisfy a structurally-matching Eq trait.
 
 fn test_int_satisfies_eq_trait {
     "int_satisfies_eq_trait" test_start
     "trait Eq { fn eq self:self other:self -> bool }\nimpl int { fn eq self:int other:int -> bool { self other == } }\n" trait_test_resolve drop
-    "satisfies" Option::None(Option[Function]) "Eq" "int" type_satisfies_trait assert_true
+    "satisfies" Option::None(Option[Function]) "Eq" "int" parse_type_str type_satisfies_trait assert_true
 }
 
 fn test_int_satisfies_ord_trait {
     "int_satisfies_ord_trait" test_start
     "trait Ord { fn lt self:self other:self -> bool }\nimpl int { fn lt self:int other:int -> bool { other self < } }\n" trait_test_resolve drop
-    "satisfies" Option::None(Option[Function]) "Ord" "int" type_satisfies_trait assert_true
+    "satisfies" Option::None(Option[Function]) "Ord" "int" parse_type_str type_satisfies_trait assert_true
 }
 
 fn test_empty_word_trait_satisfied_by_any_type {
     "empty_word_trait_satisfied_by_any_type" test_start
     "trait Word { }\n" trait_test_resolve drop
-    "int satisfies" Option::None(Option[Function]) "Word" "int" type_satisfies_trait assert_true
-    "str satisfies" Option::None(Option[Function]) "Word" "str" type_satisfies_trait assert_true
+    "int satisfies" Option::None(Option[Function]) "Word" "int" parse_type_str type_satisfies_trait assert_true
+    "str satisfies" Option::None(Option[Function]) "Word" "str" parse_type_str type_satisfies_trait assert_true
 }
 
 # ============================================================================
@@ -603,7 +603,7 @@ fn test_type_var_with_matching_bound_satisfies {
     bounds type_vars List::new(List[Type]) List::new(List[Parameter]) Signature = sig
     sig empty_location List::new(List[Op]) "test_fn" make_function_with_sig = func
     func Option::Some = func_opt
-    "satisfies" func_opt "Hashable" "K" type_satisfies_trait assert_true
+    "satisfies" func_opt "Hashable" "K" parse_type_str type_satisfies_trait assert_true
 }
 
 fn test_type_var_without_bound_does_not_satisfy {
@@ -615,7 +615,7 @@ fn test_type_var_without_bound_does_not_satisfy {
     Map::new(Map[str TraitBound]) type_vars List::new(List[Type]) List::new(List[Parameter]) Signature = sig
     sig empty_location List::new(List[Op]) "test_fn" make_function_with_sig = func
     func Option::Some = func_opt
-    "does not satisfy" func_opt "Hashable" "K" type_satisfies_trait ! assert_true
+    "does not satisfy" func_opt "Hashable" "K" parse_type_str type_satisfies_trait ! assert_true
 }
 
 fn test_type_var_with_wrong_bound_does_not_satisfy {
@@ -629,7 +629,7 @@ fn test_type_var_with_wrong_bound_does_not_satisfy {
     bounds type_vars List::new(List[Type]) List::new(List[Parameter]) Signature = sig
     sig empty_location List::new(List[Op]) "test_fn" make_function_with_sig = func
     func Option::Some = func_opt
-    "does not satisfy" func_opt "Hashable" "K" type_satisfies_trait ! assert_true
+    "does not satisfy" func_opt "Hashable" "K" parse_type_str type_satisfies_trait ! assert_true
 }
 
 # ============================================================================
@@ -865,13 +865,13 @@ fn test_trait_with_undefined_supertrait_raises {
 fn test_supertrait_method_required_for_satisfaction {
     "supertrait_method_required_for_satisfaction" test_start
     "trait Eq { fn eq self:self other:self -> bool }\ntrait Hashable: Eq { fn hash self:self -> int }\nstruct Bare { v: int }\nimpl Bare { fn hash self:Bare -> int { self Bare::v } }\n" trait_test_resolve drop
-    "Hashable not satisfied without Eq impl" Option::None(Option[Function]) "Hashable" "Bare" type_satisfies_trait ! assert_true
+    "Hashable not satisfied without Eq impl" Option::None(Option[Function]) "Hashable" "Bare" parse_type_str type_satisfies_trait ! assert_true
 }
 
 fn test_supertrait_satisfaction_with_full_impl {
     "supertrait_satisfaction_with_full_impl" test_start
     "trait Eq { fn eq self:self other:self -> bool }\ntrait Hashable: Eq { fn hash self:self -> int }\nstruct Full { v: int }\nimpl Full { fn hash self:Full -> int { self Full::v } fn eq self:Full other:Full -> bool { self Full::v other Full::v == } }\n" trait_test_resolve drop
-    "Hashable satisfied with Eq impl" Option::None(Option[Function]) "Hashable" "Full" type_satisfies_trait assert_true
+    "Hashable satisfied with Eq impl" Option::None(Option[Function]) "Hashable" "Full" parse_type_str type_satisfies_trait assert_true
 }
 
 fn test_supertrait_negative_typecheck_raises {

--- a/tests/compiler/test_traits.casa
+++ b/tests/compiler/test_traits.casa
@@ -412,12 +412,22 @@ fn test_empty_word_trait_satisfied_by_any_type {
 }
 
 # ============================================================================
-# extract_generic_params
+# Type parameter extraction
 # ============================================================================
+
+fn type_param_formats source:str -> Option[List[str]] {
+    source parse_type_str.type_params = params_opt
+    if params_opt.is_none then Option::None(Option[List[str]]) return fi
+    List::new(List[str]) = result
+    for param in params_opt.unwrap.iter do
+        param.format result.push
+    done
+    result Option::Some
+}
 
 fn test_egp_single_param {
     "egp_single_param" test_start
-    "array[int]" extract_generic_params = result
+    "array[int]" type_param_formats = result
     "is_some" result.is_some assert_true
     "count" 1 result.unwrap.length assert_eq
     "value" "int" 0 result.unwrap.get assert_str_eq
@@ -425,7 +435,7 @@ fn test_egp_single_param {
 
 fn test_egp_single_param_list {
     "egp_single_param_list" test_start
-    "List[int]" extract_generic_params = result
+    "List[int]" type_param_formats = result
     "is_some" result.is_some assert_true
     "count" 1 result.unwrap.length assert_eq
     "value" "int" 0 result.unwrap.get assert_str_eq
@@ -433,7 +443,7 @@ fn test_egp_single_param_list {
 
 fn test_egp_two_params {
     "egp_two_params" test_start
-    "Map[str int]" extract_generic_params = result
+    "Map[str int]" type_param_formats = result
     "is_some" result.is_some assert_true
     "count" 2 result.unwrap.length assert_eq
     "first" "str" 0 result.unwrap.get assert_str_eq
@@ -442,7 +452,7 @@ fn test_egp_two_params {
 
 fn test_egp_nested_param {
     "egp_nested_param" test_start
-    "Map[str List[int]]" extract_generic_params = result
+    "Map[str List[int]]" type_param_formats = result
     "is_some" result.is_some assert_true
     "count" 2 result.unwrap.length assert_eq
     "first" "str" 0 result.unwrap.get assert_str_eq
@@ -451,7 +461,7 @@ fn test_egp_nested_param {
 
 fn test_egp_two_nested_params {
     "egp_two_nested_params" test_start
-    "Map[List[str] List[int]]" extract_generic_params = result
+    "Map[List[str] List[int]]" type_param_formats = result
     "is_some" result.is_some assert_true
     "count" 2 result.unwrap.length assert_eq
     "first" "List[str]" 0 result.unwrap.get assert_str_eq
@@ -460,39 +470,39 @@ fn test_egp_two_nested_params {
 
 fn test_egp_option_param {
     "egp_option_param" test_start
-    "option[int]" extract_generic_params = result
+    "option[int]" type_param_formats = result
     "is_some" result.is_some assert_true
     "value" "int" 0 result.unwrap.get assert_str_eq
 }
 
 fn test_egp_fn_type_returns_none {
     "egp_fn_type_returns_none" test_start
-    "fn[int -> int]" extract_generic_params = result
+    "fn[int -> int]" type_param_formats = result
     "is_none" result.is_none assert_true
 }
 
 fn test_egp_bare_type_returns_none {
     "egp_bare_type_returns_none" test_start
-    "int" extract_generic_params = result
+    "int" type_param_formats = result
     "is_none" result.is_none assert_true
 }
 
 fn test_egp_bare_generic_returns_none {
     "egp_bare_generic_returns_none" test_start
-    "fn" extract_generic_params = result
+    "fn" type_param_formats = result
     "is_none" result.is_none assert_true
 }
 
 fn test_egp_set_single_param {
     "egp_set_single_param" test_start
-    "Set[str]" extract_generic_params = result
+    "Set[str]" type_param_formats = result
     "is_some" result.is_some assert_true
     "value" "str" 0 result.unwrap.get assert_str_eq
 }
 
 fn test_egp_three_levels_deep {
     "egp_three_levels_deep" test_start
-    "Map[str Map[int List[str]]]" extract_generic_params = result
+    "Map[str Map[int List[str]]]" type_param_formats = result
     "is_some" result.is_some assert_true
     "count" 2 result.unwrap.length assert_eq
     "first" "str" 0 result.unwrap.get assert_str_eq
@@ -505,7 +515,7 @@ fn test_egp_three_levels_deep {
 
 fn test_map_kv_type_params {
     "map_kv_type_params" test_start
-    "Map[str int]" extract_generic_params = result
+    "Map[str int]" type_param_formats = result
     "is_some" result.is_some assert_true
     "count" 2 result.unwrap.length assert_eq
     "first" "str" 0 result.unwrap.get assert_str_eq
@@ -514,14 +524,14 @@ fn test_map_kv_type_params {
 
 fn test_set_k_type_params {
     "set_k_type_params" test_start
-    "Set[str]" extract_generic_params = result
+    "Set[str]" type_param_formats = result
     "is_some" result.is_some assert_true
     "value" "str" 0 result.unwrap.get assert_str_eq
 }
 
 fn test_nested_generic_params {
     "nested_generic_params" test_start
-    "Map[str List[int]]" extract_generic_params = result
+    "Map[str List[int]]" type_param_formats = result
     "is_some" result.is_some assert_true
     "count" 2 result.unwrap.length assert_eq
     "first" "str" 0 result.unwrap.get assert_str_eq
@@ -646,31 +656,26 @@ fn test_trait_bounds_preserved_in_signature {
 # Trait ref resolution (K::hash, &K::hash)
 # ============================================================================
 
-fn test_k_coloncolon_method_resolved_as_push_variable_exec {
-    "k_coloncolon_method_resolved_as_push_variable_exec" test_start
+fn test_k_coloncolon_method_resolved_as_trait_method_call {
+    "k_coloncolon_method_resolved_as_trait_method_call" test_start
     enable_test_mode
     clear_errors
     HASHABLE_TRAIT "struct MyType { val: int }\nimpl MyType {\n    fn hash self:MyType -> int { self MyType::val }\n    fn eq self:MyType other:MyType -> bool { self MyType::val other MyType::val == }\n}\nfn get_hash[K: Hashable] k:K -> int { k K::hash }\n42 MyType = m\nm get_hash drop\n" str::concat trait_test_typecheck drop
     "get_hash" DEFAULT_PARSER.store.functions.get.unwrap = func
-    # K::hash resolves to OpPushVar with trait_exec annotation
-    false = found_push_var
-    false = found_trait_exec
+    # K::hash resolves to a dedicated trait method call carrying the hidden var.
+    false = found_trait_call
     0 = index
     while index func Function::ops.length > do
         index func Function::ops.get = current_op
         if
-        current_op.value OpValue::PushVar is
+        current_op.value OpValue::TraitMethodCall is
         "__trait_K_hash" current_op op_str_value == &&
         then
-            true = found_push_var
-            if "trait_exec" current_op Op::type_annotation == then
-                true = found_trait_exec
-            fi
+            true = found_trait_call
         fi
         1 += index
     done
-    "found push_var" found_push_var assert_true
-    "found trait_exec annotation" found_trait_exec assert_true
+    "found trait method call" found_trait_call assert_true
     clear_errors
     disable_test_mode
 }
@@ -681,7 +686,7 @@ fn test_ampersand_k_coloncolon_method_resolved_as_push_variable {
     clear_errors
     HASHABLE_TRAIT "struct MyType { val: int }\nimpl MyType {\n    fn hash self:MyType -> int { self MyType::val }\n    fn eq self:MyType other:MyType -> bool { self MyType::val other MyType::val == }\n}\nfn get_hash_fn[K: Hashable] -> fn[K -> int] { &K::hash }\n42 MyType = m\nm get_hash_fn drop\n" str::concat trait_test_typecheck drop
     "get_hash_fn" DEFAULT_PARSER.store.functions.get.unwrap = func
-    # &K::hash resolves to OpPushVar without trait_exec annotation (fn ref)
+    # &K::hash resolves to OpPushVar as a fn ref.
     false = found_push_var
     0 = index
     while index func Function::ops.length > do
@@ -921,7 +926,7 @@ fn test_calling_trait_bounded_fn_injects_fn_push {
 # ============================================================================
 # Run all tests
 # ============================================================================
-# extract_generic_params
+# type_param_formats
 test_egp_single_param
 test_egp_single_param_list
 test_egp_two_params
@@ -999,7 +1004,7 @@ test_type_var_with_wrong_bound_does_not_satisfy
 test_trait_bounds_default_empty
 test_trait_bounds_preserved_in_signature
 # Trait ref resolution
-test_k_coloncolon_method_resolved_as_push_variable_exec
+test_k_coloncolon_method_resolved_as_trait_method_call
 test_ampersand_k_coloncolon_method_resolved_as_push_variable
 # Auto-injection errors
 test_trait_bounded_fn_with_non_satisfying_type_raises

--- a/tests/compiler/test_type_annotations.casa
+++ b/tests/compiler/test_type_annotations.casa
@@ -64,49 +64,49 @@ fn test_annotation_int {
     ops find_assign_ops = assigns
     "count" 1 assigns.length assert_eq
     "name" "x" 0 assigns.get op_str_value assert_str_eq
-    "annotation" "int" 0 assigns.get Op::type_annotation assert_str_eq
+    "annotation" "int" parse_type_str 0 assigns.get Op::type_hint.unwrap.eq assert_true
 }
 
 fn test_annotation_str {
     "annotation_str" test_start
     "\"hello\" = x:str" test_parse = ops
     ops find_assign_ops = assigns
-    "annotation" "str" 0 assigns.get Op::type_annotation assert_str_eq
+    "annotation" "str" parse_type_str 0 assigns.get Op::type_hint.unwrap.eq assert_true
 }
 
 fn test_annotation_bool {
     "annotation_bool" test_start
     "true = x:bool" test_parse = ops
     ops find_assign_ops = assigns
-    "annotation" "bool" 0 assigns.get Op::type_annotation assert_str_eq
+    "annotation" "bool" parse_type_str 0 assigns.get Op::type_hint.unwrap.eq assert_true
 }
 
 fn test_annotation_option_int {
     "annotation_option_int" test_start
     "0 = x:Option[int]" test_parse = ops
     ops find_assign_ops = assigns
-    "annotation" "Option[int]" 0 assigns.get Op::type_annotation assert_str_eq
+    "annotation" "Option[int]" parse_type_str 0 assigns.get Op::type_hint.unwrap.eq assert_true
 }
 
 fn test_annotation_bare_option {
     "annotation_bare_option" test_start
     "0 = x:Option" test_parse = ops
     ops find_assign_ops = assigns
-    "annotation" "Option" 0 assigns.get Op::type_annotation assert_str_eq
+    "annotation" "Option" parse_type_str 0 assigns.get Op::type_hint.unwrap.eq assert_true
 }
 
 fn test_annotation_generic_list {
     "annotation_generic_list" test_start
     "0 = x:List[int]" test_parse = ops
     ops find_assign_ops = assigns
-    "annotation" "List[int]" 0 assigns.get Op::type_annotation assert_str_eq
+    "annotation" "List[int]" parse_type_str 0 assigns.get Op::type_hint.unwrap.eq assert_true
 }
 
 fn test_annotation_ptr {
     "annotation_ptr" test_start
     "0 = x:ptr" test_parse = ops
     ops find_assign_ops = assigns
-    "annotation" "ptr" 0 assigns.get Op::type_annotation assert_str_eq
+    "annotation" "ptr" parse_type_str 0 assigns.get Op::type_hint.unwrap.eq assert_true
 }
 
 fn test_no_annotation {
@@ -115,7 +115,7 @@ fn test_no_annotation {
     ops find_assign_ops = assigns
     "count" 1 assigns.length assert_eq
     "name" "x" 0 assigns.get op_str_value assert_str_eq
-    "annotation empty" "" 0 assigns.get Op::type_annotation assert_str_eq
+    "annotation empty" 0 assigns.get Op::type_hint.is_none assert_true
 }
 
 fn test_annotation_in_function {
@@ -129,7 +129,7 @@ fn test_annotation_in_function {
         index assigns.get = op
         if
         "x" op op_str_value ==
-        "int" op Op::type_annotation == &&
+        "int" parse_type_str op Op::type_hint.unwrap.eq &&
         then
             true = found
         fi
@@ -142,14 +142,14 @@ fn test_annotation_array_type {
     "annotation_array_type" test_start
     "[1, 2] = x:array[int]" test_parse = ops
     ops find_assign_ops = assigns
-    "annotation" "array[int]" 0 assigns.get Op::type_annotation assert_str_eq
+    "annotation" "array[int]" parse_type_str 0 assigns.get Op::type_hint.unwrap.eq assert_true
 }
 
 fn test_annotation_char {
     "annotation_char" test_start
     "'a' = x:char" test_parse = ops
     ops find_assign_ops = assigns
-    "annotation" "char" 0 assigns.get Op::type_annotation assert_str_eq
+    "annotation" "char" parse_type_str 0 assigns.get Op::type_hint.unwrap.eq assert_true
 }
 
 fn test_no_annotation_on_increment {
@@ -157,7 +157,7 @@ fn test_no_annotation_on_increment {
     "42 = x 1 += x" test_parse = ops
     "" OpValue::AssignInc ops find_ops_by_kind = inc_ops
     "count" 1 inc_ops.length assert_eq
-    "annotation empty" "" 0 inc_ops.get Op::type_annotation assert_str_eq
+    "annotation empty" 0 inc_ops.get Op::type_hint.is_none assert_true
 }
 
 fn test_no_annotation_on_decrement {
@@ -165,7 +165,7 @@ fn test_no_annotation_on_decrement {
     "42 = x 1 -= x" test_parse = ops
     "" OpValue::AssignDec ops find_ops_by_kind = dec_ops
     "count" 1 dec_ops.length assert_eq
-    "annotation empty" "" 0 dec_ops.get Op::type_annotation assert_str_eq
+    "annotation empty" 0 dec_ops.get Op::type_hint.is_none assert_true
 }
 
 # ============================================================================

--- a/tests/compiler/test_type_ast.casa
+++ b/tests/compiler/test_type_ast.casa
@@ -50,15 +50,15 @@ fn test_round_trip_function {
     "fn[List[int] -> Option[str]]" assert_round_trip
 }
 
-fn assert_substitute source:str expected:str subs:Map[str str] {
-    subs source parse_type_str.substitute.format = result
+fn assert_substitute source:str expected:str subs:Map[str Type] {
+    subs source parse_type_str.substitute_t.format = result
     f"substitute {source}" expected result assert_str_eq
 }
 
 fn test_substitute_function {
     "Type::substitute on Function" test_start
-    Map::new(Map[str str]) = subs
-    "T" "int" subs.set = subs
+    Map::new(Map[str Type]) = subs
+    "T" TYPE_INT_T subs.set = subs
     subs "fn[int]" "fn[T]" assert_substitute
     subs "fn[int -> str]" "fn[T -> str]" assert_substitute
     subs "fn[int int -> int]" "fn[T T -> T]" assert_substitute

--- a/tests/compiler/test_typechecker.casa
+++ b/tests/compiler/test_typechecker.casa
@@ -94,9 +94,9 @@ fn tc_check ops:List[Op] -> TypeChecker {
         elif helper_kind OpValue::Typeof is then
             helper_op helper_tc check_typeof
             # Type cast
-        elif helper_kind OpValue::TypeCast is then
+        elif helper_kind OpValue::TypeCast(cast_type) is then
             helper_tc stack_pop drop
-            helper_op op_str_value helper_tc stack_push
+            cast_type helper_tc stack_push_type
             # Syscalls
         elif
         helper_kind OpValue::Syscall0 is
@@ -342,7 +342,7 @@ fn test_type_cast {
     "type_cast" test_start
     List::new(List[Op]) = ops
     empty_location 42 OpValue::PushInt make_op ops.push
-    empty_location "str" OpValue::TypeCast make_op ops.push
+    empty_location TYPE_STR_T OpValue::TypeCast make_op ops.push
     ops tc_check = result_tc
     "stack after cast" 1 result_tc TypeChecker::live TypedStack::types.length assert_eq
     "cast to str" "str" 0 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
@@ -632,7 +632,7 @@ fn test_print_dispatch_cstr {
     "print_dispatch_cstr" test_start
     List::new(List[Op]) = ops
     empty_location 42 OpValue::PushInt make_op ops.push
-    empty_location "cstr" OpValue::TypeCast make_op ops.push
+    empty_location TYPE_CSTR_T OpValue::TypeCast make_op ops.push
     empty_location OpValue::Print make_op ops.push
     ops tc_check drop
     "print cstr resolved" 2 ops.get.value OpValue::PrintCstr is assert_true
@@ -733,7 +733,7 @@ fn test_string_comparison_annotation {
     empty_location OpValue::Eq make_op ops.push
     ops tc_check = result_tc
     "str cmp is bool" "bool" 0 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
-    "annotation is str" "str" 2 ops.get Op::type_annotation assert_str_eq
+    "hint is str" TYPE_STR_T 2 ops.get Op::type_hint.unwrap.eq assert_true
 }
 
 # ============================================================================
@@ -1614,7 +1614,7 @@ fn test_typeof_annotation {
     empty_location 42 OpValue::PushInt make_op ops.push
     empty_location OpValue::Typeof make_op ops.push
     ops tc_check drop
-    "typeof annotation" "int" 1 ops.get Op::type_annotation assert_str_eq
+    "typeof hint" TYPE_INT_T 1 ops.get Op::type_hint.unwrap.eq assert_true
 }
 
 # ============================================================================
@@ -1625,7 +1625,7 @@ fn test_type_cast_str_to_int {
     "type_cast_str_to_int" test_start
     List::new(List[Op]) = ops
     empty_location "hello" OpValue::PushStr make_op ops.push
-    empty_location "int" OpValue::TypeCast make_op ops.push
+    empty_location TYPE_INT_T OpValue::TypeCast make_op ops.push
     ops tc_check = result_tc
     "cast str to int" 1 result_tc TypeChecker::live TypedStack::types.length assert_eq
     "cast result" "int" 0 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
@@ -1635,7 +1635,7 @@ fn test_type_cast_bool_to_int {
     "type_cast_bool_to_int" test_start
     List::new(List[Op]) = ops
     empty_location 1 OpValue::PushBool make_op ops.push
-    empty_location "int" OpValue::TypeCast make_op ops.push
+    empty_location TYPE_INT_T OpValue::TypeCast make_op ops.push
     ops tc_check = result_tc
     "cast bool to int" "int" 0 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
 }

--- a/tests/compiler/test_typechecker.casa
+++ b/tests/compiler/test_typechecker.casa
@@ -472,29 +472,29 @@ fn test_argc_argv {
 }
 
 # ============================================================================
-# Tests: types_match
+# Tests: types_match_t
 # ============================================================================
 
 fn test_types_match {
-    "types_match" test_start
-    "same types" "int" "int" types_match assert_true
-    "TYPE_UNKNOWN matches int" "int" TYPE_UNKNOWN types_match assert_true
-    "int matches TYPE_UNKNOWN" TYPE_UNKNOWN "int" types_match assert_true
-    "different types" "str" "int" types_match ! assert_true
-    "fn base matches fn type" "fn[int -> int]" "fn" types_match assert_true
-    "generic base matches" "List[int]" "List" types_match assert_true
+    "types_match_t" test_start
+    "same types" "int" parse_type_str "int" parse_type_str types_match_t assert_true
+    "TYPE_UNKNOWN matches int" "int" parse_type_str TYPE_UNKNOWN_T types_match_t assert_true
+    "int matches TYPE_UNKNOWN" TYPE_UNKNOWN_T "int" parse_type_str types_match_t assert_true
+    "different types" "str" parse_type_str "int" parse_type_str types_match_t ! assert_true
+    "fn base matches fn type" "fn[int -> int]" parse_type_str "fn" parse_type_str types_match_t assert_true
+    "generic base matches" "List[int]" parse_type_str "List" parse_type_str types_match_t assert_true
 }
 
 # ============================================================================
-# Tests: unify_type
+# Tests: unify_type_t
 # ============================================================================
 
 fn test_unify_type {
-    "unify_type" test_start
-    "same" "int" "int" "int" unify_type assert_str_eq
-    "unknown + int" "int" "int" TYPE_UNKNOWN unify_type assert_str_eq
-    "int + unknown" "int" TYPE_UNKNOWN "int" unify_type assert_str_eq
-    "incompatible" "" "str" "int" unify_type assert_str_eq
+    "unify_type_t" test_start
+    "same" "int" "int" parse_type_str "int" parse_type_str unify_type_t.unwrap.format assert_str_eq
+    "unknown + int" "int" "int" parse_type_str TYPE_UNKNOWN_T unify_type_t.unwrap.format assert_str_eq
+    "int + unknown" "int" TYPE_UNKNOWN_T "int" parse_type_str unify_type_t.unwrap.format assert_str_eq
+    "incompatible" "str" parse_type_str "int" parse_type_str unify_type_t.is_none assert_true
 }
 
 # ============================================================================
@@ -1011,12 +1011,12 @@ fn test_tc_pipeline_div_mod {
 
 fn test_types_match_extended {
     "types_match_extended" test_start
-    "both unknown" TYPE_UNKNOWN TYPE_UNKNOWN types_match assert_true
-    "str str" "str" "str" types_match assert_true
-    "bool bool" "bool" "bool" types_match assert_true
-    "ptr ptr" "ptr" "ptr" types_match assert_true
-    "int vs str" "int" "str" types_match ! assert_true
-    "int vs bool" "int" "bool" types_match ! assert_true
+    "both unknown" TYPE_UNKNOWN_T TYPE_UNKNOWN_T types_match_t assert_true
+    "str str" "str" parse_type_str "str" parse_type_str types_match_t assert_true
+    "bool bool" "bool" parse_type_str "bool" parse_type_str types_match_t assert_true
+    "ptr ptr" "ptr" parse_type_str "ptr" parse_type_str types_match_t assert_true
+    "int vs str" "int" parse_type_str "str" parse_type_str types_match_t ! assert_true
+    "int vs bool" "int" parse_type_str "bool" parse_type_str types_match_t ! assert_true
 }
 
 # ============================================================================
@@ -1567,10 +1567,10 @@ fn test_stacks_compatible_different_types {
 
 fn test_types_match_fn_types {
     "types_match_fn_types" test_start
-    "fn matches fn sig" "fn[int -> int]" "fn" types_match assert_true
-    "fn sig matches fn" "fn" "fn[int -> int]" types_match assert_true
-    "fn sig matches same" "fn[int -> int]" "fn[int -> int]" types_match assert_true
-    "fn sig mismatch" "fn[int -> int]" "fn[str -> str]" types_match ! assert_true
+    "fn matches fn sig" "fn[int -> int]" parse_type_str "fn" parse_type_str types_match_t assert_true
+    "fn sig matches fn" "fn" parse_type_str "fn[int -> int]" parse_type_str types_match_t assert_true
+    "fn sig matches same" "fn[int -> int]" parse_type_str "fn[int -> int]" parse_type_str types_match_t assert_true
+    "fn sig mismatch" "fn[int -> int]" parse_type_str "fn[str -> str]" parse_type_str types_match_t ! assert_true
 }
 
 # ============================================================================
@@ -1579,10 +1579,10 @@ fn test_types_match_fn_types {
 
 fn test_types_match_array_types {
     "types_match_array_types" test_start
-    "array matches array" "array[int]" "array" types_match assert_true
-    "array base matches typed" "array" "array[int]" types_match assert_true
-    "array typed matches same" "array[int]" "array[int]" types_match assert_true
-    "array typed mismatch" "array[int]" "array[str]" types_match ! assert_true
+    "array matches array" "array[int]" parse_type_str "array" parse_type_str types_match_t assert_true
+    "array base matches typed" "array" parse_type_str "array[int]" parse_type_str types_match_t assert_true
+    "array typed matches same" "array[int]" parse_type_str "array[int]" parse_type_str types_match_t assert_true
+    "array typed mismatch" "array[int]" parse_type_str "array[str]" parse_type_str types_match_t ! assert_true
 }
 
 # ============================================================================


### PR DESCRIPTION
## Summary

- migrate op type metadata to Type-backed hints and make TypeCast carry Type directly
- replace trait-bound method execution metadata with a dedicated TraitMethodCall op
- remove the remaining string type helper layer in favor of Type methods and typed substitution
- audit parse/format boundaries and keep formatting/parsing at source, diagnostics, LSP, and tests

## Tests

- ./casac -L lib casa.casa -o casac
- tests/test_examples.sh
- tests/test_compiler.sh < /dev/null

Closes #176.
Closes #166.
Closes #167.
Completes #140.