### PR TITLE
docs: add branch naming convention for worktrees

### DIFF
--- a/docs/agents/git.md
+++ b/docs/agents/git.md
@@ -17,6 +17,8 @@ Rules for commits, branches, and pull requests in this repo.
 ## Branches
 
 - MUST NOT modify `main` directly. All work happens on a feature branch.
+- MUST use conventional prefixes: `feat/`, `refactor/`, `fix/`, etc. This applies
+  to worktree branches too — rename away from the `worktree-` default before pushing.
 
 ## Releases
 


### PR DESCRIPTION
## Summary
- Document that worktree branches must use conventional prefixes (`feat/`, `refactor/`, `fix/`) instead of the default `worktree-` prefix

## Test plan
- [x] Documentation-only change, no code affected