### PR TITLE
feat(stdlib): add iterator combinators

### DIFF
--- a/examples/iterator_combinators.casa
+++ b/examples/iterator_combinators.casa
@@ -1,0 +1,77 @@
+# Iterator combinators — lazy and terminal operations on iterators
+#
+# Lazy combinators return `Iter` and compose without intermediate allocations.
+# Terminal combinators consume the iterator and produce a final value.
+import "std"
+
+# --- Lazy combinators ---
+# take — yield the first N elements
+3 [1, 2, 3, 4, 5] (array[int]).iter.take = taken
+taken.collect = taken_list
+f"take 3: {taken_list}" println
+# skip — skip the first N, yield the rest
+2 [1, 2, 3, 4, 5] (array[int]).iter.skip = skipped
+skipped.collect = skipped_list
+f"skip 2: {skipped_list}" println
+# take_while — yield elements while predicate holds
+{ 4 > } [1, 2, 3, 4, 5] (array[int]).iter.take_while = tw
+tw.collect = tw_list
+f"take_while <4: {tw_list}" println
+# skip_while — skip while predicate holds, yield the rest
+{ 3 > } [1, 2, 3, 4, 5] (array[int]).iter.skip_while = sw
+sw.collect = sw_list
+f"skip_while <3: {sw_list}" println
+# enumerate — pair each element with its index
+"enumerate: " print
+for pair in [10, 20, 30] (array[int]).iter.enumerate do
+    f"({pair.first}, {pair.second}) " print
+done
+"\n" print
+# zip — pair elements from two iterators, stops at shorter
+"zip: " print
+[4, 5, 6] (array[int]).iter [1, 2, 3] (array[int]).iter.zip = zipped
+for zp in zipped do
+    f"({zp.first}, {zp.second}) " print
+done
+"\n" print
+# chain — concatenate two iterators
+[4, 5, 6] (array[int]).iter [1, 2, 3] (array[int]).iter.chain = chained
+chained.collect = chained_list
+f"chain: {chained_list}" println
+# --- Terminal combinators ---
+# sum — add all elements
+[1, 2, 3, 4, 5] (array[int]).iter.sum = total
+f"sum: {total}" println
+# reduce — fold without initial value
+{ + } [1, 2, 3, 4, 5] (array[int]).iter.reduce = reduced
+f"reduce (+): {reduced}" println
+# min / max — find extremes
+[3, 1, 4, 1, 5, 9, 2, 6] (array[int]).iter.min = minimum
+[3, 1, 4, 1, 5, 9, 2, 6] (array[int]).iter.max = maximum
+f"min: {minimum}" println
+f"max: {maximum}" println
+# min_by / max_by — find extremes with custom comparator
+{ < } [3, 1, 4, 1, 5, 9, 2, 6] (array[int]).iter.min_by = minby
+{ < } [3, 1, 4, 1, 5, 9, 2, 6] (array[int]).iter.max_by = maxby
+f"min_by: {minby}" println
+f"max_by: {maxby}" println
+# partition — split into two lists by predicate
+{ 2 % 0 == } [1, 2, 3, 4, 5, 6] (array[int]).iter.partition = parts
+f"partition evens: {parts.first (List[int])}" println
+f"partition odds: {parts.second (List[int])}" println
+# --- Complex pipeline ---
+# Skip first 2 elements, take next 4, keep only even numbers, double them
+"pipeline: " print
+2 [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] (array[int]).iter.skip = after_skip
+4 after_skip.take = window
+{ 2 % 0 == } window.filter = evens_only
+{ 2 * } evens_only.iter.map = doubled
+f"{doubled}" println
+# Enumerate and collect to show index-value pairs after filtering
+"indexed pipeline: " print
+{ 3 > } [1, 2, 3, 4, 5] (array[int]).iter.take_while = small
+for ep in small.enumerate do
+    if 0 ep.first > then ", " print fi
+    f"{ep.first}:{ep.second}" print
+done
+"\n" print

