### PR TITLE
refactor: explicit compiler diagnostics via PassResult

### DIFF
--- a/casa.casa
+++ b/casa.casa
@@ -58,31 +58,41 @@ fn main {
     fi
 
     Timer::new = timer
+    Diagnostics::new = diags
 
     # Lex
     f"{timer} Lexing {CLI_INPUT}" log_info
-    CLI_INPUT lex_file = tokens
+    CLI_INPUT lex_file = lex_result
+    lex_result.diagnostics diags.merge
+    lex_result.value = tokens
 
     # Parse
     f"{timer} Parsing ops" log_info
     CLI_LIBRARY_PATHS tokens parse_and_resolve = parse_result
-    parse_result ParseResolveResult::ops = ops
-    parse_result ParseResolveResult::store = store
+    parse_result.diagnostics diags.merge
+    parse_result.value ParseResolveResult::ops = ops
+    parse_result.value ParseResolveResult::store = store
 
     # Type check
     f"{timer} Type checking ops" log_info
-    store Option::None ops type_check_ops drop
-    store type_check_functions
+    store Option::None ops type_check_ops = tc_result
+    tc_result.diagnostics diags.merge
+    store type_check_functions = tc_func_diags
+    tc_func_diags diags.merge
 
     # Check for errors
-    flush_errors
+    if TEST_MODE ! RESILIENT_MODE ! && then
+        diags.report_and_exit_if_errors
+    fi
 
     # Report warnings
-    report_warnings
+    diags.report_warnings
 
     # Compile bytecode
     f"{timer} Compiling bytecode" log_info
-    ops store compile_bytecode = program
+    ops store compile_bytecode = bc_result
+    bc_result.diagnostics diags.merge
+    bc_result.value = program
 
     # Emit assembly
     f"{timer} Emitting assembly" log_info

--- a/casa.casa
+++ b/casa.casa
@@ -70,8 +70,9 @@ fn main {
     f"{timer} Parsing ops" log_info
     CLI_LIBRARY_PATHS tokens parse_and_resolve = parse_result
     parse_result.diagnostics diags.merge
-    parse_result.value ParseResolveResult::ops = ops
-    parse_result.value ParseResolveResult::store = store
+    parse_result.value = resolved
+    resolved ParseResolveResult::ops = ops
+    resolved ParseResolveResult::store = store
 
     # Type check
     f"{timer} Type checking ops" log_info

--- a/compiler/bytecode.casa
+++ b/compiler/bytecode.casa
@@ -1082,7 +1082,8 @@ fn compile_ops compiler:BytecodeCompiler bytecode:List[InstValue] {
 # Main entry: compile_bytecode
 # ============================================================================
 
-fn compile_bytecode store:SymbolStore ops:List[Op] -> Program {
+fn compile_bytecode store:SymbolStore ops:List[Op] -> PassResult[Program] {
+    diagnostics_snapshot = snap
     reset_labels
 
     List::new(List[InstValue]) = bytecode
@@ -1122,5 +1123,7 @@ fn compile_bytecode store:SymbolStore ops:List[Op] -> Program {
     compiler.string_table
     functions
     bytecode
-    Program
+    Program = program
+
+    snap diagnostics_collect_since program PassResult
 }

--- a/compiler/error.casa
+++ b/compiler/error.casa
@@ -57,6 +57,68 @@ struct CasaWarning {
 }
 
 # ============================================================================
+# Diagnostics — explicit pass result shape for compiler phases
+# ============================================================================
+
+struct Diagnostics {
+    errors:   List[CasaError]
+    warnings: List[CasaWarning]
+}
+
+struct PassResult[T] {
+    value:       T
+    diagnostics: Diagnostics
+}
+
+impl Diagnostics {
+    fn new -> Diagnostics {
+        List::new(List[CasaWarning]) List::new(List[CasaError]) Diagnostics
+    }
+
+    fn has_errors self:Diagnostics -> bool {
+        0 self.errors.length !=
+    }
+
+    fn error_count self:Diagnostics -> int {
+        self.errors.length
+    }
+
+    fn warning_count self:Diagnostics -> int {
+        self.warnings.length
+    }
+
+    fn merge self:Diagnostics other:Diagnostics {
+        for error in other.errors.iter do
+            error self.errors.push
+        done
+        for warning in other.warnings.iter do
+            warning self.warnings.push
+        done
+    }
+
+    fn report_and_exit_if_errors self:Diagnostics {
+        if self.has_errors then
+            self.errors report_errors
+            1 exit
+        fi
+    }
+
+    fn report_warnings self:Diagnostics {
+        for warning in self.warnings.iter do
+            StringBuilder::new = builder
+            "warning[" builder.append
+            warning CasaWarning::kind match
+                WarningKind::UnusedParameter => "UNUSED_PARAMETER" builder.append
+                WarningKind::LossyTypeAnnotation => "LOSSY_TYPE_ANNOTATION" builder.append
+            end
+            "]: " builder.append
+            warning CasaWarning::message builder.append
+            builder.build eprintln
+        done
+    }
+}
+
+# ============================================================================
 # Source position utilities
 # ============================================================================
 
@@ -322,4 +384,29 @@ fn flush_errors {
             1 exit
         fi
     fi
+}
+
+# ============================================================================
+# Compatibility helpers for incremental migration
+# ============================================================================
+
+fn diagnostics_snapshot -> Pair[int int] {
+    WARNINGS.length ERRORS.length Pair
+}
+
+fn diagnostics_collect_since snapshot:Pair[int int] -> Diagnostics {
+    snapshot.first = errors_start
+    snapshot.second = warnings_start
+    Diagnostics::new = diags
+    errors_start = i
+    while i ERRORS.length > do
+        i ERRORS.get diags.errors.push
+        1 += i
+    done
+    warnings_start = j
+    while j WARNINGS.length > do
+        j WARNINGS.get diags.warnings.push
+        1 += j
+    done
+    diags
 }

--- a/compiler/error.casa
+++ b/compiler/error.casa
@@ -335,20 +335,6 @@ fn report_errors errors:List[CasaError] {
     f"Found {errors.length} error(s)." eprintln
 }
 
-fn report_warnings {
-    for warning in WARNINGS.iter do
-        StringBuilder::new = builder
-        "warning[" builder.append
-        warning CasaWarning::kind match
-            WarningKind::UnusedParameter => "UNUSED_PARAMETER" builder.append
-            WarningKind::LossyTypeAnnotation => "LOSSY_TYPE_ANNOTATION" builder.append
-        end
-        "]: " builder.append
-        warning CasaWarning::message builder.append
-        builder.build eprintln
-    done
-}
-
 # ============================================================================
 # Convenience functions
 # ============================================================================

--- a/compiler/lexer.casa
+++ b/compiler/lexer.casa
@@ -524,7 +524,7 @@ fn lex_source code:str file:str -> List[Token] {
     file code Lexer::new.lex
 }
 
-fn lex_file path:str -> List[Token] {
+fn lex_file path:str -> PassResult[List[Token]] {
     global SOURCE_CACHE
     path file::read_all = read_result
     if read_result Result::Error(read_err) is then
@@ -533,7 +533,9 @@ fn lex_file path:str -> List[Token] {
     fi
     read_result.unwrap = code
     code path SOURCE_CACHE.set = SOURCE_CACHE
-    path code Lexer::new.lex
+    diagnostics_snapshot = snap
+    path code Lexer::new.lex = tokens
+    snap diagnostics_collect_since tokens PassResult
 }
 
 fn lex_source_fmt code:str file:str -> List[Token] {

--- a/compiler/syntax.casa
+++ b/compiler/syntax.casa
@@ -2500,7 +2500,7 @@ fn handle_selective_import parser:Parser selective:SelectiveImport location:Loca
     symbol_store_new make_parser = import_parser
     parser.search_paths import_parser->search_paths
     import_path import_parser.included_files.add drop
-    import_path lex_file = import_tokens
+    import_path lex_file.value = import_tokens
     import_tokens import_parser parse_ops = import_ops
     import_ops import_parser resolve_identifiers_global drop
 
@@ -3052,13 +3052,15 @@ fn parse_ops parser:Parser tokens:List[Token] -> List[Op] {
     ops
 }
 
-fn parse_and_resolve tokens:List[Token] search_paths:List[str] -> ParseResolveResult {
+fn parse_and_resolve tokens:List[Token] search_paths:List[str] -> PassResult[ParseResolveResult] {
+    diagnostics_snapshot = snap
     symbol_store_new make_parser = parser
     search_paths parser Parser::set_search_paths
     tokens parser parse_ops = ops
     ops parser resolve_identifiers_global = resolved_ops
     parser derive_hashable_for_enums
-    parser.store resolved_ops ParseResolveResult
+    parser.store resolved_ops ParseResolveResult = result
+    snap diagnostics_collect_since result PassResult
 }
 
 # ============================================================================
@@ -3166,7 +3168,7 @@ fn expand_imports parser:Parser ops:List[Op] -> List[Op] {
             fi
             if import_path parser.included_files.has ! then
                 import_path parser.included_files.add drop
-                import_path lex_file = import_tokens
+                import_path lex_file.value = import_tokens
                 import_tokens parser parse_ops = import_ops
                 List::new(List[Op]) = new_ops
                 0 = name_index

--- a/compiler/typechecker.casa
+++ b/compiler/typechecker.casa
@@ -2440,7 +2440,8 @@ fn ensure_typechecked function:Function store:SymbolStore {
     true function Function::set_is_typechecked
     function function Function::ops store resolve_identifiers = resolved_ops
     resolved_ops function Function::set_ops
-    store function Option::Some resolved_ops type_check_ops = inferred_stack_effect
+    store function Option::Some resolved_ops type_check_ops = tc_result
+    tc_result.value = inferred_stack_effect
     if function Function::stack_effect stack_effect_to_str "None -> None" == then
         inferred_stack_effect function Function::set_stack_effect
     fi
@@ -2729,7 +2730,11 @@ fn run_type_check_ops checker:TypeChecker ops:List[Op] function_opt:Option[Funct
     done
 }
 
-fn type_check_ops ops:List[Op] function_opt:Option[Function] store:SymbolStore -> StackEffect {
+fn type_check_ops
+    ops:List[Op]
+    function_opt:Option[Function]
+    store:SymbolStore
+-> PassResult[StackEffect] {
     store make_typechecker = checker
     -1 = budget
     if function_opt.is_some then
@@ -2739,6 +2744,7 @@ fn type_check_ops ops:List[Op] function_opt:Option[Function] store:SymbolStore -
         fi
     fi
     budget checker TypeChecker::set_param_cap
+    diagnostics_snapshot = snap
     ERRORS.length = errors_before_ops
     function_opt ops checker run_type_check_ops
 
@@ -2768,14 +2774,15 @@ fn type_check_ops ops:List[Op] function_opt:Option[Function] store:SymbolStore -
         fi
     fi
 
-    inferred
+    snap diagnostics_collect_since inferred PassResult
 }
 
 # ============================================================================
 # Type check all functions
 # ============================================================================
 
-fn type_check_functions store:SymbolStore {
+fn type_check_functions store:SymbolStore -> Diagnostics {
+    diagnostics_snapshot = snap
     for pair in store.functions.iter do
         pair.first = func_name
         pair.second = current_fn
@@ -2793,7 +2800,8 @@ fn type_check_functions store:SymbolStore {
             continue
         fi
         ERRORS.length = errors_before
-        store current_fn Option::Some current_fn Function::ops type_check_ops = inferred_stack_effect
+        store current_fn Option::Some current_fn Function::ops type_check_ops = tc_result
+        tc_result.value = inferred_stack_effect
         ERRORS.length errors_before < = had_errors
         if had_errors then
             continue
@@ -2802,5 +2810,5 @@ fn type_check_functions store:SymbolStore {
             inferred_stack_effect current_fn Function::set_stack_effect
         fi
     done
-    flush_errors
+    snap diagnostics_collect_since
 }

--- a/lib/test.casa
+++ b/lib/test.casa
@@ -154,5 +154,5 @@ fn clear_global_state {
 
 fn parse_resolve_test_source code:str -> ParseResolveResult {
     "test" code lex_source = tokens
-    List::new(List[str]) tokens parse_and_resolve
+    List::new(List[str]) tokens parse_and_resolve.value
 }

--- a/lsp.casa
+++ b/lsp.casa
@@ -314,13 +314,13 @@ fn compile_document file_path:str source:str open_docs:Map[str DocumentState] ->
 
     # Parse
     LSP_LIBRARY_PATHS tokens parse_and_resolve = parse_result
-    parse_result ParseResolveResult::ops = ops
-    parse_result ParseResolveResult::store = store
+    parse_result.value ParseResolveResult::ops = ops
+    parse_result.value ParseResolveResult::store = store
 
     # Type check
     if 0 ops.length != then
         store Option::None ops type_check_ops drop
-        store type_check_functions
+        store type_check_functions drop
     fi
 
     # Snapshot file source (post-include)

--- a/tests/compiler/test_argv.casa
+++ b/tests/compiler/test_argv.casa
@@ -15,7 +15,7 @@ fn tc_string_argv code:str -> StackEffect {
     code parse_resolve_test_source = result
     result ParseResolveResult::ops = ops
     result ParseResolveResult::store = store
-    store Option::None(Option[Function]) ops type_check_ops
+    store Option::None(Option[Function]) ops type_check_ops.value
 }
 
 fn compile_string_argv code:str -> Program {
@@ -23,7 +23,7 @@ fn compile_string_argv code:str -> Program {
     result ParseResolveResult::ops = ops
     result ParseResolveResult::store = store
     store Option::None(Option[Function]) ops type_check_ops drop
-    ops store compile_bytecode
+    ops store compile_bytecode.value
 }
 
 fn emit_string_argv code:str -> str {
@@ -64,14 +64,14 @@ fn test_lex_argv {
 fn test_parse_argc {
     "parse_argc" test_start
     "test" "argc" lex_source = tokens
-    List::new(List[str]) tokens parse_and_resolve ParseResolveResult::ops = ops
+    List::new(List[str]) tokens parse_and_resolve.value ParseResolveResult::ops = ops
     "argc kind" 0 ops.get.value OpValue::Argc is assert_true
 }
 
 fn test_parse_argv {
     "parse_argv" test_start
     "test" "argv" lex_source = tokens
-    List::new(List[str]) tokens parse_and_resolve ParseResolveResult::ops = ops
+    List::new(List[str]) tokens parse_and_resolve.value ParseResolveResult::ops = ops
     "argv kind" 0 ops.get.value OpValue::Argv is assert_true
 }
 

--- a/tests/compiler/test_array_methods.casa
+++ b/tests/compiler/test_array_methods.casa
@@ -21,7 +21,7 @@ fn tc_am code:str -> StackEffect {
     code parse_resolve_test_source = result
     result ParseResolveResult::ops = ops
     result ParseResolveResult::store = store
-    store Option::None(Option[Function]) ops type_check_ops
+    store Option::None(Option[Function]) ops type_check_ops.value
 }
 
 fn compile_am code:str -> Program {
@@ -30,7 +30,7 @@ fn compile_am code:str -> Program {
     result ParseResolveResult::ops = ops
     result ParseResolveResult::store = store
     store Option::None(Option[Function]) ops type_check_ops drop
-    ops store compile_bytecode
+    ops store compile_bytecode.value
 }
 
 fn emit_am code:str -> str {

--- a/tests/compiler/test_compare.casa
+++ b/tests/compiler/test_compare.casa
@@ -19,7 +19,7 @@ fn compare_test_typecheck code:str -> StackEffect {
     code parse_resolve_test_source = result
     result ParseResolveResult::ops = ops
     result ParseResolveResult::store = store
-    store Option::None(Option[Function]) ops type_check_ops
+    store Option::None(Option[Function]) ops type_check_ops.value
 }
 
 fn compare_test_typecheck_ops code:str -> List[Op] {
@@ -38,7 +38,7 @@ fn compare_test_typecheck_error code:str -> StackEffect {
     code parse_resolve_test_source = result
     result ParseResolveResult::ops = ops
     result ParseResolveResult::store = store
-    store Option::None(Option[Function]) ops type_check_ops
+    store Option::None(Option[Function]) ops type_check_ops.value
 }
 
 # ============================================================================

--- a/tests/compiler/test_display.casa
+++ b/tests/compiler/test_display.casa
@@ -29,7 +29,7 @@ fn display_test_typecheck code:str -> StackEffect {
     code parse_resolve_test_source = result
     result ParseResolveResult::ops = ops
     result ParseResolveResult::store = DISPLAY_TEST_STORE
-    DISPLAY_TEST_STORE Option::None(Option[Function]) ops type_check_ops
+    DISPLAY_TEST_STORE Option::None(Option[Function]) ops type_check_ops.value
 }
 
 fn display_test_typecheck_ops code:str -> List[Op] {
@@ -50,7 +50,7 @@ fn display_test_typecheck_error code:str -> StackEffect {
     code parse_resolve_test_source = result
     result ParseResolveResult::ops = ops
     result ParseResolveResult::store = DISPLAY_TEST_STORE
-    DISPLAY_TEST_STORE Option::None(Option[Function]) ops type_check_ops
+    DISPLAY_TEST_STORE Option::None(Option[Function]) ops type_check_ops.value
 }
 
 fn count_op_kind ops:List[Op] kind:OpValue -> int {

--- a/tests/compiler/test_enum.casa
+++ b/tests/compiler/test_enum.casa
@@ -47,7 +47,7 @@ fn tc_enum code:str -> StackEffect {
     code parse_resolve_test_source = result
     result ParseResolveResult::ops = ops
     result ParseResolveResult::store = ENUM_TEST_STORE
-    ENUM_TEST_STORE Option::None(Option[Function]) ops type_check_ops
+    ENUM_TEST_STORE Option::None(Option[Function]) ops type_check_ops.value
 }
 
 fn compile_enum code:str -> Program {
@@ -57,7 +57,7 @@ fn compile_enum code:str -> Program {
     result ParseResolveResult::ops = ops
     result ParseResolveResult::store = ENUM_TEST_STORE
     ENUM_TEST_STORE Option::None(Option[Function]) ops type_check_ops drop
-    ops ENUM_TEST_STORE compile_bytecode
+    ops ENUM_TEST_STORE compile_bytecode.value
 }
 
 fn is_push_enum_variant value:OpValue -> bool { value OpValue::PushEnumVariant is }

--- a/tests/compiler/test_enum_variant_hint.casa
+++ b/tests/compiler/test_enum_variant_hint.casa
@@ -17,7 +17,7 @@ fn tc_evh code:str -> StackEffect {
     code parse_resolve_test_source = result
     result ParseResolveResult::ops = ops
     result ParseResolveResult::store = store
-    store Option::None(Option[Function]) ops type_check_ops
+    store Option::None(Option[Function]) ops type_check_ops.value
 }
 
 # ============================================================================

--- a/tests/compiler/test_generic_structs.casa
+++ b/tests/compiler/test_generic_structs.casa
@@ -26,7 +26,7 @@ fn tc_gs code:str -> StackEffect {
     code parse_resolve_test_source = result
     result ParseResolveResult::ops = ops
     result ParseResolveResult::store = store
-    store Option::None(Option[Function]) ops type_check_ops
+    store Option::None(Option[Function]) ops type_check_ops.value
 }
 
 fn compile_gs code:str -> Program {
@@ -35,7 +35,7 @@ fn compile_gs code:str -> Program {
     result ParseResolveResult::ops = ops
     result ParseResolveResult::store = store
     store Option::None(Option[Function]) ops type_check_ops drop
-    ops store compile_bytecode
+    ops store compile_bytecode.value
 }
 
 fn emit_gs code:str -> str {

--- a/tests/compiler/test_match_underflow.casa
+++ b/tests/compiler/test_match_underflow.casa
@@ -14,7 +14,7 @@ fn tc_mu code:str -> StackEffect {
     code parse_resolve_test_source = result
     result ParseResolveResult::ops = ops
     result ParseResolveResult::store = store
-    store Option::None(Option[Function]) ops type_check_ops
+    store Option::None(Option[Function]) ops type_check_ops.value
 }
 
 # ============================================================================

--- a/tests/compiler/test_struct_literal.casa
+++ b/tests/compiler/test_struct_literal.casa
@@ -27,7 +27,7 @@ fn sl_typecheck code:str -> StackEffect {
     code parse_resolve_test_source = result
     result ParseResolveResult::ops = ops
     result ParseResolveResult::store = store
-    store Option::None(Option[Function]) ops type_check_ops
+    store Option::None(Option[Function]) ops type_check_ops.value
 }
 
 fn sl_compile code:str -> Program {
@@ -36,7 +36,7 @@ fn sl_compile code:str -> Program {
     result ParseResolveResult::ops = ops
     result ParseResolveResult::store = store
     store Option::None(Option[Function]) ops type_check_ops drop
-    ops store compile_bytecode
+    ops store compile_bytecode.value
 }
 
 fn sl_is_struct_literal value:OpValue -> bool { value OpValue::StructLiteral is }

--- a/tests/compiler/test_traits.casa
+++ b/tests/compiler/test_traits.casa
@@ -37,7 +37,7 @@ fn trait_test_typecheck code:str -> StackEffect {
     code parse_resolve_test_source = result
     result ParseResolveResult::ops = ops
     result ParseResolveResult::store = TRAIT_TEST_STORE
-    TRAIT_TEST_STORE Option::None(Option[Function]) ops type_check_ops
+    TRAIT_TEST_STORE Option::None(Option[Function]) ops type_check_ops.value
 }
 
 # ============================================================================

--- a/tests/compiler/test_type_annotations.casa
+++ b/tests/compiler/test_type_annotations.casa
@@ -29,7 +29,7 @@ fn tc_code code:str -> StackEffect {
     code parse_resolve_test_source = result
     result ParseResolveResult::ops = ops
     result ParseResolveResult::store = TYPE_ANNOTATION_TEST_STORE
-    TYPE_ANNOTATION_TEST_STORE Option::None(Option[Function]) ops type_check_ops
+    TYPE_ANNOTATION_TEST_STORE Option::None(Option[Function]) ops type_check_ops.value
 }
 
 fn find_assign_ops ops:List[Op] -> List[Op] {

--- a/tests/compiler/test_typechecker.casa
+++ b/tests/compiler/test_typechecker.casa
@@ -532,7 +532,7 @@ fn test_typecheck_simple_expression {
     "10 20 +" parse_resolve_test_source = result
     result ParseResolveResult::ops = ops
     result ParseResolveResult::store = store
-    store Option::None(Option[Function]) ops type_check_ops = sig
+    store Option::None(Option[Function]) ops type_check_ops.value = sig
     "params" 0 sig StackEffect::parameters.length assert_eq
     "returns" 1 sig StackEffect::return_types.length assert_eq
     "return type" "int" 0 sig StackEffect::return_types.get.format assert_str_eq
@@ -546,7 +546,7 @@ fn tc_string code:str -> StackEffect {
     code parse_resolve_test_source = result
     result ParseResolveResult::ops = ops
     result ParseResolveResult::store = store
-    store Option::None(Option[Function]) ops type_check_ops
+    store Option::None(Option[Function]) ops type_check_ops.value
 }
 
 # ============================================================================
@@ -1056,7 +1056,7 @@ fn tc_string_error code:str -> StackEffect {
     code parse_resolve_test_source = result
     result ParseResolveResult::ops = ops
     result ParseResolveResult::store = store
-    store Option::None(Option[Function]) ops type_check_ops
+    store Option::None(Option[Function]) ops type_check_ops.value
 }
 
 # ============================================================================
@@ -1225,7 +1225,7 @@ fn tc_full code:str {
     result ParseResolveResult::ops = ops
     result ParseResolveResult::store = store
     store Option::None(Option[Function]) ops type_check_ops drop
-    store type_check_functions
+    store type_check_functions drop
 }
 
 fn test_error_syscall_non_word_bound_type_var {

--- a/tests/compiler/test_typeof.casa
+++ b/tests/compiler/test_typeof.casa
@@ -15,7 +15,7 @@ fn tc_typeof code:str -> StackEffect {
     code parse_resolve_test_source = result
     result ParseResolveResult::ops = ops
     result ParseResolveResult::store = store
-    store Option::None(Option[Function]) ops type_check_ops
+    store Option::None(Option[Function]) ops type_check_ops.value
 }
 
 fn compile_typeof code:str -> Program {
@@ -23,7 +23,7 @@ fn compile_typeof code:str -> Program {
     result ParseResolveResult::ops = ops
     result ParseResolveResult::store = store
     store Option::None(Option[Function]) ops type_check_ops drop
-    ops store compile_bytecode
+    ops store compile_bytecode.value
 }
 
 fn emit_typeof code:str -> str {
@@ -87,7 +87,7 @@ fn test_lex_typeof {
 fn test_parse_typeof {
     "parse_typeof" test_start
     "test" "42 typeof" lex_source = tokens
-    List::new(List[str]) tokens parse_and_resolve ParseResolveResult::ops = ops
+    List::new(List[str]) tokens parse_and_resolve.value ParseResolveResult::ops = ops
     "typeof kind" 1 ops.get.value OpValue::Typeof is assert_true
 }
 

--- a/tests/compiler/test_underflow_messages.casa
+++ b/tests/compiler/test_underflow_messages.casa
@@ -14,7 +14,7 @@ fn tc_um code:str -> StackEffect {
     code parse_resolve_test_source = result
     result ParseResolveResult::ops = ops
     result ParseResolveResult::store = store
-    store Option::None(Option[Function]) ops type_check_ops
+    store Option::None(Option[Function]) ops type_check_ops.value
 }
 
 # ============================================================================


### PR DESCRIPTION
## Summary

Closes #219.

- Add `Diagnostics` struct and generic `PassResult[T]` to `compiler/error.casa` with snapshot/collect compatibility helpers for incremental migration
- Migrate all 5 phase entry points to return explicit diagnostics: `lex_file`, `parse_and_resolve`, `type_check_ops`, `type_check_functions`, `compile_bytecode`
- Update `casa.casa` main to collect and check diagnostics from each phase instead of relying on `flush_errors` and global `ERRORS`/`WARNINGS`
- Update all callers: LSP, test library, 15 test files
- Remove dead global `report_warnings` (replaced by `Diagnostics.report_warnings`)

## Test plan

- [x] `tests/test_compiler.sh` — 54/54 passed
- [x] `tests/test_examples.sh` — 47/47 passed
- [x] `tests/test_bootstrap.sh` — self-compilation + fixed-point passed