### PR TITLE
feat: add contains method to List[str] and array[str]

### DIFF
--- a/lib/std.casa
+++ b/lib/std.casa
@@ -1195,6 +1195,26 @@ impl List[str] {
         done
         builder.build
     }
+
+    fn contains self:List[str] needle:str -> bool {
+        0 = i
+        while i self.length > do
+            if needle i self.get == then true return fi
+            1 += i
+        done
+        false
+    }
+}
+
+impl array[str] {
+    fn contains self:array[str] needle:str -> bool {
+        0 = i
+        while i self.length > do
+            if needle i self.nth == then true return fi
+            1 += i
+        done
+        false
+    }
 }
 
 impl str {

--- a/tests/compiler/test_list_contains.casa
+++ b/tests/compiler/test_list_contains.casa
@@ -1,0 +1,62 @@
+import "std"
+
+0 = test_pass_count
+0 = test_fail_count
+"" = test_current_name
+
+fn test_start name:str {
+    name = test_current_name
+}
+
+fn assert_true condition:bool message:str {
+    if condition then
+        1 += test_pass_count
+    else
+        f"[FAIL] {test_current_name}: {message}\n" eprint
+        1 += test_fail_count
+    fi
+}
+
+fn assert_false condition:bool message:str {
+    message condition ! assert_true
+}
+
+fn test_summary {
+    f"{test_pass_count} passed, {test_fail_count} failed\n" print
+    if 0 test_fail_count > then
+        1 exit
+    fi
+}
+
+# ============================================================================
+# List.contains
+# ============================================================================
+"contains finds present element" test_start
+"b" ["a", "b", "c"].contains = found
+"should find 'b' in list" found assert_true
+"contains returns false for absent element" test_start
+"z" ["a", "b", "c"].contains = not_found
+"should not find 'z' in list" not_found assert_false
+"contains on empty list via to_array" test_start
+"a" List::new(List[str]).contains = empty_result
+"should return false for empty list" empty_result assert_false
+"List contains finds present element" test_start
+List::new(List[str]) = items
+"x" items.push
+"y" items.push
+"z" items.push
+"y" items.contains = list_found
+"should find 'y' in List" list_found assert_true
+"List contains returns false for absent element" test_start
+"w" items.contains = list_not_found
+"should not find 'w' in List" list_not_found assert_false
+"List contains on empty list" test_start
+"a" List::new(List[str]).contains = list_empty
+"should return false for empty List" list_empty assert_false
+"contains finds first element" test_start
+"a" ["a", "b", "c"].contains = first
+"should find first element" first assert_true
+"contains finds last element" test_start
+"c" ["a", "b", "c"].contains = last
+"should find last element" last assert_true
+test_summary


### PR DESCRIPTION
## Summary

- Add `fn contains` to `impl List[str]` and `impl array[str]` in stdlib
- Enables membership checks like `value ["a", "b", "c"].contains`
- Both implementations use direct loops for zero unnecessary allocation

## Test plan

- [x] New test file `tests/compiler/test_list_contains.casa` with 8 assertions
- [x] `tests/test_compiler.sh` passes (55/55)
- [x] `tests/test_examples.sh` passes (47/47)