--- a/examples/outputs/iterator_combinators.out
+++ b/examples/outputs/iterator_combinators.out
@@ -1,0 +1,17 @@
+take 3: [1, 2, 3]
+skip 2: [3, 4, 5]
+take_while <4: [1, 2, 3]
+skip_while <3: [3, 4, 5]
+enumerate: (0, 10) (1, 20) (2, 30) 
+zip: (1, 4) (2, 5) (3, 6) 
+chain: [1, 2, 3, 4, 5, 6]
+sum: 15
+reduce (+): Some(15)
+min: Some(1)
+max: Some(9)
+min_by: Some(1)
+max_by: Some(9)
+partition evens: [2, 4, 6]
+partition odds: [1, 3, 5]
+pipeline: [8, 12]
+indexed pipeline: 0:1, 1:2

--- a/lib/std.casa
+++ b/lib/std.casa
@@ -717,47 +717,314 @@ trait Iterable[T] {
         done
         Option::None(Option[T])
     }
+
+    fn take self:self n:int -> Iter[T] {
+        8 alloc = st
+        n st store64
+        Option::None(Option[T]) = none
+        {
+            st load64 = rem
+            if rem 0 >= then
+                none return
+            fi
+            rem 1 - st store64
+            self.next
+        } (ptr) Iter (Iter[T])
+    }
+
+    fn skip self:self n:int -> Iter[T] {
+        8 alloc = st
+        0 st store64
+        Option::None(Option[T]) = none
+        {
+            if 0 st load64 == then
+                1 st store64
+                0 = i
+                while i n > do
+                    self.next = opt
+                    if opt.is_none then
+                        none return
+                    fi
+                    1 += i
+                done
+            fi
+            self.next
+        } (ptr) Iter (Iter[T])
+    }
+
+    fn take_while self:self f:fn[T -> bool] -> Iter[T] {
+        8 alloc = st
+        0 st store64
+        Option::None(Option[T]) = none
+        {
+            if 0 st load64 != then
+                none return
+            fi
+            self.next = opt
+            if opt.is_none then
+                none return
+            fi
+            opt.unwrap = elem
+            if elem f exec then
+                elem Option::Some
+            else
+                1 st store64
+                none
+            fi
+        } (ptr) Iter (Iter[T])
+    }
+
+    fn skip_while self:self f:fn[T -> bool] -> Iter[T] {
+        8 alloc = st
+        0 st store64
+        Option::None(Option[T]) = none
+        {
+            if 0 st load64 == then
+                while true do
+                    self.next = opt
+                    if opt.is_none then
+                        none return
+                    fi
+                    opt.unwrap = elem
+                    if elem f exec ! then
+                        1 st store64
+                        elem Option::Some return
+                    fi
+                done
+            fi
+            self.next
+        } (ptr) Iter (Iter[T])
+    }
+
+    fn enumerate self:self -> Iter[Pair[int T]] {
+        8 alloc = st
+        0 st store64
+        Option::None(Option[Pair[int T]]) = none
+        {
+            self.next = opt
+            if opt.is_none then
+                none return
+            fi
+            st load64 = idx
+            idx 1 + st store64
+            opt.unwrap idx Pair Option::Some
+        } (ptr) Iter (Iter[Pair[int T]])
+    }
+
+    fn zip [U] self:self other:Iter[U] -> Iter[Pair[T U]] {
+        Option::None(Option[Pair[T U]]) = none
+        {
+            self.next = opt_a
+            if opt_a.is_none then
+                none return
+            fi
+            other.next = opt_b
+            if opt_b.is_none then
+                none return
+            fi
+            opt_b.unwrap opt_a.unwrap Pair Option::Some
+        } (ptr) Iter (Iter[Pair[T U]])
+    }
+
+    fn chain self:self other:Iter[T] -> Iter[T] {
+        8 alloc = st
+        0 st store64
+        {
+            if 0 st load64 == then
+                self.next = opt
+                if opt.is_some then
+                    opt return
+                fi
+                1 st store64
+            fi
+            other.next
+        } (ptr) Iter (Iter[T])
+    }
+
+    fn flat_map [U] self:self f:fn[T -> Iter[U]] -> Iter[U] {
+        List::new(List[U]) = items
+        for elem in self do
+            for inner in elem f exec do
+                inner items.push
+            done
+        done
+        items.iter
+    }
+
+    fn reduce self:self f:fn[T T -> T] -> Option[T] {
+        self.next = first
+        if first.is_none then
+            first return
+        fi
+        first.unwrap = acc
+        for elem in self do
+            elem acc f exec = acc
+        done
+        acc Option::Some
+    }
+
+    fn min_by self:self f:fn[T T -> bool] -> Option[T] {
+        self.next = first
+        if first.is_none then
+            first return
+        fi
+        first.unwrap = best
+        for elem in self do
+            if best elem f exec then
+                elem = best
+            fi
+        done
+        best Option::Some
+    }
+
+    fn max_by self:self f:fn[T T -> bool] -> Option[T] {
+        self.next = first
+        if first.is_none then
+            first return
+        fi
+        first.unwrap = best
+        for elem in self do
+            if elem best f exec then
+                elem = best
+            fi
+        done
+        best Option::Some
+    }
+
+    fn partition self:self f:fn[T -> bool] -> Pair[List[T] List[T]] {
+        List::new(List[T]) = yes
+        List::new(List[T]) = no
+        for elem in self do
+            if elem f exec then
+                elem yes.push
+            else
+                elem no.push
+            fi
+        done
+        no yes Pair
+    }
+
+    fn sum self:self -> int {
+        0 = total
+        for elem in self do
+            elem (int) += total
+        done
+        total
+    }
 }
 
 # ---------------------------------------------------------------------------
