### PR TITLE
refactor: rename stack effect model

### DIFF
--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -357,7 +357,7 @@ fn substitute_ops_types ops:List[Op] subs:Map[str Type] {
 }
 
 # ============================================================================
-# Function signature types
+# Stack effect types
 # ============================================================================
 
 struct Parameter {
@@ -373,27 +373,27 @@ fn make_named_param typ:Type name:str -> Parameter {
     name typ Parameter
 }
 
-struct Signature {
+struct StackEffect {
     parameters:   List[Parameter]
     return_types: List[Type]
     type_vars:    Set[str]
     trait_bounds: Map[str TraitBound]
 }
 
-fn empty_signature -> Signature {
+fn empty_stack_effect -> StackEffect {
     Map::new(Map[str TraitBound])
     Set::new(Set[str])
     List::new(List[Type])
     List::new(List[Parameter])
-    Signature
+    StackEffect
 }
 
-fn make_signature params:List[Parameter] returns:List[Type] -> Signature {
+fn make_stack_effect params:List[Parameter] returns:List[Type] -> StackEffect {
     Map::new(Map[str TraitBound])
     Set::new(Set[str])
     returns
     params
-    Signature
+    StackEffect
 }
 
 # ============================================================================
@@ -733,10 +733,10 @@ struct CasaStruct {
 # ============================================================================
 
 struct TraitMethod {
-    name:        str
-    signature:   Signature
-    default_ops: List[Op]
-    type_vars:   List[str]
+    name:         str
+    stack_effect: StackEffect
+    default_ops:  List[Op]
+    type_vars:    List[str]
 }
 
 struct CasaTrait {
@@ -825,7 +825,7 @@ struct Function {
     name:                 str
     ops:                  List[Op]
     location:             Location
-    signature:            Signature
+    stack_effect:         StackEffect
     bytecode:             List[InstValue]
     is_used:              bool
     is_typechecked:       bool
@@ -836,11 +836,16 @@ struct Function {
 }
 
 fn make_function name:str ops:List[Op] location:Location -> Function {
-    false false List::new(List[Variable]) List::new(List[Variable]) false false List::new(List[InstValue]) empty_signature location ops name Function
+    false false List::new(List[Variable]) List::new(List[Variable]) false false List::new(List[InstValue]) empty_stack_effect location ops name Function
 }
 
-fn make_function_with_sig name:str ops:List[Op] location:Location sig:Signature -> Function {
-    false false List::new(List[Variable]) List::new(List[Variable]) false false List::new(List[InstValue]) sig location ops name Function
+fn make_function_with_stack_effect
+    name:str
+    ops:List[Op]
+    location:Location
+    effect:StackEffect
+-> Function {
+    false false List::new(List[Variable]) List::new(List[Variable]) false false List::new(List[InstValue]) effect location ops name Function
 }
 
 # ============================================================================
@@ -1181,40 +1186,6 @@ impl Type {
         end
     }
 
-    fn exists_recursive self:Type function_opt:Option[Function] -> bool {
-        self match
-            Type::Unknown => { false }
-            Type::Builtin(_) => { true }
-            Type::TypeVar(name) => {
-                if function_opt Option::Some(check_fn) is then
-                    name check_fn Function::signature Signature::type_vars.has return
-                fi
-                false
-            }
-            Type::Generic(generic) => {
-                for param in generic.params.iter do
-                    if function_opt param.exists_recursive ! then false return fi
-                done
-                if generic.base DEFAULT_PARSER.store.structs.get.is_some then true return fi
-                if generic.base DEFAULT_PARSER.store.enums.get.is_some then true return fi
-                if "array" generic.base == then true return fi
-                if function_opt Option::Some(check_fn) is then
-                    if generic.base check_fn Function::signature Signature::type_vars.has then true return fi
-                fi
-                false
-            }
-            Type::Function(fn_type) => {
-                for param in fn_type.parameters.iter do
-                    if function_opt param.exists_recursive ! then false return fi
-                done
-                for ret in fn_type.return_types.iter do
-                    if function_opt ret.exists_recursive ! then false return fi
-                done
-                true
-            }
-        end
-    }
-
     fn is_self_type self:Type -> bool {
         self match
             Type::Generic(generic) => {
@@ -1438,62 +1409,62 @@ fn build_resolved_type_t base:str type_vars:List[str] bindings:Map[str Type] -> 
 }
 
 # ============================================================================
-# Signature utilities
+# StackEffect utilities
 # ============================================================================
 
-fn signature_to_str sig:Signature -> str {
+fn stack_effect_to_str effect:StackEffect -> str {
     StringBuilder::new = builder
-    if 0 sig Signature::parameters.length == then
+    if 0 effect StackEffect::parameters.length == then
         "None" builder.append
     else
         0 = index
-        while index sig Signature::parameters.length > do
+        while index effect StackEffect::parameters.length > do
             if 0 index != then
                 " " builder.append
             fi
-            index sig Signature::parameters.get Parameter::typ.format builder.append
+            index effect StackEffect::parameters.get Parameter::typ.format builder.append
             1 += index
         done
     fi
     " -> " builder.append
-    if 0 sig Signature::return_types.length == then
+    if 0 effect StackEffect::return_types.length == then
         "None" builder.append
     else
         0 = index
-        while index sig Signature::return_types.length > do
+        while index effect StackEffect::return_types.length > do
             if 0 index != then
                 " " builder.append
             fi
-            index sig Signature::return_types.get.format builder.append
+            index effect StackEffect::return_types.get.format builder.append
             1 += index
         done
     fi
     builder.build
 }
 
-fn signature_to_function_type sig:Signature -> Type {
+fn stack_effect_to_function_type effect:StackEffect -> Type {
     List::new(List[Type]) = fn_params
-    for fn_param in sig Signature::parameters.iter do
+    for fn_param in effect StackEffect::parameters.iter do
         fn_param Parameter::typ fn_params.push
     done
     List::new(List[Type]) = fn_returns
-    for fn_return in sig Signature::return_types.iter do
+    for fn_return in effect StackEffect::return_types.iter do
         fn_return fn_returns.push
     done
     fn_returns fn_params FunctionType Type::Function
 }
 
-fn function_type_to_signature fn_type:FunctionType -> Signature {
+fn function_type_to_stack_effect fn_type:FunctionType -> StackEffect {
     List::new(List[Parameter]) = params
     for param_type in fn_type FunctionType::parameters.iter do
         "" param_type Parameter params.push
     done
-    fn_type FunctionType::return_types params make_signature
+    fn_type FunctionType::return_types params make_stack_effect
 }
 
-fn signature_from_str sig_str:str -> Signature {
-    # Parse "param1 param2 -> ret1 ret2" into Signature
-    sig_str split_type_tokens = tokens
+fn stack_effect_from_str effect_str:str -> StackEffect {
+    # Parse "param1 param2 -> ret1 ret2" into StackEffect.
+    effect_str split_type_tokens = tokens
 
     # Find the -> separator
     -1 = arrow_index
@@ -1529,10 +1500,10 @@ fn signature_from_str sig_str:str -> Signature {
         1 += index
     done
 
-    returns params make_signature
+    returns params make_stack_effect
 }
 
-fn signature_type_param_matches expected:Type actual:Type type_vars:Set[str] -> bool {
+fn stack_effect_type_param_matches expected:Type actual:Type type_vars:Set[str] -> bool {
     if expected actual.eq then true return fi
     if expected.is_unknown_placeholder then true return fi
     if actual.is_unknown_placeholder then true return fi
@@ -1545,7 +1516,30 @@ fn signature_type_param_matches expected:Type actual:Type type_vars:Set[str] -> 
     false
 }
 
-fn signature_type_matches expected:Type actual:Type -> bool {
+fn collect_stack_effect_type_vars typ:Type type_vars:Set[str] -> Set[str] {
+    if typ.type_var_name Option::Some(type_var_name) is then
+        type_var_name type_vars.add return
+    fi
+    typ match
+        Type::Generic(generic) => {
+            for generic_param in generic.params.iter do
+                type_vars generic_param collect_stack_effect_type_vars = type_vars
+            done
+        }
+        Type::Function(fn_type) => {
+            for fn_param in fn_type.parameters.iter do
+                type_vars fn_param collect_stack_effect_type_vars = type_vars
+            done
+            for fn_return in fn_type.return_types.iter do
+                type_vars fn_return collect_stack_effect_type_vars = type_vars
+            done
+        }
+        _ => { }
+    end
+    type_vars
+}
+
+fn stack_effect_type_matches expected:Type actual:Type -> bool {
     if expected actual.eq then true return fi
     if expected.is_unknown_placeholder then true return fi
     if actual.is_unknown_placeholder then true return fi
@@ -1595,14 +1589,14 @@ fn signature_type_matches expected:Type actual:Type -> bool {
                     if expected_fn.return_types.length actual_fn.return_types.length != then false return fi
                     0 = fn_index
                     while fn_index expected_fn.parameters.length > do
-                        if fn_index actual_fn.parameters.get fn_index expected_fn.parameters.get signature_type_matches ! then
+                        if fn_index actual_fn.parameters.get fn_index expected_fn.parameters.get stack_effect_type_matches ! then
                             false return
                         fi
                         1 += fn_index
                     done
                     0 = fn_index
                     while fn_index expected_fn.return_types.length > do
-                        if fn_index actual_fn.return_types.get fn_index expected_fn.return_types.get signature_type_matches ! then
+                        if fn_index actual_fn.return_types.get fn_index expected_fn.return_types.get stack_effect_type_matches ! then
                             false return
                         fi
                         1 += fn_index
@@ -1618,25 +1612,15 @@ fn signature_type_matches expected:Type actual:Type -> bool {
                     if expected_generic.base actual_generic.base != then false return fi
                     if expected_generic.params.length actual_generic.params.length != then false return fi
                     Set::new(Set[str]) = type_vars
-                    expected_generic.base DEFAULT_PARSER.store.enums.get = enum_opt
-                    if enum_opt.is_some then
-                        for type_var in enum_opt.unwrap CasaEnum::type_vars.iter do
-                            type_var type_vars.add = type_vars
-                        done
-                    fi
-                    expected_generic.base DEFAULT_PARSER.store.structs.get = struct_opt
-                    if struct_opt.is_some then
-                        for type_var in struct_opt.unwrap CasaStruct::type_vars.iter do
-                            type_var type_vars.add = type_vars
-                        done
-                    fi
+                    type_vars expected collect_stack_effect_type_vars = type_vars
+                    type_vars actual collect_stack_effect_type_vars = type_vars
                     0 = param_index
                     while param_index expected_generic.params.length > do
                         if
                         type_vars
                         param_index actual_generic.params.get
                         param_index expected_generic.params.get
-                        signature_type_param_matches !
+                        stack_effect_type_param_matches !
                         then
                             false return
                         fi
@@ -1652,30 +1636,30 @@ fn signature_type_matches expected:Type actual:Type -> bool {
     false
 }
 
-fn signature_matches sig_a:Signature sig_b:Signature -> bool {
-    # Check if two signatures are compatible, respecting any types.
-    if sig_a Signature::parameters.length sig_b Signature::parameters.length != then
+fn stack_effect_matches effect_a:StackEffect effect_b:StackEffect -> bool {
+    # Check if two stack effects are compatible, respecting any types.
+    if effect_a StackEffect::parameters.length effect_b StackEffect::parameters.length != then
         false return
     fi
-    if sig_a Signature::return_types.length sig_b Signature::return_types.length != then
+    if effect_a StackEffect::return_types.length effect_b StackEffect::return_types.length != then
         false return
     fi
 
     0 = index
-    while index sig_a Signature::parameters.length > do
-        index sig_a Signature::parameters.get Parameter::typ = type_a
-        index sig_b Signature::parameters.get Parameter::typ = type_b
-        if type_b type_a signature_type_matches ! then
+    while index effect_a StackEffect::parameters.length > do
+        index effect_a StackEffect::parameters.get Parameter::typ = type_a
+        index effect_b StackEffect::parameters.get Parameter::typ = type_b
+        if type_b type_a stack_effect_type_matches ! then
             false return
         fi
         1 += index
     done
 
     0 = index
-    while index sig_a Signature::return_types.length > do
-        index sig_a Signature::return_types.get = return_a
-        index sig_b Signature::return_types.get = return_b
-        if return_b return_a signature_type_matches ! then
+    while index effect_a StackEffect::return_types.length > do
+        index effect_a StackEffect::return_types.get = return_a
+        index effect_b StackEffect::return_types.get = return_b
+        if return_b return_a stack_effect_type_matches ! then
             false return
         fi
         1 += index
@@ -1684,27 +1668,27 @@ fn signature_matches sig_a:Signature sig_b:Signature -> bool {
     true
 }
 
-fn apply_type_subs_to_sig_t sig:Signature subs:Map[str Type] -> Signature {
+fn apply_type_subs_to_stack_effect effect:StackEffect subs:Map[str Type] -> StackEffect {
     if 0 subs.length == then
-        sig return
+        effect return
     fi
     List::new(List[Parameter]) = params
-    for param in sig Signature::parameters.iter do
+    for param in effect StackEffect::parameters.iter do
         subs param Parameter::typ.substitute_t = new_typ
         param Parameter::name new_typ make_named_param params.push
     done
     List::new(List[Type]) = returns
-    for return_type in sig Signature::return_types.iter do
+    for return_type in effect StackEffect::return_types.iter do
         subs return_type.substitute_t returns.push
     done
-    returns params make_signature
+    returns params make_stack_effect
 }
 
-fn resolve_trait_sig sig:Signature type_var:str -> Signature {
-    # Replace 'self' type with type_var in a trait method signature.
+fn resolve_trait_stack_effect effect:StackEffect type_var:str -> StackEffect {
+    # Replace 'self' type with type_var in a trait method stack effect.
     type_var parse_type_str = self_replacement
     List::new(List[Parameter]) = params
-    for param in sig Signature::parameters.iter do
+    for param in effect StackEffect::parameters.iter do
         if param Parameter::typ.is_self_type then
             self_replacement
         else
@@ -1714,7 +1698,7 @@ fn resolve_trait_sig sig:Signature type_var:str -> Signature {
     done
 
     List::new(List[Type]) = returns
-    for ret in sig Signature::return_types.iter do
+    for ret in effect StackEffect::return_types.iter do
         if ret.is_self_type then
             self_replacement returns.push
         else
@@ -1722,7 +1706,7 @@ fn resolve_trait_sig sig:Signature type_var:str -> Signature {
         fi
     done
 
-    returns params make_signature
+    returns params make_stack_effect
 }
 
 # ============================================================================

--- a/compiler/syntax.casa
+++ b/compiler/syntax.casa
@@ -856,10 +856,10 @@ fn parse_return_types cursor:TokenCursor -> List[Type] {
 }
 
 # ============================================================================
-# parse_signature - parse function signature
+# parse_stack_effect - parse function stack effect
 # ============================================================================
 
-fn parse_signature cursor:TokenCursor -> Signature {
+fn parse_stack_effect cursor:TokenCursor -> StackEffect {
     cursor parse_parameters = params
     List::new(List[Type]) = returns
 
@@ -871,7 +871,7 @@ fn parse_signature cursor:TokenCursor -> Signature {
         cursor.advance # consume ->
         cursor parse_return_types = returns
     fi
-    returns params make_signature
+    returns params make_stack_effect
 }
 
 # ============================================================================
@@ -942,8 +942,8 @@ fn build_hidden_trait_methods
                 # Skip default methods — only abstract methods need hidden fn ptrs
                 if 0 bound_method TraitMethod::default_ops.length == then
                     f"__trait_{bound_type_var}_{bound_method TraitMethod::name}" = hidden_name
-                    bound_subs bound_type_var bound_method TraitMethod::signature resolve_trait_sig apply_type_subs_to_sig_t = hidden_sig
-                    hidden_sig signature_to_function_type = hidden_type
+                    bound_subs bound_type_var bound_method TraitMethod::stack_effect resolve_trait_stack_effect apply_type_subs_to_stack_effect = hidden_stack_effect
+                    hidden_stack_effect stack_effect_to_function_type = hidden_type
                     hidden_type hidden_name HiddenTraitMethod result.push
                 fi
             done
@@ -980,7 +980,7 @@ fn try_fold_const_fn_call parser:Parser ops:List[Op] op_index:int fn_name:str cu
     fn_name parser.store.functions.get = fold_fn_opt
     if fold_fn_opt.is_none then op_index return fi
     if fold_fn_opt.unwrap Function::is_const_fn ! then op_index return fi
-    fold_fn_opt.unwrap Function::signature Signature::parameters.length = fold_param_count
+    fold_fn_opt.unwrap Function::stack_effect StackEffect::parameters.length = fold_param_count
     op_index 1 - = call_idx
     call_idx fold_param_count - = first_arg_idx
     if 0 first_arg_idx > then op_index return fi
@@ -1182,7 +1182,7 @@ fn eval_const_fn
         location f"`{fn_name}` is not a const fn" ErrorKind::Syntax raise_error
     fi
     fn_name eval_stack.push
-    function Function::signature Signature::parameters.length = param_count
+    function Function::stack_effect StackEffect::parameters.length = param_count
     List::new(List[ConstantValue]) = fn_stack
     Map::new(Map[str ConstantValue]) = locals
     if param_count stack.length < then
@@ -1343,24 +1343,24 @@ fn parse_function parser:Parser cursor:TokenCursor -> Function {
         fi
     fi
 
-    cursor parse_signature = sig
+    cursor parse_stack_effect = effect
 
-    # Add type vars to the signature
+    # Add type vars to the stack effect
     if 0 type_vars.length != then
         for type_var in type_vars.iter do
-            type_var sig Signature::type_vars.add = new_type_vars
-            new_type_vars sig Signature::set_type_vars
+            type_var effect StackEffect::type_vars.add = new_type_vars
+            new_type_vars effect StackEffect::set_type_vars
         done
         # Set trait bounds from LAST_TRAIT_BOUNDS (set by parse_type_vars)
-        LAST_TRAIT_BOUNDS sig Signature::set_trait_bounds
+        LAST_TRAIT_BOUNDS effect StackEffect::set_trait_bounds
     fi
     List::new(List[Op]) = ops
     List::new(List[Variable]) = variables
 
     # Inject hidden __trait_* parameters for trait-bounded type vars
-    if 0 sig Signature::trait_bounds.keys.length != then
+    if 0 effect StackEffect::trait_bounds.keys.length != then
         List::new(List[Parameter]) = hidden_params
-        sig Signature::trait_bounds parser build_hidden_trait_methods = hidden_methods
+        effect StackEffect::trait_bounds parser build_hidden_trait_methods = hidden_methods
         for hidden in hidden_methods.iter do
             hidden HiddenTraitMethod::var_name = hidden_name
             hidden HiddenTraitMethod::fn_type = hidden_type
@@ -1370,15 +1370,15 @@ fn parse_function parser:Parser cursor:TokenCursor -> Function {
             hidden_type Option::Some hidden_assign Op::set_type_hint
             hidden_assign ops.push
         done
-        # Prepend hidden params to signature parameters
-        for sig_parameter in sig Signature::parameters.iter do
-            sig_parameter hidden_params.push
+        # Prepend hidden params to stack effect parameters
+        for effect_parameter in effect StackEffect::parameters.iter do
+            effect_parameter hidden_params.push
         done
-        hidden_params sig Signature::set_parameters
+        hidden_params effect StackEffect::set_parameters
     fi
 
     # Register named parameters as variables and generate assign ops
-    for param in sig Signature::parameters.iter do
+    for param in effect StackEffect::parameters.iter do
         if "" param Parameter::name != then
             if param Parameter::name "__trait_" str::starts_with ! then
                 param Parameter::typ param Parameter::name Variable variables.push
@@ -1392,7 +1392,7 @@ fn parse_function parser:Parser cursor:TokenCursor -> Function {
         body_op ops.push
     done
 
-    sig name_token Token::location ops name_token Token::value make_function_with_sig = function
+    effect name_token Token::location ops name_token Token::value make_function_with_stack_effect = function
     variables function Function::set_variables
     function
 }
@@ -1481,8 +1481,8 @@ fn synthesize_hashable_for_enum parser:Parser casa_enum:CasaEnum {
         enum_name make_param hash_params.push
         List::new(List[Type]) = hash_returns
         "int" parse_type_str hash_returns.push
-        hash_returns hash_params make_signature = hash_sig
-        hash_sig location hash_ops hash_name make_function_with_sig = hash_fn
+        hash_returns hash_params make_stack_effect = hash_stack_effect
+        hash_stack_effect location hash_ops hash_name make_function_with_stack_effect = hash_fn
         hash_fn hash_name parser.store.functions.set drop
     fi
 
@@ -1495,8 +1495,8 @@ fn synthesize_hashable_for_enum parser:Parser casa_enum:CasaEnum {
         enum_name make_param eq_params.push
         List::new(List[Type]) = eq_returns
         "bool" parse_type_str eq_returns.push
-        eq_returns eq_params make_signature = eq_sig
-        eq_sig location eq_ops eq_name make_function_with_sig = eq_fn
+        eq_returns eq_params make_stack_effect = eq_stack_effect
+        eq_stack_effect location eq_ops eq_name make_function_with_stack_effect = eq_fn
         eq_fn eq_name parser.store.functions.set drop
     fi
 }
@@ -1524,11 +1524,11 @@ fn create_member_accessor
 
     # Parameterize the struct name when the struct has type vars
     struct_name = param_type
-    Set::new(Set[str]) = sig_type_vars
+    Set::new(Set[str]) = effect_type_vars
     if 0 type_vars.length != then
         type_vars struct_name build_parameterized_type = param_type
         for type_var in type_vars.iter do
-            type_var sig_type_vars.add = sig_type_vars
+            type_var effect_type_vars.add = effect_type_vars
         done
     fi
 
@@ -1545,9 +1545,9 @@ fn create_member_accessor
     param_type make_param getter_params.push
     List::new(List[Type]) = getter_returns
     member_type parse_type_str getter_returns.push
-    getter_returns getter_params make_signature = getter_sig
-    sig_type_vars getter_sig Signature::set_type_vars
-    getter_sig location getter_ops getter_name make_function_with_sig = getter
+    getter_returns getter_params make_stack_effect = getter_stack_effect
+    effect_type_vars getter_stack_effect StackEffect::set_type_vars
+    getter_stack_effect location getter_ops getter_name make_function_with_stack_effect = getter
 
     if getter_name parser.store.functions.get.is_some then
         location f"Function `{getter_name}` is already defined" ErrorKind::DuplicateName raise_error
@@ -1566,9 +1566,9 @@ fn create_member_accessor
     param_type make_param setter_params.push
     member_type make_param setter_params.push
     List::new(List[Type]) = setter_returns
-    setter_returns setter_params make_signature = setter_sig
-    sig_type_vars setter_sig Signature::set_type_vars
-    setter_sig location setter_ops setter_name make_function_with_sig = setter
+    setter_returns setter_params make_stack_effect = setter_stack_effect
+    effect_type_vars setter_stack_effect StackEffect::set_type_vars
+    setter_stack_effect location setter_ops setter_name make_function_with_stack_effect = setter
 
     if setter_name parser.store.functions.get.is_some then
         location f"Function `{setter_name}` is already defined" ErrorKind::DuplicateName raise_error
@@ -1620,7 +1620,7 @@ fn parse_struct parser:Parser cursor:TokenCursor -> CasaStruct {
 # parse_trait - parse trait definition
 # ============================================================================
 
-fn parse_trait_method_signature cursor:TokenCursor -> Signature {
+fn parse_trait_method_stack_effect cursor:TokenCursor -> StackEffect {
     List::new(List[Parameter]) = params
 
     # Parse parameters, stopping at ->, fn, or }
@@ -1668,7 +1668,7 @@ fn parse_trait_method_signature cursor:TokenCursor -> Signature {
         fi
     fi
 
-    returns params make_signature
+    returns params make_stack_effect
 }
 # Parse a bracket-delimited identifier-only type-parameter list:
 # `[T1 T2 ...]`. `context` (e.g. "trait", "trait method") is interpolated
@@ -1767,7 +1767,7 @@ fn parse_trait parser:Parser cursor:TokenCursor -> CasaTrait {
                 fi
             fi
 
-            cursor parse_trait_method_signature = method_sig
+            cursor parse_trait_method_stack_effect = method_stack_effect
 
             # Parse optional default method body
             List::new(List[Op]) = default_ops
@@ -1777,7 +1777,7 @@ fn parse_trait parser:Parser cursor:TokenCursor -> CasaTrait {
                 fi
             fi
 
-            method_type_vars default_ops method_sig method_name Token::value TraitMethod methods.push
+            method_type_vars default_ops method_stack_effect method_name Token::value TraitMethod methods.push
         fi
     done
 
@@ -1794,27 +1794,27 @@ fn inject_impl_trait_params
     type_vars:List[str]
     trait_bounds:Map[str TraitBound]
 {
-    function Function::signature = sig
+    function Function::stack_effect = effect
 
-    # Merge type vars into function signature
+    # Merge type vars into function stack effect
     for type_var in type_vars.iter do
-        if type_var sig Signature::type_vars.has ! then
-            type_var sig Signature::type_vars.add = new_type_vars
-            new_type_vars sig Signature::set_type_vars
+        if type_var effect StackEffect::type_vars.has ! then
+            type_var effect StackEffect::type_vars.add = new_type_vars
+            new_type_vars effect StackEffect::set_type_vars
         fi
     done
 
     # Merge trait bounds
     trait_bounds.keys = bound_keys
     for bound_key in bound_keys.iter do
-        bound_key trait_bounds.get.unwrap bound_key sig Signature::trait_bounds.set = new_bounds
-        new_bounds sig Signature::set_trait_bounds
+        bound_key trait_bounds.get.unwrap bound_key effect StackEffect::trait_bounds.set = new_bounds
+        new_bounds effect StackEffect::set_trait_bounds
     done
 
     # Inject hidden __trait_* parameters
     List::new(List[Parameter]) = hidden_params
     0 = insert_pos
-    sig Signature::trait_bounds parser build_hidden_trait_methods = hidden_methods
+    effect StackEffect::trait_bounds parser build_hidden_trait_methods = hidden_methods
     for hidden in hidden_methods.iter do
         hidden HiddenTraitMethod::var_name = hidden_name
         hidden HiddenTraitMethod::fn_type = hidden_type
@@ -1826,12 +1826,12 @@ fn inject_impl_trait_params
         1 += insert_pos
     done
 
-    # Prepend hidden params to existing signature parameters
+    # Prepend hidden params to existing stack effect parameters
     if 0 hidden_params.length != then
-        for existing_param in sig Signature::parameters.iter do
+        for existing_param in effect StackEffect::parameters.iter do
             existing_param hidden_params.push
         done
-        hidden_params sig Signature::set_parameters
+        hidden_params effect StackEffect::set_parameters
     fi
 }
 
@@ -2318,18 +2318,18 @@ fn selective_import_type_dependencies
     end
 }
 
-fn selective_import_signature_dependencies
+fn selective_import_stack_effect_dependencies
     parser:Parser
     import_parser:Parser
     function:Function
     location:Location
     imported:Set[str]
 {
-    function Function::signature = sig
-    for param in sig Signature::parameters.iter do
+    function Function::stack_effect = effect
+    for param in effect StackEffect::parameters.iter do
         imported location param Parameter::typ import_parser parser selective_import_type_dependencies
     done
-    for return_type in sig Signature::return_types.iter do
+    for return_type in effect StackEffect::return_types.iter do
         imported location return_type import_parser parser selective_import_type_dependencies
     done
 }
@@ -2405,7 +2405,7 @@ fn selective_import_symbol
         fi
         imported_fn imported_fn Function::ops import_parser resolve_identifiers_fn = resolved_ops
         resolved_ops imported_fn Function::set_ops
-        imported location imported_fn import_parser parser selective_import_signature_dependencies
+        imported location imported_fn import_parser parser selective_import_stack_effect_dependencies
         for resolved_op in resolved_ops.iter do
             if resolved_op.value OpValue::PushVar(var_name) is then
                 if var_name imported_fn Function::variables variable_list_contains ! var_name import_parser.store.variables.has && then
@@ -3130,7 +3130,7 @@ fn try_resolve_fn_ref
     fi
     if ref_name "::" str::find 0 <= then
         ref_name 0 ref_name "::" str::find str::substring = ref_type_var
-        ref_type_var function Function::signature Signature::trait_bounds.get = ref_bound_opt
+        ref_type_var function Function::stack_effect StackEffect::trait_bounds.get = ref_bound_opt
         if ref_bound_opt.is_some then
             ref_name ref_name "::" str::find 2 + ref_name.length ref_name "::" str::find - 2 - str::substring = ref_trait_method
             f"__trait_{ref_type_var}_{ref_trait_method}" = ref_hidden
@@ -3172,12 +3172,12 @@ fn try_resolve_enum_variant_ident
     true
 }
 # Try resolving `K::method` trait-bound method calls. Returns true if K is
-# a trait-bound type variable on the enclosing function's signature.
+# a trait-bound type variable on the enclosing function's stack effect.
 
 fn try_resolve_trait_method_call parser:Parser function:Function op:Op ident:str -> bool {
     if ident "::" str::find 0 <= ! then false return fi
     ident 0 ident "::" str::find str::substring = type_var
-    if type_var function Function::signature Signature::trait_bounds.get.is_some ! then false return fi
+    if type_var function Function::stack_effect StackEffect::trait_bounds.get.is_some ! then false return fi
     ident ident "::" str::find 2 + ident.length ident "::" str::find - 2 - str::substring = trait_method
     f"__trait_{type_var}_{trait_method}" = hidden_var
     if hidden_var function Function::variables variable_list_contains ! then

--- a/compiler/typechecker.casa
+++ b/compiler/typechecker.casa
@@ -313,11 +313,45 @@ fn is_type_variable_t typ:Type -> bool {
 }
 
 fn types_match_t expected:Type actual:Type -> bool {
-    actual expected signature_type_matches
+    actual expected stack_effect_type_matches
+}
+
+fn type_exists_recursive_t typ:Type function_opt:Option[Function] store:SymbolStore -> bool {
+    typ match
+        Type::Unknown => { false }
+        Type::Builtin(_) => { true }
+        Type::TypeVar(name) => {
+            if function_opt Option::Some(check_fn) is then
+                name check_fn Function::stack_effect StackEffect::type_vars.has return
+            fi
+            false
+        }
+        Type::Generic(generic) => {
+            for param in generic.params.iter do
+                if store function_opt param type_exists_recursive_t ! then false return fi
+            done
+            if generic.base store.structs.get.is_some then true return fi
+            if generic.base store.enums.get.is_some then true return fi
+            if "array" generic.base == then true return fi
+            if function_opt Option::Some(check_fn) is then
+                if generic.base check_fn Function::stack_effect StackEffect::type_vars.has then true return fi
+            fi
+            false
+        }
+        Type::Function(fn_type) => {
+            for param in fn_type.parameters.iter do
+                if store function_opt param type_exists_recursive_t ! then false return fi
+            done
+            for ret in fn_type.return_types.iter do
+                if store function_opt ret type_exists_recursive_t ! then false return fi
+            done
+            true
+        }
+    end
 }
 
 fn validate_type_exists typ:Type function_opt:Option[Function] location:Location {
-    if function_opt typ.exists_recursive then return fi
+    if DEFAULT_PARSER.store function_opt typ type_exists_recursive_t then return fi
     location f"type `{typ.format}` does not exist" ErrorKind::Syntax raise_error
 }
 
@@ -407,7 +441,7 @@ fn stacks_equal stack_a:List[Type] stack_b:List[Type] -> bool {
 }
 
 # ============================================================================
-# Apply signature — pop params, push returns, with type variable binding
+# Apply stack effect: pop params, push returns, with type variable binding.
 # ============================================================================
 
 fn resolve_return_type_t bindings:Map[str Type] ret:Type -> Type {
@@ -479,7 +513,7 @@ fn bind_generic_param
     tc:TypeChecker
     bindings:Map[str Type]
     expected:Parameter
-    sig:Signature
+    effect:StackEffect
 -> bool {
     # Bind type vars from a parameterized param like Map[K V].
     expected Parameter::typ.base = base_opt
@@ -491,7 +525,7 @@ fn bind_generic_param
     false = has_type_var
     for expected_param in expected_params.iter do
         if expected_param.type_var_name Option::Some(probe_name) is then
-            if probe_name sig Signature::type_vars.has then
+            if probe_name effect StackEffect::type_vars.has then
                 true = has_type_var
             fi
         fi
@@ -502,7 +536,7 @@ fn bind_generic_param
     tc stack_pop_type match
         Type::Generic(actual_g) => {
             if 0 actual_g.params.length == then
-                expected_params bindings sig tc bind_unknowns = bindings
+                expected_params bindings effect tc bind_unknowns = bindings
                 true return
             fi
             if base actual_g.base != then
@@ -516,7 +550,7 @@ fn bind_generic_param
             0 = bind_index
             while bind_index expected_params.length > do
                 if bind_index expected_params.get.type_var_name Option::Some(bind_name) is then
-                    if bind_name sig Signature::type_vars.has then
+                    if bind_name effect StackEffect::type_vars.has then
                         bind_index actual_g.params.get bind_name bindings tc bind_type_var = bindings
                     fi
                 fi
@@ -525,7 +559,7 @@ fn bind_generic_param
             true return
         }
         Type::Unknown => {
-            expected_params bindings sig tc bind_unknowns = bindings
+            expected_params bindings effect tc bind_unknowns = bindings
             true return
         }
         _ => {
@@ -537,13 +571,13 @@ fn bind_generic_param
 
 fn bind_unknowns
     tc:TypeChecker
-    sig:Signature
+    effect:StackEffect
     bindings:Map[str Type]
     expected_params:List[Type]
 -> Map[str Type] {
     for expected_param in expected_params.iter do
         if expected_param.type_var_name Option::Some(unk_name) is then
-            if unk_name sig Signature::type_vars.has then
+            if unk_name effect StackEffect::type_vars.has then
                 TYPE_UNKNOWN_T unk_name bindings tc bind_type_var = bindings
             fi
         fi
@@ -551,12 +585,17 @@ fn bind_unknowns
     bindings
 }
 
-fn bind_fn_param tc:TypeChecker bindings:Map[str Type] expected:Parameter sig:Signature -> bool {
-    # Bind type vars from a fn[sig] param like fn[T -> T].
+fn bind_fn_param
+    tc:TypeChecker
+    bindings:Map[str Type]
+    expected:Parameter
+    effect:StackEffect
+-> bool {
+    # Bind type vars from a function-type param like fn[T -> T].
     if expected Parameter::typ.is_fn_type_t ! then false return fi
-    # Check if any type var appears in the fn signature
+    # Check if any type var appears in the function type.
     false = has_type_var
-    sig Signature::type_vars.to_list = type_var_list
+    effect StackEffect::type_vars.to_list = type_var_list
     for type_var in type_var_list.iter do
         if type_var expected Parameter::typ.type_contains_var then
             true = has_type_var
@@ -589,7 +628,7 @@ fn bind_fn_param tc:TypeChecker bindings:Map[str Type] expected:Parameter sig:Si
                     param_index actual_fn_params.length > &&
                     do
                         param_index expected_fn_params.get.format = expected_param_name
-                        if expected_param_name sig Signature::type_vars.has then
+                        if expected_param_name effect StackEffect::type_vars.has then
                             param_index actual_fn_params.get expected_param_name bindings tc bind_type_var = bindings
                         fi
                         1 += param_index
@@ -602,7 +641,7 @@ fn bind_fn_param tc:TypeChecker bindings:Map[str Type] expected:Parameter sig:Si
                     return_index actual_fn_returns.length > &&
                     do
                         return_index expected_fn_returns.get.format = expected_return_name
-                        if expected_return_name sig Signature::type_vars.has then
+                        if expected_return_name effect StackEffect::type_vars.has then
                             return_index actual_fn_returns.get expected_return_name bindings tc bind_type_var = bindings
                         fi
                         1 += return_index
@@ -616,19 +655,19 @@ fn bind_fn_param tc:TypeChecker bindings:Map[str Type] expected:Parameter sig:Si
     true
 }
 
-fn apply_signature tc:TypeChecker sig:Signature name:str {
+fn apply_stack_effect tc:TypeChecker effect:StackEffect name:str {
     # Simple case: no type variables
-    if 0 sig Signature::type_vars.length == then
+    if 0 effect StackEffect::type_vars.length == then
         0 = index
-        while index sig Signature::parameters.length > do
+        while index effect StackEffect::parameters.length > do
             if "" name != then
                 f"parameter {index 1 +} of `{name}`" tc TypeChecker::set_current_expect_ctx
             fi
-            index sig Signature::parameters.get Parameter::typ tc expect_type_t
+            index effect StackEffect::parameters.get Parameter::typ tc expect_type_t
             1 += index
         done
         "" tc TypeChecker::set_current_expect_ctx
-        for return_type in sig Signature::return_types.iter do
+        for return_type in effect StackEffect::return_types.iter do
             return_type tc stack_push_type
         done
         return
@@ -637,8 +676,8 @@ fn apply_signature tc:TypeChecker sig:Signature name:str {
     # Generic case: bind type variables
     Map::new(Map[str Type]) = bindings
     0 = index
-    while index sig Signature::parameters.length > do
-        index sig Signature::parameters.get = param
+    while index effect StackEffect::parameters.length > do
+        index effect StackEffect::parameters.get = param
 
         if "" name != then
             f"parameter {index 1 +} of `{name}`" tc TypeChecker::set_current_expect_ctx
@@ -646,7 +685,7 @@ fn apply_signature tc:TypeChecker sig:Signature name:str {
 
         # Direct type variable (e.g. T)
         if param Parameter::typ.type_var_name Option::Some(direct_tv) is then
-            if direct_tv sig Signature::type_vars.has then
+            if direct_tv effect StackEffect::type_vars.has then
                 tc stack_pop_type = actual_type_var_t
                 actual_type_var_t direct_tv bindings tc bind_type_var = bindings
                 1 += index
@@ -655,13 +694,13 @@ fn apply_signature tc:TypeChecker sig:Signature name:str {
         fi
 
         # Parameterized type with type vars (e.g. Option[T], Map[K V])
-        if sig param bindings tc bind_generic_param then
+        if effect param bindings tc bind_generic_param then
             1 += index
             continue
         fi
 
         # Function type with type vars (e.g. fn[T -> T])
-        if sig param bindings tc bind_fn_param then
+        if effect param bindings tc bind_fn_param then
             1 += index
             continue
         fi
@@ -672,7 +711,7 @@ fn apply_signature tc:TypeChecker sig:Signature name:str {
     "" tc TypeChecker::set_current_expect_ctx
 
     # Push resolved return types
-    for return_type in sig Signature::return_types.iter do
+    for return_type in effect StackEffect::return_types.iter do
         return_type bindings resolve_return_type_t tc stack_push_type
     done
 }
@@ -900,9 +939,9 @@ fn bound_implies_word bound:TraitBound -> bool {
 fn assert_word_bound tc:TypeChecker op:Op type_name:str function_opt:Option[Function] {
     if type_name TYPE_UNKNOWN == then return fi
     if function_opt.is_none then return fi
-    function_opt.unwrap Function::signature = word_sig
-    if type_name word_sig Signature::type_vars.has ! then return fi
-    type_name word_sig Signature::trait_bounds.get = word_bound_opt
+    function_opt.unwrap Function::stack_effect = word_stack_effect
+    if type_name word_stack_effect StackEffect::type_vars.has ! then return fi
+    type_name word_stack_effect StackEffect::trait_bounds.get = word_bound_opt
     if word_bound_opt.is_none then return fi
     if word_bound_opt.unwrap bound_implies_word then return fi
     op Op::location f"Type variable `{type_name}` does not satisfy `Word` bound; add `[{type_name}: Word]` (or a trait that extends `Word`) to the function's type parameters" ErrorKind::TypeMismatch raise_error
@@ -1002,7 +1041,7 @@ fn check_assignment tc:TypeChecker op:Op function_opt:Option[Function] {
 # Simulate the FnExec emitted by the bytecode pass for trait-bound namespace calls
 # like `K::hash`. The parser rewrites these to an OpPushVar of the hidden
 # `__trait_{type_var}_{method}` variable. At typecheck time we pop the
-# fn-pointer type we just pushed and apply the resolved trait method signature
+# fn-pointer type we just pushed and apply the resolved trait method stack effect
 # so the correct return type lands on the stack.
 
 fn simulate_trait_method_call tc:TypeChecker function:Function var_name:str {
@@ -1011,7 +1050,7 @@ fn simulate_trait_method_call tc:TypeChecker function:Function var_name:str {
     if trait_sep 0 >= then return fi
     trait_suffix 0 trait_sep str::substring = trait_type_var
     trait_suffix trait_sep 1 + trait_suffix.length trait_sep - 1 - str::substring = trait_method_name
-    trait_type_var function Function::signature Signature::trait_bounds.get = trait_bound_opt
+    trait_type_var function Function::stack_effect StackEffect::trait_bounds.get = trait_bound_opt
     if trait_bound_opt.is_none then return fi
     trait_bound_opt.unwrap TraitBound::name tc.store.traits.get = trait_def_opt
     if trait_def_opt.is_none then return fi
@@ -1019,8 +1058,8 @@ fn simulate_trait_method_call tc:TypeChecker function:Function var_name:str {
     for trait_method_entry in trait_def DEFAULT_PARSER collect_trait_methods.iter do
         if trait_method_name trait_method_entry TraitMethod::name == then
             tc stack_pop_drop
-            trait_type_var trait_method_entry TraitMethod::signature resolve_trait_sig = resolved_exec_sig
-            f"{trait_type_var}::{trait_method_name}" resolved_exec_sig tc apply_signature
+            trait_type_var trait_method_entry TraitMethod::stack_effect resolve_trait_stack_effect = resolved_exec_effect
+            f"{trait_type_var}::{trait_method_name}" resolved_exec_effect tc apply_stack_effect
             return
         fi
     done
@@ -1261,7 +1300,7 @@ fn type_satisfies_trait type_name:Type trait_name:str function_opt:Option[Functi
     fi
     # Type variable with matching bound satisfies the trait
     if function_opt.is_some then
-        function_opt.unwrap Function::signature Signature::trait_bounds = bounds
+        function_opt.unwrap Function::stack_effect StackEffect::trait_bounds = bounds
         type_name_str bounds.get = bound_opt
         if bound_opt.is_some then
             if trait_name bound_opt.unwrap trait_bound_to_str == then true return fi
@@ -1289,32 +1328,32 @@ fn type_satisfies_trait type_name:Type trait_name:str function_opt:Option[Functi
         fi
         fn_opt.unwrap = function
         function ensure_typechecked
-        if "None -> None" function Function::signature signature_to_str == then false return fi
-        # When satisfying via the generic base, skip strict signature comparison —
+        if "None -> None" function Function::stack_effect stack_effect_to_str == then false return fi
+        # When satisfying via the generic base, skip strict stack-effect comparison:
         # the concrete trait bounds are verified at the actual call site.
         if via_generic_base then
             continue
         fi
-        trait_subs type_name_str method TraitMethod::signature resolve_trait_sig apply_type_subs_to_sig_t = resolved
-        if function Function::signature Signature::parameters.length resolved Signature::parameters.length != then
+        trait_subs type_name_str method TraitMethod::stack_effect resolve_trait_stack_effect apply_type_subs_to_stack_effect = resolved
+        if function Function::stack_effect StackEffect::parameters.length resolved StackEffect::parameters.length != then
             false return
         fi
-        if function Function::signature Signature::return_types.length resolved Signature::return_types.length != then
+        if function Function::stack_effect StackEffect::return_types.length resolved StackEffect::return_types.length != then
             false return
         fi
         0 = param_index
-        while param_index resolved Signature::parameters.length > do
-            param_index function Function::signature Signature::parameters.get Parameter::typ = actual_param
-            param_index resolved Signature::parameters.get Parameter::typ = expected_param
+        while param_index resolved StackEffect::parameters.length > do
+            param_index function Function::stack_effect StackEffect::parameters.get Parameter::typ = actual_param
+            param_index resolved StackEffect::parameters.get Parameter::typ = expected_param
             if expected_param actual_param types_match_t ! then
                 false return
             fi
             1 += param_index
         done
         0 = return_index
-        while return_index resolved Signature::return_types.length > do
-            return_index function Function::signature Signature::return_types.get = actual_return
-            return_index resolved Signature::return_types.get = expected_return
+        while return_index resolved StackEffect::return_types.length > do
+            return_index function Function::stack_effect StackEffect::return_types.get = actual_return
+            return_index resolved StackEffect::return_types.get = expected_return
             if expected_return actual_return types_match_t ! then
                 false return
             fi
@@ -1338,23 +1377,23 @@ fn find_tparam_index tparams:List[str] name:str -> int {
 
 fn try_bind_caller_tvar
     bindings:Map[str Type]
-    sig:Signature
+    effect:StackEffect
     caller_ref:str
     concrete:Type
 -> Map[str Type] {
-    if caller_ref sig Signature::type_vars.has ! then bindings return fi
+    if caller_ref effect StackEffect::type_vars.has ! then bindings return fi
     if caller_ref bindings.get.is_some then bindings return fi
     concrete caller_ref bindings.set return
 }
 # Given a single (trait-side expected type, concrete-side actual type) pair
-# from a method signature diff, if the expected type references a trait
+# from a method stack-effect diff, if the expected type references a trait
 # type parameter that maps (via the current bound's type args) to an unbound
 # caller type variable, bind it to the actual type. Handles both direct
 # references (`T`) and one-level nested generics (`Option[T]` vs `Option[int]`).
 
 fn bind_from_type_slot
     bindings:Map[str Type]
-    sig:Signature
+    effect:StackEffect
     tparams:List[str]
     bargs:List[str]
     expected:Type
@@ -1364,7 +1403,7 @@ fn bind_from_type_slot
         direct_tv_name tparams find_tparam_index = direct_tp_idx
         if 0 direct_tp_idx >= then
             direct_tp_idx bargs.get = direct_caller_ref
-            actual direct_caller_ref sig bindings try_bind_caller_tvar return
+            actual direct_caller_ref effect bindings try_bind_caller_tvar return
         fi
         bindings return
     fi
@@ -1380,7 +1419,7 @@ fn bind_from_type_slot
             nested_name tparams find_tparam_index = nested_tp_idx
             if 0 nested_tp_idx >= then
                 nested_tp_idx bargs.get = nested_caller_ref
-                slot_index actual_g.params.get nested_caller_ref sig bindings try_bind_caller_tvar = bindings
+                slot_index actual_g.params.get nested_caller_ref effect bindings try_bind_caller_tvar = bindings
             fi
         fi
         1 += slot_index
@@ -1388,32 +1427,32 @@ fn bind_from_type_slot
     bindings
 }
 
-fn diff_method_sig
+fn diff_method_stack_effect
     bindings:Map[str Type]
-    sig:Signature
+    effect:StackEffect
     tparams:List[str]
     bargs:List[str]
-    trait_resolved:Signature
-    impl_sig:Signature
+    trait_resolved:StackEffect
+    impl_stack_effect:StackEffect
 -> Map[str Type] {
     0 = param_index
     while
-    param_index trait_resolved Signature::parameters.length >
-    param_index impl_sig Signature::parameters.length > &&
+    param_index trait_resolved StackEffect::parameters.length >
+    param_index impl_stack_effect StackEffect::parameters.length > &&
     do
-        param_index trait_resolved Signature::parameters.get Parameter::typ = expected_param
-        param_index impl_sig Signature::parameters.get Parameter::typ = actual_param
-        actual_param expected_param bargs tparams sig bindings bind_from_type_slot = bindings
+        param_index trait_resolved StackEffect::parameters.get Parameter::typ = expected_param
+        param_index impl_stack_effect StackEffect::parameters.get Parameter::typ = actual_param
+        actual_param expected_param bargs tparams effect bindings bind_from_type_slot = bindings
         1 += param_index
     done
     0 = return_index
     while
-    return_index trait_resolved Signature::return_types.length >
-    return_index impl_sig Signature::return_types.length > &&
+    return_index trait_resolved StackEffect::return_types.length >
+    return_index impl_stack_effect StackEffect::return_types.length > &&
     do
-        return_index trait_resolved Signature::return_types.get = expected_return
-        return_index impl_sig Signature::return_types.get = actual_return
-        actual_return expected_return bargs tparams sig bindings bind_from_type_slot = bindings
+        return_index trait_resolved StackEffect::return_types.get = expected_return
+        return_index impl_stack_effect StackEffect::return_types.get = actual_return
+        actual_return expected_return bargs tparams effect bindings bind_from_type_slot = bindings
         1 += return_index
     done
     bindings
@@ -1421,7 +1460,7 @@ fn diff_method_sig
 
 fn method_diff_bind_for_bound
     bindings:Map[str Type]
-    sig:Signature
+    effect:StackEffect
     bound:TraitBound
     concrete:str
 -> Map[str Type] {
@@ -1434,24 +1473,24 @@ fn method_diff_bind_for_bound
     for trait_method in trait_def CasaTrait::methods.iter do
         f"{concrete}::{trait_method TraitMethod::name}" DEFAULT_PARSER.store.functions.get = concrete_fn_opt
         if concrete_fn_opt.is_some then
-            concrete trait_method TraitMethod::signature resolve_trait_sig = trait_resolved
-            concrete_fn_opt.unwrap Function::signature trait_resolved bound_args trait_params sig bindings diff_method_sig = bindings
+            concrete trait_method TraitMethod::stack_effect resolve_trait_stack_effect = trait_resolved
+            concrete_fn_opt.unwrap Function::stack_effect trait_resolved bound_args trait_params effect bindings diff_method_stack_effect = bindings
         fi
     done
     bindings
 }
 
 fn method_diff_bind_all
-    sig:Signature
+    effect:StackEffect
     function_opt:Option[Function]
     bindings:Map[str Type]
 -> Map[str Type] {
-    sig Signature::trait_bounds.keys = bound_keys
+    effect StackEffect::trait_bounds.keys = bound_keys
     for bound_type_var in bound_keys.iter do
-        bound_type_var sig Signature::trait_bounds.get.unwrap = bound_constraint
+        bound_type_var effect StackEffect::trait_bounds.get.unwrap = bound_constraint
         bound_type_var bindings.get = concrete_opt
         if concrete_opt.is_some then
-            concrete_opt.unwrap.format bound_constraint sig bindings method_diff_bind_for_bound = bindings
+            concrete_opt.unwrap.format bound_constraint effect bindings method_diff_bind_for_bound = bindings
         fi
     done
     bindings
@@ -1459,7 +1498,7 @@ fn method_diff_bind_all
 
 fn inject_trait_fn_ptrs
     tc:TypeChecker
-    sig:Signature
+    effect:StackEffect
     ops:List[Op]
     op_index:int
     location:Location
@@ -1470,7 +1509,7 @@ fn inject_trait_fn_ptrs
 
     # Collect non-hidden parameters
     List::new(List[Parameter]) = non_hidden
-    for param in sig Signature::parameters.iter do
+    for param in effect StackEffect::parameters.iter do
         if param Parameter::name "__trait_" str::starts_with ! then
             param non_hidden.push
         fi
@@ -1485,7 +1524,7 @@ fn inject_trait_fn_ptrs
             index non_hidden.get = stack_param
             stack_index tc TypeChecker::live TypedStack::types.get = actual
             if stack_param Parameter::typ.type_var_name Option::Some(binding_type_var) is then
-                if binding_type_var sig Signature::type_vars.has then
+                if binding_type_var effect StackEffect::type_vars.has then
                     binding_type_var bindings.get = existing_binding_opt
                     if existing_binding_opt.is_none then
                         actual binding_type_var bindings.set = bindings
@@ -1496,43 +1535,43 @@ fn inject_trait_fn_ptrs
                         fi
                     fi
                 else
-                    sig Signature::type_vars actual stack_param Parameter::typ bindings bind_generic_params_standalone = bindings
+                    effect StackEffect::type_vars actual stack_param Parameter::typ bindings bind_generic_params_standalone = bindings
                 fi
             else
-                sig Signature::type_vars actual stack_param Parameter::typ bindings bind_generic_params_standalone = bindings
+                effect StackEffect::type_vars actual stack_param Parameter::typ bindings bind_generic_params_standalone = bindings
             fi
         fi
         1 += index
     done
 
-    # Method-signature-diff binding for bounds with type-var args.
+    # Method stack-effect diff binding for bounds with type-var args.
     # For a bound like `I: Iterable[T]` where T is still unbound but I is
     # bound from the stack, inspect the concrete type's implementation of
-    # each trait method and diff its signature against the trait's declared
-    # signature to bind T. Single pass in declaration order.
-    bindings function_opt sig method_diff_bind_all = bindings
+    # each trait method and diff its stack effect against the trait's declared
+    # stack effect to bind T. Single pass in declaration order.
+    bindings function_opt effect method_diff_bind_all = bindings
 
     # Check TYPE_CAST lookahead for return type binding
     if op_index ops.length > then
         op_index ops.get = next_op
         if next_op.value OpValue::TypeCast(cast_type) is then
-            for return_type in sig Signature::return_types.iter do
-                sig Signature::type_vars cast_type return_type bindings bind_generic_params_standalone = bindings
+            for return_type in effect StackEffect::return_types.iter do
+                effect StackEffect::type_vars cast_type return_type bindings bind_generic_params_standalone = bindings
             done
         fi
     fi
 
     # Inject FN_PUSH ops for each trait bound.
-    # Iterate type vars in reverse so the first param in the signature (which
+    # Iterate type vars in reverse so the first param in the stack effect (which
     # the parser prepends in forward key order) ends up on the top of the stack,
-    # matching the order apply_signature pops parameters in.
+    # matching the order apply_stack_effect pops parameters in.
     0 = inserted
     op_index 1 - = insert_pos
-    sig Signature::trait_bounds.keys = type_var_keys
+    effect StackEffect::trait_bounds.keys = type_var_keys
     type_var_keys.length 1 - = type_index
     while 0 type_index >= do
         type_index type_var_keys.get = type_var
-        type_var sig Signature::trait_bounds.get.unwrap = trait_bound
+        type_var effect StackEffect::trait_bounds.get.unwrap = trait_bound
         # Resolve trait type args against current bindings so that
         # `Carrier[T]` becomes `Carrier[int]` once T has been bound.
         trait_bound trait_bound_to_type = trait_bound_type
@@ -1550,7 +1589,7 @@ fn inject_trait_fn_ptrs
         # Check if forwarding (type var has same trait bound in calling function)
         false = is_forwarding
         if function_opt.is_some then
-            concrete function_opt.unwrap Function::signature Signature::trait_bounds.get = caller_bound_opt
+            concrete function_opt.unwrap Function::stack_effect StackEffect::trait_bounds.get = caller_bound_opt
             if caller_bound_opt.is_some then
                 caller_bound_opt.unwrap = caller_bound_val
                 if trait_bound caller_bound_val trait_bound_eq then
@@ -1571,8 +1610,8 @@ fn inject_trait_fn_ptrs
                     insert_pos push_op ops.insert
                     1 += insert_pos
                     1 += inserted
-                    concrete method TraitMethod::signature resolve_trait_sig = forward_sig
-                    forward_sig signature_to_function_type tc stack_push_type
+                    concrete method TraitMethod::stack_effect resolve_trait_stack_effect = forward_stack_effect
+                    forward_stack_effect stack_effect_to_function_type tc stack_push_type
                 fi
                 method_index 1 - = method_index
             done
@@ -1600,7 +1639,7 @@ fn inject_trait_fn_ptrs
                         insert_pos push_op ops.insert
                         1 += insert_pos
                         1 += inserted
-                        global_fn Function::signature signature_to_function_type tc stack_push_type
+                        global_fn Function::stack_effect stack_effect_to_function_type tc stack_push_type
                     else
                         location f"Function `{fn_name}` required by trait `{trait_name}` not found" ErrorKind::TypeMismatch raise_error
                     fi
@@ -1630,12 +1669,12 @@ fn check_function_ops
         if fn_opt.is_some then
             fn_opt.unwrap = function
             function ensure_typechecked
-            function Function::signature = sig
-            if 0 sig Signature::trait_bounds.keys.length != then
-                function_opt op Op::location op_index ops sig tc inject_trait_fn_ptrs = injected
+            function Function::stack_effect = effect
+            if 0 effect StackEffect::trait_bounds.keys.length != then
+                function_opt op Op::location op_index ops effect tc inject_trait_fn_ptrs = injected
                 injected += op_index
             fi
-            fn_name sig tc apply_signature
+            fn_name effect tc apply_stack_effect
         fi
     elif fn_value OpValue::FnExec is then
         tc stack_peek_type = fn_ptr_type
@@ -1645,7 +1684,7 @@ fn check_function_ops
             fn_ptr_type tc expect_type_t
             if fn_ptr_type Type::Function(fn_type) is then
                 if 0 fn_type FunctionType::parameters.length != 0 fn_type FunctionType::return_types.length != || then
-                    "exec" fn_type function_type_to_signature tc apply_signature
+                    "exec" fn_type function_type_to_stack_effect tc apply_stack_effect
                 fi
             fi
         fi
@@ -1654,7 +1693,7 @@ fn check_function_ops
         if push_fn_opt.is_some then
             push_fn_opt.unwrap = push_fn
             push_fn ensure_typechecked
-            push_fn Function::signature signature_to_function_type tc stack_push_type
+            push_fn Function::stack_effect stack_effect_to_function_type tc stack_push_type
         else
             "fn" tc stack_push
         fi
@@ -1930,15 +1969,15 @@ fn check_match tc:TypeChecker op:Op function_opt:Option[Function] {
     op.value = match_value
     if match_value OpValue::MatchStart is then
         if 0 tc TypeChecker::live TypedStack::types.length == then
-            tc within_param_cap = inferring_signature
+            tc within_param_cap = inferring_stack_effect
             if function_opt.is_some then
                 if function_opt.unwrap Function::name "lambda__" str::starts_with ! then
-                    false = inferring_signature
+                    false = inferring_stack_effect
                 fi
             else
-                false = inferring_signature
+                false = inferring_stack_effect
             fi
-            if inferring_signature ! then
+            if inferring_stack_effect ! then
                 op Op::location "`match` requires a subject value on the stack" ErrorKind::StackUnderflow add_error
                 true tc TypeChecker::set_underflow_reported_this_op
             fi
@@ -2238,9 +2277,9 @@ fn instantiate_default_trait_method
         else
             base_name = generic_self_type
         fi
-        generic_self_type default_method TraitMethod::signature resolve_trait_sig = resolved_sig
+        generic_self_type default_method TraitMethod::stack_effect resolve_trait_stack_effect = resolved_stack_effect
     else
-        # Infer trait type params from concrete method signatures
+        # Infer trait type params from concrete method stack effects
         Set::new(Set[str]) = type_param_set
         for type_param in type_params.iter do
             type_param type_param_set.add = type_param_set
@@ -2251,36 +2290,36 @@ fn instantiate_default_trait_method
                 if infer_fn_opt.is_some then
                     infer_fn_opt.unwrap = infer_fn
                     infer_fn ensure_typechecked
-                    receiver infer_method TraitMethod::signature resolve_trait_sig = infer_trait_resolved
+                    receiver infer_method TraitMethod::stack_effect resolve_trait_stack_effect = infer_trait_resolved
                     0 = ret_index
-                    while ret_index infer_trait_resolved Signature::return_types.length > ret_index infer_fn Function::signature Signature::return_types.length > && do
-                        type_param_set ret_index infer_fn Function::signature Signature::return_types.get ret_index infer_trait_resolved Signature::return_types.get trait_subs bind_generic_params_standalone = trait_subs
+                    while ret_index infer_trait_resolved StackEffect::return_types.length > ret_index infer_fn Function::stack_effect StackEffect::return_types.length > && do
+                        type_param_set ret_index infer_fn Function::stack_effect StackEffect::return_types.get ret_index infer_trait_resolved StackEffect::return_types.get trait_subs bind_generic_params_standalone = trait_subs
                         1 += ret_index
                     done
                 fi
             fi
         done
-        trait_subs receiver default_method TraitMethod::signature resolve_trait_sig apply_type_subs_to_sig_t = resolved_sig
+        trait_subs receiver default_method TraitMethod::stack_effect resolve_trait_stack_effect apply_type_subs_to_stack_effect = resolved_stack_effect
     fi
 
     # Add trait type params as function type vars for generic receivers
     if fn_base_opt.is_some then
         for type_param in type_params.iter do
-            type_param resolved_sig Signature::type_vars.add = new_tvs
-            new_tvs resolved_sig Signature::set_type_vars
+            type_param resolved_stack_effect StackEffect::type_vars.add = new_tvs
+            new_tvs resolved_stack_effect StackEffect::set_type_vars
         done
     fi
 
-    # Add method-level type vars to signature
+    # Add method-level type vars to stack effect
     for method_type_var in default_method TraitMethod::type_vars.iter do
-        method_type_var resolved_sig Signature::type_vars.add = new_tvs
-        new_tvs resolved_sig Signature::set_type_vars
+        method_type_var resolved_stack_effect StackEffect::type_vars.add = new_tvs
+        new_tvs resolved_stack_effect StackEffect::set_type_vars
     done
 
     # Build function ops: parameter assignments + cloned body
     List::new(List[Op]) = synth_ops
     List::new(List[Variable]) = synth_vars
-    for synth_param in resolved_sig Signature::parameters.iter do
+    for synth_param in resolved_stack_effect StackEffect::parameters.iter do
         if "" synth_param Parameter::name != then
             synth_param Parameter::typ synth_param Parameter::name Variable synth_vars.push
             empty_location synth_param Parameter::name OpValue::AssignVar make_op synth_ops.push
@@ -2296,7 +2335,7 @@ fn instantiate_default_trait_method
     done
 
     # Create, register, and typecheck the function
-    resolved_sig empty_location synth_ops synth_fn_name make_function_with_sig = synth_fn
+    resolved_stack_effect empty_location synth_ops synth_fn_name make_function_with_stack_effect = synth_fn
     synth_vars synth_fn Function::set_variables
     true synth_fn Function::set_is_used
     synth_fn synth_fn_name DEFAULT_PARSER.store.functions.set drop
@@ -2322,7 +2361,7 @@ fn check_method_call
 
     # Check if receiver is a trait-bounded type variable
     if function_opt.is_some then
-        function_opt.unwrap Function::signature Signature::trait_bounds = bounds
+        function_opt.unwrap Function::stack_effect StackEffect::trait_bounds = bounds
         receiver bounds.get = trait_opt
         if trait_opt.is_some then
             trait_opt.unwrap = bound
@@ -2348,9 +2387,9 @@ fn check_method_call
                     if method_name trait_method TraitMethod::name == then
                         f"__trait_{receiver}_{method_name}" = hidden_var
                         tc stack_pop_drop
-                        constraint_subs receiver trait_method TraitMethod::signature resolve_trait_sig apply_type_subs_to_sig_t = resolved_sig
+                        constraint_subs receiver trait_method TraitMethod::stack_effect resolve_trait_stack_effect apply_type_subs_to_stack_effect = resolved_stack_effect
                         receiver tc stack_push
-                        f"{receiver}::{method_name}" resolved_sig tc apply_signature
+                        f"{receiver}::{method_name}" resolved_stack_effect tc apply_stack_effect
                         hidden_var OpValue::PushVar op Op::set_value
                         # Insert FN_EXEC op after the PUSH_VARIABLE
                         op Op::location OpValue::FnExec make_op = exec_op
@@ -2391,11 +2430,11 @@ fn check_method_call
             true function Function::set_is_used
         fi
         function ensure_typechecked
-        function Function::signature = sig
-        if 0 sig Signature::trait_bounds.keys.length != then
-            function_opt op Op::location op_index ops sig tc inject_trait_fn_ptrs += op_index
+        function Function::stack_effect = effect
+        if 0 effect StackEffect::trait_bounds.keys.length != then
+            function_opt op Op::location op_index ops effect tc inject_trait_fn_ptrs += op_index
         fi
-        fn_name sig tc apply_signature
+        fn_name effect tc apply_stack_effect
         fn_name OpValue::FnCall op Op::set_value
     else
         op Op::location f"Method `{fn_name}` does not exist" ErrorKind::UndefinedName raise_error
@@ -2444,9 +2483,9 @@ fn ensure_typechecked function:Function {
     true function Function::set_is_typechecked
     function function Function::ops resolve_identifiers = resolved_ops
     resolved_ops function Function::set_ops
-    function Option::Some resolved_ops type_check_ops = inferred_sig
-    if function Function::signature signature_to_str "None -> None" == then
-        inferred_sig function Function::set_signature
+    function Option::Some resolved_ops type_check_ops = inferred_stack_effect
+    if function Function::stack_effect stack_effect_to_str "None -> None" == then
+        inferred_stack_effect function Function::set_stack_effect
     fi
 }
 
@@ -2729,41 +2768,41 @@ fn run_type_check_ops checker:TypeChecker ops:List[Op] function_opt:Option[Funct
     done
 }
 
-fn type_check_ops ops:List[Op] function_opt:Option[Function] -> Signature {
+fn type_check_ops ops:List[Op] function_opt:Option[Function] -> StackEffect {
     DEFAULT_PARSER.store make_typechecker = checker
     -1 = budget
     if function_opt.is_some then
         function_opt.unwrap = the_function
         if the_function Function::name "lambda__" str::starts_with ! then
-            the_function Function::signature Signature::parameters.length = budget
+            the_function Function::stack_effect StackEffect::parameters.length = budget
         fi
     fi
     budget checker TypeChecker::set_param_cap
     ERRORS.length = errors_before_ops
     function_opt ops checker run_type_check_ops
 
-    # Build inferred signature
+    # Build inferred stack effect
     List::new(List[Type]) = inferred_returns
     for inferred_type in checker TypeChecker::live TypedStack::types.iter do
         inferred_type inferred_returns.push
     done
-    inferred_returns checker TypeChecker::parameters make_signature = inferred
+    inferred_returns checker TypeChecker::parameters make_stack_effect = inferred
 
-    # Verify against declared signature if function has one
+    # Verify against declared stack effect if function has one
     ERRORS.length errors_before_ops < = had_type_errors
     if function_opt.is_some had_type_errors ! && then
         function_opt.unwrap = declared_function
-        declared_function Function::signature = declared
+        declared_function Function::stack_effect = declared
         if
-        declared signature_to_str "None -> None" !=
-        0 declared Signature::type_vars.length == &&
+        declared stack_effect_to_str "None -> None" !=
+        0 declared StackEffect::type_vars.length == &&
         then
-            if inferred declared signature_matches ! then
-                declared_function Function::location f"Invalid signature for function `{declared_function Function::name}`" ErrorKind::SignatureMismatch add_error
+            if inferred declared stack_effect_matches ! then
+                declared_function Function::location f"Invalid stack effect for function `{declared_function Function::name}`" ErrorKind::SignatureMismatch add_error
             fi
         fi
-        # Update inferred signature with declared return types for type var functions
-        if 0 declared Signature::type_vars.length != then
+        # Update inferred stack effect with declared return types for type-var functions
+        if 0 declared StackEffect::type_vars.length != then
             declared = inferred
         fi
     fi
@@ -2789,17 +2828,17 @@ fn type_check_functions {
         current_fn current_fn Function::ops resolve_identifiers = resolved_ops
         resolved_ops current_fn Function::set_ops
         # Skip type checking for functions with trait bounds (checked on demand)
-        if 0 current_fn Function::signature Signature::trait_bounds.keys.length != then
+        if 0 current_fn Function::stack_effect StackEffect::trait_bounds.keys.length != then
             continue
         fi
         ERRORS.length = errors_before
-        current_fn Option::Some current_fn Function::ops type_check_ops = inferred_sig
+        current_fn Option::Some current_fn Function::ops type_check_ops = inferred_stack_effect
         ERRORS.length errors_before < = had_errors
         if had_errors then
             continue
         fi
-        if current_fn Function::signature signature_to_str "None -> None" == then
-            inferred_sig current_fn Function::set_signature
+        if current_fn Function::stack_effect stack_effect_to_str "None -> None" == then
+            inferred_stack_effect current_fn Function::set_stack_effect
         fi
     done
     flush_errors

--- a/examples/multi_error.casa
+++ b/examples/multi_error.casa
@@ -1,7 +1,7 @@
 # Multi-error example
 # This program has multiple errors of different kinds.
 # The compiler reports all of them at once instead of stopping at the first.
-# Error 1: SIGNATURE_MISMATCH - body pushes two values but signature says one
+# Error 1: SIGNATURE_MISMATCH - body pushes two values but stack effect says one
 
 fn too_many int -> int {
     dup

--- a/examples/outputs/multi_error.err
+++ b/examples/outputs/multi_error.err
@@ -6,7 +6,7 @@ error[TYPE_MISMATCH]: Type mismatch
   Expected: int
   Got: str
 
-error[SIGNATURE_MISMATCH]: Invalid signature for function `too_many`
+error[SIGNATURE_MISMATCH]: Invalid stack effect for function `too_many`
   --> examples/multi_error.casa:6:4
   |
 6 | fn too_many int -> int {

--- a/formatter/format.casa
+++ b/formatter/format.casa
@@ -218,7 +218,7 @@ fn is_field_line line:List[Token] -> bool {
 fn emit_line_tokens line:List[Token] depth:int source:str output:StringBuilder {
     depth make_indent output.append
     0 line.get Token::value = first_val
-    "fn" first_val == = is_fn_sig
+    "fn" first_val == = is_fn_decl
     false = seen_open_brace
     0 = ti
     while ti line.length > do
@@ -257,7 +257,7 @@ fn emit_line_tokens line:List[Token] depth:int source:str output:StringBuilder {
             # Setter shorthand `self->field`: no space around -> in body.
             # In fn signatures the `->` before `{` is the return arrow and
             # keeps default spacing.
-            if is_fn_sig ! seen_open_brace || then
+            if is_fn_decl ! seen_open_brace || then
                 if "->" lv == then false = need_space fi
                 if "->" next_val == then false = need_space fi
             fi
@@ -281,7 +281,7 @@ fn emit_line_tokens line:List[Token] depth:int source:str output:StringBuilder {
 fn measure_line_length line:List[Token] depth:int source:str -> int {
     depth 4 * = len
     0 line.get Token::value = first_val
-    "fn" first_val == = is_fn_sig
+    "fn" first_val == = is_fn_decl
     false = seen_open_brace
     0 = mi
     while mi line.length > do
@@ -313,7 +313,7 @@ fn measure_line_length line:List[Token] depth:int source:str -> int {
             if "}" m_val == "[" m_next_val == && m_tok Token::kind is_fstring_interior ! && then
                 true = m_space
             fi
-            if is_fn_sig ! seen_open_brace || then
+            if is_fn_decl ! seen_open_brace || then
                 if "->" m_val == then false = m_space fi
                 if "->" m_next_val == then false = m_space fi
             fi
@@ -329,10 +329,10 @@ fn measure_line_length line:List[Token] depth:int source:str -> int {
 }
 
 # ============================================================================
-# Emit a wrapped function signature
+# Emit a wrapped function declaration
 # ============================================================================
 
-fn emit_wrapped_fn_sig line:List[Token] depth:int source:str output:StringBuilder {
+fn emit_wrapped_fn_decl line:List[Token] depth:int source:str output:StringBuilder {
     # Line 1: fn name (and optional generics)
     depth make_indent output.append
     "fn " output.append
@@ -689,10 +689,10 @@ fn format_tokens tokens:List[Token] source:str -> str {
         fi
 
         if handled_struct ! then
-            # Check if this is a fn signature (possibly wrapped across lines)
+            # Check if this is a fn declaration (possibly wrapped across lines)
             false = wrapped_fn
             if "fn" first_value == then
-                # Check if this line contains { (complete signature)
+                # Check if this line contains { (complete declaration)
                 false = has_open_brace
                 for brace_token in line_tokens.iter do
                     if "{" brace_token Token::value == then
@@ -700,45 +700,45 @@ fn format_tokens tokens:List[Token] source:str -> str {
                     fi
                 done
                 if has_open_brace ! then
-                    # Incomplete fn signature — collect continuation lines
-                    # until we find { or end of signature
-                    false = sig_complete
-                    while pos tokens.length > sig_complete ! && do
-                        pos tokens.get = sig_tok
-                        if sig_tok is_eof_token then
-                            true = sig_complete
-                        elif TokenKind::Newline sig_tok Token::kind == then
+                    # Incomplete fn declaration: collect continuation lines
+                    # until we find { or end of declaration
+                    false = decl_complete
+                    while pos tokens.length > decl_complete ! && do
+                        pos tokens.get = decl_tok
+                        if decl_tok is_eof_token then
+                            true = decl_complete
+                        elif TokenKind::Newline decl_tok Token::kind == then
                             1 += pos
-                        elif "}" sig_tok Token::value == then
+                        elif "}" decl_tok Token::value == then
                             # Closing brace of enclosing block: stop, don't consume
-                            true = sig_complete
-                        elif TokenKind::Keyword sig_tok Token::kind == then
+                            true = decl_complete
+                        elif TokenKind::Keyword decl_tok Token::kind == then
                             # New keyword (fn, struct, etc): this fn has no body
-                            sig_tok Token::value = sig_kw
-                            if "fn" sig_kw == "struct" sig_kw == ||
-                            "enum" sig_kw == || "impl" sig_kw == ||
-                            "trait" sig_kw == ||
+                            decl_tok Token::value = decl_kw
+                            if "fn" decl_kw == "struct" decl_kw == ||
+                            "enum" decl_kw == || "impl" decl_kw == ||
+                            "trait" decl_kw == ||
                             then
-                                true = sig_complete
+                                true = decl_complete
                             else
-                                sig_tok line_tokens.push
+                                decl_tok line_tokens.push
                                 1 += pos
                             fi
                         else
                             # Collect this continuation line
-                            false = sig_line_done
-                            while pos tokens.length > sig_line_done ! && do
+                            false = decl_line_done
+                            while pos tokens.length > decl_line_done ! && do
                                 pos tokens.get = sl_tok
                                 if sl_tok is_eof_token then
-                                    true = sig_line_done
+                                    true = decl_line_done
                                 elif TokenKind::Newline sl_tok Token::kind == then
-                                    true = sig_line_done
+                                    true = decl_line_done
                                 else
                                     sl_tok line_tokens.push
                                     1 += pos
                                     if "{" sl_tok Token::value == then
-                                        true = sig_complete
-                                        true = sig_line_done
+                                        true = decl_complete
+                                        true = decl_line_done
                                     fi
                                 fi
                             done
@@ -746,10 +746,10 @@ fn format_tokens tokens:List[Token] source:str -> str {
                     done
                 fi
 
-                # Now line_tokens has the full signature. Check length.
-                source depth line_tokens measure_line_length = sig_len
-                if sig_len 100 < then
-                    output source depth line_tokens emit_wrapped_fn_sig
+                # Now line_tokens has the full declaration. Check length.
+                source depth line_tokens measure_line_length = decl_len
+                if decl_len 100 < then
+                    output source depth line_tokens emit_wrapped_fn_decl
                     true = wrapped_fn
                 fi
             fi

--- a/lsp.casa
+++ b/lsp.casa
@@ -908,12 +908,12 @@ fn format_hover op:Op state:DocumentState func:Option[Function] -> Option[str] {
             "fn " builder.append
             hover_func Function::name builder.append
             # Parameters
-            if 0 hover_func Function::signature Signature::parameters.length != then
+            if 0 hover_func Function::stack_effect StackEffect::parameters.length != then
                 " " builder.append
                 0 = param_index
-                while param_index hover_func Function::signature Signature::parameters.length > do
+                while param_index hover_func Function::stack_effect StackEffect::parameters.length > do
                     if 0 param_index != then " " builder.append fi
-                    param_index hover_func Function::signature Signature::parameters.get = param
+                    param_index hover_func Function::stack_effect StackEffect::parameters.get = param
                     if "" param Parameter::name != then
                         param Parameter::name builder.append
                         ":" builder.append
@@ -923,11 +923,11 @@ fn format_hover op:Op state:DocumentState func:Option[Function] -> Option[str] {
                 done
             fi
             " -> " builder.append
-            if 0 hover_func Function::signature Signature::return_types.length != then
+            if 0 hover_func Function::stack_effect StackEffect::return_types.length != then
                 0 = return_index
-                while return_index hover_func Function::signature Signature::return_types.length > do
+                while return_index hover_func Function::stack_effect StackEffect::return_types.length > do
                     if 0 return_index != then " " builder.append fi
-                    return_index hover_func Function::signature Signature::return_types.get.format builder.append
+                    return_index hover_func Function::stack_effect StackEffect::return_types.get.format builder.append
                     1 += return_index
                 done
             else
@@ -1116,7 +1116,7 @@ fn compute_hover state:DocumentState line:int col:int -> Option[HoverContent] {
                 return
             fi
         else
-            # Member part - show function signature
+            # Member part: show function stack effect
             op state DocumentState::source qualified_member_range = member_range
             member_range state func op format_qualified_member_hover = member_hover
             if member_hover.is_some then
@@ -1319,11 +1319,11 @@ fn resolve_chain_type parts:List[str] state:DocumentState offset:int -> Option[s
             return
         fi
         fn_opt.unwrap = func
-        if 0 func Function::signature Signature::return_types.length == then
+        if 0 func Function::stack_effect StackEffect::return_types.length == then
             Option::None(Option[str])
             return
         fi
-        0 func Function::signature Signature::return_types.get.format = resolved_type
+        0 func Function::stack_effect StackEffect::return_types.get.format = resolved_type
         1 += part_index
     done
     resolved_type Option::Some
@@ -2150,7 +2150,7 @@ fn op_value_stack_effect op_value:OpValue -> Option[str] {
         OpValue::PrintBool => "print: [T: Display] T -> None" Option::Some
         OpValue::PrintChar => "print: [T: Display] T -> None" Option::Some
         OpValue::PrintCstr => "print: [T: Display] T -> None" Option::Some
-        OpValue::FnExec => "exec: fn[sig] -> ..." Option::Some
+        OpValue::FnExec => "exec: fn[...] -> ..." Option::Some
         OpValue::Typeof => "typeof: T -> str" Option::Some
         OpValue::AssignDec(_) => "-=: int -> None" Option::Some
         OpValue::AssignInc(_) => "+=: int -> None" Option::Some

--- a/tests/compiler/test_argv.casa
+++ b/tests/compiler/test_argv.casa
@@ -11,7 +11,7 @@ import "../../lib/test.casa"
 # Helpers
 # ============================================================================
 
-fn tc_string_argv code:str -> Signature {
+fn tc_string_argv code:str -> StackEffect {
     "test" code lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
     ops DEFAULT_PARSER resolve_identifiers_global = ops
@@ -82,39 +82,39 @@ fn test_parse_argv {
 fn test_typecheck_argc_pushes_int {
     "typecheck_argc_pushes_int" test_start
     "argc" tc_string_argv = sig
-    "return count" 1 sig Signature::return_types.length assert_eq
-    "return type" "int" 0 sig Signature::return_types.get.format assert_str_eq
+    "return count" 1 sig StackEffect::return_types.length assert_eq
+    "return type" "int" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_typecheck_argv_pushes_ptr {
     "typecheck_argv_pushes_ptr" test_start
     "argv" tc_string_argv = sig
-    "return count" 1 sig Signature::return_types.length assert_eq
-    "return type" "ptr" 0 sig Signature::return_types.get.format assert_str_eq
+    "return count" 1 sig StackEffect::return_types.length assert_eq
+    "return type" "ptr" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_typecheck_argc_no_inputs {
     "typecheck_argc_no_inputs" test_start
     "argc" tc_string_argv = sig
-    "no params" 0 sig Signature::parameters.length assert_eq
+    "no params" 0 sig StackEffect::parameters.length assert_eq
 }
 
 fn test_typecheck_argv_no_inputs {
     "typecheck_argv_no_inputs" test_start
     "argv" tc_string_argv = sig
-    "no params" 0 sig Signature::parameters.length assert_eq
+    "no params" 0 sig StackEffect::parameters.length assert_eq
 }
 
 fn test_typecheck_argc_in_arithmetic {
     "typecheck_argc_in_arithmetic" test_start
     "argc 1 +" tc_string_argv = sig
-    "result type" "int" 0 sig Signature::return_types.get.format assert_str_eq
+    "result type" "int" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_typecheck_argv_with_load {
     "typecheck_argv_with_load" test_start
     "argv load64" tc_string_argv = sig
-    "result type" "int" 0 sig Signature::return_types.get.format assert_str_eq
+    "result type" "int" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 # ============================================================================

--- a/tests/compiler/test_array_methods.casa
+++ b/tests/compiler/test_array_methods.casa
@@ -16,7 +16,7 @@ import "../../lib/test.casa"
 # array methods use: array literals, method calls, lambdas, and fn types.
 # ============================================================================
 
-fn tc_am code:str -> Signature {
+fn tc_am code:str -> StackEffect {
     clear_global_state
     "test" code lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
@@ -53,7 +53,7 @@ fn assert_contains needle:str haystack:str msg:str {
 fn test_array_literal_type {
     "array_literal_type" test_start
     "[1, 2, 3]" tc_am = sig
-    "returns array" 1 sig Signature::return_types.length assert_eq
+    "returns array" 1 sig StackEffect::return_types.length assert_eq
 }
 
 fn test_array_literal_compiles {
@@ -75,7 +75,7 @@ fn test_array_literal_emits {
 fn test_lambda_type {
     "lambda_type" test_start
     "{ 2 * }" tc_am = sig
-    "returns fn" 1 sig Signature::return_types.length assert_eq
+    "returns fn" 1 sig StackEffect::return_types.length assert_eq
 }
 
 fn test_lambda_compiles {
@@ -97,13 +97,13 @@ fn test_lambda_emits {
 fn test_fn_push_type {
     "fn_push_type" test_start
     "fn double x:int -> int { x 2 * }\n{ 2 * }" tc_am = sig
-    "has fn type" 1 sig Signature::return_types.length assert_eq
+    "has fn type" 1 sig StackEffect::return_types.length assert_eq
 }
 
 fn test_fn_call_compiles {
     "fn_call_compiles" test_start
     "fn double x:int -> int { x 2 * }\n42 double" tc_am = sig
-    "returns int" "int" 0 sig Signature::return_types.get.format assert_str_eq
+    "returns int" "int" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 # ============================================================================

--- a/tests/compiler/test_common.casa
+++ b/tests/compiler/test_common.casa
@@ -43,8 +43,8 @@ fn test_type_is_fn {
     "int is not fn" "int" parse_type_str.is_fn_type_t ! assert_true
 }
 
-fn test_function_type_signature {
-    "function_type_signature" test_start
+fn test_function_type_stack_effect {
+    "function_type_stack_effect" test_start
     if "fn[int -> int]" parse_type_str Type::Function(fn_type) is then
         "param count" 1 fn_type FunctionType::parameters.length assert_eq
         "return count" 1 fn_type FunctionType::return_types.length assert_eq
@@ -94,41 +94,41 @@ fn test_delimiter_lookup {
     "open brace char" DelimiterKind::OpenBrace '{' delimiter_from_char.unwrap == assert_true
 }
 
-fn test_signature_to_str {
-    "signature_to_str" test_start
+fn test_stack_effect_to_str {
+    "stack_effect_to_str" test_start
     List::new(List[Parameter]) = params
     "int" make_param params.push
     "str" make_param params.push
     List::new(List[Type]) = rets
     "bool" parse_type_str rets.push
-    rets params make_signature = sig
-    "sig to str" "int str -> bool" sig signature_to_str assert_str_eq
-    "empty sig to str" "None -> None" empty_signature signature_to_str assert_str_eq
+    rets params make_stack_effect = sig
+    "effect to str" "int str -> bool" sig stack_effect_to_str assert_str_eq
+    "empty effect to str" "None -> None" empty_stack_effect stack_effect_to_str assert_str_eq
 }
 
-fn test_signature_from_str {
-    "signature_from_str" test_start
-    "int str -> bool" signature_from_str = sig
-    "two params" 2 sig Signature::parameters.length assert_eq
-    "first param" "int" 0 sig Signature::parameters.get Parameter::typ.format assert_str_eq
-    "second param" "str" 1 sig Signature::parameters.get Parameter::typ.format assert_str_eq
-    "one return" 1 sig Signature::return_types.length assert_eq
-    "return type" "bool" 0 sig Signature::return_types.get.format assert_str_eq
+fn test_stack_effect_from_str {
+    "stack_effect_from_str" test_start
+    "int str -> bool" stack_effect_from_str = sig
+    "two params" 2 sig StackEffect::parameters.length assert_eq
+    "first param" "int" 0 sig StackEffect::parameters.get Parameter::typ.format assert_str_eq
+    "second param" "str" 1 sig StackEffect::parameters.get Parameter::typ.format assert_str_eq
+    "one return" 1 sig StackEffect::return_types.length assert_eq
+    "return type" "bool" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
-fn test_signature_matches {
-    "signature_matches" test_start
-    "int -> bool" signature_from_str = sig1
-    "int -> bool" signature_from_str = sig2
-    "same sigs match" sig2 sig1 signature_matches assert_true
+fn test_stack_effect_matches {
+    "stack_effect_matches" test_start
+    "int -> bool" stack_effect_from_str = effect1
+    "int -> bool" stack_effect_from_str = effect2
+    "same sigs match" effect2 effect1 stack_effect_matches assert_true
 
-    "int -> bool" signature_from_str = sig3
-    "str -> bool" signature_from_str = sig4
-    "different params don't match" sig4 sig3 signature_matches ! assert_true
+    "int -> bool" stack_effect_from_str = effect3
+    "str -> bool" stack_effect_from_str = effect4
+    "different params don't match" effect4 effect3 stack_effect_matches ! assert_true
 
-    f"{TYPE_UNKNOWN} -> bool" signature_from_str = sig5
-    "int -> bool" signature_from_str = sig6
-    "TYPE_UNKNOWN matches int" sig6 sig5 signature_matches assert_true
+    f"{TYPE_UNKNOWN} -> bool" stack_effect_from_str = effect5
+    "int -> bool" stack_effect_from_str = effect6
+    "TYPE_UNKNOWN matches int" effect6 effect5 stack_effect_matches assert_true
 }
 
 fn test_type_is_builtin {
@@ -181,14 +181,14 @@ test_type_base
 test_type_params
 test_split_type_tokens
 test_type_is_fn
-test_function_type_signature
+test_function_type_stack_effect
 test_keyword_lookup
 test_operator_lookup
 test_intrinsic_lookup
 test_delimiter_lookup
-test_signature_to_str
-test_signature_from_str
-test_signature_matches
+test_stack_effect_to_str
+test_stack_effect_from_str
+test_stack_effect_matches
 test_type_is_builtin
 test_variable_list_helpers
 test_build_parameterized_type

--- a/tests/compiler/test_compare.casa
+++ b/tests/compiler/test_compare.casa
@@ -14,7 +14,7 @@ import "../../lib/test.casa"
 # Helpers
 # ============================================================================
 
-fn compare_test_typecheck code:str -> Signature {
+fn compare_test_typecheck code:str -> StackEffect {
     clear_global_state
     "test" code lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
@@ -31,7 +31,7 @@ fn compare_test_typecheck_ops code:str -> List[Op] {
     ops
 }
 
-fn compare_test_typecheck_error code:str -> Signature {
+fn compare_test_typecheck_error code:str -> StackEffect {
     enable_test_mode
     clear_errors
     clear_global_state

--- a/tests/compiler/test_display.casa
+++ b/tests/compiler/test_display.casa
@@ -27,7 +27,7 @@ fn display_test_resolve code:str -> List[Op] {
     ops DEFAULT_PARSER resolve_identifiers_global
 }
 
-fn display_test_typecheck code:str -> Signature {
+fn display_test_typecheck code:str -> StackEffect {
     clear_global_state
     "test" code lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
@@ -44,7 +44,7 @@ fn display_test_typecheck_ops code:str -> List[Op] {
     ops
 }
 
-fn display_test_typecheck_error code:str -> Signature {
+fn display_test_typecheck_error code:str -> StackEffect {
     enable_test_mode
     clear_errors
     clear_global_state
@@ -191,7 +191,7 @@ fn test_trait_method_call_pushes_return_type {
     "trait_method_call_pushes_return_type" test_start
     DISPLAY_TRAIT "struct Tag { val: int }\nimpl Tag { fn to_str self:Tag -> str { \"tag\" } }\nfn show[T: Display] x:T -> str { x T::to_str }\n1 Tag = t\nt show drop\n" str::concat display_test_typecheck drop
     "show" DEFAULT_PARSER.store.functions.get.unwrap = func
-    "signature has str return type" "str" 0 func Function::signature Signature::return_types.get.format assert_str_eq
+    "stack effect has str return type" "str" 0 func Function::stack_effect StackEffect::return_types.get.format assert_str_eq
     "no errors" assert_no_errors
 }
 

--- a/tests/compiler/test_enum.casa
+++ b/tests/compiler/test_enum.casa
@@ -35,7 +35,7 @@ fn resolve_enum code:str -> List[Op] {
     ops DEFAULT_PARSER resolve_identifiers_global
 }
 
-fn tc_enum code:str -> Signature {
+fn tc_enum code:str -> StackEffect {
     clear_global_state
     "test" code lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
@@ -354,37 +354,37 @@ fn test_resolve_undefined_variant_raises {
 fn test_enum_variant_pushes_enum_type {
     "enum_variant_pushes_enum_type" test_start
     "enum Color { Red Green Blue }\nColor::Red" tc_enum = sig
-    "return type" "Color" 0 sig Signature::return_types.get.format assert_str_eq
+    "return type" "Color" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_enum_eq_same_type {
     "enum_eq_same_type" test_start
     "enum Color { Red Green Blue }\nColor::Red Color::Green ==" tc_enum = sig
-    "returns bool" "bool" 0 sig Signature::return_types.get.format assert_str_eq
+    "returns bool" "bool" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_enum_ne_same_type {
     "enum_ne_same_type" test_start
     "enum Color { Red Green Blue }\nColor::Red Color::Blue !=" tc_enum = sig
-    "returns bool" "bool" 0 sig Signature::return_types.get.format assert_str_eq
+    "returns bool" "bool" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_enum_assign_variable {
     "enum_assign_variable" test_start
     "enum Color { Red Green Blue }\nColor::Red = c c" tc_enum = sig
-    "returns Color" "Color" 0 sig Signature::return_types.get.format assert_str_eq
+    "returns Color" "Color" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_enum_as_return_type {
     "enum_as_return_type" test_start
     "enum Color { Red Green Blue }\nfn get_color -> Color { Color::Blue }\nget_color\n" tc_enum = sig
-    "returns Color" "Color" 0 sig Signature::return_types.get.format assert_str_eq
+    "returns Color" "Color" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_enum_print {
     "enum_print" test_start
     "trait Display { fn to_str self:self -> str }\nenum Color { Red Green Blue }\nimpl Color { fn to_str c:Color -> str { \"red\" } }\nColor::Red print" tc_enum = sig
-    "no returns" 0 sig Signature::return_types.length assert_eq
+    "no returns" 0 sig StackEffect::return_types.length assert_eq
 }
 
 # ============================================================================
@@ -400,19 +400,19 @@ fn test_match_exhaustive_passes {
 fn test_match_as_expression {
     "match_as_expression" test_start
     "enum Color { Red Green Blue }\nColor::Red match\n    Color::Red => 10\n    Color::Green => 20\n    Color::Blue => 30\nend\n" tc_enum = sig
-    "returns int" "int" 0 sig Signature::return_types.get.format assert_str_eq
+    "returns int" "int" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_match_as_expression_str {
     "match_as_expression_str" test_start
     "enum Color { Red Green Blue }\nColor::Red match\n    Color::Red => \"red\"\n    Color::Green => \"green\"\n    Color::Blue => \"blue\"\nend\n" tc_enum = sig
-    "returns str" "str" 0 sig Signature::return_types.get.format assert_str_eq
+    "returns str" "str" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_wildcard_only_match {
     "wildcard_only_match" test_start
     "enum Color { Red Green Blue }\nColor::Red match\n    _ => 42\nend\n" tc_enum = sig
-    "returns int" "int" 0 sig Signature::return_types.get.format assert_str_eq
+    "returns int" "int" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -422,49 +422,49 @@ fn test_wildcard_only_match {
 fn test_data_variant_pops_inner_and_pushes_enum {
     "data_variant_pops_inner_and_pushes_enum" test_start
     "enum Shape { Circle(int) Rectangle(int int) Point }\n10 Shape::Circle" tc_enum = sig
-    "returns Shape" "Shape" 0 sig Signature::return_types.get.format assert_str_eq
+    "returns Shape" "Shape" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_data_variant_two_inner_values {
     "data_variant_two_inner_values" test_start
     "enum Shape { Circle(int) Rectangle(int int) Point }\n3 4 Shape::Rectangle" tc_enum = sig
-    "returns Shape" "Shape" 0 sig Signature::return_types.get.format assert_str_eq
+    "returns Shape" "Shape" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_no_data_variant_in_data_enum {
     "no_data_variant_in_data_enum" test_start
     "enum Shape { Circle(int) Rectangle(int int) Point }\nShape::Point" tc_enum = sig
-    "returns Shape" "Shape" 0 sig Signature::return_types.get.format assert_str_eq
+    "returns Shape" "Shape" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_generic_some_pushes_option_int {
     "generic_some_pushes_option_int" test_start
     "enum Option[T] { None Some(T) }\n42 Option::Some" tc_enum = sig
-    "returns Option[int]" "Option[int]" 0 sig Signature::return_types.get.format assert_str_eq
+    "returns Option[int]" "Option[int]" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_generic_some_pushes_option_str {
     "generic_some_pushes_option_str" test_start
     "enum Option[T] { None Some(T) }\n\"hello\" Option::Some" tc_enum = sig
-    "returns Option[str]" "Option[str]" 0 sig Signature::return_types.get.format assert_str_eq
+    "returns Option[str]" "Option[str]" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_generic_none_pushes_option_t {
     "generic_none_pushes_option_t" test_start
     "enum Option[T] { None Some(T) }\nOption::None" tc_enum = sig
-    "returns Option[T]" "Option[T]" 0 sig Signature::return_types.get.format assert_str_eq
+    "returns Option[T]" "Option[T]" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_data_enum_comparison {
     "data_enum_comparison" test_start
     "enum Shape { Circle(int) Rectangle(int int) Point }\nShape::Point Shape::Point ==" tc_enum = sig
-    "returns bool" "bool" 0 sig Signature::return_types.get.format assert_str_eq
+    "returns bool" "bool" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_match_destructuring_binding_types {
     "match_destructuring_binding_types" test_start
     "enum Option[T] { None Some(T) }\n42 Option::Some match\n    Option::Some(value) => value\n    Option::None => 0\nend\n" tc_enum = sig
-    "returns int" "int" 0 sig Signature::return_types.get.format assert_str_eq
+    "returns int" "int" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -474,13 +474,13 @@ fn test_match_destructuring_binding_types {
 fn test_match_inside_function {
     "match_inside_function" test_start
     "enum Color { Red Green Blue }\nfn color_name c:Color -> str {\n    c match\n        Color::Red => \"red\"\n        Color::Green => \"green\"\n        Color::Blue => \"blue\"\n    end\n}\nColor::Blue color_name\n" tc_enum = sig
-    "returns str" "str" 0 sig Signature::return_types.get.format assert_str_eq
+    "returns str" "str" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_match_result_used_in_function {
     "match_result_used_in_function" test_start
     "enum Color { Red Green Blue }\nfn color_value c:Color -> int {\n    c match\n        Color::Red => 0\n        Color::Green => 1\n        Color::Blue => 2\n    end\n}\nColor::Green color_value\n" tc_enum = sig
-    "returns int" "int" 0 sig Signature::return_types.get.format assert_str_eq
+    "returns int" "int" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -568,19 +568,19 @@ fn test_parse_empty_braced_arm {
 fn test_bool_match_exhaustive {
     "bool_match_exhaustive" test_start
     "true match\n    true => 1\n    false => 0\nend\n" tc_enum = sig
-    "returns int" "int" 0 sig Signature::return_types.get.format assert_str_eq
+    "returns int" "int" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_int_match_with_wildcard {
     "int_match_with_wildcard" test_start
     "42 match\n    1 => \"one\"\n    2 => \"two\"\n    _ => \"other\"\nend\n" tc_enum = sig
-    "returns str" "str" 0 sig Signature::return_types.get.format assert_str_eq
+    "returns str" "str" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_str_match_with_wildcard {
     "str_match_with_wildcard" test_start
     "\"hello\" match\n    \"hello\" => 1\n    \"world\" => 2\n    _ => 0\nend\n" tc_enum = sig
-    "returns int" "int" 0 sig Signature::return_types.get.format assert_str_eq
+    "returns int" "int" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -694,7 +694,7 @@ fn test_is_type_mismatch_raises {
 fn test_is_plain_enum {
     "is_plain_enum" test_start
     "enum Color { Red Green Blue }\nColor::Red Color::Red is" tc_enum = sig
-    "returns bool" "bool" 0 sig Signature::return_types.get.format assert_str_eq
+    "returns bool" "bool" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -778,7 +778,7 @@ fn test_wrong_enum_type_in_function_raises {
 fn test_enum_in_function_param {
     "enum_in_function_param" test_start
     "enum Color { Red Green Blue }\nfn is_red c:Color -> bool { c Color::Red == }\nColor::Red is_red\n" tc_enum = sig
-    "returns bool" "bool" 0 sig Signature::return_types.get.format assert_str_eq
+    "returns bool" "bool" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -788,13 +788,13 @@ fn test_enum_in_function_param {
 fn test_result_ok_pushes_result {
     "result_ok_pushes_result" test_start
     "enum Result[T E] { Error(E) Ok(T) }\n42 Result::Ok" tc_enum = sig
-    "returns Result[int E]" "Result[int E]" 0 sig Signature::return_types.get.format assert_str_eq
+    "returns Result[int E]" "Result[int E]" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_result_error_pushes_result {
     "result_error_pushes_result" test_start
     "enum Result[T E] { Error(E) Ok(T) }\n\"oops\" Result::Error" tc_enum = sig
-    "returns Result[T str]" "Result[T str]" 0 sig Signature::return_types.get.format assert_str_eq
+    "returns Result[T str]" "Result[T str]" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_data_enum_wrong_inner_type_raises {
@@ -812,7 +812,7 @@ fn test_data_enum_wrong_inner_type_raises {
 fn test_generic_enum_in_function_return {
     "generic_enum_in_function_return" test_start
     "enum Option[T] { None Some(T) }\nfn wrap x:int -> Option[int] { x Option::Some }\n42 wrap\n" tc_enum = sig
-    "returns Option[int]" "Option[int]" 0 sig Signature::return_types.get.format assert_str_eq
+    "returns Option[int]" "Option[int]" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -822,7 +822,7 @@ fn test_generic_enum_in_function_return {
 fn test_char_match_with_wildcard {
     "char_match_with_wildcard" test_start
     "'a' match\n    'a' => 1\n    _ => 0\nend\n" tc_enum = sig
-    "returns int" "int" 0 sig Signature::return_types.get.format assert_str_eq
+    "returns int" "int" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_char_without_wildcard_raises {
@@ -839,7 +839,7 @@ fn test_char_without_wildcard_raises {
 fn test_bool_with_wildcard_passes {
     "bool_with_wildcard_passes" test_start
     "true match\n    true => 1\n    _ => 0\nend\n" tc_enum = sig
-    "returns int" "int" 0 sig Signature::return_types.get.format assert_str_eq
+    "returns int" "int" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_str_without_wildcard_raises {
@@ -908,7 +908,7 @@ fn test_is_bindings_on_plain_variant_raises {
 fn test_is_generic_enum {
     "is_generic_enum" test_start
     "enum Option[T] { None Some(T) }\n42 Option::Some = m\nm Option::Some is\n" tc_enum = sig
-    "returns bool" "bool" 0 sig Signature::return_types.get.format assert_str_eq
+    "returns bool" "bool" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_is_generic_with_bindings {
@@ -1010,26 +1010,26 @@ fn test_payload_free_enum_synthesizes_eq {
     "Color::eq registered" "Color::eq" DEFAULT_PARSER.store.functions.get.is_some assert_true
 }
 
-fn test_payload_free_enum_hash_signature {
-    "payload_free_enum_hash_signature" test_start
+fn test_payload_free_enum_hash_stack_effect {
+    "payload_free_enum_hash_stack_effect" test_start
     COLOR_ENUM test_parse_code drop
     "Color::hash" DEFAULT_PARSER.store.functions.get.unwrap = hash_fn
-    hash_fn Function::signature = sig
-    "param count" 1 sig Signature::parameters.length assert_eq
-    "param type" "Color" 0 sig Signature::parameters.get Parameter::typ.format assert_str_eq
-    "return count" 1 sig Signature::return_types.length assert_eq
-    "return type" "int" 0 sig Signature::return_types.get.format assert_str_eq
+    hash_fn Function::stack_effect = sig
+    "param count" 1 sig StackEffect::parameters.length assert_eq
+    "param type" "Color" 0 sig StackEffect::parameters.get Parameter::typ.format assert_str_eq
+    "return count" 1 sig StackEffect::return_types.length assert_eq
+    "return type" "int" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
-fn test_payload_free_enum_eq_signature {
-    "payload_free_enum_eq_signature" test_start
+fn test_payload_free_enum_eq_stack_effect {
+    "payload_free_enum_eq_stack_effect" test_start
     COLOR_ENUM test_parse_code drop
     "Color::eq" DEFAULT_PARSER.store.functions.get.unwrap = eq_fn
-    eq_fn Function::signature = sig
-    "param count" 2 sig Signature::parameters.length assert_eq
-    "param0 type" "Color" 0 sig Signature::parameters.get Parameter::typ.format assert_str_eq
-    "param1 type" "Color" 1 sig Signature::parameters.get Parameter::typ.format assert_str_eq
-    "return type" "bool" 0 sig Signature::return_types.get.format assert_str_eq
+    eq_fn Function::stack_effect = sig
+    "param count" 2 sig StackEffect::parameters.length assert_eq
+    "param0 type" "Color" 0 sig StackEffect::parameters.get Parameter::typ.format assert_str_eq
+    "param1 type" "Color" 1 sig StackEffect::parameters.get Parameter::typ.format assert_str_eq
+    "return type" "bool" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_payload_bearing_enum_skips_hash_synth {
@@ -1166,8 +1166,8 @@ test_braced_arm_as_expression_typechecks
 # Auto-derive Hashable for payload-free enums (#141)
 test_payload_free_enum_synthesizes_hash
 test_payload_free_enum_synthesizes_eq
-test_payload_free_enum_hash_signature
-test_payload_free_enum_eq_signature
+test_payload_free_enum_hash_stack_effect
+test_payload_free_enum_eq_stack_effect
 test_payload_bearing_enum_skips_hash_synth
 test_payload_bearing_enum_skips_eq_synth
 test_manual_impl_overrides_synth_hash

--- a/tests/compiler/test_enum_variant_hint.casa
+++ b/tests/compiler/test_enum_variant_hint.casa
@@ -12,7 +12,7 @@ import "../../lib/test.casa"
 # Helpers
 # ============================================================================
 
-fn tc_evh code:str -> Signature {
+fn tc_evh code:str -> StackEffect {
     clear_global_state
     "test" code lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops

--- a/tests/compiler/test_error.casa
+++ b/tests/compiler/test_error.casa
@@ -122,14 +122,14 @@ fn test_format_error_with_multiple_notes {
     "format_error_with_multiple_notes" test_start
     "if true then\n    1 2\nelse\n    3\nfi" "test_notes.casa" SOURCE_CACHE.set = SOURCE_CACHE
     2 30 "test_notes.casa" make_location "Branches have incompatible stack effects" ErrorKind::StackMismatch make_error = err
-    2 0 "test_notes.casa" make_location "`if` branch has signature `None -> int int`" CasaNote = note1
-    4 21 "test_notes.casa" make_location "`else` branch has signature `None -> int`" CasaNote = note2
+    2 0 "test_notes.casa" make_location "`if` branch has stack effect `None -> int int`" CasaNote = note1
+    4 21 "test_notes.casa" make_location "`else` branch has stack effect `None -> int`" CasaNote = note2
     note1 err CasaError::notes.push
     note2 err CasaError::notes.push
     err format_error = formatted
     "has message" formatted "Branches have incompatible stack effects" str::find 0 1 - swap > assert_true
-    "has if note" formatted "`if` branch has signature" str::find 0 1 - swap > assert_true
-    "has else note" formatted "`else` branch has signature" str::find 0 1 - swap > assert_true
+    "has if note" formatted "`if` branch has stack effect" str::find 0 1 - swap > assert_true
+    "has else note" formatted "`else` branch has stack effect" str::find 0 1 - swap > assert_true
     # Check that "Note:" appears at least twice by finding second occurrence
     formatted "Note:" str::find = first_note_pos
     "has first Note" 0 1 - first_note_pos > assert_true

--- a/tests/compiler/test_generic_structs.casa
+++ b/tests/compiler/test_generic_structs.casa
@@ -24,7 +24,7 @@ fn resolve_gs code:str -> List[Op] {
     ops DEFAULT_PARSER resolve_identifiers_global
 }
 
-fn tc_gs code:str -> Signature {
+fn tc_gs code:str -> StackEffect {
     clear_global_state
     "test" code lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
@@ -94,8 +94,8 @@ fn test_parse_generic_struct_generates_getter {
     "struct Box[T] { value: T }" parse_gs drop
     "getter exists" "Box::value" DEFAULT_PARSER.store.functions.get.is_some assert_true
     "Box::value" DEFAULT_PARSER.store.functions.get.unwrap = getter
-    "getter param type" "Box[T]" 0 getter Function::signature Signature::parameters.get Parameter::typ.format assert_str_eq
-    "getter return type" "T" 0 getter Function::signature Signature::return_types.get.format assert_str_eq
+    "getter param type" "Box[T]" 0 getter Function::stack_effect StackEffect::parameters.get Parameter::typ.format assert_str_eq
+    "getter return type" "T" 0 getter Function::stack_effect StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_parse_generic_struct_generates_setter {
@@ -103,8 +103,8 @@ fn test_parse_generic_struct_generates_setter {
     "struct Box[T] { value: T }" parse_gs drop
     "setter exists" "Box::set_value" DEFAULT_PARSER.store.functions.get.is_some assert_true
     "Box::set_value" DEFAULT_PARSER.store.functions.get.unwrap = setter
-    "setter param 0 type" "Box[T]" 0 setter Function::signature Signature::parameters.get Parameter::typ.format assert_str_eq
-    "setter param 1 type" "T" 1 setter Function::signature Signature::parameters.get Parameter::typ.format assert_str_eq
+    "setter param 0 type" "Box[T]" 0 setter Function::stack_effect StackEffect::parameters.get Parameter::typ.format assert_str_eq
+    "setter param 1 type" "T" 1 setter Function::stack_effect StackEffect::parameters.get Parameter::typ.format assert_str_eq
 }
 
 fn test_parse_nongeneric_struct_has_empty_type_vars {
@@ -127,55 +127,55 @@ fn test_parse_impl_with_type_params {
 fn test_typecheck_generic_struct_infers_type {
     "typecheck_generic_struct_infers_type" test_start
     "struct Box[T] { value: T }\n42 Box" tc_gs = sig
-    "returns Box[int]" "Box[int]" 0 sig Signature::return_types.get.format assert_str_eq
+    "returns Box[int]" "Box[int]" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_typecheck_generic_struct_str {
     "typecheck_generic_struct_str" test_start
     "struct Box[T] { value: T }\n\"hello\" Box" tc_gs = sig
-    "returns Box[str]" "Box[str]" 0 sig Signature::return_types.get.format assert_str_eq
+    "returns Box[str]" "Box[str]" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_typecheck_generic_struct_bool {
     "typecheck_generic_struct_bool" test_start
     "struct Box[T] { value: T }\ntrue Box" tc_gs = sig
-    "returns Box[bool]" "Box[bool]" 0 sig Signature::return_types.get.format assert_str_eq
+    "returns Box[bool]" "Box[bool]" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_typecheck_generic_struct_getter {
     "typecheck_generic_struct_getter" test_start
     "struct Box[T] { value: T }\n42 Box .value" tc_gs = sig
-    "returns int" "int" 0 sig Signature::return_types.get.format assert_str_eq
+    "returns int" "int" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_typecheck_generic_struct_setter {
     "typecheck_generic_struct_setter" test_start
     "struct Box[T] { value: T }\n42 Box = b\n99 b ->value" tc_gs = sig
-    "returns empty" 0 sig Signature::return_types.length assert_eq
+    "returns empty" 0 sig StackEffect::return_types.length assert_eq
 }
 
 fn test_typecheck_generic_struct_two_fields {
     "typecheck_generic_struct_two_fields" test_start
     "struct Pair[A B] { first: A second: B }\ntrue 42 Pair" tc_gs = sig
-    "returns Pair[int bool]" "Pair[int bool]" 0 sig Signature::return_types.get.format assert_str_eq
+    "returns Pair[int bool]" "Pair[int bool]" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_typecheck_generic_struct_two_fields_getter {
     "typecheck_generic_struct_two_fields_getter" test_start
     "struct Pair[A B] { first: A second: B }\ntrue 42 Pair .second" tc_gs = sig
-    "returns bool" "bool" 0 sig Signature::return_types.get.format assert_str_eq
+    "returns bool" "bool" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_typecheck_generic_struct_nested {
     "typecheck_generic_struct_nested" test_start
     "struct Box[T] { value: T }\nstruct Wrapper[U] { inner: U }\n42 Box Wrapper" tc_gs = sig
-    "returns Wrapper[Box[int]]" "Wrapper[Box[int]]" 0 sig Signature::return_types.get.format assert_str_eq
+    "returns Wrapper[Box[int]]" "Wrapper[Box[int]]" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_typecheck_generic_struct_in_function {
     "typecheck_generic_struct_in_function" test_start
     "struct Box[T] { value: T }\nfn unbox[T] b:Box[T] -> T { b .value }\n42 Box unbox" tc_gs = sig
-    "returns int" "int" 0 sig Signature::return_types.get.format assert_str_eq
+    "returns int" "int" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 # ============================================================================

--- a/tests/compiler/test_lexer.casa
+++ b/tests/compiler/test_lexer.casa
@@ -578,8 +578,8 @@ fn test_arrow_after_identifier {
     "b kind" TokenKind::Identifier 2 tokens.get Token::kind == assert_true
 }
 
-fn test_arrow_in_function_signature {
-    "arrow_in_function_signature" test_start
+fn test_arrow_in_function_declaration {
+    "arrow_in_function_declaration" test_start
     "test" "fn foo x:int -> int" lex_source = tokens
     "arrow kind" TokenKind::Delimiter 5 tokens.get Token::kind == assert_true
     "arrow value" "->" 5 tokens.get Token::value assert_str_eq
@@ -962,7 +962,7 @@ test_escape_span_multiple_escapes
 test_arrow_standalone
 test_arrow_with_spaces
 test_arrow_after_identifier
-test_arrow_in_function_signature
+test_arrow_in_function_declaration
 test_arrow_setter_syntax
 test_function_reference
 test_struct_instantiation

--- a/tests/compiler/test_lsp.casa
+++ b/tests/compiler/test_lsp.casa
@@ -622,7 +622,7 @@ fn test_compute_hover_exec {
     "{ 42 print } exec" lsp_test_state = state
     13 0 state compute_hover = result
     "is some" result.is_some assert_true
-    "contains exec effect" 0 result.unwrap HoverContent::content "exec: fn[sig] -> ..." str::find >= assert_true
+    "contains exec effect" 0 result.unwrap HoverContent::content "exec: fn[...] -> ..." str::find >= assert_true
 }
 
 # ============================================================================
@@ -980,16 +980,16 @@ fn lsp_make_synthetic_method name:str self_type:str ret_type:str -> Function {
     self_type make_param params.push
     List::new(List[Type]) = returns
     ret_type parse_type_str returns.push
-    returns params make_signature = sig
-    sig empty_location List::new(List[Op]) name make_function_with_sig
+    returns params make_stack_effect = sig
+    sig empty_location List::new(List[Op]) name make_function_with_stack_effect
 }
 
 fn lsp_make_synthetic_void name:str self_type:str -> Function {
     List::new(List[Parameter]) = params
     self_type make_param params.push
     List::new(List[Type]) = returns
-    returns params make_signature = sig
-    sig empty_location List::new(List[Op]) name make_function_with_sig
+    returns params make_stack_effect = sig
+    sig empty_location List::new(List[Op]) name make_function_with_stack_effect
 }
 # Inject int:: synthetic methods into a DocumentState's functions map.
 # Returns a new DocumentState with the updated functions map.

--- a/tests/compiler/test_match_underflow.casa
+++ b/tests/compiler/test_match_underflow.casa
@@ -9,7 +9,7 @@ import "../../lib/test.casa"
 # Helper: lex + parse + resolve + typecheck a source string
 # ============================================================================
 
-fn tc_mu code:str -> Signature {
+fn tc_mu code:str -> StackEffect {
     clear_global_state
     "test" code lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops

--- a/tests/compiler/test_parser.casa
+++ b/tests/compiler/test_parser.casa
@@ -292,9 +292,9 @@ fn test_parse_function_def {
     "fn registered" "add" DEFAULT_PARSER.store.functions.get.is_some assert_true
     "add" DEFAULT_PARSER.store.functions.get.unwrap = add_fn
     "fn name" "add" add_fn Function::name assert_str_eq
-    "param count" 2 add_fn Function::signature Signature::parameters.length assert_eq
-    "return count" 1 add_fn Function::signature Signature::return_types.length assert_eq
-    "return type" "int" 0 add_fn Function::signature Signature::return_types.get.format assert_str_eq
+    "param count" 2 add_fn Function::stack_effect StackEffect::parameters.length assert_eq
+    "return count" 1 add_fn Function::stack_effect StackEffect::return_types.length assert_eq
+    "return type" "int" 0 add_fn Function::stack_effect StackEffect::return_types.get.format assert_str_eq
 }
 
 # ============================================================================

--- a/tests/compiler/test_struct_literal.casa
+++ b/tests/compiler/test_struct_literal.casa
@@ -23,7 +23,7 @@ fn sl_parse code:str -> List[Op] {
     tokens DEFAULT_PARSER parse_ops
 }
 
-fn sl_typecheck code:str -> Signature {
+fn sl_typecheck code:str -> StackEffect {
     clear_global_state
     "test" code lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
@@ -254,13 +254,13 @@ fn test_duplicate_field_in_pattern_error {
 fn test_struct_literal_type_correct {
     "struct_literal_type_correct" test_start
     "struct Point { x: int y: int }\nPoint { x: 1 y: 2 }" sl_typecheck = sig
-    "returns Point" "Point" 0 sig Signature::return_types.get.format assert_str_eq
+    "returns Point" "Point" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_struct_literal_reverse_order_type {
     "struct_literal_reverse_order_type" test_start
     "struct Point { x: int y: int }\nPoint { y: 2 x: 1 }" sl_typecheck = sig
-    "returns Point" "Point" 0 sig Signature::return_types.get.format assert_str_eq
+    "returns Point" "Point" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_field_type_mismatch_error {
@@ -290,14 +290,14 @@ fn test_struct_match_wildcard_exhaustive {
 fn test_struct_match_binding_types {
     "struct_match_binding_types" test_start
     "struct Person { name: str age: int }\n18 \"Alice\" Person = p\np match\n    Person { name: n age: a } => n a\nend" sl_typecheck = sig
-    "returns str" "str" 0 sig Signature::return_types.get.format assert_str_eq
-    "returns int" "int" 1 sig Signature::return_types.get.format assert_str_eq
+    "returns str" "str" 0 sig StackEffect::return_types.get.format assert_str_eq
+    "returns int" "int" 1 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_struct_match_partial_binding {
     "struct_match_partial_binding" test_start
     "struct Point { x: int y: int }\n1 2 Point = p\np match\n    Point { x: px } => px\nend" sl_typecheck = sig
-    "returns int" "int" 0 sig Signature::return_types.get.format assert_str_eq
+    "returns int" "int" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_generic_struct_literal {
@@ -306,26 +306,26 @@ fn test_generic_struct_literal {
     # literals (returns "Box" instead of "Box[int]"). Test verifies no crash and
     # that a Box-prefixed type is returned.
     "struct Box[T] { value: T }\nBox { value: 42 }" sl_typecheck = sig
-    "returns Box type" 0 0 sig Signature::return_types.get.format "Box" str::find >= assert_true
+    "returns Box type" 0 0 sig StackEffect::return_types.get.format "Box" str::find >= assert_true
 }
 
 fn test_generic_struct_literal_str {
     "generic_struct_literal_str" test_start
     # NOTE: Same limitation as test_generic_struct_literal above.
     "struct Box[T] { value: T }\nBox { value: \"hello\" }" sl_typecheck = sig
-    "returns Box type" 0 0 sig Signature::return_types.get.format "Box" str::find >= assert_true
+    "returns Box type" 0 0 sig StackEffect::return_types.get.format "Box" str::find >= assert_true
 }
 
 fn test_stack_based_construction_still_works {
     "stack_based_construction_still_works" test_start
     "struct Point { x: int y: int }\n1 2 Point" sl_typecheck = sig
-    "returns Point" "Point" 0 sig Signature::return_types.get.format assert_str_eq
+    "returns Point" "Point" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_stack_and_literal_coexist {
     "stack_and_literal_coexist" test_start
     "struct Point { x: int y: int }\n1 2 Point = p1\nPoint { x: 3 y: 4 } = p2\np1.x p2.x +" sl_typecheck = sig
-    "returns int" "int" 0 sig Signature::return_types.get.format assert_str_eq
+    "returns int" "int" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 # ============================================================================

--- a/tests/compiler/test_traits.casa
+++ b/tests/compiler/test_traits.casa
@@ -27,7 +27,7 @@ fn trait_test_resolve code:str -> List[Op] {
     ops DEFAULT_PARSER resolve_identifiers_global
 }
 
-fn trait_test_typecheck code:str -> Signature {
+fn trait_test_typecheck code:str -> StackEffect {
     clear_global_state
     "test" code lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
@@ -69,38 +69,38 @@ fn test_trait_method_sig_params {
     "trait_method_sig_params" test_start
     HASHABLE_TRAIT trait_test_parse drop
     "Hashable" DEFAULT_PARSER.store.traits.get.unwrap CasaTrait::methods = methods
-    0 methods.get TraitMethod::signature = hash_sig
-    "param count" 1 hash_sig Signature::parameters.length assert_eq
-    "param type" "self" 0 hash_sig Signature::parameters.get Parameter::typ.format assert_str_eq
-    "param name" "self" 0 hash_sig Signature::parameters.get Parameter::name assert_str_eq
+    0 methods.get TraitMethod::stack_effect = hash_stack_effect
+    "param count" 1 hash_stack_effect StackEffect::parameters.length assert_eq
+    "param type" "self" 0 hash_stack_effect StackEffect::parameters.get Parameter::typ.format assert_str_eq
+    "param name" "self" 0 hash_stack_effect StackEffect::parameters.get Parameter::name assert_str_eq
 }
 
 fn test_trait_method_sig_return {
     "trait_method_sig_return" test_start
     HASHABLE_TRAIT trait_test_parse drop
     "Hashable" DEFAULT_PARSER.store.traits.get.unwrap CasaTrait::methods = methods
-    0 methods.get TraitMethod::signature = hash_sig
-    "return count" 1 hash_sig Signature::return_types.length assert_eq
-    "return type" "int" 0 hash_sig Signature::return_types.get.format assert_str_eq
+    0 methods.get TraitMethod::stack_effect = hash_stack_effect
+    "return count" 1 hash_stack_effect StackEffect::return_types.length assert_eq
+    "return type" "int" 0 hash_stack_effect StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_trait_eq_method_params {
     "trait_eq_method_params" test_start
     HASHABLE_TRAIT trait_test_parse drop
     "Hashable" DEFAULT_PARSER.store.traits.get.unwrap CasaTrait::methods = methods
-    1 methods.get TraitMethod::signature = eq_sig
-    "param count" 2 eq_sig Signature::parameters.length assert_eq
-    "param0 type" "self" 0 eq_sig Signature::parameters.get Parameter::typ.format assert_str_eq
-    "param1 type" "self" 1 eq_sig Signature::parameters.get Parameter::typ.format assert_str_eq
+    1 methods.get TraitMethod::stack_effect = eq_stack_effect
+    "param count" 2 eq_stack_effect StackEffect::parameters.length assert_eq
+    "param0 type" "self" 0 eq_stack_effect StackEffect::parameters.get Parameter::typ.format assert_str_eq
+    "param1 type" "self" 1 eq_stack_effect StackEffect::parameters.get Parameter::typ.format assert_str_eq
 }
 
 fn test_trait_eq_method_return {
     "trait_eq_method_return" test_start
     HASHABLE_TRAIT trait_test_parse drop
     "Hashable" DEFAULT_PARSER.store.traits.get.unwrap CasaTrait::methods = methods
-    1 methods.get TraitMethod::signature = eq_sig
-    "return count" 1 eq_sig Signature::return_types.length assert_eq
-    "return type" "bool" 0 eq_sig Signature::return_types.get.format assert_str_eq
+    1 methods.get TraitMethod::stack_effect = eq_stack_effect
+    "return count" 1 eq_stack_effect StackEffect::return_types.length assert_eq
+    "return type" "bool" 0 eq_stack_effect StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_trait_empty {
@@ -195,26 +195,26 @@ fn test_trait_bound_basic {
     "trait_bound_basic" test_start
     "trait Hashable { fn hash self:self -> int }\nfn tbtest[K: Hashable] K -> int { .hash }" trait_test_parse drop
     "tbtest" DEFAULT_PARSER.store.functions.get.unwrap = func
-    "K in type_vars" "K" func Function::signature Signature::type_vars.has assert_true
-    "K bound" "Hashable" "K" func Function::signature Signature::trait_bounds.get.unwrap TraitBound::name assert_str_eq
+    "K in type_vars" "K" func Function::stack_effect StackEffect::type_vars.has assert_true
+    "K bound" "Hashable" "K" func Function::stack_effect StackEffect::trait_bounds.get.unwrap TraitBound::name assert_str_eq
 }
 
 fn test_trait_bound_with_unbounded_var {
     "trait_bound_with_unbounded_var" test_start
     "trait Hashable { fn hash self:self -> int }\nfn tbtest[K: Hashable, V] K V -> int { drop .hash }" trait_test_parse drop
     "tbtest" DEFAULT_PARSER.store.functions.get.unwrap = func
-    "K in vars" "K" func Function::signature Signature::type_vars.has assert_true
-    "V in vars" "V" func Function::signature Signature::type_vars.has assert_true
-    "K bound" "Hashable" "K" func Function::signature Signature::trait_bounds.get.unwrap TraitBound::name assert_str_eq
-    "V no bound" "V" func Function::signature Signature::trait_bounds.get.is_none assert_true
+    "K in vars" "K" func Function::stack_effect StackEffect::type_vars.has assert_true
+    "V in vars" "V" func Function::stack_effect StackEffect::type_vars.has assert_true
+    "K bound" "Hashable" "K" func Function::stack_effect StackEffect::trait_bounds.get.unwrap TraitBound::name assert_str_eq
+    "V no bound" "V" func Function::stack_effect StackEffect::trait_bounds.get.is_none assert_true
 }
 
 fn test_trait_bound_multiple_bounded {
     "trait_bound_multiple_bounded" test_start
     "trait Hashable { fn hash self:self -> int }\ntrait Printable { fn to_str self:self -> str }\nfn tbtest[K: Hashable, V: Printable] K V -> int { .to_str drop .hash }" trait_test_parse drop
     "tbtest" DEFAULT_PARSER.store.functions.get.unwrap = func
-    "K bound" "Hashable" "K" func Function::signature Signature::trait_bounds.get.unwrap TraitBound::name assert_str_eq
-    "V bound" "Printable" "V" func Function::signature Signature::trait_bounds.get.unwrap TraitBound::name assert_str_eq
+    "K bound" "Hashable" "K" func Function::stack_effect StackEffect::trait_bounds.get.unwrap TraitBound::name assert_str_eq
+    "V bound" "Printable" "V" func Function::stack_effect StackEffect::trait_bounds.get.unwrap TraitBound::name assert_str_eq
 }
 
 fn test_trait_bound_undefined_raises {
@@ -239,8 +239,8 @@ fn test_trait_hidden_params_prepended {
     "tbtest" DEFAULT_PARSER.store.functions.get.unwrap = func
     0 = hidden_count
     0 = index
-    while index func Function::signature Signature::parameters.length > do
-        index func Function::signature Signature::parameters.get Parameter::name = param_name
+    while index func Function::stack_effect StackEffect::parameters.length > do
+        index func Function::stack_effect StackEffect::parameters.get Parameter::name = param_name
         if param_name "__trait_" str::starts_with then
             1 += hidden_count
         fi
@@ -255,8 +255,8 @@ fn test_trait_hidden_param_name {
     "tbtest" DEFAULT_PARSER.store.functions.get.unwrap = func
     false = found
     0 = index
-    while index func Function::signature Signature::parameters.length > do
-        if "__trait_K_hash" index func Function::signature Signature::parameters.get Parameter::name == then
+    while index func Function::stack_effect StackEffect::parameters.length > do
+        if "__trait_K_hash" index func Function::stack_effect StackEffect::parameters.get Parameter::name == then
             true = found
         fi
         1 += index
@@ -269,8 +269,8 @@ fn test_trait_hidden_param_type {
     "trait Hashable { fn hash self:self -> int }\nfn tbtest[K: Hashable] K -> int { .hash }" trait_test_parse drop
     "tbtest" DEFAULT_PARSER.store.functions.get.unwrap = func
     0 = index
-    while index func Function::signature Signature::parameters.length > do
-        index func Function::signature Signature::parameters.get = param
+    while index func Function::stack_effect StackEffect::parameters.length > do
+        index func Function::stack_effect StackEffect::parameters.get = param
         if "__trait_K_hash" param Parameter::name == then
             "type" "fn[K -> int]" param Parameter::typ.format assert_str_eq
         fi
@@ -286,8 +286,8 @@ fn test_trait_two_methods_hidden_params {
     false = has_hash
     false = has_eq
     0 = index
-    while index func Function::signature Signature::parameters.length > do
-        index func Function::signature Signature::parameters.get Parameter::name = param_name
+    while index func Function::stack_effect StackEffect::parameters.length > do
+        index func Function::stack_effect StackEffect::parameters.get Parameter::name = param_name
         if param_name "__trait_" str::starts_with then
             1 += hidden_count
             if "__trait_K_hash" param_name == then true = has_hash fi
@@ -305,8 +305,8 @@ fn test_trait_hidden_params_correct_types {
     HASHABLE_TRAIT "fn tbtest[K: Hashable] K -> int { .hash }" str::concat trait_test_parse drop
     "tbtest" DEFAULT_PARSER.store.functions.get.unwrap = func
     0 = index
-    while index func Function::signature Signature::parameters.length > do
-        index func Function::signature Signature::parameters.get = param
+    while index func Function::stack_effect StackEffect::parameters.length > do
+        index func Function::stack_effect StackEffect::parameters.get = param
         if "__trait_K_hash" param Parameter::name == then
             "hash type" "fn[K -> int]" param Parameter::typ.format assert_str_eq
         fi
@@ -594,14 +594,14 @@ fn test_stt_empty_string {
 fn test_type_var_with_matching_bound_satisfies {
     "type_var_with_matching_bound_satisfies" test_start
     HASHABLE_TRAIT trait_test_parse drop
-    # Build a Signature with K bounded by Hashable
+    # Build a StackEffect with K bounded by Hashable
     Map::new(Map[str TraitBound]) = bounds
     "Hashable" make_simple_trait_bound "K" bounds.set = bounds
     Set::new(Set[str]) = type_vars
     "K" type_vars.add = type_vars
-    # Construct Signature: parameters, return_types, type_vars, trait_bounds
-    bounds type_vars List::new(List[Type]) List::new(List[Parameter]) Signature = sig
-    sig empty_location List::new(List[Op]) "test_fn" make_function_with_sig = func
+    # Construct StackEffect: parameters, return_types, type_vars, trait_bounds
+    bounds type_vars List::new(List[Type]) List::new(List[Parameter]) StackEffect = sig
+    sig empty_location List::new(List[Op]) "test_fn" make_function_with_stack_effect = func
     func Option::Some = func_opt
     "satisfies" func_opt "Hashable" "K" parse_type_str type_satisfies_trait assert_true
 }
@@ -609,11 +609,11 @@ fn test_type_var_with_matching_bound_satisfies {
 fn test_type_var_without_bound_does_not_satisfy {
     "type_var_without_bound_does_not_satisfy" test_start
     HASHABLE_TRAIT trait_test_parse drop
-    # Build a Signature with K but no trait bounds
+    # Build a StackEffect with K but no trait bounds
     Set::new(Set[str]) = type_vars
     "K" type_vars.add = type_vars
-    Map::new(Map[str TraitBound]) type_vars List::new(List[Type]) List::new(List[Parameter]) Signature = sig
-    sig empty_location List::new(List[Op]) "test_fn" make_function_with_sig = func
+    Map::new(Map[str TraitBound]) type_vars List::new(List[Type]) List::new(List[Parameter]) StackEffect = sig
+    sig empty_location List::new(List[Op]) "test_fn" make_function_with_stack_effect = func
     func Option::Some = func_opt
     "does not satisfy" func_opt "Hashable" "K" parse_type_str type_satisfies_trait ! assert_true
 }
@@ -621,35 +621,35 @@ fn test_type_var_without_bound_does_not_satisfy {
 fn test_type_var_with_wrong_bound_does_not_satisfy {
     "type_var_with_wrong_bound_does_not_satisfy" test_start
     "trait Hashable { fn hash self:self -> int }\ntrait Printable { fn to_str self:self -> str }\n" trait_test_parse drop
-    # Build a Signature with K bounded by Printable, check against Hashable
+    # Build a StackEffect with K bounded by Printable, check against Hashable
     Map::new(Map[str TraitBound]) = bounds
     "Printable" make_simple_trait_bound "K" bounds.set = bounds
     Set::new(Set[str]) = type_vars
     "K" type_vars.add = type_vars
-    bounds type_vars List::new(List[Type]) List::new(List[Parameter]) Signature = sig
-    sig empty_location List::new(List[Op]) "test_fn" make_function_with_sig = func
+    bounds type_vars List::new(List[Type]) List::new(List[Parameter]) StackEffect = sig
+    sig empty_location List::new(List[Op]) "test_fn" make_function_with_stack_effect = func
     func Option::Some = func_opt
     "does not satisfy" func_opt "Hashable" "K" parse_type_str type_satisfies_trait ! assert_true
 }
 
 # ============================================================================
-# Signature trait_bounds field
+# StackEffect trait_bounds field
 # ============================================================================
 
 fn test_trait_bounds_default_empty {
     "trait_bounds_default_empty" test_start
-    empty_signature = sig
-    "empty" 0 sig Signature::trait_bounds.length assert_eq
+    empty_stack_effect = sig
+    "empty" 0 sig StackEffect::trait_bounds.length assert_eq
 }
 
-fn test_trait_bounds_preserved_in_signature {
-    "trait_bounds_preserved_in_signature" test_start
+fn test_trait_bounds_preserved_in_stack_effect {
+    "trait_bounds_preserved_in_stack_effect" test_start
     Map::new(Map[str TraitBound]) = bounds
     "Hashable" make_simple_trait_bound "K" bounds.set = bounds
     Set::new(Set[str]) = type_vars
     "K" type_vars.add = type_vars
-    bounds type_vars List::new(List[Type]) List::new(List[Parameter]) Signature = sig
-    "preserved" "Hashable" "K" sig Signature::trait_bounds.get.unwrap TraitBound::name assert_str_eq
+    bounds type_vars List::new(List[Type]) List::new(List[Parameter]) StackEffect = sig
+    "preserved" "Hashable" "K" sig StackEffect::trait_bounds.get.unwrap TraitBound::name assert_str_eq
 }
 
 # ============================================================================
@@ -723,7 +723,7 @@ fn test_generic_trait_bound_compound_type_arg_preserves_space {
     "generic_trait_bound_compound_type_arg_preserves_space" test_start
     "trait Carrier[T] { fn get self:self -> T }\nfn uses[I: Carrier[Map[str int]]] i:I -> int { 0 }\n" trait_test_parse drop
     "uses" DEFAULT_PARSER.store.functions.get.unwrap = func
-    "I" func Function::signature Signature::trait_bounds.get.unwrap = bound
+    "I" func Function::stack_effect StackEffect::trait_bounds.get.unwrap = bound
     "preserved" "Carrier[Map[str int]]" bound trait_bound_to_str assert_str_eq
 }
 
@@ -767,8 +767,8 @@ fn test_generic_trait_bound_concrete_hidden_param_type {
     # Find the hidden __trait_I_get parameter and assert its type substituted T with int.
     false = found
     0 = index
-    while index func Function::signature Signature::parameters.length > do
-        index func Function::signature Signature::parameters.get = param
+    while index func Function::stack_effect StackEffect::parameters.length > do
+        index func Function::stack_effect StackEffect::parameters.get = param
         if "__trait_I_get" param Parameter::name == then
             true = found
             "hidden type" "fn[I -> int]" param Parameter::typ.format assert_str_eq
@@ -886,11 +886,11 @@ fn test_supertrait_negative_typecheck_raises {
 }
 
 # ============================================================================
-# Parse map type in signature
+# Parse map type in function declaration
 # ============================================================================
 
-fn test_parse_map_type_in_signature {
-    "parse_map_type_in_signature" test_start
+fn test_parse_map_type_in_function_declaration {
+    "parse_map_type_in_function_declaration" test_start
     "trait Hashable { fn hash self:self -> int }\nstruct MapStruct { data: ptr }\nfn test_fn m:MapStruct -> int { 0 }" trait_test_parse drop
     "passes" true assert_true
 }
@@ -903,14 +903,14 @@ fn test_dot_hash_on_bounded_type_var {
     "dot_hash_on_bounded_type_var" test_start
     HASHABLE_TRAIT "fn get_hash[K: Hashable] k:K -> int { k .hash }\n" str::concat trait_test_typecheck drop
     "get_hash" DEFAULT_PARSER.store.functions.get.unwrap = func
-    "has sig" func Function::signature Signature::parameters.length 0 != assert_true
+    "has stack effect" func Function::stack_effect StackEffect::parameters.length 0 != assert_true
 }
 
 fn test_dot_eq_on_bounded_type_var {
     "dot_eq_on_bounded_type_var" test_start
     HASHABLE_TRAIT "fn are_eq[K: Hashable] a:K b:K -> bool { b a .eq }\n" str::concat trait_test_typecheck drop
     "are_eq" DEFAULT_PARSER.store.functions.get.unwrap = func
-    "has sig" func Function::signature Signature::parameters.length 0 != assert_true
+    "has stack effect" func Function::stack_effect StackEffect::parameters.length 0 != assert_true
 }
 
 # ============================================================================
@@ -1000,9 +1000,9 @@ test_stt_empty_string
 test_type_var_with_matching_bound_satisfies
 test_type_var_without_bound_does_not_satisfy
 test_type_var_with_wrong_bound_does_not_satisfy
-# Signature trait_bounds field
+# StackEffect trait_bounds field
 test_trait_bounds_default_empty
-test_trait_bounds_preserved_in_signature
+test_trait_bounds_preserved_in_stack_effect
 # Trait ref resolution
 test_k_coloncolon_method_resolved_as_trait_method_call
 test_ampersand_k_coloncolon_method_resolved_as_push_variable
@@ -1026,5 +1026,5 @@ test_supertrait_method_required_for_satisfaction
 test_supertrait_satisfaction_with_full_impl
 test_supertrait_negative_typecheck_raises
 # Parse map type
-test_parse_map_type_in_signature
+test_parse_map_type_in_function_declaration
 test_summary

--- a/tests/compiler/test_type_annotations.casa
+++ b/tests/compiler/test_type_annotations.casa
@@ -20,7 +20,7 @@ fn test_parse code:str -> List[Op] {
     tokens DEFAULT_PARSER parse_ops
 }
 
-fn tc_code code:str -> Signature {
+fn tc_code code:str -> StackEffect {
     clear_global_state
     "test" code lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
@@ -175,43 +175,43 @@ fn test_no_annotation_on_decrement {
 fn test_tc_annotation_int {
     "tc_annotation_int" test_start
     "42 = x:int x" tc_code = sig
-    "return type" "int" 0 sig Signature::return_types.get.format assert_str_eq
+    "return type" "int" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_tc_annotation_str {
     "tc_annotation_str" test_start
     "\"hello\" = x:str x" tc_code = sig
-    "return type" "str" 0 sig Signature::return_types.get.format assert_str_eq
+    "return type" "str" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_tc_annotation_bool {
     "tc_annotation_bool" test_start
     "true = x:bool x" tc_code = sig
-    "return type" "bool" 0 sig Signature::return_types.get.format assert_str_eq
+    "return type" "bool" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_tc_annotation_matches_stack {
     "tc_annotation_matches_stack" test_start
     "42 = x:int x" tc_code = sig
-    "return type" "int" 0 sig Signature::return_types.get.format assert_str_eq
+    "return type" "int" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_tc_annotation_to_int {
     "tc_annotation_to_int" test_start
     "42 = x:int x" tc_code = sig
-    "return type" "int" 0 sig Signature::return_types.get.format assert_str_eq
+    "return type" "int" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_tc_annotation_to_str {
     "tc_annotation_to_str" test_start
     "\"hello\" = x:str x" tc_code = sig
-    "return type" "str" 0 sig Signature::return_types.get.format assert_str_eq
+    "return type" "str" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_tc_annotation_to_option {
     "tc_annotation_to_option" test_start
     OPTION_ENUM "Option::None = x:Option[T] x" str::concat tc_code = sig
-    "return type" "Option[T]" 0 sig Signature::return_types.get.format assert_str_eq
+    "return type" "Option[T]" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn assert_cast_rejected_as_unknown_type source:str expected_type:str {
@@ -247,37 +247,37 @@ fn test_tc_reject_unknown_generic_param_cast {
 fn test_tc_reassignment_keeps_annotated_type {
     "tc_reassignment_keeps_annotated_type" test_start
     "42 = x:int 99 = x x" tc_code = sig
-    "return type" "int" 0 sig Signature::return_types.get.format assert_str_eq
+    "return type" "int" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_tc_without_annotation {
     "tc_without_annotation" test_start
     "42 = x x" tc_code = sig
-    "return type" "int" 0 sig Signature::return_types.get.format assert_str_eq
+    "return type" "int" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_tc_annotation_in_function_body {
     "tc_annotation_in_function_body" test_start
     "fn foo -> int { 42 = x:int x } foo" tc_code = sig
-    "return type" "int" 0 sig Signature::return_types.get.format assert_str_eq
+    "return type" "int" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_tc_annotation_in_function_explicit {
     "tc_annotation_in_function_explicit" test_start
     "fn foo -> int { 42 = x:int x } foo" tc_code = sig
-    "return type" "int" 0 sig Signature::return_types.get.format assert_str_eq
+    "return type" "int" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_tc_annotation_with_struct {
     "tc_annotation_with_struct" test_start
     "struct Point { x: int y: int }\n0 0 Point = p:Point\np" tc_code = sig
-    "return type" "Point" 0 sig Signature::return_types.get.format assert_str_eq
+    "return type" "Point" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_tc_option_int_with_some {
     "tc_option_int_with_some" test_start
     OPTION_ENUM "42 Option::Some = x:Option[int] x" str::concat tc_code = sig
-    "return type" "Option[int]" 0 sig Signature::return_types.get.format assert_str_eq
+    "return type" "Option[int]" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 # ============================================================================

--- a/tests/compiler/test_typechecker.casa
+++ b/tests/compiler/test_typechecker.casa
@@ -530,16 +530,16 @@ fn test_typecheck_simple_expression {
     "test" "10 20 +" lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
     Option::None(Option[Function]) ops type_check_ops = sig
-    "params" 0 sig Signature::parameters.length assert_eq
-    "returns" 1 sig Signature::return_types.length assert_eq
-    "return type" "int" 0 sig Signature::return_types.get.format assert_str_eq
+    "params" 0 sig StackEffect::parameters.length assert_eq
+    "returns" 1 sig StackEffect::return_types.length assert_eq
+    "return type" "int" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 # ============================================================================
 # Helper: full pipeline typecheck
 # ============================================================================
 
-fn tc_string code:str -> Signature {
+fn tc_string code:str -> StackEffect {
     "test" code lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
     ops DEFAULT_PARSER resolve_identifiers_global = ops
@@ -553,66 +553,66 @@ fn tc_string code:str -> Signature {
 
 fn test_tc_pipeline_literals {
     "tc_pipeline_literals" test_start
-    "42" tc_string = sig1
-    "int count" 1 sig1 Signature::return_types.length assert_eq
-    "int type" "int" 0 sig1 Signature::return_types.get.format assert_str_eq
-    "true" tc_string = sig2
-    "bool" "bool" 0 sig2 Signature::return_types.get.format assert_str_eq
-    "\"hello\"" tc_string = sig3
-    "str" "str" 0 sig3 Signature::return_types.get.format assert_str_eq
-    "'a'" tc_string = sig4
-    "char" "char" 0 sig4 Signature::return_types.get.format assert_str_eq
+    "42" tc_string = effect1
+    "int count" 1 effect1 StackEffect::return_types.length assert_eq
+    "int type" "int" 0 effect1 StackEffect::return_types.get.format assert_str_eq
+    "true" tc_string = effect2
+    "bool" "bool" 0 effect2 StackEffect::return_types.get.format assert_str_eq
+    "\"hello\"" tc_string = effect3
+    "str" "str" 0 effect3 StackEffect::return_types.get.format assert_str_eq
+    "'a'" tc_string = effect4
+    "char" "char" 0 effect4 StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_tc_pipeline_arithmetic {
     "tc_pipeline_arithmetic" test_start
     "1 2 +" tc_string = sa
-    "add" "int" 0 sa Signature::return_types.get.format assert_str_eq
+    "add" "int" 0 sa StackEffect::return_types.get.format assert_str_eq
     "1 2 -" tc_string = ss
-    "sub" "int" 0 ss Signature::return_types.get.format assert_str_eq
+    "sub" "int" 0 ss StackEffect::return_types.get.format assert_str_eq
     "1 2 *" tc_string = sm
-    "mul" "int" 0 sm Signature::return_types.get.format assert_str_eq
+    "mul" "int" 0 sm StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_tc_pipeline_comparison {
     "tc_pipeline_comparison" test_start
     "1 2 ==" tc_string = sc
-    "eq" "bool" 0 sc Signature::return_types.get.format assert_str_eq
+    "eq" "bool" 0 sc StackEffect::return_types.get.format assert_str_eq
     "1 2 <" tc_string = sl
-    "lt" "bool" 0 sl Signature::return_types.get.format assert_str_eq
+    "lt" "bool" 0 sl StackEffect::return_types.get.format assert_str_eq
     "1 2 >=" tc_string = sg
-    "ge" "bool" 0 sg Signature::return_types.get.format assert_str_eq
+    "ge" "bool" 0 sg StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_tc_pipeline_syscalls {
     "tc_pipeline_syscalls" test_start
     "60 syscall0" tc_string = s0
-    "syscall0" "int" 0 s0 Signature::return_types.get.format assert_str_eq
+    "syscall0" "int" 0 s0 StackEffect::return_types.get.format assert_str_eq
     "0 60 syscall1" tc_string = s1
-    "syscall1" "int" 0 s1 Signature::return_types.get.format assert_str_eq
+    "syscall1" "int" 0 s1 StackEffect::return_types.get.format assert_str_eq
     "0 0 0 0 60 syscall4" tc_string = s4
-    "syscall4" "int" 0 s4 Signature::return_types.get.format assert_str_eq
+    "syscall4" "int" 0 s4 StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_tc_pipeline_stack_ops {
     "tc_pipeline_stack_ops" test_start
     "42 dup" tc_string = sd
-    "dup count" 2 sd Signature::return_types.length assert_eq
+    "dup count" 2 sd StackEffect::return_types.length assert_eq
     "42 drop" tc_string = sdr
-    "drop count" 0 sdr Signature::return_types.length assert_eq
+    "drop count" 0 sdr StackEffect::return_types.length assert_eq
     "42 \"hi\" swap" tc_string = sw
-    "swap count" 2 sw Signature::return_types.length assert_eq
-    "swap first" "str" 0 sw Signature::return_types.get.format assert_str_eq
+    "swap count" 2 sw StackEffect::return_types.length assert_eq
+    "swap first" "str" 0 sw StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_tc_pipeline_memory {
     "tc_pipeline_memory" test_start
     "10 alloc" tc_string = sa
-    "alloc" "ptr" 0 sa Signature::return_types.get.format assert_str_eq
+    "alloc" "ptr" 0 sa StackEffect::return_types.get.format assert_str_eq
     "10 alloc load64" tc_string = sl
-    "load64" "int" 0 sl Signature::return_types.get.format assert_str_eq
+    "load64" "int" 0 sl StackEffect::return_types.get.format assert_str_eq
     "42 10 alloc store64" tc_string = ss
-    "store64" 0 ss Signature::return_types.length assert_eq
+    "store64" 0 ss StackEffect::return_types.length assert_eq
 }
 
 # ============================================================================
@@ -840,34 +840,34 @@ fn test_memory_store_sizes {
 fn test_tc_pipeline_variable_assign_and_load {
     "tc_pipeline_variable_assign_and_load" test_start
     "42 = x x" tc_string = sig
-    "var returns" 1 sig Signature::return_types.length assert_eq
-    "var type is int" "int" 0 sig Signature::return_types.get.format assert_str_eq
+    "var returns" 1 sig StackEffect::return_types.length assert_eq
+    "var type is int" "int" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_tc_pipeline_variable_str {
     "tc_pipeline_variable_str" test_start
     "\"hello\" = s s" tc_string = sig
-    "str var" "str" 0 sig Signature::return_types.get.format assert_str_eq
+    "str var" "str" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_tc_pipeline_variable_bool {
     "tc_pipeline_variable_bool" test_start
     "true = flag flag" tc_string = sig
-    "bool var" "bool" 0 sig Signature::return_types.get.format assert_str_eq
+    "bool var" "bool" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_tc_pipeline_assign_pops_stack {
     "tc_pipeline_assign_pops_stack" test_start
     "42 = x" tc_string = sig
-    "assign pops" 0 sig Signature::return_types.length assert_eq
+    "assign pops" 0 sig StackEffect::return_types.length assert_eq
 }
 
 fn test_tc_pipeline_multiple_vars {
     "tc_pipeline_multiple_vars" test_start
     "42 = x \"hi\" = y x y" tc_string = sig
-    "two returns" 2 sig Signature::return_types.length assert_eq
-    "first is int" "int" 0 sig Signature::return_types.get.format assert_str_eq
-    "second is str" "str" 1 sig Signature::return_types.get.format assert_str_eq
+    "two returns" 2 sig StackEffect::return_types.length assert_eq
+    "first is int" "int" 0 sig StackEffect::return_types.get.format assert_str_eq
+    "second is str" "str" 1 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -877,20 +877,20 @@ fn test_tc_pipeline_multiple_vars {
 fn test_tc_pipeline_fn_call {
     "tc_pipeline_fn_call" test_start
     "fn double a:int -> int { a 2 * } 5 double" tc_string = sig
-    "fn call returns" 1 sig Signature::return_types.length assert_eq
-    "fn call type" "int" 0 sig Signature::return_types.get.format assert_str_eq
+    "fn call returns" 1 sig StackEffect::return_types.length assert_eq
+    "fn call type" "int" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_tc_pipeline_fn_no_return {
     "tc_pipeline_fn_no_return" test_start
     "fn noop a:int { a drop } 5 noop" tc_string = sig
-    "fn no return" 0 sig Signature::return_types.length assert_eq
+    "fn no return" 0 sig StackEffect::return_types.length assert_eq
 }
 
 fn test_tc_pipeline_fn_multi_param {
     "tc_pipeline_fn_multi_param" test_start
     "fn add a:int b:int -> int { a b + } 3 5 add" tc_string = sig
-    "fn multi param" "int" 0 sig Signature::return_types.get.format assert_str_eq
+    "fn multi param" "int" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -900,13 +900,13 @@ fn test_tc_pipeline_fn_multi_param {
 fn test_tc_pipeline_type_cast {
     "tc_pipeline_type_cast" test_start
     "42 (str)" tc_string = sig
-    "cast result" "str" 0 sig Signature::return_types.get.format assert_str_eq
+    "cast result" "str" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_tc_pipeline_type_cast_to_ptr {
     "tc_pipeline_type_cast_to_ptr" test_start
     "42 (ptr)" tc_string = sig
-    "cast to ptr" "ptr" 0 sig Signature::return_types.get.format assert_str_eq
+    "cast to ptr" "ptr" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -916,19 +916,19 @@ fn test_tc_pipeline_type_cast_to_ptr {
 fn test_tc_pipeline_ne {
     "tc_pipeline_ne" test_start
     "1 2 !=" tc_string = sig
-    "ne" "bool" 0 sig Signature::return_types.get.format assert_str_eq
+    "ne" "bool" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_tc_pipeline_le {
     "tc_pipeline_le" test_start
     "1 2 <=" tc_string = sig
-    "le" "bool" 0 sig Signature::return_types.get.format assert_str_eq
+    "le" "bool" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_tc_pipeline_gt {
     "tc_pipeline_gt" test_start
     "5 2 >" tc_string = sig
-    "gt" "bool" 0 sig Signature::return_types.get.format assert_str_eq
+    "gt" "bool" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -938,19 +938,19 @@ fn test_tc_pipeline_gt {
 fn test_tc_pipeline_boolean_and {
     "tc_pipeline_boolean_and" test_start
     "true false &&" tc_string = sig
-    "and" "bool" 0 sig Signature::return_types.get.format assert_str_eq
+    "and" "bool" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_tc_pipeline_boolean_or {
     "tc_pipeline_boolean_or" test_start
     "true false ||" tc_string = sig
-    "or" "bool" 0 sig Signature::return_types.get.format assert_str_eq
+    "or" "bool" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_tc_pipeline_boolean_not {
     "tc_pipeline_boolean_not" test_start
     "true !" tc_string = sig
-    "not" "bool" 0 sig Signature::return_types.get.format assert_str_eq
+    "not" "bool" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -960,21 +960,21 @@ fn test_tc_pipeline_boolean_not {
 fn test_tc_pipeline_bitwise {
     "tc_pipeline_bitwise" test_start
     "3 5 &" tc_string = sig_and
-    "bitand" "int" 0 sig_and Signature::return_types.get.format assert_str_eq
+    "bitand" "int" 0 sig_and StackEffect::return_types.get.format assert_str_eq
     "3 5 |" tc_string = sig_or
-    "bitor" "int" 0 sig_or Signature::return_types.get.format assert_str_eq
+    "bitor" "int" 0 sig_or StackEffect::return_types.get.format assert_str_eq
     "3 5 ^" tc_string = sig_xor
-    "bitxor" "int" 0 sig_xor Signature::return_types.get.format assert_str_eq
+    "bitxor" "int" 0 sig_xor StackEffect::return_types.get.format assert_str_eq
     "5 ~" tc_string = sig_not
-    "bitnot" "int" 0 sig_not Signature::return_types.get.format assert_str_eq
+    "bitnot" "int" 0 sig_not StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_tc_pipeline_bitshift {
     "tc_pipeline_bitshift" test_start
     "8 2 <<" tc_string = sig_shl
-    "shl" "int" 0 sig_shl Signature::return_types.get.format assert_str_eq
+    "shl" "int" 0 sig_shl StackEffect::return_types.get.format assert_str_eq
     "8 2 >>" tc_string = sig_shr
-    "shr" "int" 0 sig_shr Signature::return_types.get.format assert_str_eq
+    "shr" "int" 0 sig_shr StackEffect::return_types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -984,13 +984,13 @@ fn test_tc_pipeline_bitshift {
 fn test_tc_pipeline_syscall_remaining {
     "tc_pipeline_syscall_remaining" test_start
     "0 0 60 syscall2" tc_string = s2
-    "syscall2" "int" 0 s2 Signature::return_types.get.format assert_str_eq
+    "syscall2" "int" 0 s2 StackEffect::return_types.get.format assert_str_eq
     "0 0 0 60 syscall3" tc_string = s3
-    "syscall3" "int" 0 s3 Signature::return_types.get.format assert_str_eq
+    "syscall3" "int" 0 s3 StackEffect::return_types.get.format assert_str_eq
     "0 0 0 0 0 60 syscall5" tc_string = s5
-    "syscall5" "int" 0 s5 Signature::return_types.get.format assert_str_eq
+    "syscall5" "int" 0 s5 StackEffect::return_types.get.format assert_str_eq
     "1 2 3 4 5 6 100 syscall6" tc_string = s6
-    "syscall6" "int" 0 s6 Signature::return_types.get.format assert_str_eq
+    "syscall6" "int" 0 s6 StackEffect::return_types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -1000,9 +1000,9 @@ fn test_tc_pipeline_syscall_remaining {
 fn test_tc_pipeline_div_mod {
     "tc_pipeline_div_mod" test_start
     "10 3 /" tc_string = sd
-    "div" "int" 0 sd Signature::return_types.get.format assert_str_eq
+    "div" "int" 0 sd StackEffect::return_types.get.format assert_str_eq
     "10 3 %" tc_string = sm
-    "mod" "int" 0 sm Signature::return_types.get.format assert_str_eq
+    "mod" "int" 0 sm StackEffect::return_types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -1045,7 +1045,7 @@ fn test_stacks_compatible_empty {
 # Helper: full pipeline typecheck with error mode
 # ============================================================================
 
-fn tc_string_error code:str -> Signature {
+fn tc_string_error code:str -> StackEffect {
     enable_test_mode
     clear_errors
     "test" code lex_source = tokens
@@ -1149,7 +1149,7 @@ fn test_error_store_non_ptr {
 fn test_store_accepts_any_value_type {
     "store_accepts_any_value_type" test_start
     "\"hello\" 10 alloc store64" tc_string = sig
-    "store str value" 0 sig Signature::return_types.length assert_eq
+    "store str value" 0 sig StackEffect::return_types.length assert_eq
 }
 
 # ============================================================================
@@ -1174,7 +1174,7 @@ fn test_memory_store64 {
 fn test_syscall_any_arg_type {
     "syscall_any_arg_type" test_start
     "\"hello\" 42 syscall1" tc_string = sig
-    "syscall with str arg" "int" 0 sig Signature::return_types.get.format assert_str_eq
+    "syscall with str arg" "int" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -1373,7 +1373,7 @@ fn test_dup_preserves_bool {
 fn test_tc_pipeline_negative_int {
     "tc_pipeline_negative_int" test_start
     "-42" tc_string = sig
-    "negative int type" "int" 0 sig Signature::return_types.get.format assert_str_eq
+    "negative int type" "int" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -1383,8 +1383,8 @@ fn test_tc_pipeline_negative_int {
 fn test_tc_pipeline_if_else_consistent {
     "tc_pipeline_if_else_consistent" test_start
     "if true then 1 else 2 fi" tc_string = sig
-    "if else returns" 1 sig Signature::return_types.length assert_eq
-    "if else type" "int" 0 sig Signature::return_types.get.format assert_str_eq
+    "if else returns" 1 sig StackEffect::return_types.length assert_eq
+    "if else type" "int" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -1420,7 +1420,7 @@ fn test_error_if_no_else_mismatch {
 fn test_tc_pipeline_while_loop {
     "tc_pipeline_while_loop" test_start
     "while false do done" tc_string = sig
-    "while empty" 0 sig Signature::return_types.length assert_eq
+    "while empty" 0 sig StackEffect::return_types.length assert_eq
 }
 
 # ============================================================================
@@ -1430,26 +1430,26 @@ fn test_tc_pipeline_while_loop {
 fn test_tc_pipeline_local_shadows_global {
     "tc_pipeline_local_shadows_global" test_start
     "\"hello\" = x fn foo x:int -> int { x } 42 foo" tc_string = sig
-    "local shadows global" "int" 0 sig Signature::return_types.get.format assert_str_eq
+    "local shadows global" "int" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 # ============================================================================
-# Tests: Error - function signature mismatch
+# Tests: Error - function stack effect mismatch
 # ============================================================================
 
-fn test_error_fn_signature_mismatch {
-    "error_fn_signature_mismatch" test_start
+fn test_error_fn_stack_effect_mismatch {
+    "error_fn_stack_effect_mismatch" test_start
     enable_test_mode
     clear_errors
-    # Build a function with declared sig "int -> str" but body returns int
-    "int -> str" signature_from_str = bad_sig
+    # Build a function with declared stack effect "int -> str" but body returns int
+    "int -> str" stack_effect_from_str = bad_stack_effect
     List::new(List[Op]) = bad_ops
     empty_location 42 OpValue::PushInt make_op bad_ops.push
-    # RPN: sig location ops name make_function_with_sig
-    bad_sig empty_location bad_ops "bad_fn" make_function_with_sig = bad_fn
+    # RPN: stack effect, location, ops, name, make_function_with_stack_effect
+    bad_stack_effect empty_location bad_ops "bad_fn" make_function_with_stack_effect = bad_fn
     bad_fn Option::Some bad_ops type_check_ops drop
     "has errors" assert_has_errors
-    "signature mismatch" ErrorKind::SignatureMismatch assert_error_kind
+    "stack effect mismatch" ErrorKind::SignatureMismatch assert_error_kind
     clear_errors
     disable_test_mode
 }
@@ -1463,12 +1463,12 @@ fn test_error_unused_fn_type_error {
     enable_test_mode
     clear_errors
     # Declared: int -> str, but body is empty (returns nothing)
-    "int -> str" signature_from_str = bad_sig
+    "int -> str" stack_effect_from_str = bad_stack_effect
     List::new(List[Op]) = empty_ops
-    bad_sig empty_location empty_ops "bad_unused" make_function_with_sig = bad_fn
+    bad_stack_effect empty_location empty_ops "bad_unused" make_function_with_stack_effect = bad_fn
     bad_fn Option::Some empty_ops type_check_ops drop
     "has errors" assert_has_errors
-    "signature mismatch" ErrorKind::SignatureMismatch assert_error_kind
+    "stack effect mismatch" ErrorKind::SignatureMismatch assert_error_kind
     clear_errors
     disable_test_mode
 }
@@ -1480,13 +1480,13 @@ fn test_error_unused_fn_type_error {
 fn test_tc_pipeline_type_cast_to_int {
     "tc_pipeline_type_cast_to_int" test_start
     "\"hello\" (int)" tc_string = sig
-    "cast to int" "int" 0 sig Signature::return_types.get.format assert_str_eq
+    "cast to int" "int" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_tc_pipeline_type_cast_to_bool {
     "tc_pipeline_type_cast_to_bool" test_start
     "42 (bool)" tc_string = sig
-    "cast to bool" "bool" 0 sig Signature::return_types.get.format assert_str_eq
+    "cast to bool" "bool" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -1496,9 +1496,9 @@ fn test_tc_pipeline_type_cast_to_bool {
 fn test_tc_pipeline_swap_type_order {
     "tc_pipeline_swap_type_order" test_start
     "42 \"hi\" swap" tc_string = sig
-    "swap count" 2 sig Signature::return_types.length assert_eq
-    "swap bottom" "str" 0 sig Signature::return_types.get.format assert_str_eq
-    "swap top" "int" 1 sig Signature::return_types.get.format assert_str_eq
+    "swap count" 2 sig StackEffect::return_types.length assert_eq
+    "swap bottom" "str" 0 sig StackEffect::return_types.get.format assert_str_eq
+    "swap top" "int" 1 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -1508,10 +1508,10 @@ fn test_tc_pipeline_swap_type_order {
 fn test_tc_pipeline_over_type_order {
     "tc_pipeline_over_type_order" test_start
     "42 \"hi\" over" tc_string = sig
-    "over count" 3 sig Signature::return_types.length assert_eq
-    "over bottom" "int" 0 sig Signature::return_types.get.format assert_str_eq
-    "over middle" "str" 1 sig Signature::return_types.get.format assert_str_eq
-    "over top" "int" 2 sig Signature::return_types.get.format assert_str_eq
+    "over count" 3 sig StackEffect::return_types.length assert_eq
+    "over bottom" "int" 0 sig StackEffect::return_types.get.format assert_str_eq
+    "over middle" "str" 1 sig StackEffect::return_types.get.format assert_str_eq
+    "over top" "int" 2 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -1521,10 +1521,10 @@ fn test_tc_pipeline_over_type_order {
 fn test_tc_pipeline_rot_type_order {
     "tc_pipeline_rot_type_order" test_start
     "1 \"a\" true rot" tc_string = sig
-    "rot count" 3 sig Signature::return_types.length assert_eq
-    "rot bottom" "str" 0 sig Signature::return_types.get.format assert_str_eq
-    "rot middle" "bool" 1 sig Signature::return_types.get.format assert_str_eq
-    "rot top" "int" 2 sig Signature::return_types.get.format assert_str_eq
+    "rot count" 3 sig StackEffect::return_types.length assert_eq
+    "rot bottom" "str" 0 sig StackEffect::return_types.get.format assert_str_eq
+    "rot middle" "bool" 1 sig StackEffect::return_types.get.format assert_str_eq
+    "rot top" "int" 2 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -1534,7 +1534,7 @@ fn test_tc_pipeline_rot_type_order {
 fn test_tc_pipeline_typeof {
     "tc_pipeline_typeof" test_start
     "42 typeof" tc_string = sig
-    "typeof returns str" "str" 0 sig Signature::return_types.get.format assert_str_eq
+    "typeof returns str" "str" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -1544,7 +1544,7 @@ fn test_tc_pipeline_typeof {
 fn test_tc_pipeline_print_pops {
     "tc_pipeline_print_pops" test_start
     "42 print" tc_string = sig
-    "print pops" 0 sig Signature::return_types.length assert_eq
+    "print pops" 0 sig StackEffect::return_types.length assert_eq
 }
 
 # ============================================================================
@@ -1567,10 +1567,10 @@ fn test_stacks_compatible_different_types {
 
 fn test_types_match_fn_types {
     "types_match_fn_types" test_start
-    "fn matches fn sig" "fn[int -> int]" parse_type_str "fn" parse_type_str types_match_t assert_true
-    "fn sig matches fn" "fn" parse_type_str "fn[int -> int]" parse_type_str types_match_t assert_true
-    "fn sig matches same" "fn[int -> int]" parse_type_str "fn[int -> int]" parse_type_str types_match_t assert_true
-    "fn sig mismatch" "fn[int -> int]" parse_type_str "fn[str -> str]" parse_type_str types_match_t ! assert_true
+    "fn matches fn type" "fn[int -> int]" parse_type_str "fn" parse_type_str types_match_t assert_true
+    "fn type matches fn" "fn" parse_type_str "fn[int -> int]" parse_type_str types_match_t assert_true
+    "fn type matches same" "fn[int -> int]" parse_type_str "fn[int -> int]" parse_type_str types_match_t assert_true
+    "fn type mismatch" "fn[int -> int]" parse_type_str "fn[str -> str]" parse_type_str types_match_t ! assert_true
 }
 
 # ============================================================================
@@ -1659,7 +1659,7 @@ fn test_error_comparison_str_lt_int {
 fn test_tc_pipeline_str_equality {
     "tc_pipeline_str_equality" test_start
     "\"a\" \"b\" ==" tc_string = sig
-    "str eq" "bool" 0 sig Signature::return_types.get.format assert_str_eq
+    "str eq" "bool" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -1791,38 +1791,38 @@ fn test_branch_frame_kind_dispatch {
 fn test_array_literal_int_inference {
     "array_literal_int_inference" test_start
     "[1 2 3]" tc_string = sig
-    "one return" 1 sig Signature::return_types.length assert_eq
-    "array[int]" "array[int]" 0 sig Signature::return_types.get.format assert_str_eq
+    "one return" 1 sig StackEffect::return_types.length assert_eq
+    "array[int]" "array[int]" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_array_literal_str_inference {
     "array_literal_str_inference" test_start
     "[\"a\" \"b\"]" tc_string = sig
-    "array[str]" "array[str]" 0 sig Signature::return_types.get.format assert_str_eq
+    "array[str]" "array[str]" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_array_literal_bool_inference {
     "array_literal_bool_inference" test_start
     "[true false]" tc_string = sig
-    "array[bool]" "array[bool]" 0 sig Signature::return_types.get.format assert_str_eq
+    "array[bool]" "array[bool]" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_array_literal_empty {
     "array_literal_empty" test_start
     "[] (array[int])" tc_string = sig
-    "explicit cast resolves" "array[int]" 0 sig Signature::return_types.get.format assert_str_eq
+    "explicit cast resolves" "array[int]" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_array_literal_empty_with_annotation {
     "array_literal_empty_with_annotation" test_start
     "[] = xs:array[int] xs" tc_string = sig
-    "annotation resolves" "array[int]" 0 sig Signature::return_types.get.format assert_str_eq
+    "annotation resolves" "array[int]" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_array_literal_empty_with_cast_then_assign {
     "array_literal_empty_with_cast_then_assign" test_start
     "[] (array[str]) = xs xs" tc_string = sig
-    "cast then assign" "array[str]" 0 sig Signature::return_types.get.format assert_str_eq
+    "cast then assign" "array[str]" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_error_array_literal_heterogeneous {
@@ -1982,7 +1982,7 @@ test_error_if_inconsistent
 test_error_if_no_else_mismatch
 test_tc_pipeline_while_loop
 test_tc_pipeline_local_shadows_global
-test_error_fn_signature_mismatch
+test_error_fn_stack_effect_mismatch
 test_error_unused_fn_type_error
 test_tc_pipeline_type_cast_to_int
 test_tc_pipeline_type_cast_to_bool

--- a/tests/compiler/test_typeof.casa
+++ b/tests/compiler/test_typeof.casa
@@ -11,7 +11,7 @@ import "../../lib/test.casa"
 # Helpers
 # ============================================================================
 
-fn tc_typeof code:str -> Signature {
+fn tc_typeof code:str -> StackEffect {
     "test" code lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops
     ops DEFAULT_PARSER resolve_identifiers_global = ops
@@ -98,52 +98,52 @@ fn test_parse_typeof {
 fn test_typecheck_typeof_returns_str_for_int {
     "typecheck_typeof_returns_str_for_int" test_start
     "42 typeof" tc_typeof = sig
-    "one return" 1 sig Signature::return_types.length assert_eq
-    "returns str" "str" 0 sig Signature::return_types.get.format assert_str_eq
+    "one return" 1 sig StackEffect::return_types.length assert_eq
+    "returns str" "str" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_typecheck_typeof_returns_str_for_bool {
     "typecheck_typeof_returns_str_for_bool" test_start
     "true typeof" tc_typeof = sig
-    "returns str" "str" 0 sig Signature::return_types.get.format assert_str_eq
+    "returns str" "str" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_typecheck_typeof_returns_str_for_str {
     "typecheck_typeof_returns_str_for_str" test_start
     "\"hello\" typeof" tc_typeof = sig
-    "returns str" "str" 0 sig Signature::return_types.get.format assert_str_eq
+    "returns str" "str" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_typecheck_typeof_returns_str_for_char {
     "typecheck_typeof_returns_str_for_char" test_start
     "'a' typeof" tc_typeof = sig
-    "returns str" "str" 0 sig Signature::return_types.get.format assert_str_eq
+    "returns str" "str" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_typecheck_typeof_no_params {
     "typecheck_typeof_no_params" test_start
     "42 typeof" tc_typeof = sig
-    "no params" 0 sig Signature::parameters.length assert_eq
+    "no params" 0 sig StackEffect::parameters.length assert_eq
 }
 
 fn test_typecheck_typeof_chained {
     "typecheck_typeof_chained" test_start
     "42 typeof drop true typeof" tc_typeof = sig
-    "one return" 1 sig Signature::return_types.length assert_eq
-    "returns str" "str" 0 sig Signature::return_types.get.format assert_str_eq
+    "one return" 1 sig StackEffect::return_types.length assert_eq
+    "returns str" "str" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_typecheck_typeof_ptr {
     "typecheck_typeof_ptr" test_start
     "10 alloc typeof" tc_typeof = sig
-    "returns str" "str" 0 sig Signature::return_types.get.format assert_str_eq
+    "returns str" "str" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_typecheck_typeof_array {
     "typecheck_typeof_array" test_start
     "[1 2 3] typeof" tc_typeof = sig
-    "one return" 1 sig Signature::return_types.length assert_eq
-    "returns str" "str" 0 sig Signature::return_types.get.format assert_str_eq
+    "one return" 1 sig StackEffect::return_types.length assert_eq
+    "returns str" "str" 0 sig StackEffect::return_types.get.format assert_str_eq
 }
 
 # ============================================================================

--- a/tests/compiler/test_underflow_messages.casa
+++ b/tests/compiler/test_underflow_messages.casa
@@ -9,7 +9,7 @@ import "../../lib/test.casa"
 # Helper: lex + parse + resolve + typecheck a source string
 # ============================================================================
 
-fn tc_um code:str -> Signature {
+fn tc_um code:str -> StackEffect {
     clear_global_state
     "test" code lex_source = tokens
     tokens DEFAULT_PARSER parse_ops = ops


### PR DESCRIPTION
## Summary

- Rename internal `Signature` / `signature_*` stack-contract model to `StackEffect` / `stack_effect_*`.
- Update compiler, LSP, formatter comments, examples, and compiler tests to use stack-effect terminology.
- Keep generated diagnostic codes like `SIGNATURE_MISMATCH` while updating explanatory prose.

Closes #188

## Validation

- `tests/test_examples.sh`
- `tests/test_compiler.sh < /dev/null`