### PR TITLE
refactor: enforce strict generic type matching

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -58,6 +58,14 @@ _Avoid_: Type string, source type text
 The user-written type expression before the parser converts it into the **Type AST**.
 _Avoid_: Type annotation metadata, internal type string
 
+**Fully parameterized type**:
+A generic type where all type parameters are specified, either as concrete types or as declared type variables. `Option[int]` and `Option[T]` (where `T` is declared) are fully parameterized; bare `Option` is not.
+_Avoid_: Raw type, unparameterized generic
+
+**Unresolved type variable**:
+A `Type::TypeVar` node in the **Type AST** that has not yet been bound to a concrete type during type inference. The type unifier treats types containing unresolved type variables as flexible; fully resolved types must match structurally.
+_Avoid_: Unknown type, type placeholder (which means `TYPE_UNKNOWN_T`)
+
 ### Documentation terminology
 
 **Documentation glossary**:
@@ -148,6 +156,9 @@ _Avoid_: Release lint, tag lint
 
 - **Source type syntax** is parsed into the **Type AST** before compiler analysis.
 - Compiler analysis should operate on the **Type AST**, not reparsed or reformatted type strings.
+- Generic types must be **Fully parameterized types** at all compiler boundaries; bare generic names are not valid type expressions.
+- The type unifier treats types containing **Unresolved type variables** as flexible; fully resolved types must match structurally.
+- Whether a type is "still flexible" is determined by the presence of `Type::TypeVar` nodes, not by checking whether the base name is a known enum or struct.
 - A **Functional compiler pass** may use local mutation internally, but pass boundaries should make compiler context and diagnostics explicit.
 - A **Pass result** should be introduced only when the compiler phase returns more than one meaningful output; single-output phases should return the value directly.
 - A **Compiler dependency** should be returned as its own value only when a later boundary uses it now; unused phase-private state should stay private until needed.

--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -1277,11 +1277,22 @@ impl Type {
     }
 }
 
