### PR TITLE
feat(stdlib): List sorting and reverse

### DIFF
--- a/examples/outputs/sorting.out
+++ b/examples/outputs/sorting.out
@@ -1,0 +1,7 @@
+Original:   [5, 3, 1, 4, 2]
+Sorted:     [1, 2, 3, 4, 5]
+Descending: [5, 4, 3, 2, 1]
+Reversed:   [5, 4, 3, 2, 1]
+Duplicates: [1, 1, 2, 3, 3, 4, 5, 5, 6, 9]
+Empty:      []
+Single:     [42]

--- a/examples/sorting.casa
+++ b/examples/sorting.casa
@@ -1,0 +1,27 @@
+# Sorting and reversing lists
+import "std"
+
+# Sort integers
+[5, 3, 1, 4, 2] List::from_array = nums
+f"Original:   {nums}" println
+nums.sort
+f"Sorted:     {nums}" println
+# Sort with custom comparator (descending)
+[5, 3, 1, 4, 2] List::from_array = desc
+{ > } desc.sort_by
+f"Descending: {desc}" println
+# Reverse a list
+[1, 2, 3, 4, 5] List::from_array = rev
+rev.reverse
+f"Reversed:   {rev}" println
+# Sort with duplicates
+[3, 1, 4, 1, 5, 9, 2, 6, 5, 3] List::from_array = dups
+dups.sort
+f"Duplicates: {dups}" println
+# Edge cases
+List::new(List[int]) = empty
+empty.sort
+f"Empty:      {empty}" println
+[42] List::from_array = single
+single.sort
+f"Single:     {single}" println

--- a/lib/std.casa
+++ b/lib/std.casa
@@ -115,6 +115,22 @@ impl List {
     fn to_array [T] self:List[T] -> array[T] {
         self.size 0 self.slice
     }
+
+    fn swap_at [T] self:List[T] i:int j:int {
+        i self.get = temp
+        j self.get i self.set
+        temp j self.set
+    }
+
+    fn reverse [T] self:List[T] {
+        0 = left
+        self.size 1 - = right
+        while left right > do
+            left right self.swap_at
+            1 += left
+            1 -= right
+        done
+    }
 }
 
 # ---------------------------------------------------------------------------
@@ -1008,6 +1024,35 @@ impl[T] List[T] {
             idx 1 + st 8 + store64
             idx self.get Option::Some
         } (ptr) Iter (Iter[T])
+    }
+
+    fn sort_by self:List[T] f:fn[T T -> bool] {
+        if 1 self.size <= then return fi
+        f self.size 1 - 0 self.sort_by_range
+    }
+
+    fn sort_by_range self:List[T] low:int high:int f:fn[T T -> bool] {
+        if high low >= then return fi
+        high low + 2 / high self.swap_at
+        high self.get = pivot
+        low = store_idx
+        low = i
+        while i high > do
+            if pivot i self.get f exec then
+                store_idx i self.swap_at
+                1 += store_idx
+            fi
+            1 += i
+        done
+        store_idx high self.swap_at
+        f store_idx 1 - low self.sort_by_range
+        f high store_idx 1 + self.sort_by_range
+    }
+}
+
+impl[T: Ord] List[T] {
+    fn sort self:List[T] {
+        { < } self.sort_by
     }
 }
 

