### PR TITLE
feat: add const declarations with literal values

### DIFF
--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -83,6 +83,7 @@ enum KeywordKind {
     For
     In
     Global
+    Const
 }
 
 # ============================================================================
@@ -324,7 +325,6 @@ fn make_op value:OpValue location:Location -> Op {
 fn make_op_with_type_hint value:OpValue location:Location type_hint:Type -> Op {
     value Option::None(Option[Type]) type_hint Option::Some location Op
 }
-
 # Op identity is its heap address: two Op values compare equal iff the same
 # allocation. Required so labels map by Op identity (Map[Op int]), not by an
 # int reinterpretation of an Op pointer at every read site.
@@ -399,6 +399,19 @@ fn make_signature params:List[Parameter] returns:List[Type] -> Signature {
 # ============================================================================
 # Variable, Member
 # ============================================================================
+
+enum ConstantValue {
+    Int (int)
+    Str (str)
+    Bool (int)
+    Char (int)
+}
+
+struct Constant {
+    name:     str
+    value:    ConstantValue
+    location: Location
+}
 
 struct Variable {
     name: str
@@ -1732,6 +1745,7 @@ Map::new(Map[str KeywordKind]) = KEYWORD_MAP
 "for" KeywordKind::For KEYWORD_MAP.set = KEYWORD_MAP
 "in" KeywordKind::In KEYWORD_MAP.set = KEYWORD_MAP
 "global" KeywordKind::Global KEYWORD_MAP.set = KEYWORD_MAP
+"const" KeywordKind::Const KEYWORD_MAP.set = KEYWORD_MAP
 
 fn keyword_from_str value:str -> Option[KeywordKind] {
     value KEYWORD_MAP.get
@@ -1978,6 +1992,7 @@ fn string_list_contains items:List[str] value:str -> bool {
 struct SymbolStore {
     functions: Map[str Function]
     variables: Map[str Variable]
+    constants: Map[str Constant]
     enums:     Map[str CasaEnum]
     structs:   Map[str CasaStruct]
     traits:    Map[str CasaTrait]
@@ -1998,6 +2013,7 @@ fn symbol_store_new -> SymbolStore {
     Map::new(Map[str CasaTrait])
     Map::new(Map[str CasaStruct])
     Map::new(Map[str CasaEnum])
+    Map::new(Map[str Constant])
     Map::new(Map[str Variable])
     Map::new(Map[str Function])
     SymbolStore

--- a/compiler/syntax.casa
+++ b/compiler/syntax.casa
@@ -2080,6 +2080,46 @@ fn get_op_keyword parser:Parser token:Token cursor:TokenCursor function_name:str
         return
     fi
 
+    # const
+    if KeywordKind::Const keyword == then
+        token Token::location "Constants" function_name require_global_scope
+        TokenKind::Identifier cursor expect_token_kind = const_name_token
+        const_name_token Token::value = const_name
+        if const_name parser.store.constants.get.is_some then
+            token Token::location f"Constant `{const_name}` is already defined" ErrorKind::DuplicateName raise_error
+        fi
+        cursor.pop = const_value_token_opt
+        if const_value_token_opt.is_none then
+            token Token::location "Expected a literal value after constant name" ErrorKind::Syntax raise_error
+        fi
+        const_value_token_opt.unwrap = const_value_token
+        if TokenKind::Literal const_value_token Token::kind == then
+            const_value_token Token::value = const_raw
+            if "true" const_raw == then
+                token Token::location 1 ConstantValue::Bool const_name Constant = casa_const
+                const_name casa_const parser.store.constants.set drop
+            elif "false" const_raw == then
+                token Token::location 0 ConstantValue::Bool const_name Constant = casa_const
+                const_name casa_const parser.store.constants.set drop
+            elif '"' 0 const_raw.at == then
+                const_raw 1 const_raw.length 2 - str::substring = const_str_val
+                token Token::location const_str_val ConstantValue::Str const_name Constant = casa_const
+                const_name casa_const parser.store.constants.set drop
+            elif '\'' 0 const_raw.at == then
+                1 const_raw.at (int) = const_char_val
+                token Token::location const_char_val ConstantValue::Char const_name Constant = casa_const
+                const_name casa_const parser.store.constants.set drop
+            else
+                const_raw str_to_int = const_int_val
+                token Token::location const_int_val ConstantValue::Int const_name Constant = casa_const
+                const_name casa_const parser.store.constants.set drop
+            fi
+        else
+            token Token::location f"Expected a literal value for constant `{const_name}`" ErrorKind::Syntax raise_error
+        fi
+        return
+    fi
+
     # trait
     if KeywordKind::TraitKw keyword == then
         token Token::location "Traits" function_name require_global_scope
@@ -2532,6 +2572,26 @@ fn resolve_plain_identifier
         return
     fi
 
+    ident parser.store.constants.get = const_opt
+    if const_opt.is_some then
+        const_opt.unwrap Constant::value = const_value
+        const_value match
+            ConstantValue::Int(const_int) => {
+                const_int OpValue::PushInt op Op::set_value
+            }
+            ConstantValue::Str(const_str) => {
+                const_str OpValue::PushStr op Op::set_value
+            }
+            ConstantValue::Bool(const_bool) => {
+                const_bool OpValue::PushBool op Op::set_value
+            }
+            ConstantValue::Char(const_char) => {
+                const_char OpValue::PushChar op Op::set_value
+            }
+        end
+        return
+    fi
+
     op Op::location f"Identifier `{ident}` is not defined" ErrorKind::UndefinedName make_error resolve_errors.push
 }
 
@@ -2552,6 +2612,10 @@ fn resolve_identifiers_fn parser:Parser ops:List[Op] function:Function -> List[O
         fi
 
         if current_op.value OpValue::AssignVar(var_name) is then
+            if var_name parser.store.constants.get.is_some then
+                current_op Op::location f"Cannot assign to constant `{var_name}`" ErrorKind::Syntax make_error resolve_errors.push
+                continue
+            fi
             var_name make_variable = variable
             # Global scope: store in parser.store.variables
             if GLOBAL_SCOPE_LABEL function Function::name == then

--- a/compiler/syntax.casa
+++ b/compiler/syntax.casa
@@ -2088,6 +2088,18 @@ fn get_op_keyword parser:Parser token:Token cursor:TokenCursor function_name:str
         if const_name parser.store.constants.get.is_some then
             token Token::location f"Constant `{const_name}` is already defined" ErrorKind::DuplicateName raise_error
         fi
+        if const_name parser.store.functions.get.is_some then
+            token Token::location f"Constant `{const_name}` conflicts with an existing function" ErrorKind::DuplicateName raise_error
+        fi
+        if const_name parser.store.variables.get.is_some then
+            token Token::location f"Constant `{const_name}` conflicts with an existing variable" ErrorKind::DuplicateName raise_error
+        fi
+        if const_name parser.store.structs.get.is_some then
+            token Token::location f"Constant `{const_name}` conflicts with an existing struct" ErrorKind::DuplicateName raise_error
+        fi
+        if const_name parser.store.enums.get.is_some then
+            token Token::location f"Constant `{const_name}` conflicts with an existing enum" ErrorKind::DuplicateName raise_error
+        fi
         cursor.pop = const_value_token_opt
         if const_value_token_opt.is_none then
             token Token::location "Expected a literal value after constant name" ErrorKind::Syntax raise_error
@@ -2560,18 +2572,6 @@ fn resolve_plain_identifier
         return
     fi
 
-    ident parser.store.structs.get = struct_opt
-    if struct_opt.is_some then
-        struct_opt.unwrap OpValue::StructNew op Op::set_value
-        return
-    fi
-
-    ident parser.store.enums.get = resolved_enum_opt
-    if resolved_enum_opt.is_some then
-        resolved_enum_opt.unwrap CasaEnum::variants.length OpValue::PushInt op Op::set_value
-        return
-    fi
-
     ident parser.store.constants.get = const_opt
     if const_opt.is_some then
         const_opt.unwrap Constant::value = const_value
@@ -2592,6 +2592,18 @@ fn resolve_plain_identifier
         return
     fi
 
+    ident parser.store.structs.get = struct_opt
+    if struct_opt.is_some then
+        struct_opt.unwrap OpValue::StructNew op Op::set_value
+        return
+    fi
+
+    ident parser.store.enums.get = resolved_enum_opt
+    if resolved_enum_opt.is_some then
+        resolved_enum_opt.unwrap CasaEnum::variants.length OpValue::PushInt op Op::set_value
+        return
+    fi
+
     op Op::location f"Identifier `{ident}` is not defined" ErrorKind::UndefinedName make_error resolve_errors.push
 }
 
@@ -2609,6 +2621,20 @@ fn resolve_identifiers_fn parser:Parser ops:List[Op] function:Function -> List[O
             fi
             global_name declared_globals.add = declared_globals
             continue
+        fi
+
+        if current_op.value OpValue::AssignInc(inc_name) is then
+            if inc_name parser.store.constants.get.is_some then
+                current_op Op::location f"Cannot assign to constant `{inc_name}`" ErrorKind::Syntax make_error resolve_errors.push
+                continue
+            fi
+        fi
+
+        if current_op.value OpValue::AssignDec(dec_name) is then
+            if dec_name parser.store.constants.get.is_some then
+                current_op Op::location f"Cannot assign to constant `{dec_name}`" ErrorKind::Syntax make_error resolve_errors.push
+                continue
+            fi
         fi
 
         if current_op.value OpValue::AssignVar(var_name) is then

--- a/tests/compiler/errors/const_non_literal.casa
+++ b/tests/compiler/errors/const_non_literal.casa
@@ -1,0 +1,2 @@
+# expect: SYNTAX
+const MAX some_variable

--- a/tests/compiler/errors/const_reassign.casa
+++ b/tests/compiler/errors/const_reassign.casa
@@ -1,0 +1,3 @@
+# expect: SYNTAX
+const MAX 100
+50 = MAX

--- a/tests/compiler/test_const.casa
+++ b/tests/compiler/test_const.casa
@@ -1,0 +1,48 @@
+import "../../compiler/common.casa"
+import "../../compiler/error.casa"
+import "../../compiler/lexer.casa"
+import "../../compiler/syntax.casa"
+import "../../lib/test.casa"
+
+const MAX_SIZE 100
+const GREETING "hello"
+const DEBUG false
+const ENABLED true
+const NEWLINE '\n'
+
+fn test_const_int {
+    "const_int" test_start
+    "value" 100 MAX_SIZE assert_eq
+}
+
+fn test_const_str {
+    "const_str" test_start
+    "value" "hello" GREETING assert_str_eq
+}
+
+fn test_const_bool_false {
+    "const_bool_false" test_start
+    "value" DEBUG ! assert_true
+}
+
+fn test_const_bool_true {
+    "const_bool_true" test_start
+    "value" ENABLED assert_true
+}
+
+fn test_const_char {
+    "const_char" test_start
+    "value" '\n' (int) NEWLINE (int) assert_eq
+}
+
+fn test_const_in_expression {
+    "const_in_expression" test_start
+    "value" 200 MAX_SIZE 2 * assert_eq
+}
+test_const_int
+test_const_str
+test_const_bool_false
+test_const_bool_true
+test_const_char
+test_const_in_expression
+test_summary


### PR DESCRIPTION
## Summary

- Add `const NAME value` syntax for compile-time constant declarations
- Support `int`, `str`, `bool`, and `char` literal values
- Constants are inlined at usage sites (no global variable slot)
- Compiler error on reassignment to a constant
- Compiler error on non-literal initializer

## Changes

- `compiler/common.casa`: Add `ConstantValue` enum, `Constant` struct, `Const` keyword variant, `constants` field on `SymbolStore`
- `compiler/syntax.casa`: Parse `const` declarations, resolve constant references to inline literals, reject reassignment
- `tests/compiler/test_const.casa`: 6 tests covering all literal types and usage in expressions
- `tests/compiler/errors/const_reassign.casa`: Error fixture for reassignment
- `tests/compiler/errors/const_non_literal.casa`: Error fixture for non-literal value

## Test plan

- [x] All 38 compiler tests pass (including new const tests)
- [x] All 40 example tests pass
- [x] Self-compilation passes
- [x] Fixed-point verification passes
- [x] Error fixtures produce correct error kinds

Closes #178