### PR TITLE
test: add error test for import inside function scope

### DIFF
--- a/tests/compiler/errors/import_in_function.casa
+++ b/tests/compiler/errors/import_in_function.casa
@@ -1,0 +1,4 @@
+# expect: INVALID_SCOPE
+fn foo {
+    import "std"
+}


### PR DESCRIPTION
## Summary
- Add error test verifying that `import` inside a function body produces an `INVALID_SCOPE` error
- Covers the `require_global_scope` guard added in #229

## Test plan
- [x] `tests/test_compiler.sh` — 52 passed, 0 failed