### PR TITLE
feat: add selective imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ source → lex → parse → resolve → type check → bytecode → emit asm �
 
 ## Documentation
 
-Start with the core language docs (1-8), then explore the library and tooling docs as needed.
+Start with the core language docs (1-9), then explore the library and tooling docs as needed.
 
 ### Core Language
 
@@ -96,18 +96,19 @@ Start with the core language docs (1-8), then explore the library and tooling do
 |---|----------|--------|
 | 1 | [Types and Literals](docs/types-and-literals.md) | Primitive types, composite types, literals, type casting, comments |
 | 2 | [Operators](docs/operators.md) | Stack-based evaluation, arithmetic, comparison, boolean, assignment |
-| 3 | [Functions and Lambdas](docs/functions-and-lambdas.md) | Functions, lambdas, closures, variables |
-| 4 | [Control Flow](docs/control-flow.md) | Conditionals, loops, `for` iterators, `match` pattern matching |
-| 5 | [Structs and Methods](docs/structs-and-methods.md) | Struct definition, accessors, `impl` blocks, dot/arrow syntax |
-| 6 | [Enums](docs/enums.md) | Enum types, variant constructors, `is` destructuring |
-| 7 | [Traits](docs/traits.md) | Trait definitions, structural satisfaction, trait bounds, `Hashable` |
-| 8 | [Built-in Intrinsics](docs/intrinsics.md) | Stack manipulation, IO, memory, and syscall intrinsics |
+| 3 | [Modules](docs/modules.md) | Import directives, module resolution, selective imports, library paths |
+| 4 | [Functions and Lambdas](docs/functions-and-lambdas.md) | Functions, lambdas, closures, variables |
+| 5 | [Control Flow](docs/control-flow.md) | Conditionals, loops, `for` iterators, `match` pattern matching |
+| 6 | [Structs and Methods](docs/structs-and-methods.md) | Struct definition, accessors, `impl` blocks, dot/arrow syntax |
+| 7 | [Enums](docs/enums.md) | Enum types, variant constructors, `is` destructuring |
+| 8 | [Traits](docs/traits.md) | Trait definitions, structural satisfaction, trait bounds, `Hashable` |
+| 9 | [Built-in Intrinsics](docs/intrinsics.md) | Stack manipulation, IO, memory, and syscall intrinsics |
 
 ### Library
 
 | Document | Topics |
 |----------|--------|
-| [Standard Library](docs/standard-library.md) | `import`, `memcpy`, arrays (`map`, `filter`, `reduce`), `Option[T]`, `Result[T E]` |
+| [Standard Library](docs/standard-library.md) | `memcpy`, arrays (`map`, `filter`, `reduce`), `Option[T]`, `Result[T E]` |
 | [Collections](docs/collections.md) | `List[T]`, `Map[K V]`, `Set[K]`, `StringBuilder` |
 | [Strings and IO](docs/strings-and-io.md) | String methods, file I/O, character classification, type conversions |
 | [Utilities](docs/utilities.md) | Logging, timer, argument parsing, process execution |

--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -503,6 +503,11 @@ enum PatternValue {
     Literal (LiteralPattern)
 }
 
+struct SelectiveImport {
+    path:    str
+    symbols: List[str]
+}
+
 # OpValue — single tagged enum that classifies every Op. Each of the 87
 # variants represents a distinct opcode; payload-bearing variants carry the
 # typed inner value directly so call sites can destructure with `is`/`match`.