--- a/tests/compiler/test_sorting.casa
+++ b/tests/compiler/test_sorting.casa
@@ -1,0 +1,154 @@
+import "std"
+
+0 = test_pass_count
+0 = test_fail_count
+"" = test_current_name
+
+fn test_start name:str {
+    name = test_current_name
+}
+
+fn assert_true condition:bool message:str {
+    if condition then
+        1 += test_pass_count
+    else
+        f"[FAIL] {test_current_name}: {message}\n" eprint
+        1 += test_fail_count
+    fi
+}
+
+fn assert_eq actual:int expected:int message:str {
+    if expected actual == then
+        1 += test_pass_count
+    else
+        f"[FAIL] {test_current_name}: {message} (expected {expected}, got {actual})\n" eprint
+        1 += test_fail_count
+    fi
+}
+
+fn test_summary {
+    f"{test_pass_count} passed, {test_fail_count} failed\n" print
+    if 0 test_fail_count > then
+        1 exit
+    fi
+}
+
+# ============================================================================
+# List::reverse
+# ============================================================================
+"reverse basic" test_start
+[1, 2, 3, 4, 5] List::from_array = rev_basic
+rev_basic.reverse
+"length" 5 rev_basic.length assert_eq
+"first" 5 0 rev_basic.get assert_eq
+"second" 4 1 rev_basic.get assert_eq
+"last" 1 4 rev_basic.get assert_eq
+"reverse empty" test_start
+List::new(List[int]) = rev_empty
+rev_empty.reverse
+"length" 0 rev_empty.length assert_eq
+"reverse single" test_start
+[42] List::from_array = rev_single
+rev_single.reverse
+"value" 42 0 rev_single.get assert_eq
+"reverse two" test_start
+[1, 2] List::from_array = rev_two
+rev_two.reverse
+"first" 2 0 rev_two.get assert_eq
+"second" 1 1 rev_two.get assert_eq
+"reverse double" test_start
+[1, 2, 3] List::from_array = rev_double
+rev_double.reverse
+rev_double.reverse
+"first" 1 0 rev_double.get assert_eq
+"second" 2 1 rev_double.get assert_eq
+"third" 3 2 rev_double.get assert_eq
+
+# ============================================================================
+# List::sort
+# ============================================================================
+"sort basic" test_start
+[5, 3, 1, 4, 2] List::from_array = sort_basic
+sort_basic.sort
+"length" 5 sort_basic.length assert_eq
+"first" 1 0 sort_basic.get assert_eq
+"second" 2 1 sort_basic.get assert_eq
+"third" 3 2 sort_basic.get assert_eq
+"fourth" 4 3 sort_basic.get assert_eq
+"fifth" 5 4 sort_basic.get assert_eq
+"sort empty" test_start
+List::new(List[int]) = sort_empty
+sort_empty.sort
+"length" 0 sort_empty.length assert_eq
+"sort single" test_start
+[42] List::from_array = sort_single
+sort_single.sort
+"value" 42 0 sort_single.get assert_eq
+"sort already sorted" test_start
+[1, 2, 3, 4, 5] List::from_array = sort_sorted
+sort_sorted.sort
+"first" 1 0 sort_sorted.get assert_eq
+"last" 5 4 sort_sorted.get assert_eq
+"sort reverse sorted" test_start
+[5, 4, 3, 2, 1] List::from_array = sort_rev
+sort_rev.sort
+"first" 1 0 sort_rev.get assert_eq
+"last" 5 4 sort_rev.get assert_eq
+"sort duplicates" test_start
+[3, 1, 4, 1, 5, 9, 2, 6, 5, 3] List::from_array = sort_dups
+sort_dups.sort
+"length" 10 sort_dups.length assert_eq
+"first" 1 0 sort_dups.get assert_eq
+"second" 1 1 sort_dups.get assert_eq
+"third" 2 2 sort_dups.get assert_eq
+"last" 9 9 sort_dups.get assert_eq
+"sort all same" test_start
+[7, 7, 7, 7] List::from_array = sort_same
+sort_same.sort
+"first" 7 0 sort_same.get assert_eq
+"last" 7 3 sort_same.get assert_eq
+"sort two elements" test_start
+[2, 1] List::from_array = sort_two
+sort_two.sort
+"first" 1 0 sort_two.get assert_eq
+"second" 2 1 sort_two.get assert_eq
+
+# ============================================================================
+# List::sort_by
+# ============================================================================
+"sort_by descending" test_start
+[5, 3, 1, 4, 2] List::from_array = sortby_desc
+{ > } sortby_desc.sort_by
+"first" 5 0 sortby_desc.get assert_eq
+"second" 4 1 sortby_desc.get assert_eq
+"last" 1 4 sortby_desc.get assert_eq
+"sort_by ascending" test_start
+[5, 3, 1, 4, 2] List::from_array = sortby_asc
+{ < } sortby_asc.sort_by
+"first" 1 0 sortby_asc.get assert_eq
+"last" 5 4 sortby_asc.get assert_eq
+"sort_by empty" test_start
+List::new(List[int]) = sortby_empty
+{ < } sortby_empty.sort_by
+"length" 0 sortby_empty.length assert_eq
+"sort_by single" test_start
+[42] List::from_array = sortby_single
+{ < } sortby_single.sort_by
+"value" 42 0 sortby_single.get assert_eq
+"sort_by duplicates" test_start
+[3, 1, 4, 1, 5] List::from_array = sortby_dups
+{ < } sortby_dups.sort_by
+"first" 1 0 sortby_dups.get assert_eq
+"second" 1 1 sortby_dups.get assert_eq
+"last" 5 4 sortby_dups.get assert_eq
+
+# ============================================================================
+# List::swap_at
+# ============================================================================
+"swap_at" test_start
+[10, 20, 30] List::from_array = swap_list
+0 1 swap_list.swap_at
+"first" 20 0 swap_list.get assert_eq
+"second" 10 1 swap_list.get assert_eq
+"third" 30 2 swap_list.get assert_eq
+test_summary


### PR DESCRIPTION
## Summary
- Add `List::sort` (in-place, ascending, requires `Ord` trait)
- Add `List::sort_by` (in-place with custom comparator `fn[T T -> bool]`)
- Add `List::reverse` (in-place)
- Add `List::swap_at` helper (swap elements at two indices)
- Quicksort with middle-element pivot selection to avoid O(n^2) on sorted input
- `sort` delegates to `sort_by` with `{ < }` comparator — no duplicated logic

Closes #199

## Test plan
- [x] 45 assertions in `tests/compiler/test_sorting.casa` covering all edge cases (empty, single, sorted, reverse-sorted, duplicates, all-same)
- [x] Example program `examples/sorting.casa` with expected output
- [x] All existing tests pass (`test_examples.sh`: 44, `test_compiler.sh`: 51)