### PR TITLE
feat: allow const declarations to reference other constants directly

### DIFF
--- a/compiler/syntax.casa
+++ b/compiler/syntax.casa
@@ -2746,7 +2746,7 @@ fn get_op_keyword parser:Parser token:Token cursor:TokenCursor function_name:str
         fi
         cursor.pop = const_value_token_opt
         if const_value_token_opt.is_none then
-            token Token::location "Expected a literal value or block expression after constant name" ErrorKind::Syntax raise_error
+            token Token::location "Expected a literal value, block expression, or constant name after constant name" ErrorKind::Syntax raise_error
         fi
         const_value_token_opt.unwrap = const_value_token
         if "{" const_value_token Token::value == then
@@ -2758,8 +2758,23 @@ fn get_op_keyword parser:Parser token:Token cursor:TokenCursor function_name:str
             const_value_token Token::value parse_literal_to_constant_value = const_lit_val
             token Token::location const_lit_val const_name Constant = casa_const
             const_name casa_const parser.store.constants.set drop
+        elif TokenKind::Identifier const_value_token Token::kind == then
+            const_value_token Token::value = const_ref_name
+            const_ref_name parser.store.constants.get = const_ref_opt
+            if const_ref_opt.is_some then
+                token Token::location const_ref_opt.unwrap Constant::value const_name Constant = casa_const
+                const_name casa_const parser.store.constants.set drop
+            elif const_ref_name parser.store.functions.get.is_some then
+                token Token::location f"Cannot use `{const_ref_name}` as a constant value; it is not a constant" ErrorKind::Syntax raise_error
+            elif const_ref_name parser.store.structs.get.is_some then
+                token Token::location f"Cannot use `{const_ref_name}` as a constant value; it is not a constant" ErrorKind::Syntax raise_error
+            elif const_ref_name parser.store.enums.get.is_some then
+                token Token::location f"Cannot use `{const_ref_name}` as a constant value; it is not a constant" ErrorKind::Syntax raise_error
+            else
+                token Token::location f"Undefined constant `{const_ref_name}` referenced in constant `{const_name}`" ErrorKind::Syntax raise_error
+            fi
         else
-            token Token::location f"Expected a literal value or block expression for constant `{const_name}`" ErrorKind::Syntax raise_error
+            token Token::location f"Expected a literal value, block expression, or constant name for constant `{const_name}`" ErrorKind::Syntax raise_error
         fi
         return
     fi


### PR DESCRIPTION
## Summary

- Allow `const FOO BAR` syntax where `BAR` is a previously-declared constant, eliminating the need for block syntax (`const FOO { BAR }`) when aliasing constants
- Add differentiated error messages: "not a constant" when referencing functions/structs/enums, "undefined constant" for unknown identifiers
- Update generic error messages to mention the new form

Closes #185

## Test plan

- [x] `const ALIAS EXISTING_CONST` resolves to the referenced constant's value
- [x] Chained aliases (`const A 1; const B A; const C B`) work correctly
- [x] Forward references produce clear error
- [x] Referencing a function/struct/enum produces "not a constant" error
- [x] Referencing an undefined identifier produces "undefined constant" error
- [x] All 46 compiler tests pass (including self-compilation and fixed-point)
- [x] All 40 example tests pass