### PR TITLE
refactor(compiler): use ? operator for Option propagation

### DIFF
--- a/compiler/lexer.casa
+++ b/compiler/lexer.casa
@@ -122,15 +122,12 @@ impl Lexer {
     }
 
     fn parse_escape self:Lexer -> Option[str] {
-        self Lexer::cursor.advance = char_opt
-        if char_opt.is_none then
-            Option::None return
-        fi
-        char_opt.unwrap (int) ESCAPE_SEQUENCES.get = result
+        self Lexer::cursor.advance ? = char_val
+        char_val (int) ESCAPE_SEQUENCES.get = result
         if result.is_some then
             result return
         fi
-        if 'x' char_opt.unwrap == then
+        if 'x' char_val == then
             self.parse_hex_escape return
         fi
         2 self Lexer::cursor Cursor::pos 2 - self.loc = loc
@@ -258,11 +255,7 @@ impl Lexer {
             str_loc TokenKind::Literal str_value make_token Option::Some return
         fi
 
-        self.peek_word = word_opt
-        if word_opt.is_none then
-            Option::None return
-        fi
-        word_opt.unwrap = value
+        self.peek_word ? = value
         value.length = length
         length start self.loc = loc
         self Lexer::cursor Cursor::pos length + self Lexer::cursor Cursor::set_pos
@@ -398,11 +391,7 @@ impl Lexer {
     }
 
     fn parse_single_token self:Lexer -> Option[Token] {
-        self Lexer::cursor.peek = peek_opt
-        if peek_opt.is_none then
-            Option::None return
-        fi
-        peek_opt.unwrap = character
+        self Lexer::cursor.peek ? = character
         # Comment
         if '#' character == then
             if FMT_LEXER_MODE then

--- a/compiler/syntax.casa
+++ b/compiler/syntax.casa
@@ -590,15 +590,12 @@ fn get_op_delimiter parser:Parser token:Token cursor:TokenCursor function_name:s
 
 fn try_parse_is_check token:Token cursor:TokenCursor -> Option[Op] {
     cursor.save = saved_pos
-    cursor.peek = peek_opt
-    if peek_opt.is_none then
-        Option::None return
-    fi
+    cursor.peek ? = peek_token
 
     List::new(List[str]) = bindings
 
     # Check for bindings: Enum::Variant(a b) is
-    if "(" peek_opt.unwrap Token::value == then
+    if "(" peek_token Token::value == then
         cursor.pop drop # consume (
         while true do
             cursor.peek = inner_opt

--- a/compiler/typechecker.casa
+++ b/compiler/typechecker.casa
@@ -370,9 +370,7 @@ fn unify_generic_params_t type_a:Type type_b:Type -> Option[Type] {
     List::new(List[Type]) = unified
     0 = index
     while index params_a.length > do
-        index params_b.get index params_a.get unify_type_t = unified_opt
-        if unified_opt.is_none then Option::None(Option[Type]) return fi
-        unified_opt.unwrap unified.push
+        index params_b.get index params_a.get unify_type_t ? unified.push
         1 += index
     done
     type_a.base.unwrap = base


### PR DESCRIPTION
## Summary
- Replace manual `is_none` / `unwrap` patterns with the postfix `?` operator in 5 sites across the compiler
- Targets `lexer.casa` (3 sites: `parse_escape`, `lex_multichar`, `parse_single_token`), `syntax.casa` (1 site: `try_parse_is_check`), and `typechecker.casa` (1 site: `unify_generic_params_t`)
- Only patterns where the enclosing function returns `Option[...]` and the None path has no custom logic

## Test plan
- [x] `tests/test_compiler.sh` — 49/49 passed (includes self-compilation + fixed-point)
- [x] `tests/test_examples.sh` — 42/42 passed
- [x] Formatted with `casafmt`