### PR TITLE
refactor: deduplicate TypedStack snapshot/restore with List::clone

### DIFF
--- a/compiler/typechecker.casa
+++ b/compiler/typechecker.casa
@@ -24,31 +24,13 @@ impl TypedStack {
         TypedStack
     }
 
-    # Deep-copy a TypedStack into a new, independent value.
     fn snapshot self:TypedStack -> TypedStack {
-        List::new(List[Type]) = new_types
-        List::new(List[Location]) = new_origins
-        0 = snapshot_index
-        while snapshot_index self TypedStack::types.length > do
-            snapshot_index self TypedStack::types.get new_types.push
-            snapshot_index self TypedStack::origins.get new_origins.push
-            1 += snapshot_index
-        done
-        new_origins new_types TypedStack
+        self TypedStack::origins.clone self TypedStack::types.clone TypedStack
     }
 
-    # Mutate `self` in place so it deep-equals `source`. `source` is unchanged.
     fn restore self:TypedStack source:TypedStack {
-        List::new(List[Type]) = new_types
-        List::new(List[Location]) = new_origins
-        0 = restore_index
-        while restore_index source TypedStack::types.length > do
-            restore_index source TypedStack::types.get new_types.push
-            restore_index source TypedStack::origins.get new_origins.push
-            1 += restore_index
-        done
-        new_types self TypedStack::set_types
-        new_origins self TypedStack::set_origins
+        source TypedStack::types.clone self TypedStack::set_types
+        source TypedStack::origins.clone self TypedStack::set_origins
     }
 
     # Pure stack comparison on the types slice (origins are not compared).

--- a/lib/std.casa
+++ b/lib/std.casa
@@ -131,6 +131,16 @@ impl List {
             1 -= right
         done
     }
+
+    fn clone [T] self:List[T] -> List[T] {
+        List::new(List[T]) = result
+        0 = i
+        while i self.length > do
+            i self.get result.push
+            1 += i
+        done
+        result
+    }
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add generic `List::clone` method to stdlib that copies a list via index loop
- Simplify `TypedStack::snapshot` and `TypedStack::restore` to one-/two-liners using `List::clone`
- Net reduction of 8 lines; eliminates duplicated copy logic

Closes #218

## Test plan
- [x] `tests/test_compiler.sh` — 53 passed
- [x] `tests/test_examples.sh` — 47 passed
- [x] Self-compilation and fixed point reached