### PR TITLE
refactor: remove DEFAULT_PARSER, thread SymbolStore explicitly

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -18,6 +18,36 @@ _Avoid_: stat buffer, metadata tuple
 
 ## Language
 
+### Compiler architecture
+
+**Functional compiler pass**:
+A compiler phase that takes its context as explicit input and returns its output, diagnostics, and updated context explicitly while keeping mutation local to phase-internal builders.
+_Avoid_: Pure compiler rewrite, immutable compiler
+
+**Typecheck result**:
+The explicit output of typechecking: updated symbols, checked global stack effect, and any resolved operation changes produced during typechecking.
+_Avoid_: Hidden typechecker side effects, global typechecker state
+
+**Pass result**:
+An explicit compiler phase output struct used only when a phase has multiple meaningful outputs.
+_Avoid_: Wrapper struct, single-field result
+
+**Compiler dependency**:
+An explicit state value returned from a compiler pass when later passes need that state, instead of passing a phase-owned object across boundaries.
+_Avoid_: Leaking parser object, omnibus context
+
+**Parse-and-resolve boundary**:
+The first explicit compiler boundary that keeps parser internals private while returning resolved operations and symbols needed by later phases.
+_Avoid_: Parser result, resolver-owned parser
+
+**Default parser**:
+The current process-global parser instance used as implicit compiler state before explicit pass boundaries replace it.
+_Avoid_: Shared compiler context, hidden parser dependency
+
+**Compiler diagnostics schema**:
+The shared representation and flow for compiler diagnostics across lexer, parser, typechecker, and later phases.
+_Avoid_: Typechecker-only diagnostics refactor, phase-local error schema
+
 ### Type representation
 
 **Type AST**:
@@ -118,6 +148,13 @@ _Avoid_: Release lint, tag lint
 
 - **Source type syntax** is parsed into the **Type AST** before compiler analysis.
 - Compiler analysis should operate on the **Type AST**, not reparsed or reformatted type strings.
+- A **Functional compiler pass** may use local mutation internally, but pass boundaries should make compiler context and diagnostics explicit.
+- A **Pass result** should be introduced only when the compiler phase returns more than one meaningful output; single-output phases should return the value directly.
+- A **Compiler dependency** should be returned as its own value only when a later boundary uses it now; unused phase-private state should stay private until needed.
+- The **Parse-and-resolve boundary** should hide `Parser` and return only resolved operations plus symbols until parsing and identifier resolution can be split cleanly.
+- The **Default parser** should trend toward zero use as explicit pass boundaries mature; if a slice can remove it fully, it should.
+- A **Typecheck result** may return the same **SymbolStore** reference it received, as long as mutations are represented at the pass boundary.
+- The **Compiler diagnostics schema** should be refactored once across the compiler, not as part of the first **Typecheck result** boundary.
 - The **Documentation glossary** names project concepts that prevent drift; language keywords and ordinary programming concepts belong in reference docs.
 - Function, operator, intrinsic, and expression docs should use **Stack effect**; **Operand order** explains how stack values map to operands.
 - Public reference docs should use one **Stack effect** line for an operation instead of separate signature and stack-effect lines.
@@ -165,6 +202,13 @@ _Avoid_: Release lint, tag lint
 ## Flagged Ambiguities
 
 - "`Op.type_annotation` / `Op.deferred_return_type` as source text" was used to justify keeping parsed type metadata as strings. Resolved: user-written type expressions are **Source type syntax** only before parsing; after parsing, compiler-owned metadata should use the **Type AST**.
+- "functional programming concepts" was broad enough to imply a full immutable rewrite. Resolved: the target is **Functional compiler pass** boundaries, with local mutation still allowed inside phases.
+- "`LexResult`" was proposed as a first slice even though it would only wrap `List[Token]`. Resolved: avoid single-field **Pass result** structs; `lex_file` should keep returning tokens until lexing has multiple explicit outputs.
+- "`ParseResult` returning `Parser`" leaked a parser-owned object past parsing, while returning every parser field exposed unused state. Resolved: return only the **Compiler dependencies** later boundaries use now, and migrate call sites instead of keeping the old API.
+- Parse and identifier resolution both need import state today, so a standalone parse result is premature. Resolved: start with a **Parse-and-resolve boundary** that keeps import state private.
+- "`DEFAULT_PARSER`" was treated as convenient shared context. Resolved: call it the **Default parser** and remove uses as explicit pass boundaries replace hidden compiler state.
+- "return updated SymbolStore" could imply deep-copying the symbol table. Resolved: **Typecheck result** may return the same reference after mutation; explicit pass output is the important boundary.
+- "typechecker diagnostics" was treated as a typechecker-specific refactor. Resolved: diagnostics belong to a compiler-wide **Compiler diagnostics schema** refactor, tracked in issue #219.
 - "glossary" was considered as a complete keyword or syntax catalog. Resolved: the **Documentation glossary** covers only project-specific concepts whose terminology must stay stable.
 - "function signature" and "stack effect" were treated as interchangeable in docs. Resolved: use **Stack effect** for public stack contracts; reserve "signature" only where the compiler's internal function type model is meant.
 - "`fn foo a:int b:str -> bool`" was called a signature. Resolved: call it a **Function declaration** when bodyless, and a **Function definition** when paired with a body.

