### PR TITLE
Add map/and_then/or_else/filter combinators to Option and Result

### DIFF
--- a/compiler/syntax.casa
+++ b/compiler/syntax.casa
@@ -794,7 +794,7 @@ fn parse_type_vars parser:Parser cursor:TokenCursor -> List[str] {
 
 fn parse_parameter_maybe_named cursor:TokenCursor token:Token -> Parameter {
     cursor.peek = next_opt
-    if next_opt.is_some ":" next_opt.unwrap Token::value == && then
+    if { Token::value ":" == } next_opt.filter.is_some then
         cursor.advance # consume :
         cursor parse_type_ast = param_type
         token Token::value param_type make_named_param return
@@ -1705,13 +1705,13 @@ fn parse_trait parser:Parser cursor:TokenCursor -> CasaTrait {
 
     List::new(List[str]) = type_params
     cursor.peek = bracket_opt
-    if bracket_opt.is_some "[" bracket_opt.unwrap Token::value == && then
+    if { Token::value "[" == } bracket_opt.filter.is_some then
         "trait" cursor parse_simple_type_vars = type_params
     fi
 
     List::new(List[TraitBound]) = supertraits
     cursor.peek = colon_opt
-    if colon_opt.is_some ":" colon_opt.unwrap Token::value == && then
+    if { Token::value ":" == } colon_opt.filter.is_some then
         cursor.pop drop
         true = parse_super_loop
         while parse_super_loop do
@@ -1730,7 +1730,7 @@ fn parse_trait parser:Parser cursor:TokenCursor -> CasaTrait {
             fi
             super_args super_name TraitBound supertraits.push
             cursor.peek = plus_opt
-            if plus_opt.is_some "+" plus_opt.unwrap Token::value == && then
+            if { Token::value "+" == } plus_opt.filter.is_some then
                 cursor.pop drop
             else
                 false = parse_super_loop
@@ -1964,7 +1964,7 @@ fn parse_struct_match_pattern parser:Parser name_token:Token cursor:TokenCursor 
 fn parse_pattern_terminator parser:Parser cursor:TokenCursor function_name:str -> List[Op] {
     List::new(List[Op]) = guard_ops
     cursor.peek = guard_peek
-    if guard_peek.is_some "if" guard_peek.unwrap Token::value == && then
+    if { Token::value "if" == } guard_peek.filter.is_some then
         cursor.pop drop # consume `if`
         0 = match_depth
         while cursor.is_finished ! do
@@ -2037,7 +2037,7 @@ fn parse_match_arm_pattern
         arm_token Token::location literal_arm OpValue::MatchArm make_op ops.push
     elif TokenKind::Identifier arm_token Token::kind != then
         arm_token Token::location "Expected match pattern or `_`" ErrorKind::UnexpectedToken raise_error
-    elif cursor.peek.is_some "{" cursor.peek.unwrap Token::value == && then
+    elif { Token::value "{" == } cursor.peek.filter.is_some then
         cursor arm_token parser parse_struct_match_pattern = struct_pattern
         function_name cursor parser parse_pattern_terminator = struct_guard_ops
         struct_guard_ops struct_pattern PatternValue::Struct make_match_arm = struct_arm
@@ -2054,7 +2054,7 @@ fn parse_match_arm_pattern
 
         List::new(List[str]) = bindings
         cursor.peek = paren_opt
-        if paren_opt.is_some "(" paren_opt.unwrap Token::value == && then
+        if { Token::value "(" == } paren_opt.filter.is_some then
             cursor.pop drop
             while true do
                 cursor.peek = inner_opt
@@ -2082,7 +2082,7 @@ fn parse_match_arm_pattern
 
 fn parse_match_arm_body parser:Parser cursor:TokenCursor function_name:str ops:List[Op] {
     cursor.peek = body_peek
-    if body_peek.is_some "{" body_peek.unwrap Token::value == && then
+    if { Token::value "{" == } body_peek.filter.is_some then
         function_name cursor parser parse_block_ops = block_ops
         for block_op in block_ops.iter do
             block_op ops.push
@@ -2092,7 +2092,7 @@ fn parse_match_arm_body parser:Parser cursor:TokenCursor function_name:str ops:L
     while cursor.is_finished ! do
         if cursor parser is_match_arm_boundary then break fi
         cursor.peek = end_peek
-        if end_peek.is_some "end" end_peek.unwrap Token::value == && then
+        if { Token::value "end" == } end_peek.filter.is_some then
             break
         fi
         cursor.pop = body_token_opt
@@ -2271,7 +2271,7 @@ fn handle_keyword_import parser:Parser cursor:TokenCursor -> Op {
         path_location spec importing_file parser resolve_import = resolved
 
         cursor.peek = next_opt
-        if next_opt.is_some "{" next_opt.unwrap Token::value == && then
+        if { Token::value "{" == } next_opt.filter.is_some then
             path_location cursor parse_selective_import_symbols = symbols
             symbols resolved SelectiveImport = selective
             path_location selective OpValue::ImportFileSelective make_op return

--- a/compiler/typechecker.casa
+++ b/compiler/typechecker.casa
@@ -1276,7 +1276,7 @@ fn type_satisfies_trait type_name:Type trait_name:str function_opt:Option[Functi
     # Accept both bare ("Iterable") and concrete generic ("Iterable[int]") trait names.
     trait_name parse_type_str = trait_type
     trait_type.base = trait_base_opt
-    if trait_base_opt.is_some then trait_base_opt.unwrap else trait_name fi = trait_lookup_name
+    trait_name trait_base_opt.unwrap_or = trait_lookup_name
     trait_lookup_name DEFAULT_PARSER.store.traits.get = trait_opt
     if trait_opt.is_none then false return fi
     trait_opt.unwrap = trait_def
@@ -2252,7 +2252,7 @@ fn instantiate_default_trait_method
 
     # Determine function name and whether to use generic or concrete form
     receiver parse_type_str.base = fn_base_opt
-    if fn_base_opt.is_some then fn_base_opt.unwrap else receiver fi = fn_type_name
+    receiver fn_base_opt.unwrap_or = fn_type_name
     f"{fn_type_name}::{method_name}" = synth_fn_name
 
     # For generic receivers, keep trait type params as function type vars.

--- a/docs/standard-library.md
+++ b/docs/standard-library.md
@@ -234,6 +234,51 @@ Returns the contained value, or a default if the option is empty.
 0 Option::None .unwrap_or print      # 0
 ```
 
+### `Option::map`
+
+Transforms the contained value with `f` if Some, otherwise returns None.
+
+**Stack effect:** `fn[T -> U] Option[T] -> Option[U]`
+
+```casa
+{ 2 * } 5 Option::Some .map       # Option::Some(10)
+{ 2 * } Option::None .map         # Option::None
+```
+
+### `Option::and_then`
+
+Returns None if the option is empty, otherwise calls `f` with the contained value and returns the result.
+
+**Stack effect:** `fn[T -> Option[U]] Option[T] -> Option[U]`
+
+```casa
+{ 1 + Option::Some } 5 Option::Some .and_then   # Option::Some(6)
+{ 1 + Option::Some } Option::None .and_then     # Option::None
+```
+
+### `Option::or_else`
+
+Returns the option if it contains a value, otherwise calls `f` and returns its result.
+
+**Stack effect:** `fn[-> Option[T]] Option[T] -> Option[T]`
+
+```casa
+{ 0 Option::Some } Option::None .or_else        # Option::Some(0)
+{ 0 Option::Some } 5 Option::Some .or_else      # Option::Some(5)
+```
+
+### `Option::filter`
+
+Returns the option if it contains a value and the predicate returns true, otherwise returns None.
+
+**Stack effect:** `fn[T -> bool] Option[T] -> Option[T]`
+
+```casa
+{ 3 > } 5 Option::Some .filter    # Option::Some(5)
+{ 3 > } 2 Option::Some .filter    # Option::None
+{ 3 > } Option::None .filter      # Option::None
+```
+
 ### Match on Option
 
 Use `match` with destructuring to handle Option values:
@@ -308,6 +353,50 @@ Returns the success value, or a default if the result is an error.
 ```casa
 0 42 Result::Ok .unwrap_or print            # 42
 0 "error" Result::Error .unwrap_or print    # 0
+```
+
+### `Result::map`
+
+Transforms the Ok value with `f`, leaving Error unchanged.
+
+**Stack effect:** `fn[T -> U] Result[T E] -> Result[U E]`
+
+```casa
+{ 2 * } 5 Result::Ok .map                 # Result::Ok(10)
+{ 2 * } "err" Result::Error .map          # Result::Error("err")
+```
+
+### `Result::map_error`
+
+Transforms the Error value with `f`, leaving Ok unchanged.
+
+**Stack effect:** `fn[E -> F] Result[T E] -> Result[T F]`
+
+```casa
+{ "wrapped: " swap str::concat } "err" Result::Error .map_error   # Result::Error("wrapped: err")
+{ "wrapped: " swap str::concat } 5 Result::Ok .map_error          # Result::Ok(5)
+```
+
+### `Result::and_then`
+
+Returns the error if the result is Error, otherwise calls `f` with the Ok value and returns the result.
+
+**Stack effect:** `fn[T -> Result[U E]] Result[T E] -> Result[U E]`
+
+```casa
+{ 1 + Result::Ok } 5 Result::Ok .and_then         # Result::Ok(6)
+{ 1 + Result::Ok } "err" Result::Error .and_then   # Result::Error("err")
+```
+
+### `Result::or_else`
+
+Returns the Ok value if present, otherwise calls `f` with the Error value for recovery.
+
+**Stack effect:** `fn[E -> Result[T F]] Result[T E] -> Result[T F]`
+
+```casa
+{ drop 0 Result::Ok } "err" Result::Error .or_else   # Result::Ok(0)
+{ drop 0 Result::Ok } 5 Result::Ok .or_else          # Result::Ok(5)
 ```
 
 ### Match on Result

--- a/lib/json.casa
+++ b/lib/json.casa
@@ -251,32 +251,17 @@ fn json_parse cursor:Cursor -> Result[JsonValue ParseError] {
     fi
     cursor.peek.unwrap = character
     if character '"' == then
-        cursor json_parse_string = string_result
-        if string_result.is_error then
-            string_result.unwrap_error Result::Error
-        else
-            string_result.unwrap JsonValue::JsonString Result::Ok
-        fi
+        { JsonValue::JsonString } cursor json_parse_string.map
     elif character '{' == then
         cursor json_parse_object
     elif character '[' == then
         cursor json_parse_array
     elif character 't' == character 'f' == || then
-        cursor json_parse_bool = bool_result
-        if bool_result.is_error then
-            bool_result.unwrap_error Result::Error
-        else
-            bool_result.unwrap JsonValue::JsonBool Result::Ok
-        fi
+        { JsonValue::JsonBool } cursor json_parse_bool.map
     elif character 'n' == then
         cursor json_parse_null
     elif character.is_digit character '-' == || then
-        cursor json_parse_number = number_result
-        if number_result.is_error then
-            number_result.unwrap_error Result::Error
-        else
-            number_result.unwrap JsonValue::JsonInt Result::Ok
-        fi
+        { JsonValue::JsonInt } cursor json_parse_number.map
     else
         cursor.pos "unexpected character in JSON" ParseError Result::Error
     fi

--- a/lib/std.casa
+++ b/lib/std.casa
@@ -626,6 +626,38 @@ impl Option {
             default
         fi
     }
+    fn map [T U] self:Option[T] f:fn[T -> U] -> Option[U] {
+        if self.is_some then
+            self.unwrap f exec Option::Some
+        else
+            Option::None(Option[U])
+        fi
+    }
+    fn and_then [T U] self:Option[T] f:fn[T -> Option[U]] -> Option[U] {
+        if self.is_some then
+            self.unwrap f exec
+        else
+            Option::None(Option[U])
+        fi
+    }
+    fn or_else [T] self:Option[T] f:fn[-> Option[T]] -> Option[T] {
+        if self.is_some then
+            self
+        else
+            f exec
+        fi
+    }
+    fn filter [T] self:Option[T] f:fn[T -> bool] -> Option[T] {
+        if self.is_none then
+            Option::None(Option[T]) return
+        fi
+        self.unwrap = val
+        if val f exec then
+            val Option::Some
+        else
+            Option::None(Option[T])
+        fi
+    }
 }
 
 impl Result {
@@ -654,6 +686,34 @@ impl Result {
             self.unwrap
         else
             default
+        fi
+    }
+    fn map [T U E] self:Result[T E] f:fn[T -> U] -> Result[U E] {
+        if self.is_ok then
+            self.unwrap f exec Result::Ok
+        else
+            self.unwrap_error Result::Error
+        fi
+    }
+    fn map_error [T E F] self:Result[T E] f:fn[E -> F] -> Result[T F] {
+        if self.is_ok then
+            self.unwrap Result::Ok
+        else
+            self.unwrap_error f exec Result::Error
+        fi
+    }
+    fn and_then [T U E] self:Result[T E] f:fn[T -> Result[U E]] -> Result[U E] {
+        if self.is_ok then
+            self.unwrap f exec
+        else
+            self.unwrap_error Result::Error
+        fi
+    }
+    fn or_else [T E F] self:Result[T E] f:fn[E -> Result[T F]] -> Result[T F] {
+        if self.is_ok then
+            self.unwrap Result::Ok
+        else
+            self.unwrap_error f exec
         fi
     }
 }


### PR DESCRIPTION
## Summary

- Add `map`, `and_then`, `or_else`, `filter` to `impl Option` and `map`, `map_error`, `and_then`, `or_else` to `impl Result` in `lib/std.casa`
- Refactor 15 call sites across `compiler/syntax.casa`, `compiler/typechecker.casa`, and `lib/json.casa` to use the new combinators
- Document all 8 combinators with stack effects and examples in `docs/standard-library.md`

Closes #213

## Test plan

- [x] Stage2 self-host passes
- [x] `tests/test_compiler.sh` — 52/52
- [x] `tests/test_examples.sh` — 47/47