### PR TITLE
Fix lazy map state for custom iterators

### DIFF
--- a/compiler/typechecker.casa
+++ b/compiler/typechecker.casa
@@ -2258,6 +2258,7 @@ fn instantiate_default_trait_method
     # For generic receivers, keep trait type params as function type vars.
     # For non-generic receivers, substitute trait type params with concrete types.
     Map::new(Map[str Type]) = trait_subs
+    receiver = default_self_type
     if fn_base_opt.is_some then
         fn_base_opt.unwrap = base_name
         if 0 type_params.length != then
@@ -2271,11 +2272,11 @@ fn instantiate_default_trait_method
                 1 += sp_index
             done
             "]" self_builder.append
-            self_builder.build = generic_self_type
+            self_builder.build = default_self_type
         else
-            base_name = generic_self_type
+            base_name = default_self_type
         fi
-        generic_self_type default_method TraitMethod::stack_effect resolve_trait_stack_effect = resolved_stack_effect
+        default_self_type default_method TraitMethod::stack_effect resolve_trait_stack_effect = resolved_stack_effect
     else
         # Infer trait type params from concrete method stack effects
         Set::new(Set[str]) = type_param_set
@@ -2308,6 +2309,8 @@ fn instantiate_default_trait_method
         done
     fi
 
+    default_self_type parse_type_str TRAIT_SELF_TYPE trait_subs.set = trait_subs
+
     # Add method-level type vars to stack effect
     for method_type_var in default_method TraitMethod::type_vars.iter do
         method_type_var resolved_stack_effect StackEffect::type_vars.add = new_tvs
@@ -2328,6 +2331,30 @@ fn instantiate_default_trait_method
     if 0 trait_subs.length != then
         trait_subs cloned_body substitute_ops_types
     fi
+    0 = cloned_lambda_index
+    for body_op in cloned_body.iter do
+        if body_op.value OpValue::FnPush(lambda_name) is ! then continue fi
+        if lambda_name "lambda__" str::starts_with ! then continue fi
+        lambda_name DEFAULT_PARSER.store.functions.get = lambda_opt
+        if lambda_opt.is_none then continue fi
+
+        f"{lambda_name}__{synth_fn_name}_{cloned_lambda_index}" = cloned_lambda_name
+        lambda_opt.unwrap Function::ops clone_ops = lambda_ops
+        if 0 trait_subs.length != then
+            trait_subs lambda_ops substitute_ops_types
+        fi
+        List::new(List[Parameter]) = lambda_params
+        List::new(List[Type]) = lambda_returns
+        lambda_returns lambda_params make_stack_effect = lambda_effect
+        for lambda_type_var in resolved_stack_effect StackEffect::type_vars.to_list.iter do
+            lambda_type_var lambda_effect StackEffect::type_vars.add = lambda_tvs
+            lambda_tvs lambda_effect StackEffect::set_type_vars
+        done
+        lambda_effect lambda_opt.unwrap Function::location lambda_ops cloned_lambda_name make_function_with_stack_effect = cloned_lambda
+        cloned_lambda cloned_lambda_name DEFAULT_PARSER.store.functions.set drop
+        cloned_lambda_name OpValue::FnPush body_op Op::set_value
+        1 += cloned_lambda_index
+    done
     for body_op in cloned_body.iter do
         body_op synth_ops.push
     done

--- a/docs/standard-library.md
+++ b/docs/standard-library.md
@@ -112,22 +112,22 @@ Collects all elements into a `List[T]`.
 
 #### `map`
 
-Applies a function to each element, returning a `List[U]`.
+Applies a function to each element, returning a lazy `Iter[U]`. Use `.collect` to materialize a `List[U]`.
 
-**Stack effect:** `Iter[T] fn[T -> U] -> List[U]`
+**Stack effect:** `Iter[T] fn[T -> U] -> Iter[U]`
 
 ```casa
-{ 2 * } [1 2 3].iter.map    # List[int] with elements 2, 4, 6
+{ 2 * } [1 2 3].iter.map.collect    # List[int] with elements 2, 4, 6
 ```
 
 #### `filter`
 
-Returns a `List[T]` of elements for which the function returns `true`.
+Returns a lazy `Iter[T]` of elements for which the function returns `true`. Use `.collect` to materialize a `List[T]`.
 
-**Stack effect:** `Iter[T] fn[T -> bool] -> List[T]`
+**Stack effect:** `Iter[T] fn[T -> bool] -> Iter[T]`
 
 ```casa
-{ 2 % 0 == } [1 2 3 4].iter.filter    # List[int] with elements 2, 4
+{ 2 % 0 == } [1 2 3 4].iter.filter.collect    # List[int] with elements 2, 4
 ```
 
 #### `fold`