--- a/casa.casa
+++ b/casa.casa
@@ -50,7 +50,7 @@ fn main {
     "run" args.get_flag = CLI_RUN
     "verbose" args.get_flag = CLI_VERBOSE
 
-    "library_path" args.get_multi.unwrap DEFAULT_PARSER->search_paths
+    "library_path" args.get_multi.unwrap = CLI_LIBRARY_PATHS
 
     # Configure logging
     if CLI_VERBOSE then
@@ -65,14 +65,14 @@ fn main {
 
     # Parse
     f"{timer} Parsing ops" log_info
-    tokens DEFAULT_PARSER parse_ops = ops
-    ops DEFAULT_PARSER resolve_identifiers_global = ops
-    DEFAULT_PARSER derive_hashable_for_enums
+    CLI_LIBRARY_PATHS tokens parse_and_resolve = parse_result
+    parse_result ParseResolveResult::ops = ops
+    parse_result ParseResolveResult::store = store
 
     # Type check
     f"{timer} Type checking ops" log_info
-    Option::None ops type_check_ops drop
-    type_check_functions
+    store Option::None ops type_check_ops drop
+    store type_check_functions
 
     # Check for errors
     flush_errors
@@ -82,7 +82,7 @@ fn main {
 
     # Compile bytecode
     f"{timer} Compiling bytecode" log_info
-    ops DEFAULT_PARSER.store compile_bytecode = program
+    ops store compile_bytecode = program
 
     # Emit assembly
     f"{timer} Emitting assembly" log_info

--- a/compiler/pattern.casa
+++ b/compiler/pattern.casa
@@ -123,7 +123,7 @@ fn unify_arm_stacks tc:TypeChecker match_ctx:MatchContext op:Op {
     match_before tc TypeChecker::live.equals
     match_after match_before.equals && !
     then
-        match_after tc TypeChecker::live.unify_types = unified
+        tc.store match_after tc TypeChecker::live.unify_types = unified
         if 0 unified.length != match_after match_before.equals ! && then
             unified match_after TypedStack::set_types
         elif match_after match_before.equals then
@@ -144,10 +144,11 @@ fn assign_struct_binding_type
     field_name:str
     bound_var:str
     function_opt:Option[Function]
+    store:SymbolStore
 {
     for member in matched_struct CasaStruct::members.iter do
         if field_name member Member::name == then
-            function_opt member Member::typ bound_var set_binding_type
+            store function_opt member Member::typ bound_var set_binding_type
         fi
     done
 }
@@ -161,7 +162,7 @@ fn register_struct_pattern_bindings
     struct_pattern StructPattern::bindings.keys = binding_keys
     for field_name in binding_keys.iter do
         field_name struct_pattern StructPattern::bindings.get.unwrap = bound_var
-        function_opt bound_var field_name matched_struct assign_struct_binding_type
+        tc.store function_opt bound_var field_name matched_struct assign_struct_binding_type
     done
 }
 
@@ -219,7 +220,7 @@ fn apply_enum_bindings
         if binding_type.format type_bindings.get Option::Some(resolved) is then
             resolved = binding_type
         fi
-        function_opt binding_type binding_var set_binding_type
+        tc.store function_opt binding_type binding_var set_binding_type
         1 += bind_index
     done
 }
@@ -281,7 +282,7 @@ fn typecheck_match_op tc:TypeChecker function_opt:Option[Function] op:Op {
 
         if op pattern_is_guarded then
             op pattern_guard_ops = guard_ops
-            DEFAULT_PARSER.store make_typechecker = guard_checker
+            tc.store make_typechecker = guard_checker
             function_opt guard_ops guard_checker run_type_check_ops
             guard_checker TypeChecker::live TypedStack::types = guard_stack
             false = guard_ok

--- a/compiler/syntax.casa
+++ b/compiler/syntax.casa
@@ -9,11 +9,10 @@ import "error"
 import "lexer"
 
 # ============================================================================
-# Parser struct and shared state
+# Parser struct and parse/resolve result
 #
-# `Parser` owns the `SymbolStore` plus parser-private `included_files`. A
-# single default parser is constructed at module load; the compiler entry
-# point and tests reuse it via `DEFAULT_PARSER`.
+# `Parser` owns parse-private state. Later compiler phases receive only the
+# dependencies they use, not the parser object itself.
 # ============================================================================
 
 struct Parser {
@@ -22,14 +21,17 @@ struct Parser {
     search_paths:   List[str]
 }
 
+struct ParseResolveResult {
+    ops:   List[Op]
+    store: SymbolStore
+}
+
 fn make_parser store:SymbolStore -> Parser {
     List::new(List[str])
     Set::new(Set[str])
     store
     Parser
 }
-symbol_store_new = DEFAULT_STORE
-DEFAULT_STORE make_parser = DEFAULT_PARSER
 
 # ============================================================================
 # Simple keyword -> OpValue lookup (no-payload variants only)
@@ -885,7 +887,7 @@ fn parse_stack_effect cursor:TokenCursor -> StackEffect {
 fn collect_trait_methods_into
     seen:Set[str]
     result:List[TraitMethod]
-    parser:Parser
+    store:SymbolStore
     trait_def:CasaTrait
 -> Set[str] {
     for ctm_method in trait_def CasaTrait::methods.iter do
@@ -895,9 +897,9 @@ fn collect_trait_methods_into
         fi
     done
     for ctm_super in trait_def CasaTrait::supertraits.iter do
-        ctm_super TraitBound::name parser.store.traits.get = ctm_super_opt
+        ctm_super TraitBound::name store.traits.get = ctm_super_opt
         if ctm_super_opt.is_some then
-            ctm_super_opt.unwrap parser result seen collect_trait_methods_into = seen
+            ctm_super_opt.unwrap store result seen collect_trait_methods_into = seen
         fi
     done
     seen
@@ -906,10 +908,10 @@ fn collect_trait_methods_into
 # transitive supertraits, deduplicated by name. The trait's own methods
 # come first; supertrait methods follow in declaration order.
 
-fn collect_trait_methods parser:Parser trait_def:CasaTrait -> List[TraitMethod] {
+fn collect_trait_methods store:SymbolStore trait_def:CasaTrait -> List[TraitMethod] {
     List::new(List[TraitMethod]) = result
     Set::new(Set[str]) = seen
-    trait_def parser result seen collect_trait_methods_into drop
+    trait_def store result seen collect_trait_methods_into drop
     result
 }
 
@@ -936,7 +938,7 @@ fn build_hidden_trait_methods
                     1 += bhtm_sub_index
                 done
             fi
-            for bound_method in bound_trait parser collect_trait_methods.iter do
+            for bound_method in bound_trait parser.store collect_trait_methods.iter do
                 # Skip default methods — only abstract methods need hidden fn ptrs
                 if 0 bound_method TraitMethod::default_ops.length == then
                     f"__trait_{bound_type_var}_{bound_method TraitMethod::name}" = hidden_name
@@ -3023,6 +3025,15 @@ fn parse_ops parser:Parser tokens:List[Token] -> List[Op] {
     ops
 }
 
+fn parse_and_resolve tokens:List[Token] search_paths:List[str] -> ParseResolveResult {
+    symbol_store_new make_parser = parser
+    search_paths parser Parser::set_search_paths
+    tokens parser parse_ops = ops
+    ops parser resolve_identifiers_global = resolved_ops
+    parser derive_hashable_for_enums
+    parser.store resolved_ops ParseResolveResult
+}
+
 # ============================================================================
 # resolve_identifiers - post-parse pass
 # ============================================================================
@@ -3112,8 +3123,9 @@ fn resolve_identifiers_global parser:Parser ops:List[Op] -> List[Op] {
     dummy ops parser resolve_identifiers_fn
 }
 
-fn resolve_identifiers ops:List[Op] function:Function -> List[Op] {
-    function ops DEFAULT_PARSER resolve_identifiers_fn
+fn resolve_identifiers store:SymbolStore ops:List[Op] function:Function -> List[Op] {
+    store make_parser = resolver
+    function ops resolver resolve_identifiers_fn
 }
 # resolve_match_op — per-arm identifier resolution entry point.
 # Registers struct-pattern field bindings as locals/globals and resolves
@@ -3354,7 +3366,7 @@ fn resolve_identifiers_fn parser:Parser ops:List[Op] function:Function -> List[O
                 lambda_opt.unwrap = lambda
                 true lambda Function::set_is_used
                 function lambda parser gather_captures
-                lambda lambda Function::ops resolve_identifiers = lambda_resolved
+                lambda lambda Function::ops parser.store resolve_identifiers = lambda_resolved
                 lambda_resolved lambda Function::set_ops
             fi
             continue

--- a/compiler/typechecker.casa
+++ b/compiler/typechecker.casa
@@ -57,8 +57,8 @@ impl TypedStack {
     }
 
     # Produce the unified types list between two TypedStacks, or empty on incompatibility.
-    fn unify_types self:TypedStack candidate:TypedStack -> List[Type] {
-        self TypedStack::types candidate TypedStack::types stacks_compatible
+    fn unify_types self:TypedStack candidate:TypedStack store:SymbolStore -> List[Type] {
+        store self TypedStack::types candidate TypedStack::types stacks_compatible
     }
 }
 
@@ -285,16 +285,16 @@ fn expect_type_t tc:TypeChecker expected:Type {
 # Type compatibility
 # ============================================================================
 
-fn is_enum_type_var_t typ:Type -> bool {
+fn is_enum_type_var_t typ:Type store:SymbolStore -> bool {
     typ.base = base_opt
     if base_opt.is_some then
-        base_opt.unwrap DEFAULT_PARSER.store.enums.get.is_some
+        base_opt.unwrap store.enums.get.is_some
     else
         false
     fi
 }
 
-fn is_type_variable_t typ:Type -> bool {
+fn is_type_variable_t typ:Type store:SymbolStore -> bool {
     typ match
         Type::TypeVar(_) => { true }
         Type::Generic(generic) => {
@@ -305,7 +305,7 @@ fn is_type_variable_t typ:Type -> bool {
                     false
                 fi
             else
-                generic.base DEFAULT_PARSER.store.enums.get.is_some
+                generic.base store.enums.get.is_some
             fi
         }
         _ => { false }
@@ -350,8 +350,8 @@ fn type_exists_recursive_t typ:Type function_opt:Option[Function] store:SymbolSt
     end
 }
 
-fn validate_type_exists typ:Type function_opt:Option[Function] location:Location {
-    if DEFAULT_PARSER.store function_opt typ type_exists_recursive_t then return fi
+fn validate_type_exists typ:Type function_opt:Option[Function] location:Location store:SymbolStore {
+    if store function_opt typ type_exists_recursive_t then return fi
     location f"type `{typ.format}` does not exist" ErrorKind::Syntax raise_error
 }
 
@@ -359,7 +359,7 @@ fn validate_type_exists typ:Type function_opt:Option[Function] location:Location
 # Unify types — returns the more specific type, or "" on incompatibility
 # ============================================================================
 
-fn unify_generic_params_t type_a:Type type_b:Type -> Option[Type] {
+fn unify_generic_params_t type_a:Type type_b:Type store:SymbolStore -> Option[Type] {
     type_a.type_params = params_a_opt
     type_b.type_params = params_b_opt
     if params_a_opt.is_none then type_b Option::Some return fi
@@ -370,26 +370,26 @@ fn unify_generic_params_t type_a:Type type_b:Type -> Option[Type] {
     List::new(List[Type]) = unified
     0 = index
     while index params_a.length > do
-        index params_b.get index params_a.get unify_type_t ? unified.push
+        store index params_b.get index params_a.get unify_type_t ? unified.push
         1 += index
     done
     type_a.base.unwrap = base
     unified base GenericType Type::Generic Option::Some
 }
 
-fn unify_type_t type_a:Type type_b:Type -> Option[Type] {
+fn unify_type_t type_a:Type type_b:Type store:SymbolStore -> Option[Type] {
     if type_a type_b.eq then type_a Option::Some return fi
     if type_a.is_unknown_placeholder then type_b Option::Some return fi
     if type_b.is_unknown_placeholder then type_a Option::Some return fi
     # Enum type variables unify with concrete types.
-    if type_a is_enum_type_var_t then type_b Option::Some return fi
-    if type_b is_enum_type_var_t then type_a Option::Some return fi
+    if store type_a is_enum_type_var_t then type_b Option::Some return fi
+    if store type_b is_enum_type_var_t then type_a Option::Some return fi
     type_a.base = base_a
     type_b.base = base_b
     if base_a.is_some then
         if base_b.is_some then
             if base_a.unwrap base_b.unwrap == then
-                type_b type_a unify_generic_params_t = generic_result
+                store type_b type_a unify_generic_params_t = generic_result
                 if generic_result.is_some then generic_result return fi
             fi
         fi
@@ -407,7 +407,7 @@ fn unify_type_t type_a:Type type_b:Type -> Option[Type] {
 # Stack compatibility — unify element-wise, returns empty list on mismatch
 # ============================================================================
 
-fn stacks_compatible stack_a:List[Type] stack_b:List[Type] -> List[Type] {
+fn stacks_compatible stack_a:List[Type] stack_b:List[Type] store:SymbolStore -> List[Type] {
     if stack_a.length stack_b.length != then
         List::new(List[Type]) return
     fi
@@ -417,7 +417,7 @@ fn stacks_compatible stack_a:List[Type] stack_b:List[Type] -> List[Type] {
         if index stack_b.get index stack_a.get.eq then
             index stack_a.get result.push
         else
-            index stack_b.get index stack_a.get unify_type_t = unified
+            store index stack_b.get index stack_a.get unify_type_t = unified
             if unified.is_none then
                 List::new(List[Type]) return
             fi
@@ -488,7 +488,7 @@ fn bind_type_var tc:TypeChecker bindings:Map[str Type] type_var:str actual:Type 
     existing.unwrap = bound
     actual.is_unknown_placeholder = actual_unknown
     bound.is_unknown_placeholder = bound_unknown
-    bound is_type_variable_t = bound_is_var
+    tc.store bound is_type_variable_t = bound_is_var
     if
     bound_unknown
     bound_is_var ||
@@ -500,7 +500,7 @@ fn bind_type_var tc:TypeChecker bindings:Map[str Type] type_var:str actual:Type 
     bound actual.eq !
     actual_unknown ! &&
     bound_unknown ! &&
-    actual is_enum_type_var_t ! &&
+    tc.store actual is_enum_type_var_t ! &&
     then
         f"Type variable `{type_var}` bound to `{bound.format}` but got `{actual.format}`" tc raise_type_mismatch
     fi
@@ -820,7 +820,7 @@ fn check_comparison
         op_index return
     fi
     # User-defined types must satisfy Eq (or Ord) explicitly.
-    if function_opt trait_name type1_t type_satisfies_trait ! then
+    if tc.store function_opt trait_name type1_t type_satisfies_trait ! then
         cmp_value comparison_op_str = cmp_str
         op Op::location f"Type `{type1}` cannot be compared with `{cmp_str}`: does not satisfy trait `{trait_name}`" ErrorKind::MissingTraitMethod add_error
         TYPE_BOOL_T tc stack_push_type
@@ -917,13 +917,13 @@ fn check_stack_ops tc:TypeChecker op:Op {
 # ============================================================================
 # Returns true if `bound` names `Word` directly or transitively via supertraits.
 
-fn bound_implies_word bound:TraitBound -> bool {
+fn bound_implies_word bound:TraitBound store:SymbolStore -> bool {
     bound TraitBound::name = bound_name
     if "Word" bound_name == then true return fi
-    bound_name DEFAULT_PARSER.store.traits.get = bound_trait_opt
+    bound_name store.traits.get = bound_trait_opt
     if bound_trait_opt.is_none then false return fi
     for super_bound in bound_trait_opt.unwrap CasaTrait::supertraits.iter do
-        if super_bound bound_implies_word then true return fi
+        if store super_bound bound_implies_word then true return fi
     done
     false
 }
@@ -941,7 +941,7 @@ fn assert_word_bound tc:TypeChecker op:Op type_name:str function_opt:Option[Func
     if type_name word_stack_effect StackEffect::type_vars.has ! then return fi
     type_name word_stack_effect StackEffect::trait_bounds.get = word_bound_opt
     if word_bound_opt.is_none then return fi
-    if word_bound_opt.unwrap bound_implies_word then return fi
+    if tc.store word_bound_opt.unwrap bound_implies_word then return fi
     op Op::location f"Type variable `{type_name}` does not satisfy `Word` bound; add `[{type_name}: Word]` (or a trait that extends `Word`) to the function's type parameters" ErrorKind::TypeMismatch raise_error
 }
 
@@ -976,14 +976,20 @@ fn check_memory tc:TypeChecker op:Op function_opt:Option[Function] {
 # Unify the stored type of `variable` with the type being assigned to it.
 # `scope` ("local" / "global") is only used in the error message.
 
-fn unify_variable_assignment op:Op variable:Variable effective_type:Type scope:str {
+fn unify_variable_assignment
+    op:Op
+    variable:Variable
+    effective_type:Type
+    scope:str
+    store:SymbolStore
+{
     variable Variable::name = var_name
     variable Variable::typ = pre_type
     pre_type.is_unknown pre_type.is_unknown_placeholder || = pre_unknown
     if pre_unknown effective_type.is_unknown_placeholder ! && then
         effective_type variable Variable::set_typ
     fi
-    effective_type variable Variable::typ unify_type_t = unified
+    store effective_type variable Variable::typ unify_type_t = unified
     if unified.is_none then
         op Op::location f"Cannot override {scope} variable `{var_name}` of type `{variable Variable::typ.format}` with other type `{effective_type.format}`" ErrorKind::InvalidVariable add_error
     else
@@ -1016,7 +1022,7 @@ fn check_assignment tc:TypeChecker op:Op function_opt:Option[Function] {
         var_name function Function::variables variable_list_index = local_index
         if 0 local_index >= then
             local_index function Function::variables.get = local_var
-            "local" effective_type_t local_var op unify_variable_assignment
+            tc.store "local" effective_type_t local_var op unify_variable_assignment
             effective_type_t tc expect_type_t
             return
         fi
@@ -1026,7 +1032,7 @@ fn check_assignment tc:TypeChecker op:Op function_opt:Option[Function] {
     var_name tc.store.variables.get = global_opt
     if global_opt.is_some then
         global_opt.unwrap = global_var
-        "global" effective_type_t global_var op unify_variable_assignment
+        tc.store "global" effective_type_t global_var op unify_variable_assignment
         effective_type_t tc expect_type_t
         return
     fi
@@ -1053,7 +1059,7 @@ fn simulate_trait_method_call tc:TypeChecker function:Function var_name:str {
     trait_bound_opt.unwrap TraitBound::name tc.store.traits.get = trait_def_opt
     if trait_def_opt.is_none then return fi
     trait_def_opt.unwrap = trait_def
-    for trait_method_entry in trait_def DEFAULT_PARSER collect_trait_methods.iter do
+    for trait_method_entry in trait_def tc.store collect_trait_methods.iter do
         if trait_method_name trait_method_entry TraitMethod::name == then
             tc stack_pop_drop
             trait_type_var trait_method_entry TraitMethod::stack_effect resolve_trait_stack_effect = resolved_exec_effect
@@ -1171,7 +1177,7 @@ fn check_if_block tc:TypeChecker op:Op {
                 op Op::location if_ctx IfContext::set_current_branch_location
                 return
             fi
-            if_after tc TypeChecker::live.unify_types = unified
+            tc.store if_after tc TypeChecker::live.unify_types = unified
             if 0 unified.length != if_after if_before.equals ! && then
                 unified if_after TypedStack::set_types
                 if_before tc TypeChecker::live.restore
@@ -1194,13 +1200,13 @@ fn check_if_block tc:TypeChecker op:Op {
             if if_before tc TypeChecker::live.equals if_after if_before.equals && then
                 return
             fi
-            if_after tc TypeChecker::live.unify_types = unified
+            tc.store if_after tc TypeChecker::live.unify_types = unified
             if 0 unified.length != if_ctx IfContext::default_present && then
                 if_after tc TypeChecker::live.restore
                 unified tc TypeChecker::live TypedStack::set_types
                 return
             fi
-            if_before tc TypeChecker::live.unify_types = unified_before
+            tc.store if_before tc TypeChecker::live.unify_types = unified_before
             if 0 unified_before.length != if_ctx IfContext::default_present ! && then
                 if_before tc TypeChecker::live.restore
                 unified_before tc TypeChecker::live TypedStack::set_types
@@ -1271,13 +1277,18 @@ fn bind_generic_params_standalone
     bindings
 }
 
-fn type_satisfies_trait type_name:Type trait_name:str function_opt:Option[Function] -> bool {
+fn type_satisfies_trait
+    type_name:Type
+    trait_name:str
+    function_opt:Option[Function]
+    store:SymbolStore
+-> bool {
     type_name.format = type_name_str
     # Accept both bare ("Iterable") and concrete generic ("Iterable[int]") trait names.
     trait_name parse_type_str = trait_type
     trait_type.base = trait_base_opt
     trait_name trait_base_opt.unwrap_or = trait_lookup_name
-    trait_lookup_name DEFAULT_PARSER.store.traits.get = trait_opt
+    trait_lookup_name store.traits.get = trait_opt
     if trait_opt.is_none then false return fi
     trait_opt.unwrap = trait_def
     # Build substitution map from trait's type_params to concrete args from trait_name.
@@ -1304,16 +1315,16 @@ fn type_satisfies_trait type_name:Type trait_name:str function_opt:Option[Functi
             if trait_name bound_opt.unwrap trait_bound_to_str == then true return fi
         fi
     fi
-    for method in trait_def DEFAULT_PARSER collect_trait_methods.iter do
+    for method in trait_def store collect_trait_methods.iter do
         f"{type_name_str}::{method TraitMethod::name}" = fn_name
-        fn_name DEFAULT_PARSER.store.functions.get = fn_opt
+        fn_name store.functions.get = fn_opt
         false = via_generic_base
         # Fall back to the generic base type (e.g. `Option::to_str` for `Option[int]`)
         if fn_opt.is_none then
             type_name.base = base_opt
             if base_opt.is_some then
                 f"{base_opt.unwrap}::{method TraitMethod::name}" = fn_name
-                fn_name DEFAULT_PARSER.store.functions.get = fn_opt
+                fn_name store.functions.get = fn_opt
                 true = via_generic_base
             fi
         fi
@@ -1325,7 +1336,7 @@ fn type_satisfies_trait type_name:Type trait_name:str function_opt:Option[Functi
             false return
         fi
         fn_opt.unwrap = function
-        function ensure_typechecked
+        store function ensure_typechecked
         if "None -> None" function Function::stack_effect stack_effect_to_str == then false return fi
         # When satisfying via the generic base, skip strict stack-effect comparison:
         # the concrete trait bounds are verified at the actual call site.
@@ -1461,15 +1472,16 @@ fn method_diff_bind_for_bound
     effect:StackEffect
     bound:TraitBound
     concrete:str
+    store:SymbolStore
 -> Map[str Type] {
-    bound TraitBound::name DEFAULT_PARSER.store.traits.get = trait_opt
+    bound TraitBound::name store.traits.get = trait_opt
     if trait_opt.is_none then bindings return fi
     trait_opt.unwrap = trait_def
     trait_def CasaTrait::type_params = trait_params
     bound TraitBound::type_args = bound_args
     if bound_args.length trait_params.length != then bindings return fi
     for trait_method in trait_def CasaTrait::methods.iter do
-        f"{concrete}::{trait_method TraitMethod::name}" DEFAULT_PARSER.store.functions.get = concrete_fn_opt
+        f"{concrete}::{trait_method TraitMethod::name}" store.functions.get = concrete_fn_opt
         if concrete_fn_opt.is_some then
             concrete trait_method TraitMethod::stack_effect resolve_trait_stack_effect = trait_resolved
             concrete_fn_opt.unwrap Function::stack_effect trait_resolved bound_args trait_params effect bindings diff_method_stack_effect = bindings
@@ -1482,13 +1494,14 @@ fn method_diff_bind_all
     effect:StackEffect
     function_opt:Option[Function]
     bindings:Map[str Type]
+    store:SymbolStore
 -> Map[str Type] {
     effect StackEffect::trait_bounds.keys = bound_keys
     for bound_type_var in bound_keys.iter do
         bound_type_var effect StackEffect::trait_bounds.get.unwrap = bound_constraint
         bound_type_var bindings.get = concrete_opt
         if concrete_opt.is_some then
-            concrete_opt.unwrap.format bound_constraint effect bindings method_diff_bind_for_bound = bindings
+            store concrete_opt.unwrap.format bound_constraint effect bindings method_diff_bind_for_bound = bindings
         fi
     done
     bindings
@@ -1547,7 +1560,7 @@ fn inject_trait_fn_ptrs
     # bound from the stack, inspect the concrete type's implementation of
     # each trait method and diff its stack effect against the trait's declared
     # stack effect to bind T. Single pass in declaration order.
-    bindings function_opt effect method_diff_bind_all = bindings
+    tc.store bindings function_opt effect method_diff_bind_all = bindings
 
     # Check TYPE_CAST lookahead for return type binding
     if op_index ops.length > then
@@ -1596,7 +1609,7 @@ fn inject_trait_fn_ptrs
             fi
         fi
 
-        trait_def DEFAULT_PARSER collect_trait_methods = expanded_methods
+        trait_def tc.store collect_trait_methods = expanded_methods
         if is_forwarding then
             # Forward hidden fn ptrs from calling function (abstract methods only)
             expanded_methods.length 1 - = method_index
@@ -1615,7 +1628,7 @@ fn inject_trait_fn_ptrs
             done
         else
             # Verify structural satisfaction
-            if function_opt trait_name concrete_t type_satisfies_trait ! then
+            if tc.store function_opt trait_name concrete_t type_satisfies_trait ! then
                 location f"Type `{concrete}` does not satisfy trait `{trait_name}`" ErrorKind::TypeMismatch raise_error
             fi
             # Inject FN_PUSH for each abstract method (reversed)
@@ -1630,9 +1643,9 @@ fn inject_trait_fn_ptrs
                         global_fn_opt.unwrap = global_fn
                         if global_fn Function::is_used ! then
                             true global_fn Function::set_is_used
-                            global_fn global_fn Function::ops resolve_identifiers global_fn Function::set_ops
+                            global_fn global_fn Function::ops tc.store resolve_identifiers global_fn Function::set_ops
                         fi
-                        global_fn ensure_typechecked
+                        tc.store global_fn ensure_typechecked
                         location fn_name OpValue::FnPush make_op = push_op
                         insert_pos push_op ops.insert
                         1 += insert_pos
@@ -1666,7 +1679,7 @@ fn check_function_ops
         fn_name tc.store.functions.get = fn_opt
         if fn_opt.is_some then
             fn_opt.unwrap = function
-            function ensure_typechecked
+            tc.store function ensure_typechecked
             function Function::stack_effect = effect
             if 0 effect StackEffect::trait_bounds.keys.length != then
                 function_opt op Op::location op_index ops effect tc inject_trait_fn_ptrs = injected
@@ -1690,7 +1703,7 @@ fn check_function_ops
         push_name tc.store.functions.get = push_fn_opt
         if push_fn_opt.is_some then
             push_fn_opt.unwrap = push_fn
-            push_fn ensure_typechecked
+            tc.store push_fn ensure_typechecked
             push_fn Function::stack_effect stack_effect_to_function_type tc stack_push_type
         else
             "fn" tc stack_push
@@ -1739,7 +1752,7 @@ fn check_literals tc:TypeChecker op:Op function_opt:Option[Function] {
             0 = items_idx
             while items_idx items.length > do
                 tc stack_pop_type = item_type_t
-                item_type_t elem_type_t unify_type_t = unified_opt
+                tc.store item_type_t elem_type_t unify_type_t = unified_opt
                 if unified_opt.is_none then
                     op Op::location f"Heterogeneous array literal: cannot unify `{elem_type_t.format}` and `{item_type_t.format}`" ErrorKind::TypeMismatch raise_error
                 else
@@ -1798,7 +1811,7 @@ fn check_io tc:TypeChecker op:Op ops:List[Op] op_index:int function_opt:Option[F
         tc stack_pop_drop
         op_index return
     fi
-    if function_opt "Display" peek_t type_satisfies_trait ! then
+    if tc.store function_opt "Display" peek_t type_satisfies_trait ! then
         op Op::location f"Type `{typ}` cannot be printed: does not satisfy trait `Display`" ErrorKind::MissingTraitMethod add_error
         tc stack_pop_drop
         op_index return
@@ -1947,7 +1960,7 @@ fn check_is tc:TypeChecker op:Op function_opt:Option[Function] {
 # Check match blocks
 # ============================================================================
 
-fn set_binding_type var_name:str field_type:Type function_opt:Option[Function] {
+fn set_binding_type var_name:str field_type:Type function_opt:Option[Function] store:SymbolStore {
     if function_opt.is_some then
         function_opt.unwrap = function
         for variable in function Function::variables.iter do
@@ -1957,7 +1970,7 @@ fn set_binding_type var_name:str field_type:Type function_opt:Option[Function] {
             fi
         done
     fi
-    var_name DEFAULT_PARSER.store.variables.get = global_opt
+    var_name store.variables.get = global_opt
     if global_opt.is_some then
         field_type global_opt.unwrap Variable::set_typ
     fi
@@ -2007,7 +2020,7 @@ fn check_match tc:TypeChecker op:Op function_opt:Option[Function] {
                 match_before tc TypeChecker::live.equals
                 match_after match_before.equals && !
                 then
-                    match_after tc TypeChecker::live.unify_types = last_unified
+                    tc.store match_after tc TypeChecker::live.unify_types = last_unified
                     if 0 last_unified.length != match_after match_before.equals ! && then
                         last_unified match_after TypedStack::set_types
                     elif match_after match_before.equals then
@@ -2090,7 +2103,7 @@ fn check_match tc:TypeChecker op:Op function_opt:Option[Function] {
                 final_after tc TypeChecker::live.restore
                 return
             fi
-            final_after tc TypeChecker::live.unify_types = unified
+            tc.store final_after tc TypeChecker::live.unify_types = unified
             if 0 unified.length != then
                 final_after tc TypeChecker::live.restore
                 unified tc TypeChecker::live TypedStack::set_types
@@ -2161,10 +2174,10 @@ fn check_struct_literal tc:TypeChecker op:Op {
 # Instantiate default trait method for a concrete type
 # ============================================================================
 
-fn find_default_trait_method method_name:str -> Option[TraitMethod] {
-    DEFAULT_PARSER.store.traits.keys = find_trait_keys
+fn find_default_trait_method method_name:str store:SymbolStore -> Option[TraitMethod] {
+    store.traits.keys = find_trait_keys
     for find_trait_key in find_trait_keys.iter do
-        find_trait_key DEFAULT_PARSER.store.traits.get.unwrap = find_trait_def
+        find_trait_key store.traits.get.unwrap = find_trait_def
         for find_method in find_trait_def CasaTrait::methods.iter do
             if method_name find_method TraitMethod::name == 0 find_method TraitMethod::default_ops.length != && then
                 find_method Option::Some return
@@ -2174,10 +2187,10 @@ fn find_default_trait_method method_name:str -> Option[TraitMethod] {
     Option::None(Option[TraitMethod])
 }
 
-fn find_trait_for_method method_name:str -> Option[CasaTrait] {
-    DEFAULT_PARSER.store.traits.keys = ftm_trait_keys
+fn find_trait_for_method method_name:str store:SymbolStore -> Option[CasaTrait] {
+    store.traits.keys = ftm_trait_keys
     for ftm_trait_key in ftm_trait_keys.iter do
-        ftm_trait_key DEFAULT_PARSER.store.traits.get.unwrap = ftm_trait_def
+        ftm_trait_key store.traits.get.unwrap = ftm_trait_def
         for ftm_method in ftm_trait_def CasaTrait::methods.iter do
             if method_name ftm_method TraitMethod::name == 0 ftm_method TraitMethod::default_ops.length != && then
                 ftm_trait_def Option::Some return
@@ -2187,14 +2200,14 @@ fn find_trait_for_method method_name:str -> Option[CasaTrait] {
     Option::None(Option[CasaTrait])
 }
 
-fn check_abstract_methods_present receiver:str trait_def:CasaTrait -> bool {
-    for cam_method in trait_def DEFAULT_PARSER collect_trait_methods.iter do
+fn check_abstract_methods_present receiver:str trait_def:CasaTrait store:SymbolStore -> bool {
+    for cam_method in trait_def store collect_trait_methods.iter do
         if 0 cam_method TraitMethod::default_ops.length == then
-            f"{receiver}::{cam_method TraitMethod::name}" DEFAULT_PARSER.store.functions.get = cam_fn_opt
+            f"{receiver}::{cam_method TraitMethod::name}" store.functions.get = cam_fn_opt
             if cam_fn_opt.is_none then
                 receiver parse_type_str.base = cam_base_opt
                 if cam_base_opt.is_some then
-                    f"{cam_base_opt.unwrap}::{cam_method TraitMethod::name}" DEFAULT_PARSER.store.functions.get = cam_fn_opt
+                    f"{cam_base_opt.unwrap}::{cam_method TraitMethod::name}" store.functions.get = cam_fn_opt
                 fi
             fi
             if cam_fn_opt.is_none then
@@ -2210,16 +2223,17 @@ fn instantiate_default_trait_method
     function_opt:Option[Function]
     method_name:str
     receiver:str
+    store:SymbolStore
 -> Option[str] {
     global DEFAULT_METHOD_INSTANTIATING
-    f"{receiver}::{method_name}" DEFAULT_PARSER.store.functions.get = already_opt
+    f"{receiver}::{method_name}" store.functions.get = already_opt
     if already_opt.is_some then
         f"{receiver}::{method_name}" Option::Some return
     fi
     # Also check generic base
     receiver parse_type_str.base = already_base_opt
     if already_base_opt.is_some then
-        f"{already_base_opt.unwrap}::{method_name}" DEFAULT_PARSER.store.functions.get = already_base_fn_opt
+        f"{already_base_opt.unwrap}::{method_name}" store.functions.get = already_base_fn_opt
         if already_base_fn_opt.is_some then
             f"{already_base_opt.unwrap}::{method_name}" Option::Some return
         fi
@@ -2228,14 +2242,14 @@ fn instantiate_default_trait_method
     true = DEFAULT_METHOD_INSTANTIATING
 
     # Find a trait with a matching default method
-    method_name find_default_trait_method = default_method_opt
+    store method_name find_default_trait_method = default_method_opt
     if default_method_opt.is_none then
         false = DEFAULT_METHOD_INSTANTIATING
         Option::None(Option[str]) return
     fi
     default_method_opt.unwrap = default_method
 
-    method_name find_trait_for_method = trait_opt
+    store method_name find_trait_for_method = trait_opt
     if trait_opt.is_none then
         false = DEFAULT_METHOD_INSTANTIATING
         Option::None(Option[str]) return
@@ -2243,7 +2257,7 @@ fn instantiate_default_trait_method
     trait_opt.unwrap = trait_def
 
     # Check that receiver implements all abstract methods
-    if trait_def receiver check_abstract_methods_present ! then
+    if store trait_def receiver check_abstract_methods_present ! then
         false = DEFAULT_METHOD_INSTANTIATING
         Option::None(Option[str]) return
     fi
@@ -2285,10 +2299,10 @@ fn instantiate_default_trait_method
         done
         for infer_method in trait_def CasaTrait::methods.iter do
             if 0 infer_method TraitMethod::default_ops.length == then
-                f"{receiver}::{infer_method TraitMethod::name}" DEFAULT_PARSER.store.functions.get = infer_fn_opt
+                f"{receiver}::{infer_method TraitMethod::name}" store.functions.get = infer_fn_opt
                 if infer_fn_opt.is_some then
                     infer_fn_opt.unwrap = infer_fn
-                    infer_fn ensure_typechecked
+                    store infer_fn ensure_typechecked
                     receiver infer_method TraitMethod::stack_effect resolve_trait_stack_effect = infer_trait_resolved
                     0 = ret_index
                     while ret_index infer_trait_resolved StackEffect::return_types.length > ret_index infer_fn Function::stack_effect StackEffect::return_types.length > && do
@@ -2335,7 +2349,7 @@ fn instantiate_default_trait_method
     for body_op in cloned_body.iter do
         if body_op.value OpValue::FnPush(lambda_name) is ! then continue fi
         if lambda_name "lambda__" str::starts_with ! then continue fi
-        lambda_name DEFAULT_PARSER.store.functions.get = lambda_opt
+        lambda_name store.functions.get = lambda_opt
         if lambda_opt.is_none then continue fi
 
         f"{lambda_name}__{synth_fn_name}_{cloned_lambda_index}" = cloned_lambda_name
@@ -2351,7 +2365,7 @@ fn instantiate_default_trait_method
             lambda_tvs lambda_effect StackEffect::set_type_vars
         done
         lambda_effect lambda_opt.unwrap Function::location lambda_ops cloned_lambda_name make_function_with_stack_effect = cloned_lambda
-        cloned_lambda cloned_lambda_name DEFAULT_PARSER.store.functions.set drop
+        cloned_lambda cloned_lambda_name store.functions.set drop
         cloned_lambda_name OpValue::FnPush body_op Op::set_value
         1 += cloned_lambda_index
     done
@@ -2363,8 +2377,8 @@ fn instantiate_default_trait_method
     resolved_stack_effect empty_location synth_ops synth_fn_name make_function_with_stack_effect = synth_fn
     synth_vars synth_fn Function::set_variables
     true synth_fn Function::set_is_used
-    synth_fn synth_fn_name DEFAULT_PARSER.store.functions.set drop
-    synth_fn ensure_typechecked
+    synth_fn synth_fn_name store.functions.set drop
+    store synth_fn ensure_typechecked
 
     false = DEFAULT_METHOD_INSTANTIATING
     synth_fn_name Option::Some
@@ -2408,7 +2422,7 @@ fn check_method_call
                         1 += constraint_index
                     done
                 fi
-                for trait_method in trait_def DEFAULT_PARSER collect_trait_methods.iter do
+                for trait_method in trait_def tc.store collect_trait_methods.iter do
                     if method_name trait_method TraitMethod::name == then
                         f"__trait_{receiver}_{method_name}" = hidden_var
                         tc stack_pop_drop
@@ -2441,7 +2455,7 @@ fn check_method_call
 
     # Try instantiating a default trait method
     if fn_opt.is_none then
-        receiver method_name function_opt instantiate_default_trait_method = default_inst_opt
+        tc.store receiver method_name function_opt instantiate_default_trait_method = default_inst_opt
         if default_inst_opt.is_some then
             default_inst_opt.unwrap = fn_name
             fn_name tc.store.functions.get = fn_opt
@@ -2451,10 +2465,10 @@ fn check_method_call
     if fn_opt.is_some then
         fn_opt.unwrap = function
         if function Function::is_typechecked ! then
-            function function Function::ops resolve_identifiers function Function::set_ops
+            function function Function::ops tc.store resolve_identifiers function Function::set_ops
             true function Function::set_is_used
         fi
-        function ensure_typechecked
+        tc.store function ensure_typechecked
         function Function::stack_effect = effect
         if 0 effect StackEffect::trait_bounds.keys.length != then
             function_opt op Op::location op_index ops effect tc inject_trait_fn_ptrs += op_index
@@ -2489,7 +2503,7 @@ fn check_fstring_to_str
         TYPE_STR_T tc stack_push_type
         op_index return
     fi
-    if function_opt "Display" fstring_type_t type_satisfies_trait ! then
+    if tc.store function_opt "Display" fstring_type_t type_satisfies_trait ! then
         op Op::location f"Type `{fstring_type}` cannot be used in f-string: does not satisfy trait `Display`" ErrorKind::MissingTraitMethod add_error
         tc stack_pop_drop
         TYPE_STR_T tc stack_push_type
@@ -2503,12 +2517,12 @@ fn check_fstring_to_str
 # Ensure a function is typechecked
 # ============================================================================
 
-fn ensure_typechecked function:Function {
+fn ensure_typechecked function:Function store:SymbolStore {
     if function Function::is_typechecked then return fi
     true function Function::set_is_typechecked
-    function function Function::ops resolve_identifiers = resolved_ops
+    function function Function::ops store resolve_identifiers = resolved_ops
     resolved_ops function Function::set_ops
-    function Option::Some resolved_ops type_check_ops = inferred_stack_effect
+    store function Option::Some resolved_ops type_check_ops = inferred_stack_effect
     if function Function::stack_effect stack_effect_to_str "None -> None" == then
         inferred_stack_effect function Function::set_stack_effect
     fi
@@ -2764,7 +2778,7 @@ fn run_type_check_ops checker:TypeChecker ops:List[Op] function_opt:Option[Funct
 
         # Type cast
         if op_value OpValue::TypeCast(cast_type) is then
-            current_op Op::location function_opt cast_type validate_type_exists
+            checker.store current_op Op::location function_opt cast_type validate_type_exists
             checker stack_pop drop
             cast_type checker stack_push_type
             continue
@@ -2797,8 +2811,8 @@ fn run_type_check_ops checker:TypeChecker ops:List[Op] function_opt:Option[Funct
     done
 }
 
-fn type_check_ops ops:List[Op] function_opt:Option[Function] -> StackEffect {
-    DEFAULT_PARSER.store make_typechecker = checker
+fn type_check_ops ops:List[Op] function_opt:Option[Function] store:SymbolStore -> StackEffect {
+    store make_typechecker = checker
     -1 = budget
     if function_opt.is_some then
         function_opt.unwrap = the_function
@@ -2843,10 +2857,10 @@ fn type_check_ops ops:List[Op] function_opt:Option[Function] -> StackEffect {
 # Type check all functions
 # ============================================================================
 
-fn type_check_functions {
-    DEFAULT_PARSER.store.functions.keys = function_keys
+fn type_check_functions store:SymbolStore {
+    store.functions.keys = function_keys
     for func_name in function_keys.iter do
-        func_name DEFAULT_PARSER.store.functions.get.unwrap = current_fn
+        func_name store.functions.get.unwrap = current_fn
         if current_fn Function::is_typechecked then
             continue
         fi
@@ -2854,14 +2868,14 @@ fn type_check_functions {
             continue
         fi
         true current_fn Function::set_is_typechecked
-        current_fn current_fn Function::ops resolve_identifiers = resolved_ops
+        current_fn current_fn Function::ops store resolve_identifiers = resolved_ops
         resolved_ops current_fn Function::set_ops
         # Skip type checking for functions with trait bounds (checked on demand)
         if 0 current_fn Function::stack_effect StackEffect::trait_bounds.keys.length != then
             continue
         fi
         ERRORS.length = errors_before
-        current_fn Option::Some current_fn Function::ops type_check_ops = inferred_stack_effect
+        store current_fn Option::Some current_fn Function::ops type_check_ops = inferred_stack_effect
         ERRORS.length errors_before < = had_errors
         if had_errors then
             continue

--- a/lib/test.casa
+++ b/lib/test.casa
@@ -147,14 +147,12 @@ fn clear_global_state {
     global SOURCE_CACHE
     global ERRORS
     global WARNINGS
-    Map::new(Map[str Function]) DEFAULT_PARSER Parser::store SymbolStore::set_functions
-    Map::new(Map[str Variable]) DEFAULT_PARSER Parser::store SymbolStore::set_variables
-    Map::new(Map[str CasaEnum]) DEFAULT_PARSER Parser::store SymbolStore::set_enums
-    Map::new(Map[str CasaStruct]) DEFAULT_PARSER Parser::store SymbolStore::set_structs
-    Map::new(Map[str CasaTrait]) DEFAULT_PARSER Parser::store SymbolStore::set_traits
-    Set::new(Set[str]) DEFAULT_PARSER Parser::set_included_files
-    List::new(List[str]) DEFAULT_PARSER Parser::set_search_paths
     Map::new(Map[str str]) = SOURCE_CACHE
     List::new(List[CasaError]) = ERRORS
     List::new(List[CasaWarning]) = WARNINGS
+}
+
+fn parse_resolve_test_source code:str -> ParseResolveResult {
+    "test" code lex_source = tokens
+    List::new(List[str]) tokens parse_and_resolve
 }

--- a/lsp.casa
+++ b/lsp.casa
@@ -120,6 +120,7 @@ const QPART_TYPE 0
 const QPART_SEPARATOR 1
 const QPART_MEMBER 2
 const QPART_NONE -1
+List::new(List[str]) = LSP_LIBRARY_PATHS
 
 # ============================================================================
 # Global state
@@ -298,13 +299,6 @@ fn compile_document file_path:str source:str open_docs:Map[str DocumentState] ->
     Map::new(Map[str str]) = SOURCE_CACHE
     List::new(List[CasaError]) = ERRORS
     List::new(List[CasaWarning]) = WARNINGS
-    Map::new(Map[str Function]) DEFAULT_PARSER Parser::store SymbolStore::set_functions
-    Map::new(Map[str Variable]) DEFAULT_PARSER Parser::store SymbolStore::set_variables
-    Map::new(Map[str CasaEnum]) DEFAULT_PARSER Parser::store SymbolStore::set_enums
-    Map::new(Map[str CasaStruct]) DEFAULT_PARSER Parser::store SymbolStore::set_structs
-    Map::new(Map[str CasaTrait]) DEFAULT_PARSER Parser::store SymbolStore::set_traits
-    Set::new(Set[str]) DEFAULT_PARSER Parser::set_included_files
-
     # Seed SOURCE_CACHE from peer open documents
     open_docs.keys = uris
     for uri in uris.iter do
@@ -319,14 +313,14 @@ fn compile_document file_path:str source:str open_docs:Map[str DocumentState] ->
     file_path source lex_source = tokens
 
     # Parse
-    tokens DEFAULT_PARSER parse_ops = ops
-    ops DEFAULT_PARSER resolve_identifiers_global = ops
-    DEFAULT_PARSER derive_hashable_for_enums
+    LSP_LIBRARY_PATHS tokens parse_and_resolve = parse_result
+    parse_result ParseResolveResult::ops = ops
+    parse_result ParseResolveResult::store = store
 
     # Type check
     if 0 ops.length != then
-        Option::None ops type_check_ops drop
-        type_check_functions
+        store Option::None ops type_check_ops drop
+        store type_check_functions
     fi
 
     # Snapshot file source (post-include)
@@ -342,33 +336,33 @@ fn compile_document file_path:str source:str open_docs:Map[str DocumentState] ->
     file_path
     final_source
     Map::new(Map[str Variable]) = vars_copy
-    DEFAULT_PARSER.store.variables.keys = var_keys
+    store.variables.keys = var_keys
     for var_name in var_keys.iter do
-        var_name DEFAULT_PARSER.store.variables.get.unwrap = var_value
+        var_name store.variables.get.unwrap = var_value
         var_value var_name vars_copy.set = vars_copy
     done
     vars_copy
 
     Map::new(Map[str CasaEnum]) = enums_copy
-    DEFAULT_PARSER.store.enums.keys = enum_keys
+    store.enums.keys = enum_keys
     for enum_name in enum_keys.iter do
-        enum_name DEFAULT_PARSER.store.enums.get.unwrap = enum_value
+        enum_name store.enums.get.unwrap = enum_value
         enum_value enum_name enums_copy.set = enums_copy
     done
     enums_copy
 
     Map::new(Map[str CasaStruct]) = structs_copy
-    DEFAULT_PARSER.store.structs.keys = struct_keys
+    store.structs.keys = struct_keys
     for struct_name in struct_keys.iter do
-        struct_name DEFAULT_PARSER.store.structs.get.unwrap = struct_value
+        struct_name store.structs.get.unwrap = struct_value
         struct_value struct_name structs_copy.set = structs_copy
     done
     structs_copy
 
     Map::new(Map[str Function]) = fns_copy
-    DEFAULT_PARSER.store.functions.keys = fn_keys
+    store.functions.keys = fn_keys
     for fn_name in fn_keys.iter do
-        fn_name DEFAULT_PARSER.store.functions.get.unwrap = fn_value
+        fn_name store.functions.get.unwrap = fn_value
         fn_value fn_name fns_copy.set = fns_copy
     done
     fns_copy
@@ -2259,9 +2253,10 @@ fn extract_library_paths message:JsonValue -> List[str] {
 }
 
 fn handle_initialize message:JsonValue {
+    global LSP_LIBRARY_PATHS
     "id" message json_get_value.unwrap = request_id
 
-    message extract_library_paths DEFAULT_PARSER Parser::set_search_paths
+    message extract_library_paths = LSP_LIBRARY_PATHS
 
     # Build semantic tokens legend
     List::new(List[JsonValue]) = token_types

--- a/tests/compiler/test_argv.casa
+++ b/tests/compiler/test_argv.casa
@@ -12,18 +12,18 @@ import "../../lib/test.casa"
 # ============================================================================
 
 fn tc_string_argv code:str -> StackEffect {
-    "test" code lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
-    ops DEFAULT_PARSER resolve_identifiers_global = ops
-    Option::None(Option[Function]) ops type_check_ops
+    code parse_resolve_test_source = result
+    result ParseResolveResult::ops = ops
+    result ParseResolveResult::store = store
+    store Option::None(Option[Function]) ops type_check_ops
 }
 
 fn compile_string_argv code:str -> Program {
-    "test" code lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
-    ops DEFAULT_PARSER resolve_identifiers_global = ops
-    Option::None(Option[Function]) ops type_check_ops drop
-    ops DEFAULT_PARSER.store compile_bytecode
+    code parse_resolve_test_source = result
+    result ParseResolveResult::ops = ops
+    result ParseResolveResult::store = store
+    store Option::None(Option[Function]) ops type_check_ops drop
+    ops store compile_bytecode
 }
 
 fn emit_string_argv code:str -> str {
@@ -64,14 +64,14 @@ fn test_lex_argv {
 fn test_parse_argc {
     "parse_argc" test_start
     "test" "argc" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    List::new(List[str]) tokens parse_and_resolve ParseResolveResult::ops = ops
     "argc kind" 0 ops.get.value OpValue::Argc is assert_true
 }
 
 fn test_parse_argv {
     "parse_argv" test_start
     "test" "argv" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    List::new(List[str]) tokens parse_and_resolve ParseResolveResult::ops = ops
     "argv kind" 0 ops.get.value OpValue::Argv is assert_true
 }
 

--- a/tests/compiler/test_array_methods.casa
+++ b/tests/compiler/test_array_methods.casa
@@ -18,19 +18,19 @@ import "../../lib/test.casa"
 
 fn tc_am code:str -> StackEffect {
     clear_global_state
-    "test" code lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
-    ops DEFAULT_PARSER resolve_identifiers_global = ops
-    Option::None(Option[Function]) ops type_check_ops
+    code parse_resolve_test_source = result
+    result ParseResolveResult::ops = ops
+    result ParseResolveResult::store = store
+    store Option::None(Option[Function]) ops type_check_ops
 }
 
 fn compile_am code:str -> Program {
     clear_global_state
-    "test" code lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
-    ops DEFAULT_PARSER resolve_identifiers_global = ops
-    Option::None(Option[Function]) ops type_check_ops drop
-    ops DEFAULT_PARSER.store compile_bytecode
+    code parse_resolve_test_source = result
+    result ParseResolveResult::ops = ops
+    result ParseResolveResult::store = store
+    store Option::None(Option[Function]) ops type_check_ops drop
+    ops store compile_bytecode
 }
 
 fn emit_am code:str -> str {

--- a/tests/compiler/test_compare.casa
+++ b/tests/compiler/test_compare.casa
@@ -16,18 +16,18 @@ import "../../lib/test.casa"
 
 fn compare_test_typecheck code:str -> StackEffect {
     clear_global_state
-    "test" code lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
-    ops DEFAULT_PARSER resolve_identifiers_global = ops
-    Option::None(Option[Function]) ops type_check_ops
+    code parse_resolve_test_source = result
+    result ParseResolveResult::ops = ops
+    result ParseResolveResult::store = store
+    store Option::None(Option[Function]) ops type_check_ops
 }
 
 fn compare_test_typecheck_ops code:str -> List[Op] {
     clear_global_state
-    "test" code lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
-    ops DEFAULT_PARSER resolve_identifiers_global = ops
-    Option::None(Option[Function]) ops type_check_ops drop
+    code parse_resolve_test_source = result
+    result ParseResolveResult::ops = ops
+    result ParseResolveResult::store = store
+    store Option::None(Option[Function]) ops type_check_ops drop
     ops
 }
 
@@ -35,10 +35,10 @@ fn compare_test_typecheck_error code:str -> StackEffect {
     enable_test_mode
     clear_errors
     clear_global_state
-    "test" code lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
-    ops DEFAULT_PARSER resolve_identifiers_global = ops
-    Option::None(Option[Function]) ops type_check_ops
+    code parse_resolve_test_source = result
+    result ParseResolveResult::ops = ops
+    result ParseResolveResult::store = store
+    store Option::None(Option[Function]) ops type_check_ops
 }
 
 # ============================================================================

--- a/tests/compiler/test_display.casa
+++ b/tests/compiler/test_display.casa
@@ -9,49 +9,48 @@ import "../../lib/test.casa"
 # Constants
 # ============================================================================
 "trait Display { fn to_str self:self -> str }\n" = DISPLAY_TRAIT
+symbol_store_new = DISPLAY_TEST_STORE
 
 # ============================================================================
 # Helpers
 # ============================================================================
 
-fn display_test_parse code:str -> List[Op] {
-    clear_global_state
-    "test" code lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops
-}
-
 fn display_test_resolve code:str -> List[Op] {
+    global DISPLAY_TEST_STORE
     clear_global_state
-    "test" code lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
-    ops DEFAULT_PARSER resolve_identifiers_global
+    code parse_resolve_test_source = result
+    result ParseResolveResult::store = DISPLAY_TEST_STORE
+    result ParseResolveResult::ops
 }
 
 fn display_test_typecheck code:str -> StackEffect {
+    global DISPLAY_TEST_STORE
     clear_global_state
-    "test" code lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
-    ops DEFAULT_PARSER resolve_identifiers_global = ops
-    Option::None(Option[Function]) ops type_check_ops
+    code parse_resolve_test_source = result
+    result ParseResolveResult::ops = ops
+    result ParseResolveResult::store = DISPLAY_TEST_STORE
+    DISPLAY_TEST_STORE Option::None(Option[Function]) ops type_check_ops
 }
 
 fn display_test_typecheck_ops code:str -> List[Op] {
+    global DISPLAY_TEST_STORE
     clear_global_state
-    "test" code lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
-    ops DEFAULT_PARSER resolve_identifiers_global = ops
-    Option::None(Option[Function]) ops type_check_ops drop
+    code parse_resolve_test_source = result
+    result ParseResolveResult::ops = ops
+    result ParseResolveResult::store = DISPLAY_TEST_STORE
+    DISPLAY_TEST_STORE Option::None(Option[Function]) ops type_check_ops drop
     ops
 }
 
 fn display_test_typecheck_error code:str -> StackEffect {
+    global DISPLAY_TEST_STORE
     enable_test_mode
     clear_errors
     clear_global_state
-    "test" code lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
-    ops DEFAULT_PARSER resolve_identifiers_global = ops
-    Option::None(Option[Function]) ops type_check_ops
+    code parse_resolve_test_source = result
+    result ParseResolveResult::ops = ops
+    result ParseResolveResult::store = DISPLAY_TEST_STORE
+    DISPLAY_TEST_STORE Option::None(Option[Function]) ops type_check_ops
 }
 
 fn count_op_kind ops:List[Op] kind:OpValue -> int {
@@ -72,7 +71,7 @@ fn count_op_kind ops:List[Op] kind:OpValue -> int {
 
 fn test_parser_emits_fstring_to_str {
     "parser_emits_fstring_to_str" test_start
-    "\"x\" = name\nf\"hi {name}\" drop\n" display_test_parse = ops
+    "\"x\" = name\nf\"hi {name}\" drop\n" display_test_resolve = ops
     # Find the lambda's enclosing function (global scope) and look for OpFstringToStr
     # in the top-level ops list.
     0 = found_count
@@ -88,7 +87,7 @@ fn test_parser_emits_fstring_to_str {
 
 fn test_parser_emits_fstring_to_str_multiple {
     "parser_emits_fstring_to_str_multiple" test_start
-    "\"a\" = a\n\"b\" = b\nf\"{a} and {b}\" drop\n" display_test_parse = ops
+    "\"a\" = a\n\"b\" = b\nf\"{a} and {b}\" drop\n" display_test_resolve = ops
     0 = found_count
     0 = index
     while index ops.length > do
@@ -102,7 +101,7 @@ fn test_parser_emits_fstring_to_str_multiple {
 
 fn test_parser_no_fstring_to_str_without_expressions {
     "parser_no_fstring_to_str_without_expressions" test_start
-    "f\"plain text\" drop\n" display_test_parse = ops
+    "f\"plain text\" drop\n" display_test_resolve = ops
     0 = found_count
     0 = index
     while index ops.length > do
@@ -172,15 +171,15 @@ fn test_type_satisfies_trait_generic_base_fallback {
     "type_satisfies_trait_generic_base_fallback" test_start
     DISPLAY_TRAIT "enum Box[T] { Boxed(T) }\nimpl Box { fn to_str self:Box -> str { \"boxed\" } }\n" str::concat display_test_resolve drop
     Option::None(Option[Function]) = no_fn
-    "Box[int] satisfies Display via base" no_fn "Display" "Box[int]" parse_type_str type_satisfies_trait assert_true
-    "Box[str] satisfies Display via base" no_fn "Display" "Box[str]" parse_type_str type_satisfies_trait assert_true
+    "Box[int] satisfies Display via base" DISPLAY_TEST_STORE no_fn "Display" "Box[int]" parse_type_str type_satisfies_trait assert_true
+    "Box[str] satisfies Display via base" DISPLAY_TEST_STORE no_fn "Display" "Box[str]" parse_type_str type_satisfies_trait assert_true
 }
 
 fn test_type_satisfies_trait_no_fallback_method {
     "type_satisfies_trait_no_fallback_method" test_start
     DISPLAY_TRAIT "enum Bag[T] { Empty Full(T) }\n" str::concat display_test_resolve drop
     Option::None(Option[Function]) = no_fn
-    "Bag[int] does not satisfy without to_str" no_fn "Display" "Bag[int]" parse_type_str type_satisfies_trait ! assert_true
+    "Bag[int] does not satisfy without to_str" DISPLAY_TEST_STORE no_fn "Display" "Bag[int]" parse_type_str type_satisfies_trait ! assert_true
 }
 
 # ============================================================================
@@ -190,7 +189,7 @@ fn test_type_satisfies_trait_no_fallback_method {
 fn test_trait_method_call_pushes_return_type {
     "trait_method_call_pushes_return_type" test_start
     DISPLAY_TRAIT "struct Tag { val: int }\nimpl Tag { fn to_str self:Tag -> str { \"tag\" } }\nfn show[T: Display] x:T -> str { x T::to_str }\n1 Tag = t\nt show drop\n" str::concat display_test_typecheck drop
-    "show" DEFAULT_PARSER.store.functions.get.unwrap = func
+    "show" DISPLAY_TEST_STORE.functions.get.unwrap = func
     "stack effect has str return type" "str" 0 func Function::stack_effect StackEffect::return_types.get.format assert_str_eq
     "no errors" assert_no_errors
 }

--- a/tests/compiler/test_enum.casa
+++ b/tests/compiler/test_enum.casa
@@ -15,41 +15,49 @@ import "../../lib/test.casa"
 "enum Shape { Circle(int) Rectangle(int int) Point }\n" = SHAPE_ENUM
 "enum Option[T] { None Some(T) }\n" = OPTION_ENUM
 "enum Result[T E] { Error(E) Ok(T) }\n" = RESULT_ENUM
+symbol_store_new = ENUM_TEST_STORE
 
 # ============================================================================
 # Helpers
 # ============================================================================
 
-fn test_parse_code code:str -> List[Op] {
+fn test_parse_code_result code:str -> ParseResolveResult {
+    global ENUM_TEST_STORE
     clear_global_state
-    "test" code lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
-    DEFAULT_PARSER derive_hashable_for_enums
-    ops
+    code parse_resolve_test_source = result
+    result ParseResolveResult::store = ENUM_TEST_STORE
+    result
+}
+
+fn test_parse_code code:str -> List[Op] {
+    code test_parse_code_result ParseResolveResult::ops
 }
 
 fn resolve_enum code:str -> List[Op] {
+    global ENUM_TEST_STORE
     clear_global_state
-    "test" code lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
-    ops DEFAULT_PARSER resolve_identifiers_global
+    code parse_resolve_test_source = result
+    result ParseResolveResult::store = ENUM_TEST_STORE
+    result ParseResolveResult::ops
 }
 
 fn tc_enum code:str -> StackEffect {
+    global ENUM_TEST_STORE
     clear_global_state
-    "test" code lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
-    ops DEFAULT_PARSER resolve_identifiers_global = ops
-    Option::None(Option[Function]) ops type_check_ops
+    code parse_resolve_test_source = result
+    result ParseResolveResult::ops = ops
+    result ParseResolveResult::store = ENUM_TEST_STORE
+    ENUM_TEST_STORE Option::None(Option[Function]) ops type_check_ops
 }
 
 fn compile_enum code:str -> Program {
+    global ENUM_TEST_STORE
     clear_global_state
-    "test" code lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
-    ops DEFAULT_PARSER resolve_identifiers_global = ops
-    Option::None(Option[Function]) ops type_check_ops drop
-    ops DEFAULT_PARSER.store compile_bytecode
+    code parse_resolve_test_source = result
+    result ParseResolveResult::ops = ops
+    result ParseResolveResult::store = ENUM_TEST_STORE
+    ENUM_TEST_STORE Option::None(Option[Function]) ops type_check_ops drop
+    ops ENUM_TEST_STORE compile_bytecode
 }
 
 fn is_push_enum_variant value:OpValue -> bool { value OpValue::PushEnumVariant is }
@@ -124,25 +132,25 @@ fn has_push_value bytecode:List[InstValue] value:int -> bool {
 fn test_test_parse_code_registers_globally {
     "test_parse_code_registers_globally" test_start
     "enum Color { Red Green Blue }" test_parse_code drop
-    "registered" "Color" DEFAULT_PARSER.store.enums.get.is_some assert_true
+    "registered" "Color" ENUM_TEST_STORE.enums.get.is_some assert_true
 }
 
 fn test_test_parse_code_name {
     "test_parse_code_name" test_start
     "enum Color { Red Green Blue }" test_parse_code drop
-    "name" "Color" "Color" DEFAULT_PARSER.store.enums.get.unwrap CasaEnum::name assert_str_eq
+    "name" "Color" "Color" ENUM_TEST_STORE.enums.get.unwrap CasaEnum::name assert_str_eq
 }
 
 fn test_test_parse_code_variant_count {
     "test_parse_code_variant_count" test_start
     "enum Color { Red Green Blue }" test_parse_code drop
-    "count" 3 "Color" DEFAULT_PARSER.store.enums.get.unwrap CasaEnum::variants.length assert_eq
+    "count" 3 "Color" ENUM_TEST_STORE.enums.get.unwrap CasaEnum::variants.length assert_eq
 }
 
 fn test_test_parse_code_variant_names {
     "test_parse_code_variant_names" test_start
     "enum Color { Red Green Blue }" test_parse_code drop
-    "Color" DEFAULT_PARSER.store.enums.get.unwrap = color
+    "Color" ENUM_TEST_STORE.enums.get.unwrap = color
     "Red" "Red" 0 color CasaEnum::variants.get assert_str_eq
     "Green" "Green" 1 color CasaEnum::variants.get assert_str_eq
     "Blue" "Blue" 2 color CasaEnum::variants.get assert_str_eq
@@ -151,26 +159,26 @@ fn test_test_parse_code_variant_names {
 fn test_test_parse_code_has_location {
     "test_parse_code_has_location" test_start
     "enum Color { Red Green Blue }" test_parse_code drop
-    "has file" "" "Color" DEFAULT_PARSER.store.enums.get.unwrap CasaEnum::location Location::file != assert_true
+    "has file" "" "Color" ENUM_TEST_STORE.enums.get.unwrap CasaEnum::location Location::file != assert_true
 }
 
 fn test_test_parse_code_single_variant {
     "test_parse_code_single_variant" test_start
     "enum Unit { Only }" test_parse_code drop
-    "count" 1 "Unit" DEFAULT_PARSER.store.enums.get.unwrap CasaEnum::variants.length assert_eq
-    "name" "Only" 0 "Unit" DEFAULT_PARSER.store.enums.get.unwrap CasaEnum::variants.get assert_str_eq
+    "count" 1 "Unit" ENUM_TEST_STORE.enums.get.unwrap CasaEnum::variants.length assert_eq
+    "name" "Only" 0 "Unit" ENUM_TEST_STORE.enums.get.unwrap CasaEnum::variants.get assert_str_eq
 }
 
 fn test_test_parse_code_many_variants {
     "test_parse_code_many_variants" test_start
     "enum Direction { North South East West }" test_parse_code drop
-    "count" 4 "Direction" DEFAULT_PARSER.store.enums.get.unwrap CasaEnum::variants.length assert_eq
+    "count" 4 "Direction" ENUM_TEST_STORE.enums.get.unwrap CasaEnum::variants.length assert_eq
 }
 
 fn test_test_parse_code_with_inner_types {
     "test_parse_code_with_inner_types" test_start
     SHAPE_ENUM test_parse_code drop
-    "Shape" DEFAULT_PARSER.store.enums.get.unwrap = shape
+    "Shape" ENUM_TEST_STORE.enums.get.unwrap = shape
     "Circle types" 1 "Circle" shape CasaEnum::variant_types.get.unwrap.length assert_eq
     "Circle type" "int" 0 "Circle" shape CasaEnum::variant_types.get.unwrap.get.format assert_str_eq
     "Rectangle types" 2 "Rectangle" shape CasaEnum::variant_types.get.unwrap.length assert_eq
@@ -180,19 +188,19 @@ fn test_test_parse_code_with_inner_types {
 fn test_test_parse_code_has_inner_values {
     "test_parse_code_has_inner_values" test_start
     SHAPE_ENUM test_parse_code drop
-    "has inner" "Shape" DEFAULT_PARSER.store.enums.get.unwrap has_inner_values assert_true
+    "has inner" "Shape" ENUM_TEST_STORE.enums.get.unwrap has_inner_values assert_true
 }
 
 fn test_parse_plain_enum_no_inner_values {
     "parse_plain_enum_no_inner_values" test_start
     COLOR_ENUM test_parse_code drop
-    "no inner" "Color" DEFAULT_PARSER.store.enums.get.unwrap has_inner_values ! assert_true
+    "no inner" "Color" ENUM_TEST_STORE.enums.get.unwrap has_inner_values ! assert_true
 }
 
 fn test_parse_generic_enum_type_vars {
     "parse_generic_enum_type_vars" test_start
     OPTION_ENUM test_parse_code drop
-    "Option" DEFAULT_PARSER.store.enums.get.unwrap = option
+    "Option" ENUM_TEST_STORE.enums.get.unwrap = option
     "type var count" 1 option CasaEnum::type_vars.length assert_eq
     "type var T" "T" 0 option CasaEnum::type_vars.get assert_str_eq
 }
@@ -200,7 +208,7 @@ fn test_parse_generic_enum_type_vars {
 fn test_parse_generic_enum_two_type_vars {
     "parse_generic_enum_two_type_vars" test_start
     RESULT_ENUM test_parse_code drop
-    "Result" DEFAULT_PARSER.store.enums.get.unwrap = result
+    "Result" ENUM_TEST_STORE.enums.get.unwrap = result
     "type var count" 2 result CasaEnum::type_vars.length assert_eq
     "type var T" "T" 0 result CasaEnum::type_vars.get assert_str_eq
     "type var E" "E" 1 result CasaEnum::type_vars.get assert_str_eq
@@ -704,7 +712,7 @@ fn test_is_plain_enum {
 fn test_parse_generic_enum_type_var_order_preserved {
     "parse_generic_enum_type_var_order_preserved" test_start
     "enum Pair[A B] { Left(A) Right(B) }\n" test_parse_code drop
-    "Pair" DEFAULT_PARSER.store.enums.get.unwrap = pair
+    "Pair" ENUM_TEST_STORE.enums.get.unwrap = pair
     "type var A" "A" 0 pair CasaEnum::type_vars.get assert_str_eq
     "type var B" "B" 1 pair CasaEnum::type_vars.get assert_str_eq
 }
@@ -920,7 +928,7 @@ fn test_is_generic_with_bindings {
 fn test_is_binding_propagates_inner_type {
     "is_binding_propagates_inner_type" test_start
     "enum Foo { Bar(int) Baz(str) }\n42 Foo::Bar = x\nif x Foo::Bar(n) is then\nn drop\nfi\n" tc_enum drop
-    "n" DEFAULT_PARSER.store.variables.get = n_opt
+    "n" ENUM_TEST_STORE.variables.get = n_opt
     if n_opt Option::Some(n_var) is then
         "n typed as int" "int" n_var.typ.format assert_str_eq
     else
@@ -931,7 +939,7 @@ fn test_is_binding_propagates_inner_type {
 fn test_is_binding_propagates_generic_type {
     "is_binding_propagates_generic_type" test_start
     "enum Option[T] { None Some(T) }\n42 Option::Some = m\nif m Option::Some(v) is then\nv drop\nfi\n" tc_enum drop
-    "v" DEFAULT_PARSER.store.variables.get = v_opt
+    "v" ENUM_TEST_STORE.variables.get = v_opt
     if v_opt Option::Some(v_var) is then
         "v typed as int" "int" v_var.typ.format assert_str_eq
     else
@@ -1001,19 +1009,19 @@ fn test_braced_arm_as_expression_typechecks {
 fn test_payload_free_enum_synthesizes_hash {
     "payload_free_enum_synthesizes_hash" test_start
     COLOR_ENUM test_parse_code drop
-    "Color::hash registered" "Color::hash" DEFAULT_PARSER.store.functions.get.is_some assert_true
+    "Color::hash registered" "Color::hash" ENUM_TEST_STORE.functions.get.is_some assert_true
 }
 
 fn test_payload_free_enum_synthesizes_eq {
     "payload_free_enum_synthesizes_eq" test_start
     COLOR_ENUM test_parse_code drop
-    "Color::eq registered" "Color::eq" DEFAULT_PARSER.store.functions.get.is_some assert_true
+    "Color::eq registered" "Color::eq" ENUM_TEST_STORE.functions.get.is_some assert_true
 }
 
 fn test_payload_free_enum_hash_stack_effect {
     "payload_free_enum_hash_stack_effect" test_start
     COLOR_ENUM test_parse_code drop
-    "Color::hash" DEFAULT_PARSER.store.functions.get.unwrap = hash_fn
+    "Color::hash" ENUM_TEST_STORE.functions.get.unwrap = hash_fn
     hash_fn Function::stack_effect = sig
     "param count" 1 sig StackEffect::parameters.length assert_eq
     "param type" "Color" 0 sig StackEffect::parameters.get Parameter::typ.format assert_str_eq
@@ -1024,7 +1032,7 @@ fn test_payload_free_enum_hash_stack_effect {
 fn test_payload_free_enum_eq_stack_effect {
     "payload_free_enum_eq_stack_effect" test_start
     COLOR_ENUM test_parse_code drop
-    "Color::eq" DEFAULT_PARSER.store.functions.get.unwrap = eq_fn
+    "Color::eq" ENUM_TEST_STORE.functions.get.unwrap = eq_fn
     eq_fn Function::stack_effect = sig
     "param count" 2 sig StackEffect::parameters.length assert_eq
     "param0 type" "Color" 0 sig StackEffect::parameters.get Parameter::typ.format assert_str_eq
@@ -1035,19 +1043,19 @@ fn test_payload_free_enum_eq_stack_effect {
 fn test_payload_bearing_enum_skips_hash_synth {
     "payload_bearing_enum_skips_hash_synth" test_start
     SHAPE_ENUM test_parse_code drop
-    "Shape::hash NOT registered" "Shape::hash" DEFAULT_PARSER.store.functions.get.is_some assert_false
+    "Shape::hash NOT registered" "Shape::hash" ENUM_TEST_STORE.functions.get.is_some assert_false
 }
 
 fn test_payload_bearing_enum_skips_eq_synth {
     "payload_bearing_enum_skips_eq_synth" test_start
     SHAPE_ENUM test_parse_code drop
-    "Shape::eq NOT registered" "Shape::eq" DEFAULT_PARSER.store.functions.get.is_some assert_false
+    "Shape::eq NOT registered" "Shape::eq" ENUM_TEST_STORE.functions.get.is_some assert_false
 }
 
 fn test_manual_impl_overrides_synth_hash {
     "manual_impl_overrides_synth_hash" test_start
     "enum Color { Red Green Blue }\nimpl Color {\n    fn hash self:Color -> int { 42 }\n    fn eq self:Color other:Color -> bool { self other == }\n}\n" test_parse_code drop
-    "Color::hash registered" "Color::hash" DEFAULT_PARSER.store.functions.get.is_some assert_true
+    "Color::hash registered" "Color::hash" ENUM_TEST_STORE.functions.get.is_some assert_true
 }
 
 # ============================================================================

--- a/tests/compiler/test_enum_variant_hint.casa
+++ b/tests/compiler/test_enum_variant_hint.casa
@@ -14,10 +14,10 @@ import "../../lib/test.casa"
 
 fn tc_evh code:str -> StackEffect {
     clear_global_state
-    "test" code lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
-    ops DEFAULT_PARSER resolve_identifiers_global = ops
-    Option::None(Option[Function]) ops type_check_ops
+    code parse_resolve_test_source = result
+    result ParseResolveResult::ops = ops
+    result ParseResolveResult::store = store
+    store Option::None(Option[Function]) ops type_check_ops
 }
 
 # ============================================================================

--- a/tests/compiler/test_generic_structs.casa
+++ b/tests/compiler/test_generic_structs.casa
@@ -11,34 +11,31 @@ import "../../lib/test.casa"
 # Helpers
 # ============================================================================
 
-fn parse_gs code:str -> List[Op] {
+fn parse_gs code:str -> ParseResolveResult {
     clear_global_state
-    "test" code lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops
+    code parse_resolve_test_source
 }
 
 fn resolve_gs code:str -> List[Op] {
     clear_global_state
-    "test" code lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
-    ops DEFAULT_PARSER resolve_identifiers_global
+    code parse_resolve_test_source ParseResolveResult::ops
 }
 
 fn tc_gs code:str -> StackEffect {
     clear_global_state
-    "test" code lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
-    ops DEFAULT_PARSER resolve_identifiers_global = ops
-    Option::None(Option[Function]) ops type_check_ops
+    code parse_resolve_test_source = result
+    result ParseResolveResult::ops = ops
+    result ParseResolveResult::store = store
+    store Option::None(Option[Function]) ops type_check_ops
 }
 
 fn compile_gs code:str -> Program {
     clear_global_state
-    "test" code lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
-    ops DEFAULT_PARSER resolve_identifiers_global = ops
-    Option::None(Option[Function]) ops type_check_ops drop
-    ops DEFAULT_PARSER.store compile_bytecode
+    code parse_resolve_test_source = result
+    result ParseResolveResult::ops = ops
+    result ParseResolveResult::store = store
+    store Option::None(Option[Function]) ops type_check_ops drop
+    ops store compile_bytecode
 }
 
 fn emit_gs code:str -> str {
@@ -60,9 +57,10 @@ fn assert_contains needle:str haystack:str msg:str {
 
 fn test_parse_generic_struct {
     "parse_generic_struct" test_start
-    "struct Box[T] { value: T }" parse_gs drop
-    "registered" "Box" DEFAULT_PARSER.store.structs.get.is_some assert_true
-    "Box" DEFAULT_PARSER.store.structs.get.unwrap = box_struct
+    "struct Box[T] { value: T }" parse_gs = result
+    result ParseResolveResult::store = store
+    "registered" "Box" store.structs.get.is_some assert_true
+    "Box" store.structs.get.unwrap = box_struct
     "type vars count" 1 box_struct CasaStruct::type_vars.length assert_eq
     "type var T" "T" 0 box_struct CasaStruct::type_vars.get assert_str_eq
     "member name" "value" 0 box_struct CasaStruct::members.get Member::name assert_str_eq
@@ -71,8 +69,9 @@ fn test_parse_generic_struct {
 
 fn test_parse_generic_struct_multiple_type_vars {
     "parse_generic_struct_multiple_type_vars" test_start
-    "struct Pair[A B] { first: A second: B }" parse_gs drop
-    "Pair" DEFAULT_PARSER.store.structs.get.unwrap = pair_struct
+    "struct Pair[A B] { first: A second: B }" parse_gs = result
+    result ParseResolveResult::store = store
+    "Pair" store.structs.get.unwrap = pair_struct
     "type vars count" 2 pair_struct CasaStruct::type_vars.length assert_eq
     "type var A" "A" 0 pair_struct CasaStruct::type_vars.get assert_str_eq
     "type var B" "B" 1 pair_struct CasaStruct::type_vars.get assert_str_eq
@@ -91,33 +90,37 @@ fn test_parse_struct_rejects_trait_bounds {
 
 fn test_parse_generic_struct_generates_getter {
     "parse_generic_struct_generates_getter" test_start
-    "struct Box[T] { value: T }" parse_gs drop
-    "getter exists" "Box::value" DEFAULT_PARSER.store.functions.get.is_some assert_true
-    "Box::value" DEFAULT_PARSER.store.functions.get.unwrap = getter
+    "struct Box[T] { value: T }" parse_gs = result
+    result ParseResolveResult::store = store
+    "getter exists" "Box::value" store.functions.get.is_some assert_true
+    "Box::value" store.functions.get.unwrap = getter
     "getter param type" "Box[T]" 0 getter Function::stack_effect StackEffect::parameters.get Parameter::typ.format assert_str_eq
     "getter return type" "T" 0 getter Function::stack_effect StackEffect::return_types.get.format assert_str_eq
 }
 
 fn test_parse_generic_struct_generates_setter {
     "parse_generic_struct_generates_setter" test_start
-    "struct Box[T] { value: T }" parse_gs drop
-    "setter exists" "Box::set_value" DEFAULT_PARSER.store.functions.get.is_some assert_true
-    "Box::set_value" DEFAULT_PARSER.store.functions.get.unwrap = setter
+    "struct Box[T] { value: T }" parse_gs = result
+    result ParseResolveResult::store = store
+    "setter exists" "Box::set_value" store.functions.get.is_some assert_true
+    "Box::set_value" store.functions.get.unwrap = setter
     "setter param 0 type" "Box[T]" 0 setter Function::stack_effect StackEffect::parameters.get Parameter::typ.format assert_str_eq
     "setter param 1 type" "T" 1 setter Function::stack_effect StackEffect::parameters.get Parameter::typ.format assert_str_eq
 }
 
 fn test_parse_nongeneric_struct_has_empty_type_vars {
     "parse_nongeneric_struct_has_empty_type_vars" test_start
-    "struct Point { x: int y: int }" parse_gs drop
-    "Point" DEFAULT_PARSER.store.structs.get.unwrap = point_struct
+    "struct Point { x: int y: int }" parse_gs = result
+    result ParseResolveResult::store = store
+    "Point" store.structs.get.unwrap = point_struct
     "no type vars" 0 point_struct CasaStruct::type_vars.length assert_eq
 }
 
 fn test_parse_impl_with_type_params {
     "parse_impl_with_type_params" test_start
-    "trait Hashable { fn hash int -> int }\nstruct Box[K] { data: K }\nimpl[K: Hashable] Box[K] {\n    fn get self:Box[K] -> K { self Box::data }\n}\n" parse_gs drop
-    "method exists" "Box::get" DEFAULT_PARSER.store.functions.get.is_some assert_true
+    "trait Hashable { fn hash int -> int }\nstruct Box[K] { data: K }\nimpl[K: Hashable] Box[K] {\n    fn get self:Box[K] -> K { self Box::data }\n}\n" parse_gs = result
+    result ParseResolveResult::store = store
+    "method exists" "Box::get" store.functions.get.is_some assert_true
 }
 
 # ============================================================================

--- a/tests/compiler/test_global_keyword.casa
+++ b/tests/compiler/test_global_keyword.casa
@@ -11,23 +11,20 @@ import "../../lib/test.casa"
 
 fn parse_snippet code:str {
     clear_global_state
-    "test" code lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops drop
+    code parse_resolve_test_source drop
 }
 
-fn parse_and_resolve code:str {
+fn parse_resolve_snippet code:str {
     clear_global_state
-    "test" code lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
-    ops DEFAULT_PARSER resolve_identifiers_global drop
+    code parse_resolve_test_source drop
 }
 
 fn parse_resolve_typecheck code:str {
     clear_global_state
-    "test" code lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
-    ops DEFAULT_PARSER resolve_identifiers_global = ops
-    Option::None(Option[Function]) ops type_check_ops drop
+    code parse_resolve_test_source = result
+    result ParseResolveResult::ops = ops
+    result ParseResolveResult::store = store
+    store Option::None(Option[Function]) ops type_check_ops drop
 }
 
 # ============================================================================
@@ -51,7 +48,7 @@ fn test_global_decl_resolves {
     "global_decl_resolves" test_start
     enable_test_mode
     clear_errors
-    "0 = LOG_LEVEL\nfn set_level level:int {\n    global LOG_LEVEL\n    level = LOG_LEVEL\n}\n" parse_and_resolve
+    "0 = LOG_LEVEL\nfn set_level level:int {\n    global LOG_LEVEL\n    level = LOG_LEVEL\n}\n" parse_resolve_snippet
     "no resolve errors" assert_no_errors
     disable_test_mode
 }

--- a/tests/compiler/test_lsp.casa
+++ b/tests/compiler/test_lsp.casa
@@ -133,8 +133,9 @@ fn test_extract_library_paths_skips_non_string_entries {
 }
 
 fn test_compile_document_unresolved_module_does_not_crash {
+    global LSP_LIBRARY_PATHS
     "compile_document_unresolved_module_does_not_crash" test_start
-    List::new(List[str]) DEFAULT_PARSER Parser::set_search_paths
+    List::new(List[str]) = LSP_LIBRARY_PATHS
     lsp_empty_documents "import \"this_module_does_not_exist\"\n42 print" LSP_TEST_FILE compile_document = result
     result CompileResult::document_state = state
     "has ops" 0 state DocumentState::ops.length > assert_true

--- a/tests/compiler/test_match_underflow.casa
+++ b/tests/compiler/test_match_underflow.casa
@@ -11,10 +11,10 @@ import "../../lib/test.casa"
 
 fn tc_mu code:str -> StackEffect {
     clear_global_state
-    "test" code lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
-    ops DEFAULT_PARSER resolve_identifiers_global = ops
-    Option::None(Option[Function]) ops type_check_ops
+    code parse_resolve_test_source = result
+    result ParseResolveResult::ops = ops
+    result ParseResolveResult::store = store
+    store Option::None(Option[Function]) ops type_check_ops
 }
 
 # ============================================================================

--- a/tests/compiler/test_parser.casa
+++ b/tests/compiler/test_parser.casa
@@ -4,6 +4,16 @@ import "../../compiler/lexer.casa"
 import "../../compiler/syntax.casa"
 import "../../lib/test.casa"
 
+symbol_store_new = PARSER_TEST_STORE
+
+fn parser_test_parse tokens:List[Token] -> List[Op] {
+    global PARSER_TEST_STORE
+    symbol_store_new make_parser = parser
+    tokens parser parse_ops = ops
+    parser.store = PARSER_TEST_STORE
+    ops
+}
+
 # ============================================================================
 # Literal parsing tests
 # ============================================================================
@@ -11,7 +21,7 @@ import "../../lib/test.casa"
 fn test_parse_integer {
     "parse_integer" test_start
     "test" "42" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    tokens parser_test_parse = ops
     "count" 1 ops.length assert_eq
     "kind" 0 ops.get.value OpValue::PushInt is assert_true
     "value" 42 0 ops.get op_int_value assert_eq
@@ -20,7 +30,7 @@ fn test_parse_integer {
 fn test_parse_negative_integer {
     "parse_negative_integer" test_start
     "test" "-7" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    tokens parser_test_parse = ops
     "count" 1 ops.length assert_eq
     "kind" 0 ops.get.value OpValue::PushInt is assert_true
     "value" 0 7 - 0 ops.get op_int_value assert_eq
@@ -29,7 +39,7 @@ fn test_parse_negative_integer {
 fn test_parse_bool_true {
     "parse_bool_true" test_start
     "test" "true" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    tokens parser_test_parse = ops
     "count" 1 ops.length assert_eq
     "kind" 0 ops.get.value OpValue::PushBool is assert_true
     "value" 1 0 ops.get op_int_value assert_eq
@@ -38,7 +48,7 @@ fn test_parse_bool_true {
 fn test_parse_bool_false {
     "parse_bool_false" test_start
     "test" "false" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    tokens parser_test_parse = ops
     "count" 1 ops.length assert_eq
     "kind" 0 ops.get.value OpValue::PushBool is assert_true
     "value" 0 0 ops.get op_int_value assert_eq
@@ -47,7 +57,7 @@ fn test_parse_bool_false {
 fn test_parse_string {
     "parse_string" test_start
     "test" "\"hello\"" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    tokens parser_test_parse = ops
     "count" 1 ops.length assert_eq
     "kind" 0 ops.get.value OpValue::PushStr is assert_true
     "value" "hello" 0 ops.get op_str_value assert_str_eq
@@ -56,7 +66,7 @@ fn test_parse_string {
 fn test_parse_char {
     "parse_char" test_start
     "test" "'A'" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    tokens parser_test_parse = ops
     "count" 1 ops.length assert_eq
     "kind" 0 ops.get.value OpValue::PushChar is assert_true
     "value" 65 0 ops.get op_int_value assert_eq
@@ -69,56 +79,56 @@ fn test_parse_char {
 fn test_parse_keyword_if {
     "parse_keyword_if" test_start
     "test" "if" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    tokens parser_test_parse = ops
     "kind" 0 ops.get.value OpValue::IfStart is assert_true
 }
 
 fn test_parse_keyword_then {
     "parse_keyword_then" test_start
     "test" "then" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    tokens parser_test_parse = ops
     "kind" 0 ops.get.value OpValue::IfCondition is assert_true
 }
 
 fn test_parse_keyword_else {
     "parse_keyword_else" test_start
     "test" "else" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    tokens parser_test_parse = ops
     "kind" 0 ops.get.value OpValue::IfElse is assert_true
 }
 
 fn test_parse_keyword_fi {
     "parse_keyword_fi" test_start
     "test" "fi" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    tokens parser_test_parse = ops
     "kind" 0 ops.get.value OpValue::IfEnd is assert_true
 }
 
 fn test_parse_keyword_while {
     "parse_keyword_while" test_start
     "test" "while" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    tokens parser_test_parse = ops
     "kind" 0 ops.get.value OpValue::WhileStart is assert_true
 }
 
 fn test_parse_keyword_do {
     "parse_keyword_do" test_start
     "test" "do" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    tokens parser_test_parse = ops
     "kind" 0 ops.get.value OpValue::WhileCondition is assert_true
 }
 
 fn test_parse_keyword_done {
     "parse_keyword_done" test_start
     "test" "done" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    tokens parser_test_parse = ops
     "kind" 0 ops.get.value OpValue::WhileEnd is assert_true
 }
 
 fn test_parse_keyword_return {
     "parse_keyword_return" test_start
     "test" "return" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    tokens parser_test_parse = ops
     "kind" 0 ops.get.value OpValue::FnReturn is assert_true
 }
 
@@ -129,42 +139,42 @@ fn test_parse_keyword_return {
 fn test_parse_operator_add {
     "parse_operator_add" test_start
     "test" "+" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    tokens parser_test_parse = ops
     "kind" 0 ops.get.value OpValue::Add is assert_true
 }
 
 fn test_parse_operator_sub {
     "parse_operator_sub" test_start
     "test" "1 -" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    tokens parser_test_parse = ops
     "kind" 1 ops.get.value OpValue::Sub is assert_true
 }
 
 fn test_parse_operator_eq {
     "parse_operator_eq" test_start
     "test" "==" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    tokens parser_test_parse = ops
     "kind" 0 ops.get.value OpValue::Eq is assert_true
 }
 
 fn test_parse_operator_not {
     "parse_operator_not" test_start
     "test" "!" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    tokens parser_test_parse = ops
     "kind" 0 ops.get.value OpValue::Not is assert_true
 }
 
 fn test_parse_operator_and {
     "parse_operator_and" test_start
     "test" "&&" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    tokens parser_test_parse = ops
     "kind" 0 ops.get.value OpValue::And is assert_true
 }
 
 fn test_parse_operator_or {
     "parse_operator_or" test_start
     "test" "||" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    tokens parser_test_parse = ops
     "kind" 0 ops.get.value OpValue::Or is assert_true
 }
 
@@ -175,28 +185,28 @@ fn test_parse_operator_or {
 fn test_parse_intrinsic_drop {
     "parse_intrinsic_drop" test_start
     "test" "drop" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    tokens parser_test_parse = ops
     "kind" 0 ops.get.value OpValue::Drop is assert_true
 }
 
 fn test_parse_intrinsic_dup {
     "parse_intrinsic_dup" test_start
     "test" "dup" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    tokens parser_test_parse = ops
     "kind" 0 ops.get.value OpValue::Dup is assert_true
 }
 
 fn test_parse_intrinsic_swap {
     "parse_intrinsic_swap" test_start
     "test" "swap" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    tokens parser_test_parse = ops
     "kind" 0 ops.get.value OpValue::Swap is assert_true
 }
 
 fn test_parse_intrinsic_print {
     "parse_intrinsic_print" test_start
     "test" "print" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    tokens parser_test_parse = ops
     "kind" 0 ops.get.value OpValue::Print is assert_true
 }
 
@@ -207,7 +217,7 @@ fn test_parse_intrinsic_print {
 fn test_parse_type_cast {
     "parse_type_cast" test_start
     "test" "(int)" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    tokens parser_test_parse = ops
     "count" 1 ops.length assert_eq
     "kind" 0 ops.get.value OpValue::TypeCast is assert_true
     if 0 ops.get.value OpValue::TypeCast(cast_type) is then
@@ -218,7 +228,7 @@ fn test_parse_type_cast {
 fn test_parse_type_cast_str {
     "parse_type_cast_str" test_start
     "test" "(str)" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    tokens parser_test_parse = ops
     "kind" 0 ops.get.value OpValue::TypeCast is assert_true
     if 0 ops.get.value OpValue::TypeCast(cast_type) is then
         "value" "str" parse_type_str cast_type.eq assert_true
@@ -232,7 +242,7 @@ fn test_parse_type_cast_str {
 fn test_parse_variable_assign {
     "parse_variable_assign" test_start
     "test" "42 = foo" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    tokens parser_test_parse = ops
     "count" 2 ops.length assert_eq
     "push kind" 0 ops.get.value OpValue::PushInt is assert_true
     "assign kind" 1 ops.get.value OpValue::AssignVar is assert_true
@@ -242,7 +252,7 @@ fn test_parse_variable_assign {
 fn test_parse_variable_inc {
     "parse_variable_inc" test_start
     "test" "1 += counter" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    tokens parser_test_parse = ops
     "push kind" 0 ops.get.value OpValue::PushInt is assert_true
     "inc kind" 1 ops.get.value OpValue::AssignInc is assert_true
     "inc name" "counter" 1 ops.get op_str_value assert_str_eq
@@ -255,7 +265,7 @@ fn test_parse_variable_inc {
 fn test_parse_method_call {
     "parse_method_call" test_start
     "test" ".length" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    tokens parser_test_parse = ops
     "kind" 0 ops.get.value OpValue::MethodCall is assert_true
     "value" "length" 0 ops.get op_str_value assert_str_eq
 }
@@ -263,7 +273,7 @@ fn test_parse_method_call {
 fn test_parse_setter_call {
     "parse_setter_call" test_start
     "test" "->name" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    tokens parser_test_parse = ops
     "kind" 0 ops.get.value OpValue::MethodCall is assert_true
     "value" "set_name" 0 ops.get op_str_value assert_str_eq
 }
@@ -275,7 +285,7 @@ fn test_parse_setter_call {
 fn test_parse_identifier {
     "parse_identifier" test_start
     "test" "foo" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    tokens parser_test_parse = ops
     "kind" 0 ops.get.value OpValue::Identifier is assert_true
     "value" "foo" 0 ops.get op_str_value assert_str_eq
 }
@@ -287,10 +297,10 @@ fn test_parse_identifier {
 fn test_parse_function_def {
     "parse_function_def" test_start
     "test" "fn add a:int b:int -> int { a b + }" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
-    # parse_ops should register the function in DEFAULT_PARSER.store.functions
-    "fn registered" "add" DEFAULT_PARSER.store.functions.get.is_some assert_true
-    "add" DEFAULT_PARSER.store.functions.get.unwrap = add_fn
+    tokens parser_test_parse = ops
+    # parse_ops should register the function in PARSER_TEST_STORE.functions
+    "fn registered" "add" PARSER_TEST_STORE.functions.get.is_some assert_true
+    "add" PARSER_TEST_STORE.functions.get.unwrap = add_fn
     "fn name" "add" add_fn Function::name assert_str_eq
     "param count" 2 add_fn Function::stack_effect StackEffect::parameters.length assert_eq
     "return count" 1 add_fn Function::stack_effect StackEffect::return_types.length assert_eq
@@ -304,9 +314,9 @@ fn test_parse_function_def {
 fn test_parse_enum_def {
     "parse_enum_def" test_start
     "test" "enum Color { Red Green Blue }" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
-    "enum registered" "Color" DEFAULT_PARSER.store.enums.get.is_some assert_true
-    "Color" DEFAULT_PARSER.store.enums.get.unwrap = color_enum
+    tokens parser_test_parse = ops
+    "enum registered" "Color" PARSER_TEST_STORE.enums.get.is_some assert_true
+    "Color" PARSER_TEST_STORE.enums.get.unwrap = color_enum
     "variant count" 3 color_enum CasaEnum::variants.length assert_eq
     "variant 0" "Red" 0 color_enum CasaEnum::variants.get assert_str_eq
     "variant 1" "Green" 1 color_enum CasaEnum::variants.get assert_str_eq
@@ -320,14 +330,14 @@ fn test_parse_enum_def {
 fn test_parse_struct_def {
     "parse_struct_def" test_start
     "test" "struct Point { x: int y: int }" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
-    "struct registered" "Point" DEFAULT_PARSER.store.structs.get.is_some assert_true
-    "Point" DEFAULT_PARSER.store.structs.get.unwrap = point_struct
+    tokens parser_test_parse = ops
+    "struct registered" "Point" PARSER_TEST_STORE.structs.get.is_some assert_true
+    "Point" PARSER_TEST_STORE.structs.get.unwrap = point_struct
     "member count" 2 point_struct CasaStruct::members.length assert_eq
     "member 0 name" "x" 0 point_struct CasaStruct::members.get Member::name assert_str_eq
     "member 0 type" "int" 0 point_struct CasaStruct::members.get Member::typ.format assert_str_eq
-    "getter registered" "Point::x" DEFAULT_PARSER.store.functions.get.is_some assert_true
-    "setter registered" "Point::set_x" DEFAULT_PARSER.store.functions.get.is_some assert_true
+    "getter registered" "Point::x" PARSER_TEST_STORE.functions.get.is_some assert_true
+    "setter registered" "Point::set_x" PARSER_TEST_STORE.functions.get.is_some assert_true
 }
 
 # ============================================================================
@@ -337,7 +347,7 @@ fn test_parse_struct_def {
 fn test_parse_if_construct {
     "parse_if_construct" test_start
     "test" "if true then 42 else 0 fi" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    tokens parser_test_parse = ops
     "if" 0 ops.get.value OpValue::IfStart is assert_true
     "true" 1 ops.get.value OpValue::PushBool is assert_true
     "then" 2 ops.get.value OpValue::IfCondition is assert_true
@@ -350,7 +360,7 @@ fn test_parse_if_construct {
 fn test_parse_while_construct {
     "parse_while_construct" test_start
     "test" "while true do break done" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    tokens parser_test_parse = ops
     "while" 0 ops.get.value OpValue::WhileStart is assert_true
     "true" 1 ops.get.value OpValue::PushBool is assert_true
     "do" 2 ops.get.value OpValue::WhileCondition is assert_true
@@ -365,7 +375,7 @@ fn test_parse_while_construct {
 fn test_parse_match_construct {
     "parse_match_construct" test_start
     "test" "enum Dir { Up Down }\nmatch Up => 1 Down => 2 end" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    tokens parser_test_parse = ops
     "match start" 0 ops.get.value OpValue::MatchStart is assert_true
 }
 
@@ -376,7 +386,7 @@ fn test_parse_match_construct {
 fn test_parse_multiple_ops {
     "parse_multiple_ops" test_start
     "test" "1 2 + = result" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    tokens parser_test_parse = ops
     "count" 4 ops.length assert_eq
     "push 1" 0 ops.get.value OpValue::PushInt is assert_true
     "push 2" 1 ops.get.value OpValue::PushInt is assert_true
@@ -391,63 +401,63 @@ fn test_parse_multiple_ops {
 fn test_parse_operator_mul {
     "parse_operator_mul" test_start
     "test" "1 2 *" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    tokens parser_test_parse = ops
     "kind" 2 ops.get.value OpValue::Mul is assert_true
 }
 
 fn test_parse_operator_div {
     "parse_operator_div" test_start
     "test" "1 2 /" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    tokens parser_test_parse = ops
     "kind" 2 ops.get.value OpValue::Div is assert_true
 }
 
 fn test_parse_operator_mod {
     "parse_operator_mod" test_start
     "test" "1 2 %" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    tokens parser_test_parse = ops
     "kind" 2 ops.get.value OpValue::Mod is assert_true
 }
 
 fn test_parse_operator_lt {
     "parse_operator_lt" test_start
     "test" "1 2 <" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    tokens parser_test_parse = ops
     "kind" 2 ops.get.value OpValue::Lt is assert_true
 }
 
 fn test_parse_operator_gt {
     "parse_operator_gt" test_start
     "test" "1 2 >" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    tokens parser_test_parse = ops
     "kind" 2 ops.get.value OpValue::Gt is assert_true
 }
 
 fn test_parse_operator_le {
     "parse_operator_le" test_start
     "test" "1 2 <=" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    tokens parser_test_parse = ops
     "kind" 2 ops.get.value OpValue::Le is assert_true
 }
 
 fn test_parse_operator_ge {
     "parse_operator_ge" test_start
     "test" "1 2 >=" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    tokens parser_test_parse = ops
     "kind" 2 ops.get.value OpValue::Ge is assert_true
 }
 
 fn test_parse_operator_ne {
     "parse_operator_ne" test_start
     "test" "1 2 !=" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    tokens parser_test_parse = ops
     "kind" 2 ops.get.value OpValue::Ne is assert_true
 }
 
 fn test_parse_operator_bit_not {
     "parse_operator_bit_not" test_start
     "test" "1 ~" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    tokens parser_test_parse = ops
     "kind" 1 ops.get.value OpValue::BitNot is assert_true
 }
 
@@ -458,28 +468,28 @@ fn test_parse_operator_bit_not {
 fn test_parse_intrinsic_over {
     "parse_intrinsic_over" test_start
     "test" "over" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    tokens parser_test_parse = ops
     "kind" 0 ops.get.value OpValue::Over is assert_true
 }
 
 fn test_parse_intrinsic_rot {
     "parse_intrinsic_rot" test_start
     "test" "rot" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    tokens parser_test_parse = ops
     "kind" 0 ops.get.value OpValue::Rot is assert_true
 }
 
 fn test_parse_intrinsic_typeof {
     "parse_intrinsic_typeof" test_start
     "test" "typeof" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    tokens parser_test_parse = ops
     "kind" 0 ops.get.value OpValue::Typeof is assert_true
 }
 
 fn test_parse_intrinsic_alloc {
     "parse_intrinsic_alloc" test_start
     "test" "alloc" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    tokens parser_test_parse = ops
     "kind" 0 ops.get.value OpValue::HeapAlloc is assert_true
 }
 
@@ -490,7 +500,7 @@ fn test_parse_intrinsic_alloc {
 fn test_parse_variable_dec {
     "parse_variable_dec" test_start
     "test" "1 -= counter" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    tokens parser_test_parse = ops
     "push kind" 0 ops.get.value OpValue::PushInt is assert_true
     "dec kind" 1 ops.get.value OpValue::AssignDec is assert_true
     "dec name" "counter" 1 ops.get op_str_value assert_str_eq
@@ -503,7 +513,7 @@ fn test_parse_variable_dec {
 fn test_parse_keyword_elif {
     "parse_keyword_elif" test_start
     "test" "elif" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    tokens parser_test_parse = ops
     "kind" 0 ops.get.value OpValue::IfElif is assert_true
 }
 
@@ -514,14 +524,14 @@ fn test_parse_keyword_elif {
 fn test_parse_keyword_break {
     "parse_keyword_break" test_start
     "test" "break" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    tokens parser_test_parse = ops
     "kind" 0 ops.get.value OpValue::WhileBreak is assert_true
 }
 
 fn test_parse_keyword_continue {
     "parse_keyword_continue" test_start
     "test" "continue" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    tokens parser_test_parse = ops
     "kind" 0 ops.get.value OpValue::WhileContinue is assert_true
 }
 
@@ -529,7 +539,7 @@ fn test_parse_keyword_import {
     "parse_keyword_import" test_start
     # Absolute path bypasses base-file directory resolution.
     "test" "import \"/foo.casa\"" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    tokens parser_test_parse = ops
     "count" 1 ops.length assert_eq
     "kind" 0 ops.get.value OpValue::ImportFile is assert_true
     "path" "/foo.casa" 0 ops.get op_str_value assert_str_eq
@@ -538,7 +548,7 @@ fn test_parse_keyword_import {
 fn test_parse_keyword_selective_import {
     "parse_keyword_selective_import" test_start
     "test" "import \"/foo.casa\" { alpha Beta::gamma }" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    tokens parser_test_parse = ops
     "count" 1 ops.length assert_eq
     "kind" 0 ops.get.value OpValue::ImportFileSelective is assert_true
     if 0 ops.get.value OpValue::ImportFileSelective(selective_import) is then
@@ -590,26 +600,29 @@ fn test_dir_of_path_root {
 
 fn test_resolve_import_path_absolute {
     "resolve_import_path_absolute" test_start
+    symbol_store_new make_parser = parser
     "resolved"
     "/abs/foo.casa"
-    empty_location "/abs/foo.casa" "casa.casa" DEFAULT_PARSER resolve_import
+    empty_location "/abs/foo.casa" "casa.casa" parser resolve_import
     assert_str_eq
 }
 
 fn test_resolve_import_path_relative {
     "resolve_import_path_relative" test_start
+    symbol_store_new make_parser = parser
     "resolved"
     "lib/std.casa"
-    empty_location "lib/std.casa" "casa.casa" DEFAULT_PARSER resolve_import
+    empty_location "lib/std.casa" "casa.casa" parser resolve_import
     assert_str_eq
 }
 
 fn test_resolve_import_module_in_source_dir {
     "resolve_import_module_in_source_dir" test_start
+    symbol_store_new make_parser = parser
     # Importing "std" from a sibling lib file resolves to lib/std.casa.
     "resolved"
     "lib/std.casa"
-    empty_location "std" "lib/io.casa" DEFAULT_PARSER resolve_import
+    empty_location "std" "lib/io.casa" parser resolve_import
     assert_str_eq
 }
 
@@ -619,12 +632,12 @@ fn test_resolve_import_module_skips_self_match {
     # self-match and resolve via the lib/ search path instead.
     List::new(List[str]) = paths
     "lib" paths.push
-    paths DEFAULT_PARSER->search_paths
+    symbol_store_new make_parser = parser
+    paths parser->search_paths
     "resolved"
     "lib/argparse.casa"
-    empty_location "argparse" "examples/argparse.casa" DEFAULT_PARSER resolve_import
+    empty_location "argparse" "examples/argparse.casa" parser resolve_import
     assert_str_eq
-    List::new(List[str]) DEFAULT_PARSER->search_paths
 }
 
 fn test_resolve_import_module_via_search_path {
@@ -632,12 +645,12 @@ fn test_resolve_import_module_via_search_path {
     # No std.casa in tests/compiler/, so resolver falls through to "lib".
     List::new(List[str]) = paths
     "lib" paths.push
-    paths DEFAULT_PARSER->search_paths
+    symbol_store_new make_parser = parser
+    paths parser->search_paths
     "resolved"
     "lib/std.casa"
-    empty_location "std" "tests/compiler/test_parser.casa" DEFAULT_PARSER resolve_import
+    empty_location "std" "tests/compiler/test_parser.casa" parser resolve_import
     assert_str_eq
-    List::new(List[str]) DEFAULT_PARSER->search_paths
 }
 
 fn test_resolve_import_search_paths_skips_missing {
@@ -645,12 +658,12 @@ fn test_resolve_import_search_paths_skips_missing {
     List::new(List[str]) = paths
     "no_such_dir" paths.push
     "lib" paths.push
-    paths DEFAULT_PARSER->search_paths
+    symbol_store_new make_parser = parser
+    paths parser->search_paths
     "resolved"
     "lib/std.casa"
-    empty_location "std" "tests/compiler/test_parser.casa" DEFAULT_PARSER resolve_import
+    empty_location "std" "tests/compiler/test_parser.casa" parser resolve_import
     assert_str_eq
-    List::new(List[str]) DEFAULT_PARSER->search_paths
 }
 
 # ============================================================================
@@ -660,7 +673,7 @@ fn test_resolve_import_search_paths_skips_missing {
 fn test_parse_string_with_escapes {
     "parse_string_with_escapes" test_start
     "test" "\"hello\\nworld\"" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    tokens parser_test_parse = ops
     "count" 1 ops.length assert_eq
     "kind" 0 ops.get.value OpValue::PushStr is assert_true
     "value" "hello\nworld" 0 ops.get op_str_value assert_str_eq

--- a/tests/compiler/test_pattern.casa
+++ b/tests/compiler/test_pattern.casa
@@ -136,10 +136,10 @@ fn test_mixed_match_parses_and_typechecks {
     "mixed_match_parses_and_typechecks" test_start
     clear_global_state
     enable_test_mode
-    "mixed" "1 match 1 => \"one\" 2 => \"two\" _ => \"other\" end" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
-    ops DEFAULT_PARSER resolve_identifiers_global = ops
-    Option::None ops type_check_ops drop
+    "1 match 1 => \"one\" 2 => \"two\" _ => \"other\" end" parse_resolve_test_source = result
+    result ParseResolveResult::ops = ops
+    result ParseResolveResult::store = store
+    store Option::None ops type_check_ops drop
     "mixed-kind match typechecks" assert_no_errors
     disable_test_mode
 }
@@ -148,10 +148,10 @@ fn test_duplicate_literal_arm_detected {
     "duplicate_literal_arm_detected" test_start
     clear_global_state
     enable_test_mode
-    "dup" "1 match 1 => \"a\" 1 => \"b\" _ => \"c\" end" lex_source = dup_tokens
-    dup_tokens DEFAULT_PARSER parse_ops = dup_ops
-    dup_ops DEFAULT_PARSER resolve_identifiers_global = dup_ops
-    Option::None dup_ops type_check_ops drop
+    "1 match 1 => \"a\" 1 => \"b\" _ => \"c\" end" parse_resolve_test_source = dup_result
+    dup_result ParseResolveResult::ops = dup_ops
+    dup_result ParseResolveResult::store = dup_store
+    dup_store Option::None dup_ops type_check_ops drop
     "duplicate arm flagged" "Duplicate match arm" assert_error_contains
     disable_test_mode
 }
@@ -163,8 +163,7 @@ fn test_duplicate_literal_arm_detected {
 fn test_guard_parser_collects_ops {
     "guard_parser_collects_ops" test_start
     clear_global_state
-    "g" "0 match _ if 0 1 == => \"y\" _ => \"n\" end" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    "0 match _ if 0 1 == => \"y\" _ => \"n\" end" parse_resolve_test_source ParseResolveResult::ops = ops
     0 = arm_index
     0 = guarded_count
     0 = unguarded_count
@@ -201,10 +200,10 @@ fn test_guard_allows_shadow_literal_arm {
     clear_global_state
     enable_test_mode
     clear_errors
-    "sg" "1 match 1 if 0 1 == => \"a\" 1 => \"b\" _ => \"c\" end" lex_source = sg_tokens
-    sg_tokens DEFAULT_PARSER parse_ops = sg_ops
-    sg_ops DEFAULT_PARSER resolve_identifiers_global = sg_ops
-    Option::None sg_ops type_check_ops drop
+    "1 match 1 if 0 1 == => \"a\" 1 => \"b\" _ => \"c\" end" parse_resolve_test_source = sg_result
+    sg_result ParseResolveResult::ops = sg_ops
+    sg_result ParseResolveResult::store = sg_store
+    sg_store Option::None sg_ops type_check_ops drop
     "guarded arm does not collide" assert_no_errors
     disable_test_mode
 }
@@ -214,10 +213,10 @@ fn test_guard_non_bool_rejected {
     clear_global_state
     enable_test_mode
     clear_errors
-    "nb" "1 match 1 if 42 => \"a\" _ => \"b\" end" lex_source = nb_tokens
-    nb_tokens DEFAULT_PARSER parse_ops = nb_ops
-    nb_ops DEFAULT_PARSER resolve_identifiers_global = nb_ops
-    Option::None nb_ops type_check_ops drop
+    "1 match 1 if 42 => \"a\" _ => \"b\" end" parse_resolve_test_source = nb_result
+    nb_result ParseResolveResult::ops = nb_ops
+    nb_result ParseResolveResult::store = nb_store
+    nb_store Option::None nb_ops type_check_ops drop
     "non-bool guard flagged" "Guard expression must leave a single `bool`" assert_error_contains
     disable_test_mode
 }
@@ -227,10 +226,10 @@ fn test_guard_non_exhaustive_without_fallback {
     clear_global_state
     enable_test_mode
     clear_errors
-    "ne" "1 match 1 if 0 1 == => \"a\" end" lex_source = ne_tokens
-    ne_tokens DEFAULT_PARSER parse_ops = ne_ops
-    ne_ops DEFAULT_PARSER resolve_identifiers_global = ne_ops
-    Option::None ne_ops type_check_ops drop
+    "1 match 1 if 0 1 == => \"a\" end" parse_resolve_test_source = ne_result
+    ne_result ParseResolveResult::ops = ne_ops
+    ne_result ParseResolveResult::store = ne_store
+    ne_store Option::None ne_ops type_check_ops drop
     "guard alone non-exhaustive" "Non-exhaustive match" assert_error_contains
     disable_test_mode
 }

--- a/tests/compiler/test_struct_literal.casa
+++ b/tests/compiler/test_struct_literal.casa
@@ -19,25 +19,24 @@ import "../../lib/test.casa"
 
 fn sl_parse code:str -> List[Op] {
     clear_global_state
-    "test" code lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops
+    code parse_resolve_test_source ParseResolveResult::ops
 }
 
 fn sl_typecheck code:str -> StackEffect {
     clear_global_state
-    "test" code lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
-    ops DEFAULT_PARSER resolve_identifiers_global = ops
-    Option::None(Option[Function]) ops type_check_ops
+    code parse_resolve_test_source = result
+    result ParseResolveResult::ops = ops
+    result ParseResolveResult::store = store
+    store Option::None(Option[Function]) ops type_check_ops
 }
 
 fn sl_compile code:str -> Program {
     clear_global_state
-    "test" code lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
-    ops DEFAULT_PARSER resolve_identifiers_global = ops
-    Option::None(Option[Function]) ops type_check_ops drop
-    ops DEFAULT_PARSER.store compile_bytecode
+    code parse_resolve_test_source = result
+    result ParseResolveResult::ops = ops
+    result ParseResolveResult::store = store
+    store Option::None(Option[Function]) ops type_check_ops drop
+    ops store compile_bytecode
 }
 
 fn sl_is_struct_literal value:OpValue -> bool { value OpValue::StructLiteral is }

--- a/tests/compiler/test_traits.casa
+++ b/tests/compiler/test_traits.casa
@@ -9,30 +9,35 @@ import "../../lib/test.casa"
 # Constants
 # ============================================================================
 "trait Hashable { fn hash self:self -> int  fn eq self:self other:self -> bool }\n" = HASHABLE_TRAIT
+symbol_store_new = TRAIT_TEST_STORE
 
 # ============================================================================
 # Helpers
 # ============================================================================
 
 fn trait_test_parse code:str -> List[Op] {
+    global TRAIT_TEST_STORE
     clear_global_state
-    "test" code lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops
+    code parse_resolve_test_source = result
+    result ParseResolveResult::store = TRAIT_TEST_STORE
+    result ParseResolveResult::ops
 }
 
 fn trait_test_resolve code:str -> List[Op] {
+    global TRAIT_TEST_STORE
     clear_global_state
-    "test" code lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
-    ops DEFAULT_PARSER resolve_identifiers_global
+    code parse_resolve_test_source = result
+    result ParseResolveResult::store = TRAIT_TEST_STORE
+    result ParseResolveResult::ops
 }
 
 fn trait_test_typecheck code:str -> StackEffect {
+    global TRAIT_TEST_STORE
     clear_global_state
-    "test" code lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
-    ops DEFAULT_PARSER resolve_identifiers_global = ops
-    Option::None(Option[Function]) ops type_check_ops
+    code parse_resolve_test_source = result
+    result ParseResolveResult::ops = ops
+    result ParseResolveResult::store = TRAIT_TEST_STORE
+    TRAIT_TEST_STORE Option::None(Option[Function]) ops type_check_ops
 }
 
 # ============================================================================
@@ -42,25 +47,25 @@ fn trait_test_typecheck code:str -> StackEffect {
 fn test_trait_registers_globally {
     "trait_registers_globally" test_start
     HASHABLE_TRAIT trait_test_parse drop
-    "registered" "Hashable" DEFAULT_PARSER.store.traits.get.is_some assert_true
+    "registered" "Hashable" TRAIT_TEST_STORE.traits.get.is_some assert_true
 }
 
 fn test_trait_name {
     "trait_name" test_start
     "trait Hashable { fn hash self:self -> int }" trait_test_parse drop
-    "name" "Hashable" "Hashable" DEFAULT_PARSER.store.traits.get.unwrap CasaTrait::name assert_str_eq
+    "name" "Hashable" "Hashable" TRAIT_TEST_STORE.traits.get.unwrap CasaTrait::name assert_str_eq
 }
 
 fn test_trait_method_count {
     "trait_method_count" test_start
     HASHABLE_TRAIT trait_test_parse drop
-    "count" 2 "Hashable" DEFAULT_PARSER.store.traits.get.unwrap CasaTrait::methods.length assert_eq
+    "count" 2 "Hashable" TRAIT_TEST_STORE.traits.get.unwrap CasaTrait::methods.length assert_eq
 }
 
 fn test_trait_method_names {
     "trait_method_names" test_start
     HASHABLE_TRAIT trait_test_parse drop
-    "Hashable" DEFAULT_PARSER.store.traits.get.unwrap = hashable
+    "Hashable" TRAIT_TEST_STORE.traits.get.unwrap = hashable
     "hash" "hash" 0 hashable CasaTrait::methods.get TraitMethod::name assert_str_eq
     "eq" "eq" 1 hashable CasaTrait::methods.get TraitMethod::name assert_str_eq
 }
@@ -68,7 +73,7 @@ fn test_trait_method_names {
 fn test_trait_method_sig_params {
     "trait_method_sig_params" test_start
     HASHABLE_TRAIT trait_test_parse drop
-    "Hashable" DEFAULT_PARSER.store.traits.get.unwrap CasaTrait::methods = methods
+    "Hashable" TRAIT_TEST_STORE.traits.get.unwrap CasaTrait::methods = methods
     0 methods.get TraitMethod::stack_effect = hash_stack_effect
     "param count" 1 hash_stack_effect StackEffect::parameters.length assert_eq
     "param type" "self" 0 hash_stack_effect StackEffect::parameters.get Parameter::typ.format assert_str_eq
@@ -78,7 +83,7 @@ fn test_trait_method_sig_params {
 fn test_trait_method_sig_return {
     "trait_method_sig_return" test_start
     HASHABLE_TRAIT trait_test_parse drop
-    "Hashable" DEFAULT_PARSER.store.traits.get.unwrap CasaTrait::methods = methods
+    "Hashable" TRAIT_TEST_STORE.traits.get.unwrap CasaTrait::methods = methods
     0 methods.get TraitMethod::stack_effect = hash_stack_effect
     "return count" 1 hash_stack_effect StackEffect::return_types.length assert_eq
     "return type" "int" 0 hash_stack_effect StackEffect::return_types.get.format assert_str_eq
@@ -87,7 +92,7 @@ fn test_trait_method_sig_return {
 fn test_trait_eq_method_params {
     "trait_eq_method_params" test_start
     HASHABLE_TRAIT trait_test_parse drop
-    "Hashable" DEFAULT_PARSER.store.traits.get.unwrap CasaTrait::methods = methods
+    "Hashable" TRAIT_TEST_STORE.traits.get.unwrap CasaTrait::methods = methods
     1 methods.get TraitMethod::stack_effect = eq_stack_effect
     "param count" 2 eq_stack_effect StackEffect::parameters.length assert_eq
     "param0 type" "self" 0 eq_stack_effect StackEffect::parameters.get Parameter::typ.format assert_str_eq
@@ -97,7 +102,7 @@ fn test_trait_eq_method_params {
 fn test_trait_eq_method_return {
     "trait_eq_method_return" test_start
     HASHABLE_TRAIT trait_test_parse drop
-    "Hashable" DEFAULT_PARSER.store.traits.get.unwrap CasaTrait::methods = methods
+    "Hashable" TRAIT_TEST_STORE.traits.get.unwrap CasaTrait::methods = methods
     1 methods.get TraitMethod::stack_effect = eq_stack_effect
     "return count" 1 eq_stack_effect StackEffect::return_types.length assert_eq
     "return type" "bool" 0 eq_stack_effect StackEffect::return_types.get.format assert_str_eq
@@ -106,14 +111,14 @@ fn test_trait_eq_method_return {
 fn test_trait_empty {
     "trait_empty" test_start
     "trait Empty { }" trait_test_parse drop
-    "registered" "Empty" DEFAULT_PARSER.store.traits.get.is_some assert_true
-    "no methods" 0 "Empty" DEFAULT_PARSER.store.traits.get.unwrap CasaTrait::methods.length assert_eq
+    "registered" "Empty" TRAIT_TEST_STORE.traits.get.is_some assert_true
+    "no methods" 0 "Empty" TRAIT_TEST_STORE.traits.get.unwrap CasaTrait::methods.length assert_eq
 }
 
 fn test_trait_single_method {
     "trait_single_method" test_start
     "trait Printable { fn to_str self:self -> str }" trait_test_parse drop
-    "Printable" DEFAULT_PARSER.store.traits.get.unwrap = printable
+    "Printable" TRAIT_TEST_STORE.traits.get.unwrap = printable
     "method count" 1 printable CasaTrait::methods.length assert_eq
     "method name" "to_str" 0 printable CasaTrait::methods.get TraitMethod::name assert_str_eq
 }
@@ -121,28 +126,28 @@ fn test_trait_single_method {
 fn test_trait_has_location {
     "trait_has_location" test_start
     "trait MyTrait { fn do_thing self:self -> int }" trait_test_parse drop
-    "has file" "" "MyTrait" DEFAULT_PARSER.store.traits.get.unwrap CasaTrait::location Location::file != assert_true
+    "has file" "" "MyTrait" TRAIT_TEST_STORE.traits.get.unwrap CasaTrait::location Location::file != assert_true
 }
 
 fn test_trait_non_generic_has_empty_type_params {
     "trait_non_generic_has_empty_type_params" test_start
     HASHABLE_TRAIT trait_test_parse drop
-    "empty type params" 0 "Hashable" DEFAULT_PARSER.store.traits.get.unwrap CasaTrait::type_params.length assert_eq
+    "empty type params" 0 "Hashable" TRAIT_TEST_STORE.traits.get.unwrap CasaTrait::type_params.length assert_eq
 }
 
 fn test_trait_generic_single_type_param {
     "trait_generic_single_type_param" test_start
     "trait TestIter[T] { fn next self:self -> Option[T] }" trait_test_parse drop
-    "registered" "TestIter" DEFAULT_PARSER.store.traits.get.is_some assert_true
-    "type params count" 1 "TestIter" DEFAULT_PARSER.store.traits.get.unwrap CasaTrait::type_params.length assert_eq
-    "type param name" "T" 0 "TestIter" DEFAULT_PARSER.store.traits.get.unwrap CasaTrait::type_params.get assert_str_eq
+    "registered" "TestIter" TRAIT_TEST_STORE.traits.get.is_some assert_true
+    "type params count" 1 "TestIter" TRAIT_TEST_STORE.traits.get.unwrap CasaTrait::type_params.length assert_eq
+    "type param name" "T" 0 "TestIter" TRAIT_TEST_STORE.traits.get.unwrap CasaTrait::type_params.get assert_str_eq
 }
 
 fn test_trait_generic_multi_type_params {
     "trait_generic_multi_type_params" test_start
     "trait Mapper[K V] { fn map self:self -> V }" trait_test_parse drop
-    "registered" "Mapper" DEFAULT_PARSER.store.traits.get.is_some assert_true
-    "Mapper" DEFAULT_PARSER.store.traits.get.unwrap CasaTrait::type_params = tps
+    "registered" "Mapper" TRAIT_TEST_STORE.traits.get.is_some assert_true
+    "Mapper" TRAIT_TEST_STORE.traits.get.unwrap CasaTrait::type_params = tps
     "type params count" 2 tps.length assert_eq
     "first" "K" 0 tps.get assert_str_eq
     "second" "V" 1 tps.get assert_str_eq
@@ -194,7 +199,7 @@ fn test_trait_duplicate_raises {
 fn test_trait_bound_basic {
     "trait_bound_basic" test_start
     "trait Hashable { fn hash self:self -> int }\nfn tbtest[K: Hashable] K -> int { .hash }" trait_test_parse drop
-    "tbtest" DEFAULT_PARSER.store.functions.get.unwrap = func
+    "tbtest" TRAIT_TEST_STORE.functions.get.unwrap = func
     "K in type_vars" "K" func Function::stack_effect StackEffect::type_vars.has assert_true
     "K bound" "Hashable" "K" func Function::stack_effect StackEffect::trait_bounds.get.unwrap TraitBound::name assert_str_eq
 }
@@ -202,7 +207,7 @@ fn test_trait_bound_basic {
 fn test_trait_bound_with_unbounded_var {
     "trait_bound_with_unbounded_var" test_start
     "trait Hashable { fn hash self:self -> int }\nfn tbtest[K: Hashable, V] K V -> int { drop .hash }" trait_test_parse drop
-    "tbtest" DEFAULT_PARSER.store.functions.get.unwrap = func
+    "tbtest" TRAIT_TEST_STORE.functions.get.unwrap = func
     "K in vars" "K" func Function::stack_effect StackEffect::type_vars.has assert_true
     "V in vars" "V" func Function::stack_effect StackEffect::type_vars.has assert_true
     "K bound" "Hashable" "K" func Function::stack_effect StackEffect::trait_bounds.get.unwrap TraitBound::name assert_str_eq
@@ -212,7 +217,7 @@ fn test_trait_bound_with_unbounded_var {
 fn test_trait_bound_multiple_bounded {
     "trait_bound_multiple_bounded" test_start
     "trait Hashable { fn hash self:self -> int }\ntrait Printable { fn to_str self:self -> str }\nfn tbtest[K: Hashable, V: Printable] K V -> int { .to_str drop .hash }" trait_test_parse drop
-    "tbtest" DEFAULT_PARSER.store.functions.get.unwrap = func
+    "tbtest" TRAIT_TEST_STORE.functions.get.unwrap = func
     "K bound" "Hashable" "K" func Function::stack_effect StackEffect::trait_bounds.get.unwrap TraitBound::name assert_str_eq
     "V bound" "Printable" "V" func Function::stack_effect StackEffect::trait_bounds.get.unwrap TraitBound::name assert_str_eq
 }
@@ -236,7 +241,7 @@ fn test_trait_bound_undefined_raises {
 fn test_trait_hidden_params_prepended {
     "trait_hidden_params_prepended" test_start
     "trait Hashable { fn hash self:self -> int }\nfn tbtest[K: Hashable] K -> int { .hash }" trait_test_parse drop
-    "tbtest" DEFAULT_PARSER.store.functions.get.unwrap = func
+    "tbtest" TRAIT_TEST_STORE.functions.get.unwrap = func
     0 = hidden_count
     0 = index
     while index func Function::stack_effect StackEffect::parameters.length > do
@@ -252,7 +257,7 @@ fn test_trait_hidden_params_prepended {
 fn test_trait_hidden_param_name {
     "trait_hidden_param_name" test_start
     "trait Hashable { fn hash self:self -> int }\nfn tbtest[K: Hashable] K -> int { .hash }" trait_test_parse drop
-    "tbtest" DEFAULT_PARSER.store.functions.get.unwrap = func
+    "tbtest" TRAIT_TEST_STORE.functions.get.unwrap = func
     false = found
     0 = index
     while index func Function::stack_effect StackEffect::parameters.length > do
@@ -267,7 +272,7 @@ fn test_trait_hidden_param_name {
 fn test_trait_hidden_param_type {
     "trait_hidden_param_type" test_start
     "trait Hashable { fn hash self:self -> int }\nfn tbtest[K: Hashable] K -> int { .hash }" trait_test_parse drop
-    "tbtest" DEFAULT_PARSER.store.functions.get.unwrap = func
+    "tbtest" TRAIT_TEST_STORE.functions.get.unwrap = func
     0 = index
     while index func Function::stack_effect StackEffect::parameters.length > do
         index func Function::stack_effect StackEffect::parameters.get = param
@@ -281,7 +286,7 @@ fn test_trait_hidden_param_type {
 fn test_trait_two_methods_hidden_params {
     "trait_two_methods_hidden_params" test_start
     HASHABLE_TRAIT "fn tbtest[K: Hashable] K -> int { .hash }" str::concat trait_test_parse drop
-    "tbtest" DEFAULT_PARSER.store.functions.get.unwrap = func
+    "tbtest" TRAIT_TEST_STORE.functions.get.unwrap = func
     0 = hidden_count
     false = has_hash
     false = has_eq
@@ -303,7 +308,7 @@ fn test_trait_two_methods_hidden_params {
 fn test_trait_hidden_params_correct_types {
     "trait_hidden_params_correct_types" test_start
     HASHABLE_TRAIT "fn tbtest[K: Hashable] K -> int { .hash }" str::concat trait_test_parse drop
-    "tbtest" DEFAULT_PARSER.store.functions.get.unwrap = func
+    "tbtest" TRAIT_TEST_STORE.functions.get.unwrap = func
     0 = index
     while index func Function::stack_effect StackEffect::parameters.length > do
         index func Function::stack_effect StackEffect::parameters.get = param
@@ -320,7 +325,7 @@ fn test_trait_hidden_params_correct_types {
 fn test_trait_hidden_params_creates_variables {
     "trait_hidden_params_creates_variables" test_start
     "trait Hashable { fn hash self:self -> int }\nfn tbtest[K: Hashable] K -> int { .hash }" trait_test_parse drop
-    "tbtest" DEFAULT_PARSER.store.functions.get.unwrap = func
+    "tbtest" TRAIT_TEST_STORE.functions.get.unwrap = func
     false = found
     0 = index
     while index func Function::variables.length > do
@@ -335,7 +340,7 @@ fn test_trait_hidden_params_creates_variables {
 fn test_trait_hidden_params_creates_assign_ops {
     "trait_hidden_params_creates_assign_ops" test_start
     "trait Hashable { fn hash self:self -> int }\nfn tbtest[K: Hashable] K -> int { .hash }" trait_test_parse drop
-    "tbtest" DEFAULT_PARSER.store.functions.get.unwrap = func
+    "tbtest" TRAIT_TEST_STORE.functions.get.unwrap = func
     false = found
     0 = index
     while index func Function::ops.length > do
@@ -358,57 +363,57 @@ fn test_trait_hidden_params_creates_assign_ops {
 fn test_struct_with_impl_satisfies {
     "struct_with_impl_satisfies" test_start
     HASHABLE_TRAIT "struct Foo { val: int }\nimpl Foo { fn hash self:Foo -> int { self Foo::val } fn eq self:Foo other:Foo -> bool { self Foo::val other Foo::val == } }\n" str::concat trait_test_resolve drop
-    "satisfies" Option::None(Option[Function]) "Hashable" "Foo" parse_type_str type_satisfies_trait assert_true
+    "satisfies" TRAIT_TEST_STORE Option::None(Option[Function]) "Hashable" "Foo" parse_type_str type_satisfies_trait assert_true
 }
 
 fn test_struct_without_impl_does_not_satisfy {
     "struct_without_impl_does_not_satisfy" test_start
     HASHABLE_TRAIT "struct Bar { val: int }\n" str::concat trait_test_resolve drop
-    "does not satisfy" Option::None(Option[Function]) "Hashable" "Bar" parse_type_str type_satisfies_trait ! assert_true
+    "does not satisfy" TRAIT_TEST_STORE Option::None(Option[Function]) "Hashable" "Bar" parse_type_str type_satisfies_trait ! assert_true
 }
 
 fn test_partial_impl_does_not_satisfy {
     "partial_impl_does_not_satisfy" test_start
     HASHABLE_TRAIT "struct Baz { val: int }\nimpl Baz { fn hash self:Baz -> int { self Baz::val } }\n" str::concat trait_test_resolve drop
-    "does not satisfy" Option::None(Option[Function]) "Hashable" "Baz" parse_type_str type_satisfies_trait ! assert_true
+    "does not satisfy" TRAIT_TEST_STORE Option::None(Option[Function]) "Hashable" "Baz" parse_type_str type_satisfies_trait ! assert_true
 }
 
 fn test_struct_satisfies_generic_trait_concrete_int {
     "struct_satisfies_generic_trait_concrete_int" test_start
     "trait Carrier[T] { fn get self:self -> T }\nstruct Counter { val: int }\nimpl Counter { fn get self:Counter -> int { self Counter::val } }\n" trait_test_resolve drop
-    "satisfies" Option::None(Option[Function]) "Carrier[int]" "Counter" parse_type_str type_satisfies_trait assert_true
+    "satisfies" TRAIT_TEST_STORE Option::None(Option[Function]) "Carrier[int]" "Counter" parse_type_str type_satisfies_trait assert_true
 }
 
 fn test_struct_does_not_satisfy_generic_trait_wrong_inner {
     "struct_does_not_satisfy_generic_trait_wrong_inner" test_start
     "trait Carrier[T] { fn get self:self -> T }\nstruct Counter { val: int }\nimpl Counter { fn get self:Counter -> int { self Counter::val } }\n" trait_test_resolve drop
-    "does not satisfy str" Option::None(Option[Function]) "Carrier[str]" "Counter" parse_type_str type_satisfies_trait ! assert_true
+    "does not satisfy str" TRAIT_TEST_STORE Option::None(Option[Function]) "Carrier[str]" "Counter" parse_type_str type_satisfies_trait ! assert_true
 }
 
 fn test_undefined_trait_returns_false {
     "undefined_trait_returns_false" test_start
     clear_global_state
-    "does not satisfy" Option::None(Option[Function]) "Nonexistent" "int" parse_type_str type_satisfies_trait ! assert_true
+    "does not satisfy" TRAIT_TEST_STORE Option::None(Option[Function]) "Nonexistent" "int" parse_type_str type_satisfies_trait ! assert_true
 }
 # Primitive Eq impls must satisfy a structurally-matching Eq trait.
 
 fn test_int_satisfies_eq_trait {
     "int_satisfies_eq_trait" test_start
     "trait Eq { fn eq self:self other:self -> bool }\nimpl int { fn eq self:int other:int -> bool { self other == } }\n" trait_test_resolve drop
-    "satisfies" Option::None(Option[Function]) "Eq" "int" parse_type_str type_satisfies_trait assert_true
+    "satisfies" TRAIT_TEST_STORE Option::None(Option[Function]) "Eq" "int" parse_type_str type_satisfies_trait assert_true
 }
 
 fn test_int_satisfies_ord_trait {
     "int_satisfies_ord_trait" test_start
     "trait Ord { fn lt self:self other:self -> bool }\nimpl int { fn lt self:int other:int -> bool { other self < } }\n" trait_test_resolve drop
-    "satisfies" Option::None(Option[Function]) "Ord" "int" parse_type_str type_satisfies_trait assert_true
+    "satisfies" TRAIT_TEST_STORE Option::None(Option[Function]) "Ord" "int" parse_type_str type_satisfies_trait assert_true
 }
 
 fn test_empty_word_trait_satisfied_by_any_type {
     "empty_word_trait_satisfied_by_any_type" test_start
     "trait Word { }\n" trait_test_resolve drop
-    "int satisfies" Option::None(Option[Function]) "Word" "int" parse_type_str type_satisfies_trait assert_true
-    "str satisfies" Option::None(Option[Function]) "Word" "str" parse_type_str type_satisfies_trait assert_true
+    "int satisfies" TRAIT_TEST_STORE Option::None(Option[Function]) "Word" "int" parse_type_str type_satisfies_trait assert_true
+    "str satisfies" TRAIT_TEST_STORE Option::None(Option[Function]) "Word" "str" parse_type_str type_satisfies_trait assert_true
 }
 
 # ============================================================================
@@ -603,7 +608,7 @@ fn test_type_var_with_matching_bound_satisfies {
     bounds type_vars List::new(List[Type]) List::new(List[Parameter]) StackEffect = sig
     sig empty_location List::new(List[Op]) "test_fn" make_function_with_stack_effect = func
     func Option::Some = func_opt
-    "satisfies" func_opt "Hashable" "K" parse_type_str type_satisfies_trait assert_true
+    "satisfies" TRAIT_TEST_STORE func_opt "Hashable" "K" parse_type_str type_satisfies_trait assert_true
 }
 
 fn test_type_var_without_bound_does_not_satisfy {
@@ -615,7 +620,7 @@ fn test_type_var_without_bound_does_not_satisfy {
     Map::new(Map[str TraitBound]) type_vars List::new(List[Type]) List::new(List[Parameter]) StackEffect = sig
     sig empty_location List::new(List[Op]) "test_fn" make_function_with_stack_effect = func
     func Option::Some = func_opt
-    "does not satisfy" func_opt "Hashable" "K" parse_type_str type_satisfies_trait ! assert_true
+    "does not satisfy" TRAIT_TEST_STORE func_opt "Hashable" "K" parse_type_str type_satisfies_trait ! assert_true
 }
 
 fn test_type_var_with_wrong_bound_does_not_satisfy {
@@ -629,7 +634,7 @@ fn test_type_var_with_wrong_bound_does_not_satisfy {
     bounds type_vars List::new(List[Type]) List::new(List[Parameter]) StackEffect = sig
     sig empty_location List::new(List[Op]) "test_fn" make_function_with_stack_effect = func
     func Option::Some = func_opt
-    "does not satisfy" func_opt "Hashable" "K" parse_type_str type_satisfies_trait ! assert_true
+    "does not satisfy" TRAIT_TEST_STORE func_opt "Hashable" "K" parse_type_str type_satisfies_trait ! assert_true
 }
 
 # ============================================================================
@@ -661,7 +666,7 @@ fn test_k_coloncolon_method_resolved_as_trait_method_call {
     enable_test_mode
     clear_errors
     HASHABLE_TRAIT "struct MyType { val: int }\nimpl MyType {\n    fn hash self:MyType -> int { self MyType::val }\n    fn eq self:MyType other:MyType -> bool { self MyType::val other MyType::val == }\n}\nfn get_hash[K: Hashable] k:K -> int { k K::hash }\n42 MyType = m\nm get_hash drop\n" str::concat trait_test_typecheck drop
-    "get_hash" DEFAULT_PARSER.store.functions.get.unwrap = func
+    "get_hash" TRAIT_TEST_STORE.functions.get.unwrap = func
     # K::hash resolves to a dedicated trait method call carrying the hidden var.
     false = found_trait_call
     0 = index
@@ -685,7 +690,7 @@ fn test_ampersand_k_coloncolon_method_resolved_as_push_variable {
     enable_test_mode
     clear_errors
     HASHABLE_TRAIT "struct MyType { val: int }\nimpl MyType {\n    fn hash self:MyType -> int { self MyType::val }\n    fn eq self:MyType other:MyType -> bool { self MyType::val other MyType::val == }\n}\nfn get_hash_fn[K: Hashable] -> fn[K -> int] { &K::hash }\n42 MyType = m\nm get_hash_fn drop\n" str::concat trait_test_typecheck drop
-    "get_hash_fn" DEFAULT_PARSER.store.functions.get.unwrap = func
+    "get_hash_fn" TRAIT_TEST_STORE.functions.get.unwrap = func
     # &K::hash resolves to OpPushVar as a fn ref.
     false = found_push_var
     0 = index
@@ -722,7 +727,7 @@ fn test_trait_bounded_fn_with_non_satisfying_type_raises {
 fn test_generic_trait_bound_compound_type_arg_preserves_space {
     "generic_trait_bound_compound_type_arg_preserves_space" test_start
     "trait Carrier[T] { fn get self:self -> T }\nfn uses[I: Carrier[Map[str int]]] i:I -> int { 0 }\n" trait_test_parse drop
-    "uses" DEFAULT_PARSER.store.functions.get.unwrap = func
+    "uses" TRAIT_TEST_STORE.functions.get.unwrap = func
     "I" func Function::stack_effect StackEffect::trait_bounds.get.unwrap = bound
     "preserved" "Carrier[Map[str int]]" bound trait_bound_to_str assert_str_eq
 }
@@ -763,7 +768,7 @@ fn test_non_generic_trait_with_args_raises {
 fn test_generic_trait_bound_concrete_hidden_param_type {
     "generic_trait_bound_concrete_hidden_param_type" test_start
     "trait Carrier[T] { fn get self:self -> T }\nstruct Counter { val: int }\nimpl Counter { fn get self:Counter -> int { self Counter::val } }\nfn use_carrier[I: Carrier[int]] i:I -> int { i .get }\n" trait_test_typecheck drop
-    "use_carrier" DEFAULT_PARSER.store.functions.get.unwrap = func
+    "use_carrier" TRAIT_TEST_STORE.functions.get.unwrap = func
     # Find the hidden __trait_I_get parameter and assert its type substituted T with int.
     false = found
     0 = index
@@ -846,7 +851,7 @@ fn test_trait_bounded_fn_with_conflicting_type_var_raises {
 fn test_trait_with_supertrait_parses {
     "trait_with_supertrait_parses" test_start
     "trait Eq { fn eq self:self other:self -> bool }\ntrait Hashable: Eq { fn hash self:self -> int }\n" trait_test_parse drop
-    "Hashable" DEFAULT_PARSER.store.traits.get.unwrap = hashable
+    "Hashable" TRAIT_TEST_STORE.traits.get.unwrap = hashable
     "supertrait count" 1 hashable CasaTrait::supertraits.length assert_eq
     "supertrait name" "Eq" 0 hashable CasaTrait::supertraits.get TraitBound::name assert_str_eq
 }
@@ -865,13 +870,13 @@ fn test_trait_with_undefined_supertrait_raises {
 fn test_supertrait_method_required_for_satisfaction {
     "supertrait_method_required_for_satisfaction" test_start
     "trait Eq { fn eq self:self other:self -> bool }\ntrait Hashable: Eq { fn hash self:self -> int }\nstruct Bare { v: int }\nimpl Bare { fn hash self:Bare -> int { self Bare::v } }\n" trait_test_resolve drop
-    "Hashable not satisfied without Eq impl" Option::None(Option[Function]) "Hashable" "Bare" parse_type_str type_satisfies_trait ! assert_true
+    "Hashable not satisfied without Eq impl" TRAIT_TEST_STORE Option::None(Option[Function]) "Hashable" "Bare" parse_type_str type_satisfies_trait ! assert_true
 }
 
 fn test_supertrait_satisfaction_with_full_impl {
     "supertrait_satisfaction_with_full_impl" test_start
     "trait Eq { fn eq self:self other:self -> bool }\ntrait Hashable: Eq { fn hash self:self -> int }\nstruct Full { v: int }\nimpl Full { fn hash self:Full -> int { self Full::v } fn eq self:Full other:Full -> bool { self Full::v other Full::v == } }\n" trait_test_resolve drop
-    "Hashable satisfied with Eq impl" Option::None(Option[Function]) "Hashable" "Full" parse_type_str type_satisfies_trait assert_true
+    "Hashable satisfied with Eq impl" TRAIT_TEST_STORE Option::None(Option[Function]) "Hashable" "Full" parse_type_str type_satisfies_trait assert_true
 }
 
 fn test_supertrait_negative_typecheck_raises {
@@ -902,14 +907,14 @@ fn test_parse_map_type_in_function_declaration {
 fn test_dot_hash_on_bounded_type_var {
     "dot_hash_on_bounded_type_var" test_start
     HASHABLE_TRAIT "fn get_hash[K: Hashable] k:K -> int { k .hash }\n" str::concat trait_test_typecheck drop
-    "get_hash" DEFAULT_PARSER.store.functions.get.unwrap = func
+    "get_hash" TRAIT_TEST_STORE.functions.get.unwrap = func
     "has stack effect" func Function::stack_effect StackEffect::parameters.length 0 != assert_true
 }
 
 fn test_dot_eq_on_bounded_type_var {
     "dot_eq_on_bounded_type_var" test_start
     HASHABLE_TRAIT "fn are_eq[K: Hashable] a:K b:K -> bool { b a .eq }\n" str::concat trait_test_typecheck drop
-    "are_eq" DEFAULT_PARSER.store.functions.get.unwrap = func
+    "are_eq" TRAIT_TEST_STORE.functions.get.unwrap = func
     "has stack effect" func Function::stack_effect StackEffect::parameters.length 0 != assert_true
 }
 

--- a/tests/compiler/test_type_annotations.casa
+++ b/tests/compiler/test_type_annotations.casa
@@ -9,23 +9,27 @@ import "../../lib/test.casa"
 # Constants
 # ============================================================================
 "enum Option[T] { None Some(T) }\n" = OPTION_ENUM
+symbol_store_new = TYPE_ANNOTATION_TEST_STORE
 
 # ============================================================================
 # Helpers
 # ============================================================================
 
 fn test_parse code:str -> List[Op] {
+    global TYPE_ANNOTATION_TEST_STORE
     clear_global_state
-    "test" code lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops
+    code parse_resolve_test_source = result
+    result ParseResolveResult::store = TYPE_ANNOTATION_TEST_STORE
+    result ParseResolveResult::ops
 }
 
 fn tc_code code:str -> StackEffect {
+    global TYPE_ANNOTATION_TEST_STORE
     clear_global_state
-    "test" code lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
-    ops DEFAULT_PARSER resolve_identifiers_global = ops
-    Option::None(Option[Function]) ops type_check_ops
+    code parse_resolve_test_source = result
+    result ParseResolveResult::ops = ops
+    result ParseResolveResult::store = TYPE_ANNOTATION_TEST_STORE
+    TYPE_ANNOTATION_TEST_STORE Option::None(Option[Function]) ops type_check_ops
 }
 
 fn find_assign_ops ops:List[Op] -> List[Op] {
@@ -121,7 +125,7 @@ fn test_no_annotation {
 fn test_annotation_in_function {
     "annotation_in_function" test_start
     "fn foo { 42 = x:int x drop }" test_parse drop
-    "foo" DEFAULT_PARSER.store.functions.get.unwrap = function
+    "foo" TYPE_ANNOTATION_TEST_STORE.functions.get.unwrap = function
     function Function::ops find_assign_ops = assigns
     false = found
     0 = index
@@ -215,13 +219,14 @@ fn test_tc_annotation_to_option {
 }
 
 fn assert_cast_rejected_as_unknown_type source:str expected_type:str {
+    global TYPE_ANNOTATION_TEST_STORE
     enable_test_mode
     clear_global_state
     clear_errors
-    "test" source lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
-    ops DEFAULT_PARSER resolve_identifiers_global = ops
-    Option::None(Option[Function]) ops type_check_ops drop
+    source parse_resolve_test_source = result
+    result ParseResolveResult::ops = ops
+    result ParseResolveResult::store = TYPE_ANNOTATION_TEST_STORE
+    TYPE_ANNOTATION_TEST_STORE Option::None(Option[Function]) ops type_check_ops drop
     "has errors" assert_has_errors
     "syntax error" ErrorKind::Syntax assert_error_kind
     "type message" f"type `{expected_type}` does not exist" assert_error_contains

--- a/tests/compiler/test_typechecker.casa
+++ b/tests/compiler/test_typechecker.casa
@@ -10,7 +10,7 @@ import "../../lib/test.casa"
 # ============================================================================
 
 fn tc_check ops:List[Op] -> TypeChecker {
-    DEFAULT_PARSER.store make_typechecker = helper_tc
+    symbol_store_new make_typechecker = helper_tc
     0 = helper_i
     while helper_i ops.length > do
         helper_i ops.get = helper_op
@@ -491,10 +491,11 @@ fn test_types_match {
 
 fn test_unify_type {
     "unify_type_t" test_start
-    "same" "int" "int" parse_type_str "int" parse_type_str unify_type_t.unwrap.format assert_str_eq
-    "unknown + int" "int" "int" parse_type_str TYPE_UNKNOWN_T unify_type_t.unwrap.format assert_str_eq
-    "int + unknown" "int" TYPE_UNKNOWN_T "int" parse_type_str unify_type_t.unwrap.format assert_str_eq
-    "incompatible" "str" parse_type_str "int" parse_type_str unify_type_t.is_none assert_true
+    symbol_store_new = store
+    "same" "int" store "int" parse_type_str "int" parse_type_str unify_type_t.unwrap.format assert_str_eq
+    "unknown + int" "int" store "int" parse_type_str TYPE_UNKNOWN_T unify_type_t.unwrap.format assert_str_eq
+    "int + unknown" "int" store TYPE_UNKNOWN_T "int" parse_type_str unify_type_t.unwrap.format assert_str_eq
+    "incompatible" store "str" parse_type_str "int" parse_type_str unify_type_t.is_none assert_true
 }
 
 # ============================================================================
@@ -503,13 +504,14 @@ fn test_unify_type {
 
 fn test_stacks_compatible {
     "stacks_compatible" test_start
+    symbol_store_new = store
     List::new(List[Type]) = stack_a
     "int" parse_type_str stack_a.push
     "str" parse_type_str stack_a.push
     List::new(List[Type]) = stack_b
     "int" parse_type_str stack_b.push
     "str" parse_type_str stack_b.push
-    stack_b stack_a stacks_compatible = result
+    store stack_b stack_a stacks_compatible = result
     "compatible stacks" 2 result.length assert_eq
 
     List::new(List[Type]) = stack_c
@@ -517,7 +519,7 @@ fn test_stacks_compatible {
     List::new(List[Type]) = stack_d
     "int" parse_type_str stack_d.push
     "str" parse_type_str stack_d.push
-    stack_d stack_c stacks_compatible = result2
+    store stack_d stack_c stacks_compatible = result2
     "incompatible lengths" 0 result2.length assert_eq
 }
 
@@ -527,9 +529,10 @@ fn test_stacks_compatible {
 
 fn test_typecheck_simple_expression {
     "typecheck_simple_expression" test_start
-    "test" "10 20 +" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
-    Option::None(Option[Function]) ops type_check_ops = sig
+    "10 20 +" parse_resolve_test_source = result
+    result ParseResolveResult::ops = ops
+    result ParseResolveResult::store = store
+    store Option::None(Option[Function]) ops type_check_ops = sig
     "params" 0 sig StackEffect::parameters.length assert_eq
     "returns" 1 sig StackEffect::return_types.length assert_eq
     "return type" "int" 0 sig StackEffect::return_types.get.format assert_str_eq
@@ -540,10 +543,10 @@ fn test_typecheck_simple_expression {
 # ============================================================================
 
 fn tc_string code:str -> StackEffect {
-    "test" code lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
-    ops DEFAULT_PARSER resolve_identifiers_global = ops
-    Option::None(Option[Function]) ops type_check_ops
+    code parse_resolve_test_source = result
+    result ParseResolveResult::ops = ops
+    result ParseResolveResult::store = store
+    store Option::None(Option[Function]) ops type_check_ops
 }
 
 # ============================================================================
@@ -1025,19 +1028,21 @@ fn test_types_match_extended {
 
 fn test_stacks_compatible_with_unknown {
     "stacks_compatible_with_unknown" test_start
+    symbol_store_new = store
     List::new(List[Type]) = stack_a
     "int" parse_type_str stack_a.push
     List::new(List[Type]) = stack_b
     TYPE_UNKNOWN parse_type_str stack_b.push
-    stack_b stack_a stacks_compatible = result
+    store stack_b stack_a stacks_compatible = result
     "TYPE_UNKNOWN matches int" 1 result.length assert_eq
 }
 
 fn test_stacks_compatible_empty {
     "stacks_compatible_empty" test_start
+    symbol_store_new = store
     List::new(List[Type]) = stack_a
     List::new(List[Type]) = stack_b
-    stack_b stack_a stacks_compatible = result
+    store stack_b stack_a stacks_compatible = result
     "empty stacks compatible" 0 result.length assert_eq
 }
 
@@ -1048,10 +1053,10 @@ fn test_stacks_compatible_empty {
 fn tc_string_error code:str -> StackEffect {
     enable_test_mode
     clear_errors
-    "test" code lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
-    ops DEFAULT_PARSER resolve_identifiers_global = ops
-    Option::None(Option[Function]) ops type_check_ops
+    code parse_resolve_test_source = result
+    result ParseResolveResult::ops = ops
+    result ParseResolveResult::store = store
+    store Option::None(Option[Function]) ops type_check_ops
 }
 
 # ============================================================================
@@ -1216,11 +1221,11 @@ fn tc_full code:str {
     clear_global_state
     enable_test_mode
     clear_errors
-    "test" code lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
-    ops DEFAULT_PARSER resolve_identifiers_global = ops
-    Option::None(Option[Function]) ops type_check_ops drop
-    type_check_functions
+    code parse_resolve_test_source = result
+    result ParseResolveResult::ops = ops
+    result ParseResolveResult::store = store
+    store Option::None(Option[Function]) ops type_check_ops drop
+    store type_check_functions
 }
 
 fn test_error_syscall_non_word_bound_type_var {
@@ -1447,7 +1452,7 @@ fn test_error_fn_stack_effect_mismatch {
     empty_location 42 OpValue::PushInt make_op bad_ops.push
     # RPN: stack effect, location, ops, name, make_function_with_stack_effect
     bad_stack_effect empty_location bad_ops "bad_fn" make_function_with_stack_effect = bad_fn
-    bad_fn Option::Some bad_ops type_check_ops drop
+    symbol_store_new bad_fn Option::Some bad_ops type_check_ops drop
     "has errors" assert_has_errors
     "stack effect mismatch" ErrorKind::SignatureMismatch assert_error_kind
     clear_errors
@@ -1466,7 +1471,7 @@ fn test_error_unused_fn_type_error {
     "int -> str" stack_effect_from_str = bad_stack_effect
     List::new(List[Op]) = empty_ops
     bad_stack_effect empty_location empty_ops "bad_unused" make_function_with_stack_effect = bad_fn
-    bad_fn Option::Some empty_ops type_check_ops drop
+    symbol_store_new bad_fn Option::Some empty_ops type_check_ops drop
     "has errors" assert_has_errors
     "stack effect mismatch" ErrorKind::SignatureMismatch assert_error_kind
     clear_errors
@@ -1553,11 +1558,12 @@ fn test_tc_pipeline_print_pops {
 
 fn test_stacks_compatible_different_types {
     "stacks_compatible_different_types" test_start
+    symbol_store_new = store
     List::new(List[Type]) = stack_a
     "int" parse_type_str stack_a.push
     List::new(List[Type]) = stack_b
     "str" parse_type_str stack_b.push
-    stack_b stack_a stacks_compatible = result
+    store stack_b stack_a stacks_compatible = result
     "incompatible types" 0 result.length assert_eq
 }
 
@@ -1748,7 +1754,7 @@ fn test_branch_while_empty_body {
 
 fn test_branch_frame_kind_dispatch {
     "branch_frame_kind_dispatch" test_start
-    DEFAULT_PARSER.store make_typechecker = tc
+    symbol_store_new make_typechecker = tc
     List::new(List[Op]) = ops
     empty_location OpValue::IfStart make_op ops.push
     0 = bd_i
@@ -1846,7 +1852,7 @@ fn test_error_array_literal_unresolved_assignment {
 
 fn test_branch_return_inside_if_restores_live {
     "branch_return_inside_if_restores_live" test_start
-    DEFAULT_PARSER.store make_typechecker = tc
+    symbol_store_new make_typechecker = tc
     # Seed the live stack with a single `int`.
     "int" tc stack_push
     # Begin an `if true then` block.

--- a/tests/compiler/test_typeof.casa
+++ b/tests/compiler/test_typeof.casa
@@ -12,18 +12,18 @@ import "../../lib/test.casa"
 # ============================================================================
 
 fn tc_typeof code:str -> StackEffect {
-    "test" code lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
-    ops DEFAULT_PARSER resolve_identifiers_global = ops
-    Option::None(Option[Function]) ops type_check_ops
+    code parse_resolve_test_source = result
+    result ParseResolveResult::ops = ops
+    result ParseResolveResult::store = store
+    store Option::None(Option[Function]) ops type_check_ops
 }
 
 fn compile_typeof code:str -> Program {
-    "test" code lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
-    ops DEFAULT_PARSER resolve_identifiers_global = ops
-    Option::None(Option[Function]) ops type_check_ops drop
-    ops DEFAULT_PARSER.store compile_bytecode
+    code parse_resolve_test_source = result
+    result ParseResolveResult::ops = ops
+    result ParseResolveResult::store = store
+    store Option::None(Option[Function]) ops type_check_ops drop
+    ops store compile_bytecode
 }
 
 fn emit_typeof code:str -> str {
@@ -87,7 +87,7 @@ fn test_lex_typeof {
 fn test_parse_typeof {
     "parse_typeof" test_start
     "test" "42 typeof" lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
+    List::new(List[str]) tokens parse_and_resolve ParseResolveResult::ops = ops
     "typeof kind" 1 ops.get.value OpValue::Typeof is assert_true
 }
 

--- a/tests/compiler/test_underflow_messages.casa
+++ b/tests/compiler/test_underflow_messages.casa
@@ -11,10 +11,10 @@ import "../../lib/test.casa"
 
 fn tc_um code:str -> StackEffect {
     clear_global_state
-    "test" code lex_source = tokens
-    tokens DEFAULT_PARSER parse_ops = ops
-    ops DEFAULT_PARSER resolve_identifiers_global = ops
-    Option::None(Option[Function]) ops type_check_ops
+    code parse_resolve_test_source = result
+    result ParseResolveResult::ops = ops
+    result ParseResolveResult::store = store
+    store Option::None(Option[Function]) ops type_check_ops
 }
 
 # ============================================================================


### PR DESCRIPTION
## Summary

- Remove `DEFAULT_PARSER` / `DEFAULT_STORE` process globals from the compiler
- Add `ParseResolveResult` struct and `parse_and_resolve` entry point that keeps `Parser` private behind the parse-and-resolve boundary
- Thread `store:SymbolStore` explicitly through typechecker, pattern matcher, and identifier resolution (~50 functions)
- Update all entry points (`casa.casa`, `lsp.casa`, `lib/test.casa`) and 18 test files

## Test plan

- [x] Stage-2 self-compilation succeeds
- [x] `tests/test_compiler.sh` — 52/52 pass
- [x] `tests/test_examples.sh` — 47/47 pass
- [x] All `.casa` files formatted with `casafmt`

## Follow-up

- #223 — Remove disposable `Parser` allocation in `resolve_identifiers` wrapper