### PR TITLE
fix: keep compiler tests headless

### DIFF
--- a/docs/agents/pitfalls.md
+++ b/docs/agents/pitfalls.md
@@ -4,14 +4,6 @@ Known Casa gotchas that aren't yet captured as fixes. Each entry has a one-line
 description, a workaround, and a link to the tracking issue. Remove an entry when its
 issue closes.
 
-## `test_lsp` blocks on stdin
-
-`tests/test_compiler.sh` includes a `test_lsp` unit that reads from stdin and waits
-for Enter. When the script is run non-interactively the suite hangs forever.
-
-- **Workaround:** redirect stdin — `tests/test_compiler.sh < /dev/null`.
-- **Tracking:** [#170](https://github.com/frendsick/casa/issues/170).
-
 ## Type enum methods may consume the value (context-dependent)
 
 Casa enum values (`Type`, `Option[T]`) are usually safe to call methods on multiple
@@ -23,7 +15,6 @@ extractions feed into multiple methods.
 - **Default:** write the cleaner reuse-the-value code.
 - **If you hit a stage2 crash** after an enum method call: bind the intermediate
   result to a fresh variable, or fall back to formatting once and threading the
-  string through. Then verify with `tests/test_compiler.sh < /dev/null` and
-  `tests/test_examples.sh`.
+  string through. Then verify with `tests/test_compiler.sh` and `tests/test_examples.sh`.
 - No tracking issue yet — root cause unconfirmed. File one if you reproduce a
   specific crash pattern.

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -14,12 +14,8 @@ Rules for running and updating tests.
 
   ```
   tests/test_examples.sh
-  tests/test_compiler.sh < /dev/null
+  tests/test_compiler.sh
   ```
-
-  The stdin redirect on `test_compiler.sh` is required to avoid hanging in the
-  `test_lsp` unit when run non-interactively. Tracked in
-  [issue #170](https://github.com/frendsick/casa/issues/170).
 
 - Both scripts default to the `./casac` binary at the repo root. Rebuild casac before
   testing if compiler sources changed:

--- a/tests/test_compiler.sh
+++ b/tests/test_compiler.sh
@@ -34,7 +34,8 @@ for f in "$TESTS_DIR"/test_*.casa; do
         continue
     fi
 
-    output=$("$binary" 2>&1) || {
+    # Keep tests headless even when a compiled test reads stdin.
+    output=$("$binary" 2>&1 < /dev/null) || {
         printf "${RED}RUNTIME FAIL${RESET}\n"
         echo "$output"
         fail=$((fail+1))


### PR DESCRIPTION
## Summary
- run compiled compiler-test binaries with stdin closed from inside the test harness
- remove the old external redirect workaround from agent docs

Closes #170

## Tests
- tests/test_compiler.sh
- tests/test_examples.sh