--- a/docs/traits.md
+++ b/docs/traits.md
@@ -313,8 +313,8 @@ The standard library defines the `Iterable[T]` trait for iteration. Any type wit
 | Method | Stack effect | Description |
 |--------|-------------|-------------|
 | `collect` | `self -> List[T]` | Collect all elements into a `List[T]` |
-| `map` | `self fn[T -> U] -> List[U]` | Apply a function to each element, returning a new list |
-| `filter` | `self fn[T -> bool] -> List[T]` | Return a list of elements for which the function returns `true` |
+| `map` | `self fn[T -> U] -> Iter[U]` | Lazily apply a function to each element |
+| `filter` | `self fn[T -> bool] -> Iter[T]` | Lazily keep elements for which the function returns `true` |
 | `fold` | `self U fn[U T -> U] -> U` | Reduce to a single value using an accumulator |
 | `count` | `self -> int` | Count the number of elements |
 | `any` | `self fn[T -> bool] -> bool` | Return `true` if any element satisfies the predicate |

--- a/examples/iterable.casa
+++ b/examples/iterable.casa
@@ -29,8 +29,7 @@ f"all positive: {all_positive}" println
 # find — first matching element
 { 3 < } [1 2 3 4 5] (array[int]).iter.find = big
 f"find >3: {big}" println
-# Custom iterator — collect first, then use lazy combinators via .iter
-# (Value-type iterators need .collect.iter because lazy closures copy-capture)
+# Custom iterator — lazy combinators work directly and can be chained
 
 struct Counter {
     value: int
@@ -47,5 +46,5 @@ impl Counter {
         current Option::Some
     }
 }
-{ 2 * } Counter { value: 0 limit: 5 }.collect.iter.map.collect = counter_doubled
+{ 1 + } { 2 * } Counter { value: 0 limit: 5 }.map.map.collect = counter_doubled: List[int]
 f"counter map: {counter_doubled}" println

--- a/examples/outputs/iterable.out
+++ b/examples/outputs/iterable.out
@@ -6,4 +6,4 @@ count: 5
 any 3: true
 all positive: true
 find >3: Some(4)
-counter map: [0, 2, 4, 6, 8]
+counter map: [1, 3, 5, 7, 9]

--- a/lib/std.casa
+++ b/lib/std.casa
@@ -708,9 +708,11 @@ trait Iterable[T] {
     }
 
     fn map [U] self:self f:fn[T -> U] -> Iter[U] {
+        8 alloc = st
+        self st store64
         Option::None(Option[U]) = none
         {
-            self.next = opt
+            st load64 (self).next = opt
             if opt.is_none then
                 none return
             fi
@@ -719,10 +721,12 @@ trait Iterable[T] {
     }
 
     fn filter self:self f:fn[T -> bool] -> Iter[T] {
+        8 alloc = st
+        self st store64
         Option::None(Option[T]) = none
         {
             while true do
-                self.next = opt
+                st load64 (self).next = opt
                 if opt.is_none then
                     none return
                 fi

--- a/tests/compiler/test_iterator_combinators.casa
+++ b/tests/compiler/test_iterator_combinators.casa
@@ -145,6 +145,33 @@ fm (Iter[int]).collect = fm_result
 "first" 1 0 fm_result.get assert_eq
 "second" 1 1 fm_result.get assert_eq
 "third" 2 2 fm_result.get assert_eq
+# --- custom iterator map/filter chaining ---
+"custom iterator chained map" test_start
+
+struct Counter {
+    value: int
+    limit: int
+}
+
+impl Counter {
+    fn next self:Counter -> Option[int] {
+        if self Counter::limit self Counter::value >= then
+            Option::None(Option[int]) return
+        fi
+        self Counter::value = current
+        self Counter::value 1 + self->value
+        current Option::Some
+    }
+}
+{ 1 + } { 2 * } Counter { value: 0 limit: 5 }.map.map.collect = counter_mapped: List[int]
+"length" 5 counter_mapped.length assert_eq
+"first" 1 0 counter_mapped.get assert_eq
+"last" 9 4 counter_mapped.get assert_eq
+"custom iterator filter+map" test_start
+{ 10 + } { 2 % 0 == } Counter { value: 0 limit: 6 }.filter.map.collect = counter_filtered: List[int]
+"length" 3 counter_filtered.length assert_eq
+"first" 10 0 counter_filtered.get assert_eq
+"last" 14 2 counter_filtered.get assert_eq
 # --- sum ---
 "sum" test_start
 [1, 2, 3, 4, 5] (array[int]).iter.sum = sum_result


### PR DESCRIPTION
## Summary
- preserve lazy map/filter source iterator state in heap-backed storage
- substitute trait default-method self casts into cloned default lambdas
- add custom iterator map/filter chaining regression coverage and update lazy return docs/examples

## Tests
- tests/test_examples.sh
- tests/test_compiler.sh