### PR TITLE
fix(lsp): omit unbounded type-variable prefixes in stack effects

### DIFF
--- a/lsp.casa
+++ b/lsp.casa
@@ -2139,11 +2139,11 @@ fn op_value_stack_effect op_value:OpValue -> Option[str] {
         OpValue::Ge => ">=: [T: Ord] T T -> bool" Option::Some
         OpValue::And => "&&: bool bool -> bool" Option::Some
         OpValue::Or => "||: bool bool -> bool" Option::Some
-        OpValue::Drop => "drop[T]: T -> None" Option::Some
-        OpValue::Dup => "dup[T]: T -> T T" Option::Some
-        OpValue::Swap => "swap[T1 T2]: T1 T2 -> T2 T1" Option::Some
-        OpValue::Over => "over[T1 T2]: T1 T2 -> T2 T1 T2" Option::Some
-        OpValue::Rot => "rot[T1 T2 T3]: T1 T2 T3 -> T3 T1 T2" Option::Some
+        OpValue::Drop => "drop: T -> None" Option::Some
+        OpValue::Dup => "dup: T -> T T" Option::Some
+        OpValue::Swap => "swap: T1 T2 -> T2 T1" Option::Some
+        OpValue::Over => "over: T1 T2 -> T2 T1 T2" Option::Some
+        OpValue::Rot => "rot: T1 T2 T3 -> T3 T1 T2" Option::Some
         OpValue::Print => "print: [T: Display] T -> None" Option::Some
         OpValue::PrintInt => "print: [T: Display] T -> None" Option::Some
         OpValue::PrintStr => "print: [T: Display] T -> None" Option::Some
@@ -2151,7 +2151,7 @@ fn op_value_stack_effect op_value:OpValue -> Option[str] {
         OpValue::PrintChar => "print: [T: Display] T -> None" Option::Some
         OpValue::PrintCstr => "print: [T: Display] T -> None" Option::Some
         OpValue::FnExec => "exec: fn[sig] -> ..." Option::Some
-        OpValue::Typeof => "typeof: [T] T -> str" Option::Some
+        OpValue::Typeof => "typeof: T -> str" Option::Some
         OpValue::AssignDec(_) => "-=: int -> None" Option::Some
         OpValue::AssignInc(_) => "+=: int -> None" Option::Some
         OpValue::HeapAlloc => "alloc: int -> ptr" Option::Some

--- a/tests/compiler/test_lsp.casa
+++ b/tests/compiler/test_lsp.casa
@@ -558,7 +558,7 @@ fn test_compute_hover_drop {
     "42 drop" lsp_test_state = state
     3 0 state compute_hover = result
     "is some" result.is_some assert_true
-    "contains drop effect" 0 result.unwrap HoverContent::content "drop[T]: T -> None" str::find >= assert_true
+    "contains drop effect" 0 result.unwrap HoverContent::content "drop: T -> None" str::find >= assert_true
 }
 
 fn test_compute_hover_dup {
@@ -566,7 +566,7 @@ fn test_compute_hover_dup {
     "42 dup drop drop" lsp_test_state = state
     3 0 state compute_hover = result
     "is some" result.is_some assert_true
-    "contains dup effect" 0 result.unwrap HoverContent::content "dup[T]: T -> T T" str::find >= assert_true
+    "contains dup effect" 0 result.unwrap HoverContent::content "dup: T -> T T" str::find >= assert_true
 }
 
 fn test_compute_hover_swap {
@@ -574,7 +574,7 @@ fn test_compute_hover_swap {
     "1 2 swap drop drop" lsp_test_state = state
     4 0 state compute_hover = result
     "is some" result.is_some assert_true
-    "contains swap effect" 0 result.unwrap HoverContent::content "swap[T1 T2]: T1 T2 -> T2 T1" str::find >= assert_true
+    "contains swap effect" 0 result.unwrap HoverContent::content "swap: T1 T2 -> T2 T1" str::find >= assert_true
 }
 
 fn test_compute_hover_over {
@@ -582,7 +582,7 @@ fn test_compute_hover_over {
     "1 2 over drop drop drop" lsp_test_state = state
     4 0 state compute_hover = result
     "is some" result.is_some assert_true
-    "contains over effect" 0 result.unwrap HoverContent::content "over[T1 T2]: T1 T2 -> T2 T1 T2" str::find >= assert_true
+    "contains over effect" 0 result.unwrap HoverContent::content "over: T1 T2 -> T2 T1 T2" str::find >= assert_true
 }
 
 fn test_compute_hover_rot {
@@ -590,7 +590,7 @@ fn test_compute_hover_rot {
     "1 2 3 rot drop drop drop" lsp_test_state = state
     6 0 state compute_hover = result
     "is some" result.is_some assert_true
-    "contains rot effect" 0 result.unwrap HoverContent::content "rot[T1 T2 T3]: T1 T2 T3 -> T3 T1 T2" str::find >= assert_true
+    "contains rot effect" 0 result.unwrap HoverContent::content "rot: T1 T2 T3 -> T3 T1 T2" str::find >= assert_true
 }
 
 fn test_compute_hover_not {


### PR DESCRIPTION
Closes #190

Unbounded type variables are already visible in the stack effect itself, so the `[T]` prefix adds noise. This PR removes them from LSP hover strings.

## Changes

- `drop[T]: T -> None` → `drop: T -> None`
- `dup[T]: T -> T T` → `dup: T -> T T`
- `swap[T1 T2]: T1 T2 -> T2 T1` → `swap: T1 T2 -> T2 T1`
- `over[T1 T2]: T1 T2 -> T2 T1 T2` → `over: T1 T2 -> T2 T1 T2`
- `rot[T1 T2 T3]: T1 T2 T3 -> T3 T1 T2` → `rot: T1 T2 T3 -> T3 T1 T2`
- `typeof: [T] T -> str` → `typeof: T -> str`

Constrained prefixes (`[T: Eq]`, `[T: Display]`, `[T: Word]`, etc.) are unchanged.

## Test plan

- [x] `tests/test_compiler.sh` — 46 passed, 0 failed
- [x] `tests/test_examples.sh` — 40 passed, 0 failed