### PR TITLE
feat(stdlib): add Map::iter for lazy entry iteration

### DIFF
--- a/docs/collections.md
+++ b/docs/collections.md
@@ -246,9 +246,36 @@ Removes a key from the map. Returns the updated map. If the key does not exist, 
 "one" m.delete = m
 ```
 
+### `Map::iter`
+
+Returns a lazy `Iter[Pair[K V]]` that yields key-value pairs on demand. Each pair's `.first` field is the key (`K`) and `.second` field is the value (`V`). The iterator walks hash buckets using closure state, so no intermediate list is allocated.
+
+**Stack effect:** `Map[K V] -> Iter[Pair[K V]]`
+
+```casa
+for pair in m.iter do
+    pair.first (str) = key
+    pair.second (int) = val
+    f"{key}: {val}\n" print
+done
+```
+
+Because `Iter` implements the `Iterable` trait, all iterator combinators (`map`, `filter`, `take`, `count`, `collect`, etc.) work on the result:
+
+```casa
+# Count entries
+m.iter.count print
+
+# Collect into a list of pairs
+m.iter.collect = pairs
+
+# Take first 5 entries
+5 m.iter.take.collect = first_five
+```
+
 ### `Map::keys`
 
-Returns a `List[K]` of all keys in the map.
+Returns a `List[K]` of all keys in the map. Implemented in terms of `Map::iter`.
 
 **Stack effect:** `Map[K V] -> List[K]`
 
@@ -258,7 +285,7 @@ m.keys = key_list
 
 ### `Map::values`
 
-Returns a `List[V]` of all values in the map.
+Returns a `List[V]` of all values in the map. Implemented in terms of `Map::iter`.
 
 **Stack effect:** `Map[K V] -> List[V]`
 

--- a/lib/std.casa
+++ b/lib/std.casa
@@ -1353,30 +1353,40 @@ impl[K: Hashable, V] Map[K V] {
         new_capacity self->capacity
     }
 
+    fn iter self:Map[K V] -> Iter[Pair[K V]] {
+        16 alloc = st
+        0 st store64
+        0 st 8 + store64
+        Option::None(Option[Pair[K V]]) = none
+        {
+            st 8 + load64 = current_entry
+            while 0 current_entry == do
+                st load64 = bucket_index
+                if self.capacity bucket_index >= then
+                    none return
+                fi
+                self.buckets bucket_index 8 * + load64 = current_entry
+                bucket_index 1 + st store64
+            done
+            current_entry (ptr) 16 + load64 st 8 + store64
+            current_entry (ptr) 8 + load64
+            current_entry (ptr) load64
+            Pair Option::Some
+        } (ptr) Iter (Iter[Pair[K V]])
+    }
+
     fn keys self:Map[K V] -> List[K] {
         List::new(List[K]) = key_list
-        0 = bucket_iter
-        while bucket_iter self.capacity > do
-            self.buckets bucket_iter 8 * + load64 = current_entry
-            while 0 current_entry != do
-                current_entry (ptr) load64 (K) key_list.push
-                current_entry (ptr) 16 + load64 = current_entry
-            done
-            1 += bucket_iter
+        for pair in self.iter do
+            pair.first (K) key_list.push
         done
         key_list
     }
 
     fn values self:Map[K V] -> List[V] {
         List::new(List[V]) = value_list
-        0 = bucket_iter
-        while bucket_iter self.capacity > do
-            self.buckets bucket_iter 8 * + load64 = current_entry
-            while 0 current_entry != do
-                current_entry (ptr) 8 + load64 (V) value_list.push
-                current_entry (ptr) 16 + load64 = current_entry
-            done
-            1 += bucket_iter
+        for pair in self.iter do
+            pair.second (V) value_list.push
         done
         value_list
     }

--- a/tests/compiler/test_map_iter.casa
+++ b/tests/compiler/test_map_iter.casa
@@ -1,0 +1,129 @@
+import "std"
+
+0 = test_pass_count
+0 = test_fail_count
+"" = test_current_name
+
+fn test_start name:str {
+    name = test_current_name
+}
+
+fn assert_true condition:bool message:str {
+    if condition then
+        1 += test_pass_count
+    else
+        f"[FAIL] {test_current_name}: {message}\n" eprint
+        1 += test_fail_count
+    fi
+}
+
+fn assert_eq actual:int expected:int message:str {
+    if expected actual == then
+        1 += test_pass_count
+    else
+        f"[FAIL] {test_current_name}: {message} (expected {expected}, got {actual})\n" eprint
+        1 += test_fail_count
+    fi
+}
+
+fn test_summary {
+    f"{test_pass_count} passed, {test_fail_count} failed\n" print
+    if 0 test_fail_count > then
+        1 exit
+    fi
+}
+
+# ============================================================================
+# Map::iter tests
+# ============================================================================
+# --- empty map ---
+"iter empty map" test_start
+Map::new(Map[str int]) = empty
+empty.iter.collect = empty_result: List[Pair[str int]]
+"length" 0 empty_result.length assert_eq
+# --- basic iteration ---
+"iter basic" test_start
+Map::new(Map[str int]) = m
+1 "a" m.set = m
+2 "b" m.set = m
+3 "c" m.set = m
+m.iter.collect = pairs: List[Pair[str int]]
+"length" 3 pairs.length assert_eq
+# --- verify all entries present via get ---
+"iter entries match get" test_start
+0 = idx
+while idx pairs.length > do
+    idx pairs.get = pair
+    pair.first (str) = key
+    pair.second (int) = val
+    key m.get.unwrap = expected
+    f"value for key at {idx}" expected val assert_eq
+    1 += idx
+done
+# --- for loop works ---
+"for loop" test_start
+0 = total
+for pair in m.iter do
+    pair.second (int) += total
+done
+"sum" 6 total assert_eq
+# --- keys via iter ---
+"keys" test_start
+m.keys = key_list
+"keys length" 3 key_list.length assert_eq
+# --- values via iter ---
+"values" test_start
+m.values = val_list
+"values length" 3 val_list.length assert_eq
+0 = val_sum
+0 = vi
+while vi val_list.length > do
+    vi val_list.get += val_sum
+    1 += vi
+done
+"values sum" 6 val_sum assert_eq
+# --- iter with take ---
+"iter take" test_start
+2 m.iter.take.collect = taken: List[Pair[str int]]
+"taken length" 2 taken.length assert_eq
+# --- iter count ---
+"iter count" test_start
+"count" 3 m.iter.count assert_eq
+# --- single entry map ---
+"single entry" test_start
+Map::new(Map[int int]) = m1
+42 1 m1.set = m1
+m1.iter.collect = single_pairs: List[Pair[int int]]
+"length" 1 single_pairs.length assert_eq
+0 single_pairs.get = sp
+"key" 1 sp.first assert_eq
+"value" 42 sp.second assert_eq
+# --- iter after delete ---
+"iter after delete" test_start
+Map::new(Map[str int]) = md
+1 "x" md.set = md
+2 "y" md.set = md
+3 "z" md.set = md
+"y" md.delete = md
+md.iter.collect = del_pairs: List[Pair[str int]]
+"length after delete" 2 del_pairs.length assert_eq
+0 = del_sum
+for pair in md.iter do
+    pair.second (int) += del_sum
+done
+"sum after delete" 4 del_sum assert_eq
+# --- multiple iterations of same map ---
+"multiple iterations" test_start
+"first count" 3 m.iter.count assert_eq
+"second count" 3 m.iter.count assert_eq
+# --- large map ---
+"large map" test_start
+Map::new(Map[int int]) = big
+0 = i
+while i 100 > do
+    i i big.set = big
+    1 += i
+done
+big.iter.collect = big_pairs: List[Pair[int int]]
+"large length" 100 big_pairs.length assert_eq
+test_summary


### PR DESCRIPTION
## Summary

- Add `Map::iter` returning lazy `Iter[Pair[K V]]` that walks hash buckets on demand using closure state
- Rewrite `Map::keys` and `Map::values` in terms of `Map::iter`, replacing duplicated bucket-walking logic
- Add `Map::iter` documentation to `docs/collections.md`

Closes #216

## Test plan

- [x] New `tests/compiler/test_map_iter.casa` with 19 assertions covering:
  - Empty map, single entry, 3-entry, and 100-entry maps
  - `for` loop, `.collect`, `.take`, `.count` combinators
  - Entry values cross-checked against `Map::get`
  - `keys`/`values` length and value sums
  - Iteration after `delete`
  - Multiple independent iterations of the same map
  - Both `Map[str int]` and `Map[int int]` key types
- [x] `tests/test_compiler.sh` — 53 passed, 0 failed
- [x] `tests/test_examples.sh` — 47 passed, 0 failed