### PR TITLE
feat(stdlib): string utilities (join, case conversion, repeat, reverse, to_int)

### DIFF
--- a/docs/collections.md
+++ b/docs/collections.md
@@ -127,6 +127,18 @@ list.to_array = arr
 arr.length print    # 3
 ```
 
+### `List[str]::join`
+
+Joins a list of strings with a separator, returning a single string.
+
+**Stack effect:** `List[str] str -> str`
+
+```casa
+["a", "b", "c"] List::from_array = parts
+", " parts.join print    # a, b, c
+"" parts.join print      # abc
+```
+
 ### Complete Example
 
 ```casa

--- a/docs/strings-and-io.md
+++ b/docs/strings-and-io.md
@@ -160,6 +160,70 @@ Replaces all occurrences of `old` with `new_str`, returning a new string.
 "world" "there" "hello there".replace print    # hello world
 ```
 
+### `str::to_upper`
+
+Returns a new string with all ASCII lowercase letters converted to uppercase. Non-alpha characters are unchanged.
+
+**Stack effect:** `str -> str`
+
+```casa
+"hello".to_upper print    # HELLO
+```
+
+### `str::to_lower`
+
+Returns a new string with all ASCII uppercase letters converted to lowercase. Non-alpha characters are unchanged.
+
+**Stack effect:** `str -> str`
+
+```casa
+"HELLO".to_lower print    # hello
+```
+
+### `str::repeat`
+
+Returns a new string that repeats the original `n` times. Returns an empty string when `n` is 0.
+
+**Stack effect:** `str int -> str`
+
+```casa
+3 "ha".repeat print    # hahaha
+0 "x".repeat print     # (empty)
+```
+
+### `str::reverse`
+
+Returns a new string with the characters in reverse order.
+
+**Stack effect:** `str -> str`
+
+```casa
+"hello".reverse print    # olleh
+```
+
+### `str::to_int`
+
+Parses a string as an integer, returning `Option[int]`. Handles negative numbers (leading `-`). Returns `None` for empty strings, non-digit characters, or a bare `-`. Does not tolerate leading or trailing whitespace — use `str::trim` first if needed.
+
+**Stack effect:** `str -> Option[int]`
+
+```casa
+"42".to_int.unwrap print          # 42
+"-7".to_int.unwrap print          # -7
+"abc".to_int.is_none print        # true
+```
+
+### `List[str]::join`
+
+Joins a list of strings with a separator, returning a single string.
+
+**Stack effect:** `List[str] str -> str`
+
+```casa
+["a", "b", "c"] List::from_array = parts
+", " parts.join print    # a, b, c
+```
+
 ## C String Methods
 
 Methods for working with `cstr` values. Method calls on any `cstr` receiver are resolved to `cstr::method`.

--- a/examples/outputs/string_utilities.out
+++ b/examples/outputs/string_utilities.out
@@ -1,0 +1,26 @@
+=== case conversion ===
+HELLO WORLD
+hello world
+MIXED CASE 123
+mixed case 123
+=== repeat ===
+hahaha
+-----
+
+=== reverse ===
+olleh
+racecar
+a
+=== to_int ===
+42
+-7
+abc is not a number
+parsed: 123
+=== join ===
+red, green, blue
+red | green | blue
+solo
+=== combined ===
+RED, GREEN, BLUE
+OLLEH
+bababa

--- a/examples/string_utilities.casa
+++ b/examples/string_utilities.casa
@@ -1,0 +1,40 @@
+import "std"
+
+# to_upper / to_lower
+"=== case conversion ===" print "\n" print
+"hello world".to_upper print "\n" print
+"HELLO WORLD".to_lower print "\n" print
+"Mixed Case 123".to_upper print "\n" print
+"Mixed Case 123".to_lower print "\n" print
+# repeat
+"=== repeat ===" print "\n" print
+3 "ha".repeat print "\n" print
+5 "-".repeat print "\n" print
+0 "gone".repeat print "\n" print
+# reverse
+"=== reverse ===" print "\n" print
+"hello".reverse print "\n" print
+"racecar".reverse print "\n" print
+"a".reverse print "\n" print
+# to_int
+"=== to_int ===" print "\n" print
+"42".to_int.unwrap print "\n" print
+"-7".to_int.unwrap print "\n" print
+if "abc".to_int.is_none then
+    "abc is not a number" print "\n" print
+fi
+if "123".to_int Option::Some(value) is then
+    f"parsed: {value}" print "\n" print
+fi
+# join
+"=== join ===" print "\n" print
+["red", "green", "blue"] List::from_array = colors
+", " colors.join print "\n" print
+" | " colors.join print "\n" print
+["solo"] List::from_array = solo
+"-" solo.join print "\n" print
+# combining operations
+"=== combined ===" print "\n" print
+", " colors.join.to_upper print "\n" print
+"hello".reverse.to_upper print "\n" print
+3 "ab".repeat.reverse print "\n" print

--- a/lib/std.casa
+++ b/lib/std.casa
@@ -368,6 +368,99 @@ impl str {
         done
         builder.build
     }
+
+    fn to_upper self:str -> str {
+        self.length = len
+        len 9 + alloc (str) = result
+        len result (ptr) store64
+        0 = idx
+        while idx len > do
+            idx self.at = ch
+            if ch.is_lower then
+                ch (int) 32 - (char) idx result.set
+            else
+                ch idx result.set
+            fi
+            1 += idx
+        done
+        0 (char) len result.set
+        result
+    }
+
+    fn to_lower self:str -> str {
+        self.length = len
+        len 9 + alloc (str) = result
+        len result (ptr) store64
+        0 = idx
+        while idx len > do
+            idx self.at = ch
+            if ch.is_upper then
+                ch (int) 32 + (char) idx result.set
+            else
+                ch idx result.set
+            fi
+            1 += idx
+        done
+        0 (char) len result.set
+        result
+    }
+
+    fn repeat self:str n:int -> str {
+        self.length = len
+        len n * = total
+        total 9 + alloc (str) = result
+        total result (ptr) store64
+        0 = idx
+        while idx total > do
+            idx len % self.at idx result.set
+            1 += idx
+        done
+        0 (char) total result.set
+        result
+    }
+
+    fn reverse self:str -> str {
+        self.length = len
+        len 9 + alloc (str) = result
+        len result (ptr) store64
+        0 = idx
+        while idx len > do
+            len 1 - idx - self.at idx result.set
+            1 += idx
+        done
+        0 (char) len result.set
+        result
+    }
+
+    fn to_int self:str -> Option[int] {
+        self.length = len
+        if 0 len == then
+            Option::None(Option[int]) return
+        fi
+        0 = idx
+        false = negative
+        if 0 self.at '-' == then
+            if 1 len == then
+                Option::None(Option[int]) return
+            fi
+            true = negative
+            1 = idx
+        fi
+        0 = result
+        while idx len > do
+            idx self.at = ch
+            if ch.is_digit ! then
+                Option::None(Option[int]) return
+            fi
+            result 10 * ch (int) 48 - + = result
+            1 += idx
+        done
+        if negative then
+            0 result - Option::Some
+        else
+            result Option::Some
+        fi
+    }
 }
 
 impl cstr {
@@ -1053,6 +1146,21 @@ impl[T] List[T] {
 impl[T: Ord] List[T] {
     fn sort self:List[T] {
         { < } self.sort_by
+    }
+}
+
+impl List[str] {
+    fn join self:List[str] sep:str -> str {
+        StringBuilder::new = builder
+        0 = idx
+        while idx self.length > do
+            if 0 idx > then
+                sep builder.append
+            fi
+            idx self.get builder.append
+            1 += idx
+        done
+        builder.build
     }
 }
 

--- a/lib/std.casa
+++ b/lib/std.casa
@@ -377,7 +377,7 @@ impl str {
         while idx len > do
             idx self.at = ch
             if ch.is_lower then
-                ch (int) 32 - (char) idx result.set
+                ch (int) 'a' (int) - 'A' (int) + (char) idx result.set
             else
                 ch idx result.set
             fi
@@ -395,7 +395,7 @@ impl str {
         while idx len > do
             idx self.at = ch
             if ch.is_upper then
-                ch (int) 32 + (char) idx result.set
+                ch (int) 'A' (int) - 'a' (int) + (char) idx result.set
             else
                 ch idx result.set
             fi
@@ -406,14 +406,21 @@ impl str {
     }
 
     fn repeat self:str n:int -> str {
+        if n 0 >= then
+            "" return
+        fi
         self.length = len
         len n * = total
         total 9 + alloc (str) = result
         total result (ptr) store64
-        0 = idx
-        while idx total > do
-            idx len % self.at idx result.set
-            1 += idx
+        0 = rep
+        while rep n > do
+            0 = char_idx
+            while char_idx len > do
+                char_idx self.at rep len * char_idx + result.set
+                1 += char_idx
+            done
+            1 += rep
         done
         0 (char) total result.set
         result
@@ -452,7 +459,7 @@ impl str {
             if ch.is_digit ! then
                 Option::None(Option[int]) return
             fi
-            result 10 * ch (int) 48 - + = result
+            result 10 * ch (int) '0' (int) - + = result
             1 += idx
         done
         if negative then

--- a/tests/compiler/test_string_utilities.casa
+++ b/tests/compiler/test_string_utilities.casa
@@ -1,0 +1,141 @@
+import "std"
+
+0 = test_pass_count
+0 = test_fail_count
+"" = test_current_name
+
+fn test_start name:str {
+    name = test_current_name
+}
+
+fn assert_true condition:bool message:str {
+    if condition then
+        1 += test_pass_count
+    else
+        f"[FAIL] {test_current_name}: {message}\n" eprint
+        1 += test_fail_count
+    fi
+}
+
+fn assert_eq actual:int expected:int message:str {
+    if expected actual == then
+        1 += test_pass_count
+    else
+        f"[FAIL] {test_current_name}: {message} (expected {expected}, got {actual})\n" eprint
+        1 += test_fail_count
+    fi
+}
+
+fn assert_str_eq actual:str expected:str message:str {
+    if expected actual == then
+        1 += test_pass_count
+    else
+        f"[FAIL] {test_current_name}: {message} (expected '{expected}', got '{actual}')\n" eprint
+        1 += test_fail_count
+    fi
+}
+
+fn test_summary {
+    f"{test_pass_count} passed, {test_fail_count} failed\n" print
+    if 0 test_fail_count > then
+        1 exit
+    fi
+}
+
+# ============================================================================
+# to_upper
+# ============================================================================
+"to_upper basic" test_start
+"result" "HELLO" "hello".to_upper assert_str_eq
+"to_upper mixed" test_start
+"result" "HELLO WORLD" "hElLo wOrLd".to_upper assert_str_eq
+"to_upper already upper" test_start
+"result" "ABC" "ABC".to_upper assert_str_eq
+"to_upper non-alpha" test_start
+"result" "123!@#" "123!@#".to_upper assert_str_eq
+"to_upper empty" test_start
+"result" "" "".to_upper assert_str_eq
+
+# ============================================================================
+# to_lower
+# ============================================================================
+"to_lower basic" test_start
+"result" "hello" "HELLO".to_lower assert_str_eq
+"to_lower mixed" test_start
+"result" "hello world" "hElLo wOrLd".to_lower assert_str_eq
+"to_lower already lower" test_start
+"result" "abc" "abc".to_lower assert_str_eq
+"to_lower non-alpha" test_start
+"result" "123!@#" "123!@#".to_lower assert_str_eq
+"to_lower empty" test_start
+"result" "" "".to_lower assert_str_eq
+
+# ============================================================================
+# repeat
+# ============================================================================
+"repeat basic" test_start
+"result" "abcabc" 2 "abc".repeat assert_str_eq
+"repeat 0" test_start
+"result" "" 0 "abc".repeat assert_str_eq
+"repeat 1" test_start
+"result" "abc" 1 "abc".repeat assert_str_eq
+"repeat many" test_start
+"result" "xxxxx" 5 "x".repeat assert_str_eq
+"repeat empty" test_start
+"result" "" 3 "".repeat assert_str_eq
+
+# ============================================================================
+# reverse
+# ============================================================================
+"reverse basic" test_start
+"result" "olleh" "hello".reverse assert_str_eq
+"reverse single" test_start
+"result" "a" "a".reverse assert_str_eq
+"reverse empty" test_start
+"result" "" "".reverse assert_str_eq
+"reverse palindrome" test_start
+"result" "aba" "aba".reverse assert_str_eq
+"reverse spaces" test_start
+"result" "cba 321" "123 abc".reverse assert_str_eq
+
+# ============================================================================
+# to_int
+# ============================================================================
+"to_int basic" test_start
+"is_some" "42".to_int.is_some assert_true
+"value" 42 "42".to_int.unwrap assert_eq
+"to_int zero" test_start
+"is_some" "0".to_int.is_some assert_true
+"value" 0 "0".to_int.unwrap assert_eq
+"to_int negative" test_start
+"is_some" "-7".to_int.is_some assert_true
+"value" 0 7 - "-7".to_int.unwrap assert_eq
+"to_int empty" test_start
+"is_none" "".to_int.is_none assert_true
+"to_int invalid" test_start
+"is_none" "abc".to_int.is_none assert_true
+"to_int mixed" test_start
+"is_none" "12abc".to_int.is_none assert_true
+"to_int bare minus" test_start
+"is_none" "-".to_int.is_none assert_true
+"to_int large" test_start
+"value" 12345 "12345".to_int.unwrap assert_eq
+
+# ============================================================================
+# join
+# ============================================================================
+"join basic" test_start
+["hello", "world"] List::from_array = words
+"result" "hello, world" ", " words.join assert_str_eq
+"join empty sep" test_start
+"result" "helloworld" "" words.join assert_str_eq
+"join single" test_start
+["only"] List::from_array = single
+"result" "only" ", " single.join assert_str_eq
+"join empty list" test_start
+List::new(List[str]) = empty_list
+"result" "" ", " empty_list.join assert_str_eq
+"join three" test_start
+["a", "b", "c"] List::from_array = three
+"result" "a-b-c" "-" three.join assert_str_eq
+test_summary


### PR DESCRIPTION
## Summary

Closes #201

- Add `str::to_upper`, `str::to_lower` (ASCII-only, return new strings)
- Add `str::repeat` with negative-n guard and nested-loop implementation
- Add `str::reverse` (single-alloc, fill backwards)
- Add `str::to_int` returning `Option[int]` (strict, no whitespace tolerance)
- Add `List[str]::join` with separator

## Test plan

- [x] 36 assertions in `tests/compiler/test_string_utilities.casa` covering all methods and edge cases
- [x] Example program `examples/string_utilities.casa` with expected output
- [x] `tests/test_compiler.sh` — 52 passed, 0 failed
- [x] `tests/test_examples.sh` — 45 passed, 0 failed