### PR TITLE
feat(tests): add selective test running with substring filters

### DIFF
--- a/.github/workflows/test-compiler.yml
+++ b/.github/workflows/test-compiler.yml
@@ -42,4 +42,6 @@ jobs:
     - name: Bootstrap stage1 compiler from branch
       run: ./casac-release -L lib casa.casa -o casac-stage1
     - name: Run compiler tests
-      run: ./tests/test_compiler.sh ./casac-stage1
+      run: CASA_COMPILER=./casac-stage1 ./tests/test_compiler.sh
+    - name: Run bootstrap tests
+      run: CASA_COMPILER=./casac-stage1 ./tests/test_bootstrap.sh

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -42,4 +42,4 @@ jobs:
     - name: Bootstrap stage1 compiler from branch
       run: ./casac-release -L lib casa.casa -o casac-stage1
     - name: Test example programs
-      run: ./tests/test_examples.sh ./casac-stage1
+      run: CASA_COMPILER=./casac-stage1 ./tests/test_examples.sh

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -10,19 +10,53 @@ Rules for running and updating tests.
   ./casafmt < file.casa > tmp && mv tmp file.casa
   ```
 
-- **MUST** run both test scripts:
+- **MUST** run test scripts:
 
   ```
-  tests/test_examples.sh
   tests/test_compiler.sh