+fn string_list_to_set items:List[str] -> Set[str] {
+    Set::new(Set[str]) = result
+    for item in items.iter do
+        item result.add = result
+    done
+    result
+}
+
 fn canonicalize_type_var typ:Type type_vars:Set[str] -> Type {
     typ match
         Type::Generic(generic) => {
-            if 0 generic.params.length == generic.base type_vars.has && then
-                generic.base Type::TypeVar return
+            if 0 generic.params.length == then
+                if generic.base type_vars.has then
+                    generic.base Type::TypeVar return
+                fi
+                typ return
             fi
             List::new(List[Type]) = new_params
             for param in generic.params.iter do
@@ -1443,11 +1454,7 @@ fn build_parameterized_type base:str params:List[str] -> str {
 }
 
 fn build_parameterized_type_t base:str params:List[str] -> Type {
-    List::new(List[Type]) = type_params
-    for param in params.iter do
-        param Type::TypeVar type_params.push
-    done
-    type_params base GenericType Type::Generic
+    Map::new(Map[str Type]) params base build_resolved_type_t
 }
 
 fn build_resolved_type base:str type_vars:List[str] bindings:Map[str str] -> str {

--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -1080,14 +1080,29 @@ impl Type {
     fn type_var_name self:Type -> Option[str] {
         self match
             Type::TypeVar(name) => { name Option::Some }
-            Type::Generic(generic) => {
-                if 0 generic.params.length == then
-                    generic.base Option::Some
-                else
-                    Option::None
-                fi
-            }
             _ => { Option::None }
+        end
+    }
+
+    fn has_unresolved_type_var self:Type -> bool {
+        self match
+            Type::TypeVar(_) => { true }
+            Type::Generic(generic) => {
+                for param in generic.params.iter do
+                    if param.has_unresolved_type_var then true return fi
+                done
+                false
+            }
+            Type::Function(fn_type) => {
+                for param in fn_type.parameters.iter do
+                    if param.has_unresolved_type_var then true return fi
+                done
+                for ret in fn_type.return_types.iter do
+                    if ret.has_unresolved_type_var then true return fi
+                done
+                false
+            }
+            _ => { false }
         end
     }
 
@@ -1105,9 +1120,6 @@ impl Type {
         self match
             Type::TypeVar(name) => { name type_var == }
             Type::Generic(generic) => {
-                if 0 generic.params.length == then
-                    generic.base type_var == return
-                fi
                 for param in generic.params.iter do
                     if type_var param.type_contains_var then true return fi
                 done
@@ -1265,6 +1277,48 @@ impl Type {
     }
 }
 
+fn canonicalize_type_var typ:Type type_vars:Set[str] -> Type {
+    typ match
+        Type::Generic(generic) => {
+            if 0 generic.params.length == generic.base type_vars.has && then
+                generic.base Type::TypeVar return
+            fi
+            List::new(List[Type]) = new_params
+            for param in generic.params.iter do
+                type_vars param canonicalize_type_var new_params.push
+            done
+            new_params generic.base GenericType Type::Generic
+        }
+        Type::Function(fn_type) => {
+            List::new(List[Type]) = new_params
+            for param in fn_type.parameters.iter do
+                type_vars param canonicalize_type_var new_params.push
+            done
+            List::new(List[Type]) = new_returns
+            for ret in fn_type.return_types.iter do
+                type_vars ret canonicalize_type_var new_returns.push
+            done
+            new_returns new_params FunctionType Type::Function
+        }
+        _ => { typ }
+    end
+}
+
+fn canonicalize_stack_effect_type_vars effect:StackEffect type_vars:Set[str] {
+    if 0 type_vars.length == then return fi
+    0 = index
+    while index effect StackEffect::parameters.length > do
+        index effect StackEffect::parameters.get = param
+        type_vars param Parameter::typ canonicalize_type_var param Parameter::set_typ
+        1 += index
+    done
+    0 = ret_index
+    while ret_index effect StackEffect::return_types.length > do
+        type_vars ret_index effect StackEffect::return_types.get canonicalize_type_var ret_index effect StackEffect::return_types.set
+        1 += ret_index
+    done
+}
+
 fn make_named_type name:str -> Type {
     List::new(List[Type]) name GenericType Type::Generic
 }
@@ -1386,6 +1440,14 @@ fn build_parameterized_type base:str params:List[str] -> str {
     done
     "]" builder.append
     builder.build
+}
+
+fn build_parameterized_type_t base:str params:List[str] -> Type {
+    List::new(List[Type]) = type_params
+    for param in params.iter do
+        param Type::TypeVar type_params.push
+    done
+    type_params base GenericType Type::Generic
 }
 
 fn build_resolved_type base:str type_vars:List[str] bindings:Map[str str] -> str {
@@ -1547,38 +1609,6 @@ fn stack_effect_type_matches expected:Type actual:Type -> bool {
     if expected actual.eq then true return fi
     if expected.is_unknown_placeholder then true return fi
     if actual.is_unknown_placeholder then true return fi
-    expected match
-        Type::Function(_) => { }
-        Type::Generic(expected_generic) => {
-            if 0 expected_generic.params.length == then
-                actual match
-                    Type::Generic(actual_generic) => {
-                        if 0 actual_generic.params.length != expected_generic.base actual_generic.base == && then
-                            true return
-                        fi
-                    }
-                    _ => { }
-                end
-            fi
-        }
-        _ => { }
-    end
-    actual match
-        Type::Function(_) => { }
-        Type::Generic(actual_generic) => {
-            if 0 actual_generic.params.length == then
-                expected match
-                    Type::Generic(expected_generic) => {
-                        if 0 expected_generic.params.length != actual_generic.base expected_generic.base == && then
-                            true return
-                        fi
-                    }
-                    _ => { }
-                end
-            fi
-        }
-        _ => { }
-    end
     expected match
         Type::Function(expected_fn) => {
             actual match

--- a/compiler/syntax.casa
+++ b/compiler/syntax.casa
@@ -1467,12 +1467,8 @@ fn parse_enum parser:Parser cursor:TokenCursor -> CasaEnum {
         name_token Token::location "Enum must have at least one variant" ErrorKind::Syntax raise_error
     fi
 
-    # Canonicalize type variables in variant inner types
     if 0 type_vars.length != then
-        Set::new(Set[str]) = tv_set
-        for tv in type_vars.iter do
-            tv tv_set.add = tv_set
-        done
+        type_vars string_list_to_set = tv_set
         for variant_name in variants.iter do
             variant_name variant_types.get = vt_opt
             if vt_opt.is_some then
@@ -1550,12 +1546,9 @@ fn create_member_accessor
 
     # Parameterize the struct name when the struct has type vars
     struct_name = param_type
-    Set::new(Set[str]) = effect_type_vars
+    type_vars string_list_to_set = effect_type_vars
     if 0 type_vars.length != then
         type_vars struct_name build_parameterized_type = param_type
-        for type_var in type_vars.iter do
-            type_var effect_type_vars.add = effect_type_vars
-        done
     fi
 
     # Getter
@@ -1641,12 +1634,8 @@ fn parse_struct parser:Parser cursor:TokenCursor -> CasaStruct {
         member_type parse_type_str member_token Token::value Member members.push
     done
 
-    # Canonicalize type variables in member types
     if 0 type_vars.length != then
-        Set::new(Set[str]) = struct_tv_set
-        for stv in type_vars.iter do
-            stv struct_tv_set.add = struct_tv_set
-        done
+        type_vars string_list_to_set = struct_tv_set
         for member in members.iter do
             struct_tv_set member Member::typ canonicalize_type_var member Member::set_typ
         done
@@ -1808,12 +1797,8 @@ fn parse_trait parser:Parser cursor:TokenCursor -> CasaTrait {
 
             cursor parse_trait_method_stack_effect = method_stack_effect
 
-            # Canonicalize type variables in trait method stack effect
-            Set::new(Set[str]) = trait_tv_set
+            type_params string_list_to_set = trait_tv_set
             TRAIT_SELF_TYPE trait_tv_set.add = trait_tv_set
-            for tp in type_params.iter do
-                tp trait_tv_set.add = trait_tv_set
-            done
             for mtv in method_type_vars.iter do
                 mtv trait_tv_set.add = trait_tv_set
             done

--- a/compiler/syntax.casa
+++ b/compiler/syntax.casa
@@ -1359,6 +1359,7 @@ fn parse_function parser:Parser cursor:TokenCursor -> Function {
         done
         # Set trait bounds from LAST_TRAIT_BOUNDS (set by parse_type_vars)
         LAST_TRAIT_BOUNDS effect StackEffect::set_trait_bounds
+        effect StackEffect::type_vars effect canonicalize_stack_effect_type_vars
     fi
     List::new(List[Op]) = ops
     List::new(List[Variable]) = variables
@@ -1466,6 +1467,25 @@ fn parse_enum parser:Parser cursor:TokenCursor -> CasaEnum {
         name_token Token::location "Enum must have at least one variant" ErrorKind::Syntax raise_error
     fi
 
+    # Canonicalize type variables in variant inner types
+    if 0 type_vars.length != then
+        Set::new(Set[str]) = tv_set
+        for tv in type_vars.iter do
+            tv tv_set.add = tv_set
+        done
+        for variant_name in variants.iter do
+            variant_name variant_types.get = vt_opt
+            if vt_opt.is_some then
+                vt_opt.unwrap = vt_inner
+                0 = vt_index
+                while vt_index vt_inner.length > do
+                    tv_set vt_index vt_inner.get canonicalize_type_var vt_index vt_inner.set
+                    1 += vt_index
+                done
+            fi
+        done
+    fi
+
     variant_locations type_vars variant_types name_token Token::location variants name_token Token::value CasaEnum
 }
 
@@ -1553,6 +1573,7 @@ fn create_member_accessor
     member_type parse_type_str getter_returns.push
     getter_returns getter_params make_stack_effect = getter_stack_effect
     effect_type_vars getter_stack_effect StackEffect::set_type_vars
+    effect_type_vars getter_stack_effect canonicalize_stack_effect_type_vars
     getter_stack_effect location getter_ops getter_name make_function_with_stack_effect = getter
 
     if getter_name parser.store.functions.get.is_some then
@@ -1574,6 +1595,7 @@ fn create_member_accessor
     List::new(List[Type]) = setter_returns
     setter_returns setter_params make_stack_effect = setter_stack_effect
     effect_type_vars setter_stack_effect StackEffect::set_type_vars
+    effect_type_vars setter_stack_effect canonicalize_stack_effect_type_vars
     setter_stack_effect location setter_ops setter_name make_function_with_stack_effect = setter
 
     if setter_name parser.store.functions.get.is_some then
@@ -1618,6 +1640,17 @@ fn parse_struct parser:Parser cursor:TokenCursor -> CasaStruct {
         type_vars member_token Token::location members.length member_type member_token Token::value name_token Token::value parser create_member_accessor
         member_type parse_type_str member_token Token::value Member members.push
     done
+
+    # Canonicalize type variables in member types
+    if 0 type_vars.length != then
+        Set::new(Set[str]) = struct_tv_set
+        for stv in type_vars.iter do
+            stv struct_tv_set.add = struct_tv_set
+        done
+        for member in members.iter do
+            struct_tv_set member Member::typ canonicalize_type_var member Member::set_typ
+        done
+    fi
 
     type_vars name_token Token::location members name_token Token::value CasaStruct
 }
@@ -1774,6 +1807,17 @@ fn parse_trait parser:Parser cursor:TokenCursor -> CasaTrait {
             fi
 
             cursor parse_trait_method_stack_effect = method_stack_effect
+
+            # Canonicalize type variables in trait method stack effect
+            Set::new(Set[str]) = trait_tv_set
+            TRAIT_SELF_TYPE trait_tv_set.add = trait_tv_set
+            for tp in type_params.iter do
+                tp trait_tv_set.add = trait_tv_set
+            done
+            for mtv in method_type_vars.iter do
+                mtv trait_tv_set.add = trait_tv_set
+            done
+            trait_tv_set method_stack_effect canonicalize_stack_effect_type_vars
 
             # Parse optional default method body
             List::new(List[Op]) = default_ops

--- a/compiler/typechecker.casa
+++ b/compiler/typechecker.casa
@@ -251,9 +251,7 @@ fn expect_type_t tc:TypeChecker expected:Type {
     fi
     tc TypeChecker::live TypedStack::origins.pop drop
     tc TypeChecker::live TypedStack::types.pop = et_actual_t
-    if expected et_actual_t.eq then return fi
-    if et_actual_t expected types_match_t then return fi
-    if expected et_actual_t types_match_t then return fi
+    if tc.store et_actual_t expected unify_type_t.is_some then return fi
     et_actual_t.format = et_actual
     expected.format = et_expected
     "Type mismatch" = et_message
@@ -266,37 +264,6 @@ fn expect_type_t tc:TypeChecker expected:Type {
 # ============================================================================
 # Type compatibility
 # ============================================================================
-
-fn is_enum_type_var_t typ:Type store:SymbolStore -> bool {
-    typ.base = base_opt
-    if base_opt.is_some then
-        base_opt.unwrap store.enums.get.is_some
-    else
-        false
-    fi
-}
-
-fn is_type_variable_t typ:Type store:SymbolStore -> bool {
-    typ match
-        Type::TypeVar(_) => { true }
-        Type::Generic(generic) => {
-            if 0 generic.params.length == then
-                if 1 generic.base.length == then
-                    0 generic.base.at.is_upper
-                else
-                    false
-                fi
-            else
-                generic.base store.enums.get.is_some
-            fi
-        }
-        _ => { false }
-    end
-}
-
-fn types_match_t expected:Type actual:Type -> bool {
-    actual expected stack_effect_type_matches
-}
 
 fn type_exists_recursive_t typ:Type function_opt:Option[Function] store:SymbolStore -> bool {
     typ match
@@ -363,9 +330,8 @@ fn unify_type_t type_a:Type type_b:Type store:SymbolStore -> Option[Type] {
     if type_a type_b.eq then type_a Option::Some return fi
     if type_a.is_unknown_placeholder then type_b Option::Some return fi
     if type_b.is_unknown_placeholder then type_a Option::Some return fi
-    # Enum type variables unify with concrete types.
-    if store type_a is_enum_type_var_t then type_b Option::Some return fi
-    if store type_b is_enum_type_var_t then type_a Option::Some return fi
+    if type_a.has_unresolved_type_var then type_b Option::Some return fi
+    if type_b.has_unresolved_type_var then type_a Option::Some return fi
     type_a.base = base_a
     type_b.base = base_b
     if base_a.is_some then
@@ -470,10 +436,9 @@ fn bind_type_var tc:TypeChecker bindings:Map[str Type] type_var:str actual:Type 
     existing.unwrap = bound
     actual.is_unknown_placeholder = actual_unknown
     bound.is_unknown_placeholder = bound_unknown
-    tc.store bound is_type_variable_t = bound_is_var
     if
     bound_unknown
-    bound_is_var ||
+    bound.has_unresolved_type_var ||
     actual_unknown ! &&
     then
         actual type_var bindings.set return
@@ -482,7 +447,7 @@ fn bind_type_var tc:TypeChecker bindings:Map[str Type] type_var:str actual:Type 
     bound actual.eq !
     actual_unknown ! &&
     bound_unknown ! &&
-    tc.store actual is_enum_type_var_t ! &&
+    actual.has_unresolved_type_var ! &&
     then
         f"Type variable `{type_var}` bound to `{bound.format}` but got `{actual.format}`" tc raise_type_mismatch
     fi
@@ -1336,7 +1301,7 @@ fn type_satisfies_trait
         while param_index resolved StackEffect::parameters.length > do
             param_index function Function::stack_effect StackEffect::parameters.get Parameter::typ = actual_param
             param_index resolved StackEffect::parameters.get Parameter::typ = expected_param
-            if expected_param actual_param types_match_t ! then
+            if actual_param expected_param stack_effect_type_matches ! then
                 false return
             fi
             1 += param_index
@@ -1345,7 +1310,7 @@ fn type_satisfies_trait
         while return_index resolved StackEffect::return_types.length > do
             return_index function Function::stack_effect StackEffect::return_types.get = actual_return
             return_index resolved StackEffect::return_types.get = expected_return
-            if expected_return actual_return types_match_t ! then
+            if actual_return expected_return stack_effect_type_matches ! then
                 false return
             fi
             1 += return_index
@@ -1857,7 +1822,7 @@ fn check_enum_variant tc:TypeChecker op:Op {
     if inner_opt.is_none then
         # No inner values - push the enum type
         if 0 casa_enum CasaEnum::type_vars.length != then
-            casa_enum CasaEnum::type_vars enum_name build_parameterized_type tc stack_push
+            casa_enum CasaEnum::type_vars enum_name build_parameterized_type_t tc stack_push_type
         else
             enum_name make_named_type tc stack_push_type
         fi
@@ -1866,7 +1831,7 @@ fn check_enum_variant tc:TypeChecker op:Op {
     inner_opt.unwrap = inner_types
     if 0 inner_types.length == then
         if 0 casa_enum CasaEnum::type_vars.length != then
-            casa_enum CasaEnum::type_vars enum_name build_parameterized_type tc stack_push
+            casa_enum CasaEnum::type_vars enum_name build_parameterized_type_t tc stack_push_type
         else
             enum_name make_named_type tc stack_push_type
         fi

--- a/docs/adr/0005-strict-generic-type-matching.md
+++ b/docs/adr/0005-strict-generic-type-matching.md
@@ -1,0 +1,16 @@
+# Strict generic type matching
+
+Generic types must be fully parameterized at all boundaries: function parameters, variable assignments, and stack effect declarations. Bare generic types like `self:Option` (without type parameters) are no longer accepted; write `[T] self:Option[T]` instead. The type unifier rejects incompatible concrete types even when one side is an enum, closing a hole where `Option[int]` could silently unify with `str` or `Option[str]` during variable assignment.
+
+**Considered Options**
+
+- Keep the zero-param matching rule and only fix `is_enum_type_var_t`: rejected because bare generic types erase type parameters, silently bypassing the type checker for any code that omits them. Two separate permissiveness holes are easier to reason about as one policy.
+- Require full parameterization only in function signatures, not variable types: rejected because the unification bug is in variable assignment (`unify_type_t`), and allowing bare generics anywhere keeps the ambiguity between `Type::Generic("Option", [])` meaning "Option with erased params" vs "Option with unknown params."
+
+**Consequences**
+
+- `is_enum_type_var_t` is replaced by a check for unresolved `Type::TypeVar` nodes in the type tree. `Option[T]` (unresolved) unifies flexibly; `Option[int]` (resolved) unifies structurally.
+- `is_type_variable_t` is deleted. `type_var_name` only matches `Type::TypeVar`.
+- `types_match_t` is deleted. `expect_type_t` uses `unify_type_t`; `type_satisfies_trait` and `stack_effect_matches` call `stack_effect_type_matches` directly.
+- The zero-param-matches-any-param rule in `stack_effect_type_matches` is removed.
+- Stdlib methods `is_ok`, `is_some`, `is_none`, `is_error` gain explicit type parameters.

--- a/lib/std.casa
+++ b/lib/std.casa
@@ -613,13 +613,13 @@ enum Option[T] { None Some (T) }
 enum Result[T E] { Error (E) Ok (T) }
 
 impl Option {
-    fn is_ok self:Option -> bool {
+    fn is_ok [T] self:Option[T] -> bool {
         self (ptr) load64 1 ==
     }
-    fn is_some self:Option -> bool {
+    fn is_some [T] self:Option[T] -> bool {
         self (ptr) load64 1 ==
     }
-    fn is_none self:Option -> bool {
+    fn is_none [T] self:Option[T] -> bool {
         self (ptr) load64 0 ==
     }
     fn unwrap [T] self:Option[T] -> T {
@@ -671,10 +671,10 @@ impl Option {
 }
 
 impl Result {
-    fn is_ok self:Result -> bool {
+    fn is_ok [T E] self:Result[T E] -> bool {
         self (ptr) load64 1 ==
     }
-    fn is_error self:Result -> bool {
+    fn is_error [T E] self:Result[T E] -> bool {
         self (ptr) load64 0 ==
     }
     fn unwrap [T E] self:Result[T E] -> T {

--- a/tests/compiler/errors/generic_enum_param_mismatch.casa
+++ b/tests/compiler/errors/generic_enum_param_mismatch.casa
@@ -1,0 +1,8 @@
+# expect: TYPE_MISMATCH
+import "std"
+
+fn takes_option_str x:Option[str] { x drop }
+
+fn main {
+    42 Option::Some takes_option_str
+}

--- a/tests/compiler/errors/generic_enum_type_mismatch.casa
+++ b/tests/compiler/errors/generic_enum_type_mismatch.casa
@@ -1,0 +1,6 @@
+# expect: SIGNATURE_MISMATCH
+import "std"
+
+fn bad -> Option[str] {
+    42 Option::Some
+}

--- a/tests/compiler/test_typechecker.casa
+++ b/tests/compiler/test_typechecker.casa
@@ -472,17 +472,17 @@ fn test_argc_argv {
 }
 
 # ============================================================================
-# Tests: types_match_t
+# Tests: stack_effect_type_matches
 # ============================================================================
 
 fn test_types_match {
-    "types_match_t" test_start
-    "same types" "int" parse_type_str "int" parse_type_str types_match_t assert_true
-    "TYPE_UNKNOWN matches int" "int" parse_type_str TYPE_UNKNOWN_T types_match_t assert_true
-    "int matches TYPE_UNKNOWN" TYPE_UNKNOWN_T "int" parse_type_str types_match_t assert_true
-    "different types" "str" parse_type_str "int" parse_type_str types_match_t ! assert_true
-    "fn base matches fn type" "fn[int -> int]" parse_type_str "fn" parse_type_str types_match_t assert_true
-    "generic base matches" "List[int]" parse_type_str "List" parse_type_str types_match_t assert_true
+    "stack_effect_type_matches" test_start
+    "same types" "int" parse_type_str "int" parse_type_str stack_effect_type_matches assert_true
+    "TYPE_UNKNOWN matches int" "int" parse_type_str TYPE_UNKNOWN_T stack_effect_type_matches assert_true
+    "int matches TYPE_UNKNOWN" TYPE_UNKNOWN_T "int" parse_type_str stack_effect_type_matches assert_true
+    "different types" "str" parse_type_str "int" parse_type_str stack_effect_type_matches ! assert_true
+    "fn base matches fn type" "fn[int -> int]" parse_type_str "fn" parse_type_str stack_effect_type_matches assert_true
+    "bare generic rejects parameterized" "List[int]" parse_type_str "List" parse_type_str stack_effect_type_matches ! assert_true
 }
 
 # ============================================================================
@@ -1014,12 +1014,12 @@ fn test_tc_pipeline_div_mod {
 
 fn test_types_match_extended {
     "types_match_extended" test_start
-    "both unknown" TYPE_UNKNOWN_T TYPE_UNKNOWN_T types_match_t assert_true
-    "str str" "str" parse_type_str "str" parse_type_str types_match_t assert_true
-    "bool bool" "bool" parse_type_str "bool" parse_type_str types_match_t assert_true
-    "ptr ptr" "ptr" parse_type_str "ptr" parse_type_str types_match_t assert_true
-    "int vs str" "int" parse_type_str "str" parse_type_str types_match_t ! assert_true
-    "int vs bool" "int" parse_type_str "bool" parse_type_str types_match_t ! assert_true
+    "both unknown" TYPE_UNKNOWN_T TYPE_UNKNOWN_T stack_effect_type_matches assert_true
+    "str str" "str" parse_type_str "str" parse_type_str stack_effect_type_matches assert_true
+    "bool bool" "bool" parse_type_str "bool" parse_type_str stack_effect_type_matches assert_true
+    "ptr ptr" "ptr" parse_type_str "ptr" parse_type_str stack_effect_type_matches assert_true
+    "int vs str" "int" parse_type_str "str" parse_type_str stack_effect_type_matches ! assert_true
+    "int vs bool" "int" parse_type_str "bool" parse_type_str stack_effect_type_matches ! assert_true
 }
 
 # ============================================================================
@@ -1573,10 +1573,10 @@ fn test_stacks_compatible_different_types {
 
 fn test_types_match_fn_types {
     "types_match_fn_types" test_start
-    "fn matches fn type" "fn[int -> int]" parse_type_str "fn" parse_type_str types_match_t assert_true
-    "fn type matches fn" "fn" parse_type_str "fn[int -> int]" parse_type_str types_match_t assert_true
-    "fn type matches same" "fn[int -> int]" parse_type_str "fn[int -> int]" parse_type_str types_match_t assert_true
-    "fn type mismatch" "fn[int -> int]" parse_type_str "fn[str -> str]" parse_type_str types_match_t ! assert_true
+    "fn matches fn type" "fn[int -> int]" parse_type_str "fn" parse_type_str stack_effect_type_matches assert_true
+    "fn type matches fn" "fn" parse_type_str "fn[int -> int]" parse_type_str stack_effect_type_matches assert_true
+    "fn type matches same" "fn[int -> int]" parse_type_str "fn[int -> int]" parse_type_str stack_effect_type_matches assert_true
+    "fn type mismatch" "fn[int -> int]" parse_type_str "fn[str -> str]" parse_type_str stack_effect_type_matches ! assert_true
 }
 
 # ============================================================================
@@ -1585,10 +1585,10 @@ fn test_types_match_fn_types {
 
 fn test_types_match_array_types {
     "types_match_array_types" test_start
-    "array matches array" "array[int]" parse_type_str "array" parse_type_str types_match_t assert_true
-    "array base matches typed" "array" parse_type_str "array[int]" parse_type_str types_match_t assert_true
-    "array typed matches same" "array[int]" parse_type_str "array[int]" parse_type_str types_match_t assert_true
-    "array typed mismatch" "array[int]" parse_type_str "array[str]" parse_type_str types_match_t ! assert_true
+    "bare array rejects parameterized" "array[int]" parse_type_str "array" parse_type_str stack_effect_type_matches ! assert_true
+    "parameterized rejects bare array" "array" parse_type_str "array[int]" parse_type_str stack_effect_type_matches ! assert_true
+    "array typed matches same" "array[int]" parse_type_str "array[int]" parse_type_str stack_effect_type_matches assert_true
+    "array typed mismatch" "array[int]" parse_type_str "array[str]" parse_type_str stack_effect_type_matches ! assert_true
 }
 
 # ============================================================================


### PR DESCRIPTION
## Summary

- Fix type safety hole where `Option[int]` could silently unify with `str` or `Option[str]` during variable assignment (caused by `is_enum_type_var_t` treating any enum-based type as a type variable)
- Canonicalize type variables to `Type::TypeVar` at parse time, removing the single-uppercase-letter restriction and eliminating three heuristic functions (`is_enum_type_var_t`, `is_type_variable_t`, `types_match_t`)
- Remove zero-param-matches-any-param rule from `stack_effect_type_matches`; require fully parameterized types on stdlib `Option`/`Result` methods

## Test plan

- [x] All 54 compiler tests pass (including 2 new error tests for generic enum mismatches)
- [x] All 47 example tests pass (including `generics.casa` with multi-char type vars `T1`, `T2`)
- [x] Bootstrap self-compilation and fixed-point verification pass
- [x] Verified `Option[int]` assigned to `str` variable now produces `INVALID_VARIABLE` error
- [x] Verified `Option[int]` passed to `Option[str]` parameter now produces `TYPE_MISMATCH` error