@@ -611,6 +616,7 @@ enum OpValue {
     TypeCast (Type)
     # Import
     ImportFile (str)
+    ImportFileSelective (SelectiveImport)
     # F-strings
     FstringConcat (int)
     FstringToStr

--- a/compiler/syntax.casa
+++ b/compiler/syntax.casa
@@ -2273,12 +2273,10 @@ fn handle_keyword_import parser:Parser cursor:TokenCursor -> Op {
         path_location spec importing_file parser resolve_import = resolved
 
         cursor.peek = next_opt
-        if next_opt.is_some then
-            if "{" next_opt.unwrap Token::value == then
-                path_location cursor parse_selective_import_symbols = symbols
-                symbols resolved SelectiveImport = selective
-                path_location selective OpValue::ImportFileSelective make_op return
-            fi
+        if next_opt.is_some "{" next_opt.unwrap Token::value == && then
+            path_location cursor parse_selective_import_symbols = symbols
+            symbols resolved SelectiveImport = selective
+            path_location selective OpValue::ImportFileSelective make_op return
         fi
         path_location resolved OpValue::ImportFile make_op return
     fi
@@ -2296,12 +2294,13 @@ fn selective_import_type_dependencies
 {
     typ match
         Type::Generic(generic) => {
+            generic GenericType::base = base_name
             if
-            generic GenericType::base import_parser.store.structs.has
-            generic GenericType::base import_parser.store.enums.has ||
-            generic GenericType::base import_parser.store.traits.has ||
+            base_name import_parser.store.structs.has
+            base_name import_parser.store.enums.has ||
+            base_name import_parser.store.traits.has ||
             then
-                imported location generic GenericType::base import_parser parser selective_import_symbol
+                imported location base_name import_parser parser selective_import_symbol
             fi
             for param_type in generic GenericType::params.iter do
                 imported location param_type import_parser parser selective_import_type_dependencies
@@ -2335,6 +2334,57 @@ fn selective_import_signature_dependencies
     done
 }
 
+fn selective_import_op_dependencies
+    parser:Parser
+    import_parser:Parser
+    op:Op
+    location:Location
+    imported:Set[str]
+{
+    if op.value OpValue::FnCall(dep_name) is then
+        imported location dep_name import_parser parser selective_import_symbol
+        return
+    fi
+    if op.value OpValue::FnPush(dep_push_name) is then
+        imported location dep_push_name import_parser parser selective_import_symbol
+        return
+    fi
+    if op.value OpValue::StructNew(dep_struct) is then
+        imported location dep_struct CasaStruct::name import_parser parser selective_import_symbol
+        return
+    fi
+    if op.value OpValue::StructLiteral(dep_literal) is then
+        imported location dep_literal StructLiteral::struct_name import_parser parser selective_import_symbol
+        return
+    fi
+    if op.value OpValue::PushEnumVariant(dep_variant) is then
+        imported location dep_variant EnumVariant::enum_name import_parser parser selective_import_symbol
+        return
+    fi
+    if op.value OpValue::IsCheck(dep_is_variant) is then
+        imported location dep_is_variant EnumVariant::enum_name import_parser parser selective_import_symbol
+        return
+    fi
+    if op.value OpValue::TypeCast(dep_type) is then
+        imported location dep_type import_parser parser selective_import_type_dependencies
+    fi
+}
+
+fn selective_import_methods
+    parser:Parser
+    import_parser:Parser
+    symbol:str
+    location:Location
+    imported:Set[str]
+{
+    f"{symbol}::" = method_prefix
+    for fn_name in import_parser.store.functions.keys.iter do
+        if fn_name method_prefix str::starts_with then
+            imported location fn_name import_parser parser selective_import_symbol
+        fi
+    done
+}
+
 fn selective_import_symbol
     parser:Parser
     import_parser:Parser
@@ -2365,21 +2415,7 @@ fn selective_import_symbol
         done
         symbol imported_fn parser.store.functions.set drop
         for resolved_op in resolved_ops.iter do
-            if resolved_op.value OpValue::FnCall(dep_name) is then
-                imported location dep_name import_parser parser selective_import_symbol
-            elif resolved_op.value OpValue::FnPush(dep_push_name) is then
-                imported location dep_push_name import_parser parser selective_import_symbol
-            elif resolved_op.value OpValue::StructNew(dep_struct) is then
-                imported location dep_struct CasaStruct::name import_parser parser selective_import_symbol
-            elif resolved_op.value OpValue::StructLiteral(dep_literal) is then
-                imported location dep_literal StructLiteral::struct_name import_parser parser selective_import_symbol
-            elif resolved_op.value OpValue::PushEnumVariant(dep_variant) is then
-                imported location dep_variant EnumVariant::enum_name import_parser parser selective_import_symbol
-            elif resolved_op.value OpValue::IsCheck(dep_is_variant) is then
-                imported location dep_is_variant EnumVariant::enum_name import_parser parser selective_import_symbol
-            elif resolved_op.value OpValue::TypeCast(dep_type) is then
-                imported location dep_type import_parser parser selective_import_type_dependencies
-            fi
+            imported location resolved_op import_parser parser selective_import_op_dependencies
         done
         return
     fi
@@ -2399,12 +2435,7 @@ fn selective_import_symbol
             location f"Imported symbol `{symbol}` conflicts with an existing struct" ErrorKind::DuplicateName raise_error
         fi
         symbol struct_opt.unwrap parser.store.structs.set drop
-        f"{symbol}::" = method_prefix
-        for fn_name in import_parser.store.functions.keys.iter do
-            if fn_name method_prefix str::starts_with then
-                imported location fn_name import_parser parser selective_import_symbol
-            fi
-        done
+        imported location symbol import_parser parser selective_import_methods
         return
     fi
 
@@ -2414,12 +2445,7 @@ fn selective_import_symbol
             location f"Imported symbol `{symbol}` conflicts with an existing enum" ErrorKind::DuplicateName raise_error
         fi
         symbol enum_opt.unwrap parser.store.enums.set drop
-        f"{symbol}::" = method_prefix
-        for fn_name in import_parser.store.functions.keys.iter do
-            if fn_name method_prefix str::starts_with then
-                imported location fn_name import_parser parser selective_import_symbol
-            fi
-        done
+        imported location symbol import_parser parser selective_import_methods
         return
     fi
 

--- a/compiler/syntax.casa
+++ b/compiler/syntax.casa
@@ -1054,7 +1054,11 @@ fn validate_const_fn_body function:Function {
 # eval_const_block - compile-time evaluation of const { ... } expressions
 # ============================================================================
 
-fn const_eval_apply_operator stack:List[ConstantValue] operator_kind:OperatorKind location:Location {
+fn const_eval_apply_operator
+    stack:List[ConstantValue]
+    operator_kind:OperatorKind
+    location:Location
+{
     if operator_kind OperatorKind::Not == then
         if 0 stack.length == then
             location "Stack underflow in const expression" ErrorKind::Syntax raise_error
@@ -1159,7 +1163,13 @@ fn const_eval_apply_operator stack:List[ConstantValue] operator_kind:OperatorKin
     location "Type mismatch in const expression" ErrorKind::Syntax raise_error
 }
 
-fn eval_const_fn parser:Parser fn_name:str stack:List[ConstantValue] location:Location eval_stack:List[str] {
+fn eval_const_fn
+    parser:Parser
+    fn_name:str
+    stack:List[ConstantValue]
+    location:Location
+    eval_stack:List[str]
+{
     if fn_name eval_stack string_list_contains then
         location f"Cycle detected in const evaluation: `{fn_name}`" ErrorKind::Syntax raise_error
     fi
@@ -2229,6 +2239,31 @@ fn resolve_import parser:Parser importing_file:str spec:str location:Location ->
     ""
 }
 
+fn parse_selective_import_symbols cursor:TokenCursor location:Location -> List[str] {
+    List::new(List[str]) = symbols
+    "{" cursor expect_token_value drop
+    while true do
+        cursor.pop = symbol_opt
+        if symbol_opt.is_none then
+            location "Unclosed selective import list" ErrorKind::UnmatchedBlock raise_error
+        fi
+        symbol_opt.unwrap = symbol_token
+        if TokenKind::Comment symbol_token Token::kind == then continue fi
+        if TokenKind::Newline symbol_token Token::kind == then continue fi
+        if "}" symbol_token Token::value == then
+            if 0 symbols.length == then
+                symbol_token Token::location "Selective import list cannot be empty" ErrorKind::Syntax raise_error
+            fi
+            symbols return
+        fi
+        if TokenKind::Identifier symbol_token Token::kind != then
+            symbol_token Token::location "Expected identifier in selective import list" ErrorKind::UnexpectedToken raise_error
+        fi
+        symbol_token Token::value symbols.push
+    done
+    symbols
+}
+
 fn handle_keyword_import parser:Parser cursor:TokenCursor -> Op {
     TokenKind::Literal cursor expect_token_kind = path_token
     path_token get_op_literal = literal_op
@@ -2237,11 +2272,190 @@ fn handle_keyword_import parser:Parser cursor:TokenCursor -> Op {
         path_location Location::file = importing_file
         path_location spec importing_file parser resolve_import = resolved
 
+        cursor.peek = next_opt
+        if next_opt.is_some then
+            if "{" next_opt.unwrap Token::value == then
+                path_location cursor parse_selective_import_symbols = symbols
+                symbols resolved SelectiveImport = selective
+                path_location selective OpValue::ImportFileSelective make_op return
+            fi
+        fi
         path_location resolved OpValue::ImportFile make_op return
     fi
     path_token Token::location "Expected string literal for import path" ErrorKind::UnexpectedToken raise_error
     # Unreachable - raise_error exits
     path_token Token::location "" OpValue::ImportFile make_op
+}
+
+fn selective_import_type_dependencies
+    parser:Parser
+    import_parser:Parser
+    typ:Type
+    location:Location
+    imported:Set[str]
+{
+    typ match
+        Type::Generic(generic) => {
+            if
+            generic GenericType::base import_parser.store.structs.has
+            generic GenericType::base import_parser.store.enums.has ||
+            generic GenericType::base import_parser.store.traits.has ||
+            then
+                imported location generic GenericType::base import_parser parser selective_import_symbol
+            fi
+            for param_type in generic GenericType::params.iter do
+                imported location param_type import_parser parser selective_import_type_dependencies
+            done
+        }
+        Type::Function(fn_type) => {
+            for param_type in fn_type FunctionType::parameters.iter do
+                imported location param_type import_parser parser selective_import_type_dependencies
+            done
+            for return_type in fn_type FunctionType::return_types.iter do
+                imported location return_type import_parser parser selective_import_type_dependencies
+            done
+        }
+        _ => { }
+    end
+}
+
+fn selective_import_signature_dependencies
+    parser:Parser
+    import_parser:Parser
+    function:Function
+    location:Location
+    imported:Set[str]
+{
+    function Function::signature = sig
+    for param in sig Signature::parameters.iter do
+        imported location param Parameter::typ import_parser parser selective_import_type_dependencies
+    done
+    for return_type in sig Signature::return_types.iter do
+        imported location return_type import_parser parser selective_import_type_dependencies
+    done
+}
+
+fn selective_import_symbol
+    parser:Parser
+    import_parser:Parser
+    symbol:str
+    location:Location
+    imported:Set[str]
+{
+    if symbol imported.has then
+        return
+    fi
+    symbol imported.add = imported
+
+    symbol import_parser.store.functions.get = fn_opt
+    if fn_opt.is_some then
+        fn_opt.unwrap = imported_fn
+        if symbol parser.store.functions.has then
+            location f"Imported symbol `{symbol}` conflicts with an existing function" ErrorKind::DuplicateName raise_error
+        fi
+        imported_fn imported_fn Function::ops import_parser resolve_identifiers_fn = resolved_ops
+        resolved_ops imported_fn Function::set_ops
+        imported location imported_fn import_parser parser selective_import_signature_dependencies
+        for resolved_op in resolved_ops.iter do
+            if resolved_op.value OpValue::PushVar(var_name) is then
+                if var_name imported_fn Function::variables variable_list_contains ! var_name import_parser.store.variables.has && then
+                    resolved_op Op::location f"Selective import `{symbol}` depends on global variable `{var_name}`" ErrorKind::InvalidVariable raise_error
+                fi
+            fi
+        done
+        symbol imported_fn parser.store.functions.set drop
+        for resolved_op in resolved_ops.iter do
+            if resolved_op.value OpValue::FnCall(dep_name) is then
+                imported location dep_name import_parser parser selective_import_symbol
+            elif resolved_op.value OpValue::FnPush(dep_push_name) is then
+                imported location dep_push_name import_parser parser selective_import_symbol
+            elif resolved_op.value OpValue::StructNew(dep_struct) is then
+                imported location dep_struct CasaStruct::name import_parser parser selective_import_symbol
+            elif resolved_op.value OpValue::StructLiteral(dep_literal) is then
+                imported location dep_literal StructLiteral::struct_name import_parser parser selective_import_symbol
+            elif resolved_op.value OpValue::PushEnumVariant(dep_variant) is then
+                imported location dep_variant EnumVariant::enum_name import_parser parser selective_import_symbol
+            elif resolved_op.value OpValue::IsCheck(dep_is_variant) is then
+                imported location dep_is_variant EnumVariant::enum_name import_parser parser selective_import_symbol
+            elif resolved_op.value OpValue::TypeCast(dep_type) is then
+                imported location dep_type import_parser parser selective_import_type_dependencies
+            fi
+        done
+        return
+    fi
+
+    symbol import_parser.store.constants.get = const_opt
+    if const_opt.is_some then
+        if symbol parser.store.constants.has then
+            location f"Imported symbol `{symbol}` conflicts with an existing constant" ErrorKind::DuplicateName raise_error
+        fi
+        symbol const_opt.unwrap parser.store.constants.set drop
+        return
+    fi
+
+    symbol import_parser.store.structs.get = struct_opt
+    if struct_opt.is_some then
+        if symbol parser.store.structs.has then
+            location f"Imported symbol `{symbol}` conflicts with an existing struct" ErrorKind::DuplicateName raise_error
+        fi
+        symbol struct_opt.unwrap parser.store.structs.set drop
+        f"{symbol}::" = method_prefix
+        for fn_name in import_parser.store.functions.keys.iter do
+            if fn_name method_prefix str::starts_with then
+                imported location fn_name import_parser parser selective_import_symbol
+            fi
+        done
+        return
+    fi
+
+    symbol import_parser.store.enums.get = enum_opt
+    if enum_opt.is_some then
+        if symbol parser.store.enums.has then
+            location f"Imported symbol `{symbol}` conflicts with an existing enum" ErrorKind::DuplicateName raise_error
+        fi
+        symbol enum_opt.unwrap parser.store.enums.set drop
+        f"{symbol}::" = method_prefix
+        for fn_name in import_parser.store.functions.keys.iter do
+            if fn_name method_prefix str::starts_with then
+                imported location fn_name import_parser parser selective_import_symbol
+            fi
+        done
+        return
+    fi
+
+    symbol import_parser.store.traits.get = trait_opt
+    if trait_opt.is_some then
+        if symbol parser.store.traits.has then
+            location f"Imported symbol `{symbol}` conflicts with an existing trait" ErrorKind::DuplicateName raise_error
+        fi
+        symbol trait_opt.unwrap parser.store.traits.set drop
+        return
+    fi
+
+    if symbol import_parser.store.variables.has then
+        location f"Selective import cannot import global variable `{symbol}`" ErrorKind::InvalidVariable raise_error
+    fi
+
+    location f"Symbol `{symbol}` not found in selective import" ErrorKind::UndefinedName raise_error
+}
+
+fn handle_selective_import parser:Parser selective:SelectiveImport location:Location {
+    selective SelectiveImport::path = import_path
+    if 0 import_path.length == then
+        return
+    fi
+
+    symbol_store_new make_parser = import_parser
+    parser.search_paths import_parser->search_paths
+    import_path import_parser.included_files.add drop
+    import_path lex_file = import_tokens
+    import_tokens import_parser parse_ops = import_ops
+    import_ops import_parser resolve_identifiers_global drop
+
+    Set::new(Set[str]) = imported
+    for symbol in selective SelectiveImport::symbols.iter do
+        imported location symbol import_parser parser selective_import_symbol
+    done
 }
 
 # ============================================================================
@@ -3089,6 +3303,12 @@ fn resolve_identifiers_fn parser:Parser ops:List[Op] function:Function -> List[O
         # IS_CHECK: resolve enum variant
         if current_op.value OpValue::IsCheck(is_enum_variant) is then
             resolve_errors function current_op is_enum_variant parser resolve_enum_variant
+            continue
+        fi
+
+        # IMPORT_FILE_SELECTIVE: register only requested declarations.
+        if current_op.value OpValue::ImportFileSelective(selective_import) is then
+            current_op Op::location selective_import parser handle_selective_import
             continue
         fi
 

--- a/compiler/typechecker.casa
+++ b/compiler/typechecker.casa
@@ -258,7 +258,6 @@ fn stack_pop_drop tc:TypeChecker {
     tc TypeChecker::live TypedStack::types.pop drop
 }
 
-
 fn expect_type_t tc:TypeChecker expected:Type {
     if 0 tc TypeChecker::live TypedStack::types.length == then
         if tc within_param_cap then
@@ -2704,7 +2703,11 @@ fn run_type_check_ops checker:TypeChecker ops:List[Op] function_opt:Option[Funct
         fi
 
         # Import file and DeclareGlobal (compile-time only, no type effect)
-        if op_value OpValue::ImportFile is op_value OpValue::DeclareGlobal is || then
+        if
+        op_value OpValue::ImportFile is
+        op_value OpValue::ImportFileSelective is ||
+        op_value OpValue::DeclareGlobal is ||
+        then
             continue
         fi
 

--- a/docs/collections.md
+++ b/docs/collections.md
@@ -500,6 +500,7 @@ Returns the number of characters in the builder.
 
 ## See Also
 
-- [Standard Library](standard-library.md) -- arrays, Option, Result, and the `import` directive
+- [Standard Library](standard-library.md) -- arrays, Option, and Result
+- [Modules](modules.md) -- import directives and module resolution
 - [Strings and IO](strings-and-io.md) -- string methods, file I/O, and type conversions
 - [Traits](traits.md) -- the `Hashable` trait required by Map and Set keys

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -1,0 +1,60 @@
+# Modules
+
+Casa source files can load declarations from other files with the `import` directive.
+
+## `import` Directive
+
+`import` loads another Casa source file. Each file is imported at most once, regardless of how many times it appears, and the deduplication uses the canonicalized resolved path.
+
+There are three forms:
+
+### Path-style
+
+```casa
+import "relative/path/to/file.casa"
+import "/absolute/path/to/file.casa"
+```
+
+A specifier is treated as a path when it contains `/` or ends with `.casa`. Relative paths resolve from the directory of the importing file. Absolute paths are used as-is. No search is performed.
+
+### Module-style
+
+```casa
+import "std"
+```
+
+A specifier without `/` and without a `.casa` suffix is treated as a module name. The resolver looks for `<module>.casa` in:
+
+1. the directory of the importing file, then
+2. each directory passed via `-L` / `--library-path`, in CLI order.
+
+The first existing match wins. A same-directory candidate that resolves to the importing file itself is skipped, so an example file `examples/argparse.casa` can `import "argparse"` and reach the library copy via `-L`. If no candidate exists, the compiler reports an error listing every directory searched.
+
+### Selective imports
+
+```casa
+import "path/to/tool.casa" { parse_message DispatchState }
+import "std" {
+    List
+    Map
+}
+```
+
+Selective imports use the same path-style and module-style resolution rules as bare imports, then extract only the named declarations and the transitive dependencies needed by those declarations.
+
+- Function imports include referenced functions, constants, structs, enums, traits, and methods needed by the imported function body and signature.
+- Struct and enum imports include generated accessors plus functions in their `impl` blocks.
+- Constants can be imported directly.
+- Top-level expressions and bare calls in the imported file are skipped.
+- Top-level global assignments are skipped and cannot be imported.
+- Importing a function that depends on a skipped global variable is a compile error.
+- Names referenced directly by the importing file must be listed explicitly.
+
+### `-L` / `--library-path`
+
+Repeatable. Adds a directory to the module search path:
+
+```sh
+casac -L lib program.casa
+casac -L lib -L vendor program.casa
+```

--- a/docs/standard-library.md
+++ b/docs/standard-library.md
@@ -12,62 +12,7 @@ import "std"
 import "path/to/lib/std.casa"
 ```
 
-## `import` Directive
-
-`import` loads another Casa source file. Each file is imported at most once, regardless of how many times it appears, and the deduplication uses the canonicalized resolved path.
-
-There are three forms:
-
-### Path-style
-
-```casa
-import "relative/path/to/file.casa"
-import "/absolute/path/to/file.casa"
-```
-
-A specifier is treated as a path when it contains `/` or ends with `.casa`. Relative paths resolve from the directory of the importing file. Absolute paths are used as-is. No search is performed.
-
-### Module-style
-
-```casa
-import "std"
-```
-
-A specifier without `/` and without a `.casa` suffix is treated as a module name. The resolver looks for `<module>.casa` in:
-
-1. the directory of the importing file, then
-2. each directory passed via `-L` / `--library-path`, in CLI order.
-
-The first existing match wins. A same-directory candidate that resolves to the importing file itself is skipped, so an example file `examples/argparse.casa` can `import "argparse"` and reach the library copy via `-L`. If no candidate exists, the compiler reports an error listing every directory searched.
-
-### Selective imports
-
-```casa
-import "path/to/tool.casa" { parse_message DispatchState }
-import "std" {
-    List
-    Map
-}
-```
-
-Selective imports use the same path-style and module-style resolution rules as bare imports, then extract only the named declarations and the transitive dependencies needed by those declarations.
-
-- Function imports include referenced functions, constants, structs, enums, traits, and methods needed by the imported function body and signature.
-- Struct and enum imports include generated accessors plus functions in their `impl` blocks.
-- Constants can be imported directly.
-- Top-level expressions and bare calls in the imported file are skipped.
-- Top-level global assignments are skipped and cannot be imported.
-- Importing a function that depends on a skipped global variable is a compile error.
-- Names referenced directly by the importing file must be listed explicitly.
-
-### `-L` / `--library-path`
-
-Repeatable. Adds a directory to the module search path:
-
-```sh
-casac -L lib program.casa
-casac -L lib -L vendor program.casa
-```
+For full import resolution rules, selective imports, and `-L` search paths, see [Modules](modules.md).
 
 ## `memcpy`
 

--- a/docs/standard-library.md
+++ b/docs/standard-library.md
@@ -16,7 +16,7 @@ import "path/to/lib/std.casa"
 
 `import` loads another Casa source file. Each file is imported at most once, regardless of how many times it appears, and the deduplication uses the canonicalized resolved path.
 
-There are two forms:
+There are three forms:
 
 ### Path-style
 
@@ -39,6 +39,26 @@ A specifier without `/` and without a `.casa` suffix is treated as a module name
 2. each directory passed via `-L` / `--library-path`, in CLI order.
 
 The first existing match wins. A same-directory candidate that resolves to the importing file itself is skipped, so an example file `examples/argparse.casa` can `import "argparse"` and reach the library copy via `-L`. If no candidate exists, the compiler reports an error listing every directory searched.
+
+### Selective imports
+
+```casa
+import "path/to/tool.casa" { parse_message DispatchState }
+import "std" {
+    List
+    Map
+}
+```
+
+Selective imports use the same path-style and module-style resolution rules as bare imports, then extract only the named declarations and the transitive dependencies needed by those declarations.
+
+- Function imports include referenced functions, constants, structs, enums, traits, and methods needed by the imported function body and signature.
+- Struct and enum imports include generated accessors plus functions in their `impl` blocks.
+- Constants can be imported directly.
+- Top-level expressions and bare calls in the imported file are skipped.
+- Top-level global assignments are skipped and cannot be imported.
+- Importing a function that depends on a skipped global variable is a compile error.
+- Names referenced directly by the importing file must be listed explicitly.
 
 ### `-L` / `--library-path`
 

--- a/docs/strings-and-io.md
+++ b/docs/strings-and-io.md
@@ -556,7 +556,8 @@ Returns the absolute value of an integer, for use as a hash.
 
 ## See Also
 
-- [Standard Library](standard-library.md) -- arrays, Option, Result, and the `import` directive
+- [Standard Library](standard-library.md) -- arrays, Option, and Result
+- [Modules](modules.md) -- import directives and module resolution
 - [Collections](collections.md) -- List, Map, Set, and StringBuilder
 - [Traits](traits.md) -- the `Display` trait used by type conversions
 - [Types and Literals](types-and-literals.md) -- primitive type definitions

--- a/docs/utilities.md
+++ b/docs/utilities.md
@@ -418,6 +418,7 @@ Converts a `List[char]` to a `str`. Used internally by `StringBuilder::build`.
 
 ## See Also
 
-- [Standard Library](standard-library.md) -- arrays, Option, Result, and the `import` directive
+- [Standard Library](standard-library.md) -- arrays, Option, and Result
+- [Modules](modules.md) -- import directives and module resolution
 - [Collections](collections.md) -- List, Map, Set, and StringBuilder
 - [Strings and IO](strings-and-io.md) -- string methods and file I/O

--- a/tests/compiler/errors/selective_import_global_dependency.casa
+++ b/tests/compiler/errors/selective_import_global_dependency.casa
@@ -1,0 +1,4 @@
+# expect: INVALID_VARIABLE
+import "../fixtures/selective_import_global_lib.casa" { read_state }
+
+read_state

--- a/tests/compiler/errors/selective_import_global_write_dependency.casa
+++ b/tests/compiler/errors/selective_import_global_write_dependency.casa
@@ -1,0 +1,4 @@
+# expect: UNDEFINED_GLOBAL
+import "../fixtures/selective_import_global_lib.casa" { write_state }
+
+write_state

--- a/tests/compiler/errors/selective_import_missing_symbol.casa
+++ b/tests/compiler/errors/selective_import_missing_symbol.casa
@@ -1,0 +1,4 @@
+# expect: UNDEFINED_NAME
+import "../fixtures/selective_import_lib.casa" { not_here }
+
+not_here

--- a/tests/compiler/fixtures/selective_import_global_lib.casa
+++ b/tests/compiler/fixtures/selective_import_global_lib.casa
@@ -1,0 +1,10 @@
+10 = SHARED_STATE
+
+fn read_state -> int {
+    SHARED_STATE
+}
+
+fn write_state {
+    global SHARED_STATE
+    11 = SHARED_STATE
+}

--- a/tests/compiler/fixtures/selective_import_lib.casa
+++ b/tests/compiler/fixtures/selective_import_lib.casa
@@ -1,0 +1,44 @@
+import "../../../lib/std.casa"
+
+const SELECTIVE_BASE 40
+
+fn selective_inc x:int -> int {
+    x 2 +
+}
+
+fn selected_value -> int {
+    SELECTIVE_BASE selective_inc
+}
+
+fn hidden_value -> int {
+    0
+}
+
+struct SelectiveBox {
+    value: int
+}
+
+impl SelectiveBox {
+    fn double self:SelectiveBox -> int {
+        self SelectiveBox::value 2 *
+    }
+}
+
+fn make_box -> SelectiveBox {
+    5 SelectiveBox
+}
+
+enum SelectiveColor {
+    Red
+    Green
+}
+
+impl SelectiveColor {
+    fn code self:SelectiveColor -> int {
+        self match
+            SelectiveColor::Red => 1
+            SelectiveColor::Green => 2
+        end
+    }
+}
+1 exit

--- a/tests/compiler/selective_import_module_fixture.casa
+++ b/tests/compiler/selective_import_module_fixture.casa
@@ -1,0 +1,6 @@
+import "../../lib/std.casa"
+
+fn module_value -> int {
+    7
+}
+1 exit

--- a/tests/compiler/test_parser.casa
+++ b/tests/compiler/test_parser.casa
@@ -535,6 +535,20 @@ fn test_parse_keyword_import {
     "path" "/foo.casa" 0 ops.get op_str_value assert_str_eq
 }
 
+fn test_parse_keyword_selective_import {
+    "parse_keyword_selective_import" test_start
+    "test" "import \"/foo.casa\" { alpha Beta::gamma }" lex_source = tokens
+    tokens DEFAULT_PARSER parse_ops = ops
+    "count" 1 ops.length assert_eq
+    "kind" 0 ops.get.value OpValue::ImportFileSelective is assert_true
+    if 0 ops.get.value OpValue::ImportFileSelective(selective_import) is then
+        "path" "/foo.casa" selective_import SelectiveImport::path assert_str_eq
+        "symbol count" 2 selective_import SelectiveImport::symbols.length assert_eq
+        "first symbol" "alpha" 0 selective_import SelectiveImport::symbols.get assert_str_eq
+        "second symbol" "Beta::gamma" 1 selective_import SelectiveImport::symbols.get assert_str_eq
+    fi
+}
+
 # ============================================================================
 # Import resolver tests
 # ============================================================================
@@ -711,6 +725,7 @@ test_parse_keyword_elif
 test_parse_keyword_break
 test_parse_keyword_continue
 test_parse_keyword_import
+test_parse_keyword_selective_import
 test_is_path_specifier_casa_extension
 test_is_path_specifier_slash
 test_is_path_specifier_module

--- a/tests/compiler/test_selective_import.casa
+++ b/tests/compiler/test_selective_import.casa
@@ -1,0 +1,27 @@
+import "../../lib/std.casa"
+import "fixtures/selective_import_lib.casa" { selected_value SelectiveBox SelectiveColor SELECTIVE_BASE }
+import "selective_import_module_fixture" { module_value }
+
+fn assert_selected_value actual:int {
+    if actual 42 != then
+        1 exit
+    fi
+}
+selected_value assert_selected_value
+if module_value 7 != then
+    1 exit
+fi
+21 SelectiveBox = box
+if box SelectiveBox::double 42 != then
+    1 exit
+fi
+if box SelectiveBox::value 21 != then
+    1 exit
+fi
+if SelectiveColor::Green.code 2 != then
+    1 exit
+fi
+if SELECTIVE_BASE 40 != then
+    1 exit
+fi
+"1 passed, 0 failed" print

--- a/tests/compiler/test_selective_import_type_deps.casa
+++ b/tests/compiler/test_selective_import_type_deps.casa
@@ -1,0 +1,7 @@
+import "../../lib/std.casa"
+import "fixtures/selective_import_lib.casa" { make_box }
+
+if make_box.value 5 != then
+    1 exit
+fi
+"1 passed, 0 failed" print


### PR DESCRIPTION
## Summary
- add selective import parsing for `import "path" { symbol ... }`
- extract named functions, constants, structs, enums, traits, and transitive dependencies while skipping imported top-level code
- reject missing symbols and skipped global variable dependencies
- document selective import semantics

Closes #180

## Validation
- `./casafmt` on changed Casa files
- `./casac -L lib casa.casa -o casac`
- `tests/test_examples.sh`
- `tests/test_compiler.sh < /dev/null`