### PR TITLE
refactor: use Map::iter at call sites that need both key and value

### DIFF
--- a/compiler/bytecode.casa
+++ b/compiler/bytecode.casa
@@ -1109,9 +1109,9 @@ fn compile_bytecode store:SymbolStore ops:List[Op] -> Program {
 
     # Compile all used functions
     Map::new(Map[str List[InstValue]]) = functions
-    compiler.store.functions.keys = function_names
-    for function_name in function_names.iter do
-        function_name compiler.store.functions.get.unwrap = function
+    for pair in compiler.store.functions.iter do
+        pair.first (str) = function_name
+        pair.second (Function) = function
         if 0 function Function::bytecode.length != then
             function Function::bytecode function_name functions.set = functions
         fi

--- a/compiler/emitter.casa
+++ b/compiler/emitter.casa
@@ -286,11 +286,11 @@ fn emit_helpers asm:StringBuilder {
 # ============================================================================
 
 fn emit_functions asm:StringBuilder program:Program {
-    program Program::functions.keys = keys
-    for name in keys.iter do
+    for pair in program Program::functions.iter do
+        pair.first (str) = name
+        pair.second (List[InstValue]) = bytecode
         name sanitize_name = label
         f"fn_{label}:" asm emit_line
-        name program Program::functions.get.unwrap = bytecode
         false bytecode asm emit_bytecode
         "" asm emit_line
     done

--- a/compiler/typechecker.casa
+++ b/compiler/typechecker.casa
@@ -2858,9 +2858,9 @@ fn type_check_ops ops:List[Op] function_opt:Option[Function] store:SymbolStore -
 # ============================================================================
 
 fn type_check_functions store:SymbolStore {
-    store.functions.keys = function_keys
-    for func_name in function_keys.iter do
-        func_name store.functions.get.unwrap = current_fn
+    for pair in store.functions.iter do
+        pair.first (str) = func_name
+        pair.second (Function) = current_fn
         if current_fn Function::is_typechecked then
             continue
         fi


### PR DESCRIPTION
## Summary

- Replace `.keys` + `.get.unwrap` anti-pattern with `Map::iter` at three compiler call sites
- Eliminates intermediate `List` allocation and per-key hash rehashing at each site
- **bytecode.casa**: `compile_bytecode` function iteration
- **emitter.casa**: `emit_functions` bytecode emission
- **typechecker.casa**: `type_check_functions` type checking loop

## Test plan

- [x] `tests/test_compiler.sh` — 53 passed, 0 failed (includes self-compilation and fixed-point)
- [x] `tests/test_examples.sh` — 47 passed, 0 failed