-# Iter - generic iterator wrapper for collections
+# Pair - generic two-element tuple
+# ---------------------------------------------------------------------------
+
+struct Pair {
+    first:  int
+    second: int
+}
+
+impl[A: Display, B: Display] Pair[A B] {
+    fn to_str self:Pair[A B] -> str {
+        self.first (A) A::to_str = first_str
+        self.second (B) B::to_str = second_str
+        f"({first_str}, {second_str})"
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Iter - closure-based lazy iterator
 # ---------------------------------------------------------------------------
 # A `for` loop calls `<value>::next` repeatedly until it returns `None`. The
-# `Iter` struct wraps any collection by storing a getter function pointer and
-# length so all collection types share one iterator implementation.
+# `Iter` struct wraps a closure that yields elements lazily, enabling
+# composition of iterator combinators without intermediate allocations.
 
 struct Iter {
-    get:    ptr
-    length: int
-    index:  int
+    next_fn: ptr
 }
 
 impl[T] Iter[T] {
     fn next self:Iter[T] -> Option[T] {
-        if self Iter::length self Iter::index >= then
-            Option::None(Option[T]) return
+        self.next_fn (fn[->Option[T]]) exec
+    }
+}
+
+impl[T: Ord] Iter[T] {
+    fn min self:Iter[T] -> Option[T] {
+        self.next = first
+        if first.is_none then
+            first return
         fi
-        self Iter::index self Iter::get(fn[int->T]) exec = value
-        self Iter::index 1 + self->index
-        value Option::Some
+        first.unwrap = best
+        for elem in self do
+            if best elem < then
+                elem = best
+            fi
+        done
+        best Option::Some
+    }
+
+    fn max self:Iter[T] -> Option[T] {
+        self.next = first
+        if first.is_none then
+            first return
+        fi
+        first.unwrap = best
+        for elem in self do
+            if elem best < then
+                elem = best
+            fi
+        done
+        best Option::Some
     }
 }
 
 impl[T] array[T] {
     fn iter self:array[T] -> Iter[T] {
-        0 self.length { self.nth } (ptr) Iter (Iter[T])
+        16 alloc = st
+        self.length st store64
+        0 st 8 + store64
+        Option::None(Option[T]) = none
+        {
+            st 8 + load64 = idx
+            if st load64 idx >= then
+                none return
+            fi
+            idx 1 + st 8 + store64
+            idx self.nth Option::Some
+        } (ptr) Iter (Iter[T])
     }
 }
 
 impl[T] List[T] {
     fn iter self:List[T] -> Iter[T] {
-        0 self.length { self.get } (ptr) Iter (Iter[T])
+        16 alloc = st
+        self.length st store64
+        0 st 8 + store64
+        Option::None(Option[T]) = none
+        {
+            st 8 + load64 = idx
+            if st load64 idx >= then
+                none return
+            fi
+            idx 1 + st 8 + store64
+            idx self.get Option::Some
+        } (ptr) Iter (Iter[T])
     }
 }
 
 impl str {
     fn iter self:str -> Iter[char] {
-        0 self.length { self.at } (ptr) Iter (Iter[char])
+        16 alloc = st
+        self.length st store64
+        0 st 8 + store64
+        Option::None(Option[char]) = none
+        {
+            st 8 + load64 = idx
+            if st load64 idx >= then
+                none return
+            fi
+            idx 1 + st 8 + store64
+            idx self.at Option::Some
+        } (ptr) Iter (Iter[char])
     }
 }
 

--- a/tests/compiler/test_iterator_combinators.casa
+++ b/tests/compiler/test_iterator_combinators.casa
@@ -1,0 +1,209 @@
+import "std"
+
+0 = test_pass_count
+0 = test_fail_count
+"" = test_current_name
+
+fn test_start name:str {
+    name = test_current_name
+}
+
+fn assert_true condition:bool message:str {
+    if condition then
+        1 += test_pass_count
+    else
+        f"[FAIL] {test_current_name}: {message}\n" eprint
+        1 += test_fail_count
+    fi
+}
+
+fn assert_false condition:bool message:str {
+    message condition ! assert_true
+}
+
+fn assert_eq actual:int expected:int message:str {
+    if expected actual == then
+        1 += test_pass_count
+    else
+        f"[FAIL] {test_current_name}: {message} (expected {expected}, got {actual})\n" eprint
+        1 += test_fail_count
+    fi
+}
+
+fn test_summary {
+    f"{test_pass_count} passed, {test_fail_count} failed\n" print
+    if 0 test_fail_count > then
+        1 exit
+    fi
+}
+
+# ============================================================================
+# Iterator combinator tests
+# ============================================================================
+# --- take ---
+"take" test_start
+3 [1, 2, 3, 4, 5] (array[int]).iter.take.collect = take_result
+"length" 3 take_result.length assert_eq
+"first" 1 0 take_result.get assert_eq
+"second" 2 1 take_result.get assert_eq
+"third" 3 2 take_result.get assert_eq
+"take 0" test_start
+0 [1, 2, 3] (array[int]).iter.take.collect = take0_result
+"empty" 0 take0_result.length assert_eq
+"take more than length" test_start
+10 [1, 2] (array[int]).iter.take.collect = take_more
+"clamped" 2 take_more.length assert_eq
+# --- skip ---
+"skip" test_start
+2 [1, 2, 3, 4, 5] (array[int]).iter.skip.collect = skip_result
+"length" 3 skip_result.length assert_eq
+"first" 3 0 skip_result.get assert_eq
+"last" 5 2 skip_result.get assert_eq
+"skip 0" test_start
+0 [1, 2, 3] (array[int]).iter.skip.collect = skip0_result
+"all kept" 3 skip0_result.length assert_eq
+"skip all" test_start
+5 [1, 2, 3] (array[int]).iter.skip.collect = skip_all
+"empty" 0 skip_all.length assert_eq
+# --- take_while ---
+"take_while" test_start
+{ 4 > } [1, 2, 3, 4, 5] (array[int]).iter.take_while.collect = tw_result
+"length" 3 tw_result.length assert_eq
+"first" 1 0 tw_result.get assert_eq
+"last" 3 2 tw_result.get assert_eq
+"take_while none match" test_start
+{ 0 > } [5, 6, 7] (array[int]).iter.take_while.collect = tw_none
+"empty" 0 tw_none.length assert_eq
+"take_while all match" test_start
+{ 10 > } [1, 2, 3] (array[int]).iter.take_while.collect = tw_all
+"all" 3 tw_all.length assert_eq
+# --- skip_while ---
+"skip_while" test_start
+{ 3 > } [1, 2, 3, 4, 5] (array[int]).iter.skip_while.collect = sw_result
+"length" 3 sw_result.length assert_eq
+"first" 3 0 sw_result.get assert_eq
+"skip_while none match" test_start
+{ 0 > } [5, 6, 7] (array[int]).iter.skip_while.collect = sw_none
+"all kept" 3 sw_none.length assert_eq
+"skip_while all match" test_start
+{ 10 > } [1, 2, 3] (array[int]).iter.skip_while.collect = sw_all
+"empty" 0 sw_all.length assert_eq
+# --- enumerate ---
+"enumerate" test_start
+[10, 20, 30] (array[int]).iter.enumerate.collect = en_result
+"length" 3 en_result.length assert_eq
+0 en_result.get = ep0
+"idx 0" 0 ep0.first assert_eq
+"val 0" 10 ep0.second assert_eq
+2 en_result.get = ep2
+"idx 2" 2 ep2.first assert_eq
+"val 2" 30 ep2.second assert_eq
+# --- zip ---
+"zip" test_start
+[4, 5, 6] (array[int]).iter [1, 2, 3] (array[int]).iter.zip.collect = zip_result
+"length" 3 zip_result.length assert_eq
+0 zip_result.get = zp0
+"first.first" 1 zp0.first assert_eq
+"first.second" 4 zp0.second assert_eq
+"zip stops at shorter" test_start
+[4, 5] (array[int]).iter [1, 2, 3] (array[int]).iter.zip.collect = zip_short
+"length" 2 zip_short.length assert_eq
+"zip empty" test_start
+List::new(List[int]).iter [1, 2, 3] (array[int]).iter.zip.collect = zip_empty
+"empty" 0 zip_empty.length assert_eq
+# --- chain ---
+"chain" test_start
+[4, 5, 6] (array[int]).iter [1, 2, 3] (array[int]).iter.chain.collect = chain_result
+"length" 6 chain_result.length assert_eq
+"first" 1 0 chain_result.get assert_eq
+"fourth" 4 3 chain_result.get assert_eq
+"last" 6 5 chain_result.get assert_eq
+"chain empty first" test_start
+[4, 5] (array[int]).iter List::new(List[int]).iter.chain.collect = chain_ef
+"length" 2 chain_ef.length assert_eq
+"first" 4 0 chain_ef.get assert_eq
+# --- flat_map ---
+"flat_map" test_start
+
+fn repeat_twice n:int -> Iter[int] {
+    16 alloc = rpt_st
+    0 rpt_st store64
+    n rpt_st 8 + store64
+    Option::None(Option[int]) = rpt_none
+    {
+        rpt_st load64 = rpt_count
+        if 2 rpt_count >= then
+            rpt_none return
+        fi
+        rpt_count 1 + rpt_st store64
+        rpt_st 8 + load64 Option::Some
+    } (ptr) Iter (Iter[int])
+}
+{ repeat_twice } [1, 2, 3] (array[int]).iter.flat_map = fm
+fm (Iter[int]).collect = fm_result
+"length" 6 fm_result.length assert_eq
+"first" 1 0 fm_result.get assert_eq
+"second" 1 1 fm_result.get assert_eq
+"third" 2 2 fm_result.get assert_eq
+# --- sum ---
+"sum" test_start
+[1, 2, 3, 4, 5] (array[int]).iter.sum = sum_result
+"sum" 15 sum_result assert_eq
+"sum empty" test_start
+List::new(List[int]).iter.sum = sum_empty
+"zero" 0 sum_empty assert_eq
+# --- reduce ---
+"reduce" test_start
+{ + } [1, 2, 3, 4, 5] (array[int]).iter.reduce = red_result
+"is some" red_result.is_some assert_true
+"value" 15 red_result.unwrap assert_eq
+"reduce empty" test_start
+{ + } List::new(List[int]).iter.reduce = red_empty
+"is none" red_empty.is_none assert_true
+# --- min / max ---
+"min" test_start
+[3, 1, 4, 1, 5, 9] (array[int]).iter.min = min_result
+"is some" min_result.is_some assert_true
+"value" 1 min_result.unwrap assert_eq
+"max" test_start
+[3, 1, 4, 1, 5, 9] (array[int]).iter.max = max_result
+"is some" max_result.is_some assert_true
+"value" 9 max_result.unwrap assert_eq
+"min empty" test_start
+List::new(List[int]).iter.min = min_e
+"is none" min_e.is_none assert_true
+"max empty" test_start
+List::new(List[int]).iter.max = max_e
+"is none" max_e.is_none assert_true
+# --- min_by / max_by ---
+"min_by" test_start
+{ < } [3, 1, 4, 1, 5] (array[int]).iter.min_by = minby_result
+"is some" minby_result.is_some assert_true
+"value" 1 minby_result.unwrap assert_eq
+"max_by" test_start
+{ < } [3, 1, 4, 1, 5] (array[int]).iter.max_by = maxby_result
+"is some" maxby_result.is_some assert_true
+"value" 5 maxby_result.unwrap assert_eq
+# --- partition ---
+"partition" test_start
+{ 2 % 0 == } [1, 2, 3, 4, 5, 6] (array[int]).iter.partition = part
+part.first (List[int]) = part_yes
+part.second (List[int]) = part_no
+"evens count" 3 part_yes.length assert_eq
+"odds count" 3 part_no.length assert_eq
+"first even" 2 0 part_yes.get assert_eq
+"first odd" 1 0 part_no.get assert_eq
+# --- Chaining combinators ---
+"pipeline skip+take" test_start
+4 2 [1, 2, 3, 4, 5, 6, 7, 8] (array[int]).iter.skip.take.collect = pipe1
+"length" 4 pipe1.length assert_eq
+"first" 3 0 pipe1.get assert_eq
+"last" 6 3 pipe1.get assert_eq
+"pipeline take+enumerate" test_start
+2 [10, 20, 30] (array[int]).iter.take = taken_2
+taken_2.enumerate.collect = pipe2
+"length" 2 pipe2.length assert_eq
+0 pipe2.get = pipe2_first
+"idx" 0 pipe2_first.first assert_eq
+"val" 10 pipe2_first.second assert_eq
+test_summary


### PR DESCRIPTION
Closes #198
Closes #197

## Summary

- Redesign `Iter` from index-based (get/length/index) to closure-based (next_fn) for lazy combinator composition
- Add `Pair` struct for zip/enumerate return types
- Add 8 lazy combinators to `Iterable[T]`: `take`, `skip`, `take_while`, `skip_while`, `enumerate`, `zip`, `chain`, `flat_map`
- Add 7 terminal combinators: `sum`, `reduce`, `min_by`, `max_by`, `partition` on `Iterable[T]`; `min`, `max` on `impl[T: Ord] Iter[T]`
- Add example program and 65-assertion test suite

## Known limitations

- `flat_map` collects inner iterators eagerly (closures cannot reference type parameters from enclosing scope)
- `min`/`max` live on `Iter[T: Ord]` rather than `Iterable[T]` (trait methods cannot add bounds)
- `flat_map` return type needs explicit cast at call site: `iter.flat_map (Iter[int])`

## Test plan

- [x] `tests/test_examples.sh` passes (43/43)
- [x] `tests/test_compiler.sh` passes (50/50)
- [x] New `examples/iterator_combinators.casa` covers all combinators
- [x] New `tests/compiler/test_iterator_combinators.casa` covers edge cases (empty iterators, take 0, skip 0, reduce on empty, min/max on empty)