+  tests/test_examples.sh
+  tests/test_bootstrap.sh
   ```
 
-- Both scripts default to the `./casac` binary at the repo root. Rebuild casac before
-  testing if compiler sources changed:
+- All scripts default to `./casac` (or `./casafmt` for formatter tests). Rebuild
+  casac before testing if compiler sources changed:
 
   ```
   ./casac -L lib casa.casa -o casac
   ```
+
+- Override the compiler with `CASA_COMPILER`:
+
+  ```
+  CASA_COMPILER=./casac_debug tests/test_compiler.sh
+  ```
+
+## Selective test running
+
+All test scripts accept substring filters as arguments. Only tests whose name
+contains at least one filter run. No filters = full suite.
+
+```
+tests/test_compiler.sh lexer              # only test_lexer + any error fixture matching "lexer"
+tests/test_compiler.sh lexer typechecker  # tests matching "lexer" OR "typechecker"
+tests/test_examples.sh fibonacci          # only fibonacci example
+tests/test_formatter.sh indent            # only golden file tests matching "indent"
+```
+
+When `test_formatter.sh` has filters, idempotency and error passthrough tests
+are skipped (they only run in the full suite).
+
+`test_bootstrap.sh` has no filters — it always runs both self-compilation and
+fixed-point tests.
+
+## Test categories
+
+| Script | What it tests |
+|---|---|
+| `test_compiler.sh` | Unit tests (`tests/compiler/test_*.casa`) and error fixtures (`tests/compiler/errors/*.casa`) |
+| `test_examples.sh` | Example programs (`examples/*.casa`) against expected output |
+| `test_formatter.sh` | Golden file formatting, idempotency sweep, error passthrough |
+| `test_bootstrap.sh` | Self-compilation (3-stage) and fixed-point verification |
 
 ## CI bootstrap compiler
 

--- a/tests/test_bootstrap.sh
+++ b/tests/test_bootstrap.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env sh
+set -eu
+
+ROOT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+LIB_DIR="$ROOT_DIR/lib"
+cd "$ROOT_DIR"
+
+# Compiler: env var > positional path (backward compat) > default
+if [ -n "${CASA_COMPILER:-}" ]; then
+    COMPILER="$CASA_COMPILER"
+elif [ $# -ge 1 ] && echo "$1" | grep -q '/'; then
+    COMPILER="$1"
+    shift
+else
+    COMPILER="$ROOT_DIR/casac"
+fi
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+RESET='\033[0m'
+
+pass=0
+fail=0
+
+# Self-compilation test: stage1 (released casac) compiles itself to stage2
+printf "Running: self_compilation ... "
+
+stage1="/tmp/casa_stage1"
+stage2="/tmp/casa_stage2"
+stage2_test_bin="/tmp/casa_stage2_test"
+
+if ! $COMPILER -L "$LIB_DIR" "$ROOT_DIR/casa.casa" -o "$stage1" 2>/tmp/casa_compile_err; then
+    printf "${RED}STAGE1 COMPILE FAIL${RESET}\n"
+    cat /tmp/casa_compile_err
+    fail=$((fail+1))
+else
+    if ! "$stage1" -L "$LIB_DIR" "$ROOT_DIR/casa.casa" -o "$stage2" 2>/tmp/casa_compile_err; then
+        printf "${RED}STAGE2 COMPILE FAIL${RESET}\n"
+        cat /tmp/casa_compile_err
+        fail=$((fail+1))
+    else
+        # Verify stage2 can compile and run a program
+        if ! "$stage2" -L "$LIB_DIR" "$ROOT_DIR/examples/hello_world.casa" -o "$stage2_test_bin" 2>/tmp/casa_compile_err; then
+            printf "${RED}STAGE2 COMPILE OUTPUT FAIL${RESET}\n"
+            cat /tmp/casa_compile_err
+            fail=$((fail+1))
+        else
+            stage2_output=$("$stage2_test_bin" 2>&1) || true
+            expected="Hello world!"
+            if [ "$stage2_output" = "$expected" ]; then
+                printf "${GREEN}OK${RESET}\n"
+                pass=$((pass+1))
+            else
+                printf "${RED}STAGE2 RUNTIME FAIL${RESET}\n"
+                echo "  expected: $expected"
+                echo "  got:      $stage2_output"
+                fail=$((fail+1))
+            fi
+        fi
+    fi
+fi
+rm -f "$stage1" "$stage2" "$stage2_test_bin"
+
+# Fixed-point verification: stage2.s == stage3.s
+printf "Running: fixed_point ... "
+
+stage1="/tmp/casa_fp_stage1"
+stage2="/tmp/casa_fp_stage2"
+stage3="/tmp/casa_fp_stage3"
+
+if ! $COMPILER -L "$LIB_DIR" "$ROOT_DIR/casa.casa" -o "$stage1" 2>/tmp/casa_compile_err; then
+    printf "${RED}STAGE1 COMPILE FAIL${RESET}\n"
+    cat /tmp/casa_compile_err
+    fail=$((fail+1))
+else
+    if ! "$stage1" -L "$LIB_DIR" "$ROOT_DIR/casa.casa" -o "$stage2" --keep-asm 2>/tmp/casa_compile_err; then
+        printf "${RED}STAGE2 COMPILE FAIL${RESET}\n"
+        cat /tmp/casa_compile_err
+        fail=$((fail+1))
+    else
+        if ! "$stage2" -L "$LIB_DIR" "$ROOT_DIR/casa.casa" -o "$stage3" --keep-asm 2>/tmp/casa_compile_err; then
+            printf "${RED}STAGE3 COMPILE FAIL${RESET}\n"
+            cat /tmp/casa_compile_err
+            fail=$((fail+1))
+        else
+            if diff "$stage2.s" "$stage3.s" > /dev/null 2>&1; then
+                printf "${GREEN}OK${RESET}\n"
+                pass=$((pass+1))
+            else
+                printf "${RED}STAGE2/STAGE3 ASSEMBLY DIFFERS${RESET}\n"
+                diff "$stage2.s" "$stage3.s" | head -20
+                fail=$((fail+1))
+            fi
+        fi
+    fi
+fi
+rm -f "$stage1" "$stage2" "$stage3" "$stage2.s" "$stage3.s"
+
+echo
+echo "Summary: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/tests/test_compiler.sh
+++ b/tests/test_compiler.sh
@@ -6,9 +6,12 @@ TESTS_DIR="$ROOT_DIR/tests/compiler"
 LIB_DIR="$ROOT_DIR/lib"
 cd "$ROOT_DIR"
 
-# Accept optional compiler path as first argument
-if [ $# -ge 1 ]; then
+# Compiler: env var > positional path (backward compat) > default
+if [ -n "${CASA_COMPILER:-}" ]; then
+    COMPILER="$CASA_COMPILER"
+elif [ $# -ge 1 ] && echo "$1" | grep -q '/'; then
     COMPILER="$1"
+    shift
 else
     COMPILER="$ROOT_DIR/casac"
 fi
@@ -20,8 +23,27 @@ RESET='\033[0m'
 pass=0
 fail=0
 
+matches_filter() {
+    name="$1"
+    shift
+    if [ $# -eq 0 ]; then
+        return 0
+    fi
+    for pattern in "$@"; do
+        case "$name" in
+            *"$pattern"*) return 0 ;;
+        esac
+    done
+    return 1
+}
+
 for f in "$TESTS_DIR"/test_*.casa; do
     base=$(basename "$f" .casa)
+
+    if ! matches_filter "$base" "$@"; then
+        continue
+    fi
+
     binary="/tmp/casa_${base}"
 
     printf "Running: %s ... " "$base"
@@ -52,6 +74,11 @@ done
 for f in "$TESTS_DIR"/errors/*.casa; do
     [ -f "$f" ] || continue
     base=$(basename "$f" .casa)
+
+    if ! matches_filter "$base" "$@"; then
+        continue
+    fi
+
     expected_tag=$(head -1 "$f" | sed 's/^# expect: //')
 
     printf "Running: error/%s ... " "$base"
@@ -68,80 +95,6 @@ for f in "$TESTS_DIR"/errors/*.casa; do
         pass=$((pass+1))
     fi
 done
-
-# Self-compilation test: stage1 (released casac) compiles itself to stage2
-printf "Running: self_compilation ... "
-
-stage1="/tmp/casa_stage1"
-stage2="/tmp/casa_stage2"
-stage2_test_bin="/tmp/casa_stage2_test"
-
-if ! $COMPILER -L "$LIB_DIR" "$ROOT_DIR/casa.casa" -o "$stage1" 2>/tmp/casa_compile_err; then
-    printf "${RED}STAGE1 COMPILE FAIL${RESET}\n"
-    cat /tmp/casa_compile_err
-    fail=$((fail+1))
-else
-    if ! "$stage1" -L "$LIB_DIR" "$ROOT_DIR/casa.casa" -o "$stage2" 2>/tmp/casa_compile_err; then
-        printf "${RED}STAGE2 COMPILE FAIL${RESET}\n"
-        cat /tmp/casa_compile_err
-        fail=$((fail+1))
-    else
-        # Verify stage2 can compile and run a program
-        if ! "$stage2" -L "$LIB_DIR" "$ROOT_DIR/examples/hello_world.casa" -o "$stage2_test_bin" 2>/tmp/casa_compile_err; then
-            printf "${RED}STAGE2 COMPILE OUTPUT FAIL${RESET}\n"
-            cat /tmp/casa_compile_err
-            fail=$((fail+1))
-        else
-            stage2_output=$("$stage2_test_bin" 2>&1) || true
-            expected="Hello world!"
-            if [ "$stage2_output" = "$expected" ]; then
-                printf "${GREEN}OK${RESET}\n"
-                pass=$((pass+1))
-            else
-                printf "${RED}STAGE2 RUNTIME FAIL${RESET}\n"
-                echo "  expected: $expected"
-                echo "  got:      $stage2_output"
-                fail=$((fail+1))
-            fi
-        fi
-    fi
-fi
-rm -f "$stage1" "$stage2" "$stage2_test_bin"
-
-# Fixed-point verification: stage2.s == stage3.s
-printf "Running: fixed_point ... "
-
-stage1="/tmp/casa_fp_stage1"
-stage2="/tmp/casa_fp_stage2"
-stage3="/tmp/casa_fp_stage3"
-
-if ! $COMPILER -L "$LIB_DIR" "$ROOT_DIR/casa.casa" -o "$stage1" 2>/tmp/casa_compile_err; then
-    printf "${RED}STAGE1 COMPILE FAIL${RESET}\n"
-    cat /tmp/casa_compile_err
-    fail=$((fail+1))
-else
-    if ! "$stage1" -L "$LIB_DIR" "$ROOT_DIR/casa.casa" -o "$stage2" --keep-asm 2>/tmp/casa_compile_err; then
-        printf "${RED}STAGE2 COMPILE FAIL${RESET}\n"
-        cat /tmp/casa_compile_err
-        fail=$((fail+1))
-    else
-        if ! "$stage2" -L "$LIB_DIR" "$ROOT_DIR/casa.casa" -o "$stage3" --keep-asm 2>/tmp/casa_compile_err; then
-            printf "${RED}STAGE3 COMPILE FAIL${RESET}\n"
-            cat /tmp/casa_compile_err
-            fail=$((fail+1))
-        else
-            if diff "$stage2.s" "$stage3.s" > /dev/null 2>&1; then
-                printf "${GREEN}OK${RESET}\n"
-                pass=$((pass+1))
-            else
-                printf "${RED}STAGE2/STAGE3 ASSEMBLY DIFFERS${RESET}\n"
-                diff "$stage2.s" "$stage3.s" | head -20
-                fail=$((fail+1))
-            fi
-        fi
-    fi
-fi
-rm -f "$stage1" "$stage2" "$stage3" "$stage2.s" "$stage3.s"
 
 echo
 echo "Summary: $pass passed, $fail failed"

--- a/tests/test_examples.sh
+++ b/tests/test_examples.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env sh
 set -eu
 
-ROOT_DIR=$(git rev-parse --show-toplevel)
+ROOT_DIR=$(cd "$(dirname "$0")/.." && pwd)
 
-# Accept optional compiler path as first argument
-if [ $# -ge 1 ]; then
+# Compiler: env var > positional path (backward compat) > default
+if [ -n "${CASA_COMPILER:-}" ]; then
+    COMPILER="$CASA_COMPILER"
+elif [ $# -ge 1 ] && echo "$1" | grep -q '/'; then
     COMPILER="$1"
+    shift
 else
     COMPILER="$ROOT_DIR/casac"
 fi
@@ -23,8 +26,27 @@ RESET='\033[0m'
 pass=0
 fail=0
 
+matches_filter() {
+    name="$1"
+    shift
+    if [ $# -eq 0 ]; then
+        return 0
+    fi
+    for pattern in "$@"; do
+        case "$name" in
+            *"$pattern"*) return 0 ;;
+        esac
+    done
+    return 1
+}
+
 for f in "$EXAMPLES_DIR"/*.casa; do
     base=$(basename "$f" .casa)
+
+    if ! matches_filter "$base" "$@"; then
+        continue
+    fi
+
     out_file="$EXAMPLES_DIR/outputs/$base.out"
     err_file="$EXAMPLES_DIR/outputs/$base.err"
     binary="/tmp/casa_test_$base"

--- a/tests/test_formatter.sh
+++ b/tests/test_formatter.sh
@@ -3,9 +3,12 @@ set -eu
 
 ROOT_DIR=$(git rev-parse --show-toplevel)
 
-# Accept optional formatter path as first argument
-if [ $# -ge 1 ]; then
+# Formatter: env var > positional path (backward compat) > default
+if [ -n "${CASA_FORMATTER:-}" ]; then
+    FORMATTER="$CASA_FORMATTER"
+elif [ $# -ge 1 ] && echo "$1" | grep -q '/'; then
     FORMATTER="$1"
+    shift
 else
     FORMATTER="$ROOT_DIR/casafmt"
 fi
@@ -19,6 +22,24 @@ RESET='\033[0m'
 
 pass=0
 fail=0
+has_filter=false
+if [ $# -gt 0 ]; then
+    has_filter=true
+fi
+
+matches_filter() {
+    name="$1"
+    shift
+    if [ $# -eq 0 ]; then
+        return 0
+    fi
+    for pattern in "$@"; do
+        case "$name" in
+            *"$pattern"*) return 0 ;;
+        esac
+    done
+    return 1
+}
 
 # ============================================================================
 # Golden file tests
@@ -27,6 +48,11 @@ fail=0
 for input_file in "$TESTS_DIR"/*.input.casa; do
     [ -f "$input_file" ] || continue
     base=$(basename "$input_file" .input.casa)
+
+    if ! matches_filter "$base" "$@"; then
+        continue
+    fi
+
     expected_file="$TESTS_DIR/$base.expected.casa"
 
     if [ ! -f "$expected_file" ]; then
@@ -47,8 +73,10 @@ for input_file in "$TESTS_DIR"/*.input.casa; do
     fi
 done
 
+if [ "$has_filter" = false ]; then
+
 # ============================================================================
-# Idempotency tests
+# Idempotency tests (full suite only)
 # ============================================================================
 
 printf "\nRunning idempotency tests...\n"
@@ -73,7 +101,7 @@ pass=$((pass + idem_pass))
 fail=$((fail + idem_fail))
 
 # ============================================================================
-# Error handling test
+# Error handling test (full suite only)
 # ============================================================================
 
 printf "\nRunning error handling test...\n"
@@ -86,6 +114,8 @@ else
     printf "${RED}[FAIL]${RESET} Failed: error_passthrough\n"
     fail=$((fail + 1))
 fi
+
+fi # has_filter
 
 # ============================================================================
 # Summary


### PR DESCRIPTION
## Summary
- All test scripts accept substring filters as positional args (`tests/test_compiler.sh lexer typechecker`)
- Bootstrap tests (self-compilation, fixed-point) extracted to `tests/test_bootstrap.sh`
- Compiler/formatter path override via `CASA_COMPILER`/`CASA_FORMATTER` env vars (positional path backward compat preserved)
- Formatter skips idempotency and error passthrough when filtered
- CI workflows updated to use env vars and run bootstrap tests separately

## Test plan
- [x] `tests/test_compiler.sh lexer` — runs only test_lexer
- [x] `tests/test_compiler.sh lexer common` — runs test_lexer and test_common (OR logic)
- [x] `tests/test_examples.sh fibonacci` — runs only fibonacci example
- [x] `tests/test_formatter.sh indent` — runs only indent golden file test
- [x] `tests/test_compiler.sh ./casac lexer` — backward-compat positional path + filter
- [x] `CASA_COMPILER=./casac tests/test_examples.sh hello` — env var override + filter
- [x] Full suite (no args) passes for compiler (51/51) and examples (47/47)