### PR TITLE
feat: emit array literals as static data instead of heap-allocating

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -48,6 +48,10 @@ _Avoid_: Shared compiler context, hidden parser dependency
 The shared representation and flow for compiler diagnostics across lexer, parser, typechecker, and later phases.
 _Avoid_: Typechecker-only diagnostics refactor, phase-local error schema
 
+**Array literal**:
+A bracket-delimited list of values (`[1, 2, 3]`, `["a", "b"]`) that produces a fixed-size `array[T]`. When all elements are compile-time constants, the compiler emits the data into `.data` as a static struct; otherwise the array is heap-allocated at runtime.
+_Avoid_: Static array, const array, inline array
+
 ### Type representation
 
 **Type AST**:
@@ -166,6 +170,9 @@ _Avoid_: Release lint, tag lint
 - The **Default parser** should trend toward zero use as explicit pass boundaries mature; if a slice can remove it fully, it should.
 - A **Typecheck result** may return the same **SymbolStore** reference it received, as long as mutations are represented at the pass boundary.
 - The **Compiler diagnostics schema** should be refactored once across the compiler, not as part of the first **Typecheck result** boundary.
+- An **Array literal** is determined at bytecode compilation time: if all element ops are literal push values, the array qualifies. `const` values and `const fn` calls are already folded to literals during parsing, so they qualify automatically.
+- Multiple uses of the same **Array literal** contents produce separate `static_array_N` labels; no deduplication is performed.
+- An **Array literal** lives in `.data` (writable), not `.rodata`. Multiple references to the same literal share the same pointer; mutation through one reference is visible to others — consistent with how string literals behave.
 - The **Documentation glossary** names project concepts that prevent drift; language keywords and ordinary programming concepts belong in reference docs.
 - Function, operator, intrinsic, and expression docs should use **Stack effect**; **Operand order** explains how stack values map to operands.
 - Public reference docs should use one **Stack effect** line for an operation instead of separate signature and stack-effect lines.

--- a/compiler/bytecode.casa
+++ b/compiler/bytecode.casa
@@ -51,11 +51,13 @@ struct BytecodeCompiler {
     locals_count:    int
     string_table:    List[str]
     constants_table: List[str]
+    static_arrays:   List[StaticArray]
     store:           SymbolStore
 }
 
 fn make_compiler store:SymbolStore ops:List[Op] -> BytecodeCompiler {
     store
+    List::new(List[StaticArray])
     List::new(List[str])
     List::new(List[str])
     0
@@ -70,8 +72,10 @@ fn make_compiler_with_tables
     function:Option[Function]
     string_table:List[str]
     constants_table:List[str]
+    static_arrays:List[StaticArray]
 -> BytecodeCompiler {
     store
+    static_arrays
     constants_table
     string_table
     0
@@ -729,9 +733,37 @@ fn compile_struct_literal compiler:BytecodeCompiler op:Op bytecode:List[InstValu
 # Compile push array
 # ============================================================================
 
+fn is_all_literal_array items:List[Op] -> bool {
+    for item in items.iter do
+        if item op_is_literal ! then false return fi
+    done
+    true
+}
+
+fn compile_static_array compiler:BytecodeCompiler items:List[Op] bytecode:List[InstValue] {
+    List::new(List[StaticArrayElement]) = elements
+    for item in items.iter do
+        item Op::value match
+            OpValue::PushInt(val) => { val StaticArrayElement::Int elements.push }
+            OpValue::PushStr(val) => { val compiler intern_string StaticArrayElement::Str elements.push }
+            OpValue::PushBool(val) => { val StaticArrayElement::Bool elements.push }
+            OpValue::PushChar(val) => { val StaticArrayElement::Char elements.push }
+            _ => { }
+        end
+    done
+    compiler.static_arrays.length = array_index
+    elements StaticArray compiler.static_arrays.push
+    array_index InstValue::PushStaticArray bytecode.push
+}
+
 fn compile_push_array compiler:BytecodeCompiler op:Op bytecode:List[InstValue] {
     if op.value OpValue::PushArray(items) is ! then return fi
     items.length = length
+
+    if items is_all_literal_array then
+        bytecode items compiler compile_static_array
+        return
+    fi
 
     # Compile items in reverse order
     length 1 - = reverse_index
@@ -814,7 +846,7 @@ fn compile_function compiler:BytecodeCompiler function:Function op:Op {
     function Function::name COMPILED_FUNCTIONS.add = COMPILED_FUNCTIONS
 
     List::new(List[InstValue]) = function_bytecode
-    compiler.constants_table compiler.string_table function Option::Some ops compiler.store make_compiler_with_tables = function_compiler
+    compiler.static_arrays compiler.constants_table compiler.string_table function Option::Some ops compiler.store make_compiler_with_tables = function_compiler
     function_bytecode function_compiler compile_ops
 
     # Handle locals
@@ -1119,6 +1151,7 @@ fn compile_bytecode store:SymbolStore ops:List[Op] -> Program {
 
     compiler.constants_table.length
     compiler.store.variables.length
+    compiler.static_arrays
     compiler.string_table
     functions
     bytecode

--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -227,6 +227,8 @@ enum InstValue {
     FnPushStatic (str)
     # Strings
     StrEq
+    # Static arrays
+    PushStaticArray (int)
     # F-strings
     FstringConcat (int)
     # Syscalls
@@ -408,6 +410,17 @@ enum ConstantValue {
     Str (str)
     Bool (int)
     Char (int)
+}
+
+enum StaticArrayElement {
+    Int (int)
+    Str (int)
+    Bool (int)
+    Char (int)
+}
+
+struct StaticArray {
+    elements: List[StaticArrayElement]
 }
 
 struct Constant {
@@ -663,6 +676,13 @@ fn op_int_value op:Op -> int {
     0
 }
 
+fn op_is_literal op:Op -> bool {
+    op.value OpValue::PushInt is
+    op.value OpValue::PushStr is ||
+    op.value OpValue::PushBool is ||
+    op.value OpValue::PushChar is ||
+}
+
 fn enum_variant_of op:Op -> EnumVariant {
     if op.value OpValue::PushEnumVariant(variant) is then variant return fi
     if op.value OpValue::IsCheck(variant) is then variant return fi
@@ -845,6 +865,7 @@ struct Program {
     bytecode:        List[InstValue]
     functions:       Map[str List[InstValue]]
     strings:         List[str]
+    static_arrays:   List[StaticArray]
     globals_count:   int
     constants_count: int
 }

--- a/compiler/emitter.casa
+++ b/compiler/emitter.casa
@@ -150,14 +150,33 @@ fn emit_data asm:StringBuilder program:Program {
     "bool_false: .ascii \"false\"" asm emit_line
     "env_stack_overflow_msg: .ascii \"error: env stack overflow\\n\"" asm emit_line
     ".equ env_stack_overflow_msg_len, . - env_stack_overflow_msg" asm emit_line
-    # Static closure record per function: a 1-word [fn_ptr] used by
-    # InstFnPushStatic for zero-capture closures (trait dispatch, named
-    # function references). Avoids a heap allocation per push site.
+    # Static closure record per function
     for name in program Program::functions.keys.iter do
         name sanitize_name = label
         ".align 8" asm emit_line
         f"closure_{label}: .quad fn_{label}" asm emit_line
     done
+
+    # Static array literals
+    0 = sa_index
+    while sa_index program Program::static_arrays.length > do
+        sa_index program Program::static_arrays.get = sa
+        sa StaticArray::elements = elems
+        ".align 8" asm emit_line
+        f"static_array_{sa_index}:" asm emit_line
+        f".quad static_array_{sa_index} + 16" asm emit_line
+        f".quad {elems.length}" asm emit_line
+        for elem in elems.iter do
+            elem match
+                StaticArrayElement::Int(v) => { f".quad {v}" asm emit_line }
+                StaticArrayElement::Str(si) => { f".quad str_{si}" asm emit_line }
+                StaticArrayElement::Bool(v) => { f".quad {v}" asm emit_line }
+                StaticArrayElement::Char(v) => { f".quad {v}" asm emit_line }
+            end
+        done
+        1 += sa_index
+    done
+
     "" asm emit_line
 }
 
@@ -407,6 +426,10 @@ fn emit_stack_ops asm:StringBuilder inst:InstValue {
         }
         InstValue::PushStr(str_index) => {
             f"leaq str_{str_index}(%rip), %rax" asm emit_indent
+            "pushq %rax" asm emit_indent
+        }
+        InstValue::PushStaticArray(array_index) => {
+            f"leaq static_array_{array_index}(%rip), %rax" asm emit_indent
             "pushq %rax" asm emit_indent
         }
         InstValue::PushChar(char_value) => f"pushq ${char_value}" asm emit_indent
@@ -803,6 +826,7 @@ fn emit_inst asm:StringBuilder inst:InstValue is_global:bool {
         InstValue::Push => inst asm emit_stack_ops
         InstValue::PushChar => inst asm emit_stack_ops
         InstValue::PushStr => inst asm emit_stack_ops
+        InstValue::PushStaticArray => inst asm emit_stack_ops
         InstValue::Rot => inst asm emit_stack_ops
         InstValue::Swap => inst asm emit_stack_ops
 

--- a/docs/adr/0006-static-array-literals.md
+++ b/docs/adr/0006-static-array-literals.md
@@ -1,0 +1,15 @@
+# Static emission for array literals
+
+Array literals whose elements are all compile-time constants (int, str, bool, char literals — including values folded from `const` declarations and `const fn` calls) are emitted as static data in the `.data` section rather than heap-allocated at runtime. The full array struct (header + elements) lives in `.data` with the linker resolving internal pointers. This makes patterns like `["a", "b", "c"].contains` zero-cost, unblocking #217.
+
+**Considered Options**
+
+- `.rodata` (read-only): eliminates accidental mutation but segfaults at runtime if anyone writes to a static array, with no compile-time guard. Rejected because Casa has no `const`/`mut` distinction for variables, so the failure mode is a silent crash.
+- `.data` with copy-on-use: emit the template statically but `memcpy` into a fresh heap allocation when the array is bound to a mutable context. Preserves per-use isolation but adds complexity and only eliminates allocation for read-only uses — the common case already, so the complexity buys little.
+- `.data` shared (chosen): all references to the same literal get the same static address. Mutating a literal array is an exotic edge case (writing past bounds is already undefined), and the motivating uses are read-only. Consistent with how string literals already work in `.data`.
+
+**Consequences**
+
+- Two calls to a function containing `["a", "b"]` receive the same array pointer. Mutation through one reference is visible to others. This is a semantic change from heap-allocated arrays where each call got a fresh copy.
+- A new `InstValue::PushStaticArray` variant carries element data from bytecode compilation to the emitter, which writes the array into `.data` as `static_array_N` labels and pushes the label address at runtime.
+- Arrays containing any non-literal element (variables, function call results from non-const fns) remain heap-allocated as before.

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -2,7 +2,25 @@
 
 Rules for running and updating tests.
 
-## Before running tests or opening a PR
+## During development
+
+Use selective filters to run only relevant tests while iterating:
+
+```
+tests/test_compiler.sh array_methods       # just the test you're working on
+tests/test_examples.sh game_of_life        # just the example you changed
+```
+
+Rebuild the compiler before testing if compiler sources changed:
+
+```
+./casac -L lib casa.casa -o casac_new
+CASA_COMPILER=./casac_new tests/test_compiler.sh array_methods
+```
+
+## Before opening a PR
+
+Run the full suite — no filters:
 
 - **MUST** autoformat every changed `.casa` file with `./casafmt`:
 
@@ -10,7 +28,7 @@ Rules for running and updating tests.
   ./casafmt < file.casa > tmp && mv tmp file.casa
   ```
 
-- **MUST** run test scripts:
+- **MUST** run all test scripts:
 
   ```
   tests/test_compiler.sh

--- a/tests/compiler/test_array_methods.casa
+++ b/tests/compiler/test_array_methods.casa
@@ -68,6 +68,43 @@ fn test_array_literal_emits {
     "has _start" asm "_start:" assert_contains
 }
 
+fn test_int_array_literal_emits_static {
+    "int_array_literal_emits_static" test_start
+    "[1, 2, 3] drop" emit_am = asm
+    "has static_array label" asm "static_array_0:" assert_contains
+    "has data_ptr" asm "static_array_0 + 16" assert_contains
+    "has length 3" asm ".quad 3" assert_contains
+    "loads static addr" asm "leaq static_array_0(%rip)" assert_contains
+}
+
+fn test_str_array_literal_emits_static {
+    "str_array_literal_emits_static" test_start
+    "[\"hello\", \"world\"] drop" emit_am = asm
+    "has static_array label" asm "static_array_0:" assert_contains
+    "has length 2" asm ".quad 2" assert_contains
+    "has str ref" asm ".quad str_" assert_contains
+}
+
+fn test_empty_array_literal_emits_static {
+    "empty_array_literal_emits_static" test_start
+    "[] (array[int]) drop" emit_am = asm
+    "has static_array label" asm "static_array_0:" assert_contains
+    "has length 0" asm ".quad 0" assert_contains
+}
+
+fn test_non_literal_array_heap_allocates {
+    "non_literal_array_heap_allocates" test_start
+    "42 = x [x] drop" compile_am = prog
+    false = has_static
+    false = has_heap
+    for inst in prog Program::bytecode.iter do
+        if inst InstValue::PushStaticArray is then true = has_static fi
+        if inst InstValue::HeapAlloc is then true = has_heap fi
+    done
+    "no static array" has_static ! assert_true
+    "uses heap alloc" has_heap assert_true
+}
+
 # ============================================================================
 # Lambda tests (used by map/filter/reduce)
 # ============================================================================
@@ -128,6 +165,10 @@ fn test_array_and_lambda_emits {
 test_array_literal_type
 test_array_literal_compiles
 test_array_literal_emits
+test_int_array_literal_emits_static
+test_str_array_literal_emits_static
+test_empty_array_literal_emits_static
+test_non_literal_array_heap_allocates
 test_lambda_type
 test_lambda_compiles
 test_lambda_emits

--- a/tests/compiler/test_bytecode.casa
+++ b/tests/compiler/test_bytecode.casa
@@ -195,7 +195,7 @@ fn test_compile_local_variable {
     "y" make_variable func Function::variables.push
 
     List::new(List[InstValue]) = bytecode
-    List::new(List[str]) List::new(List[str]) func Option::Some fn_ops TEST_STORE make_compiler_with_tables = compiler
+    List::new(List[StaticArray]) List::new(List[str]) List::new(List[str]) func Option::Some fn_ops TEST_STORE make_compiler_with_tables = compiler
     bytecode compiler compile_ops
 
     # Index 0 is label, 1 is LOCAL_SET, 2 is LOCAL_GET
@@ -572,34 +572,20 @@ fn test_compile_push_array {
     List::new(List[InstValue]) = bytecode
     bytecode compiler compile_ops
 
-    # Should contain: PUSH instructions for items, HEAP_ALLOC, STORE64, LABEL, JUMP, JUMP_NE
-    # Check that HEAP_ALLOC is emitted
+    0 = has_static_array
     0 = has_alloc
-    0 = has_store
-    0 = has_label
-    0 = has_jump
-    0 = has_jump_ne
     0 = i
     while i bytecode.length > do
         i bytecode.get = inst_value
-        if inst_value InstValue::HeapAlloc is then
+        if inst_value InstValue::PushStaticArray is then
+            1 = has_static_array
+        elif inst_value InstValue::HeapAlloc is then
             1 = has_alloc
-        elif inst_value InstValue::Store64 is then
-            1 = has_store
-        elif inst_value InstValue::Label is then
-            1 = has_label
-        elif inst_value InstValue::Jump is then
-            1 = has_jump
-        elif inst_value InstValue::JumpNe is then
-            1 = has_jump_ne
         fi
         1 += i
     done
-    "array has heap_alloc" 1 has_alloc assert_eq
-    "array has store64" 1 has_store assert_eq
-    "array has label" 1 has_label assert_eq
-    "array has jump" 1 has_jump assert_eq
-    "array has jump_ne" 1 has_jump_ne assert_eq
+    "literal array emits PushStaticArray" 1 has_static_array assert_eq
+    "literal array has no HeapAlloc" 0 has_alloc assert_eq
 }
 
 fn test_compile_if_elif_else {

--- a/tests/compiler/test_emitter.casa
+++ b/tests/compiler/test_emitter.casa
@@ -19,6 +19,7 @@ fn assert_contains needle:str haystack:str msg:str {
 
 fn make_empty_program -> Program {
     0 0
+    List::new(List[StaticArray])
     List::new(List[str])
     Map::new(Map[str List[InstValue]])
     List::new(List[InstValue])
@@ -32,7 +33,9 @@ fn make_simple_program
     globals:int
     constants:int
 -> Program {
-    constants globals strings
+    constants globals
+    List::new(List[StaticArray])
+    strings
     Map::new(Map[str List[InstValue]])
     bytecode
     Program
@@ -61,6 +64,7 @@ fn test_emit_bss {
     3 = globals
     2 = constants
     constants globals
+    List::new(List[StaticArray])
     List::new(List[str])
     Map::new(Map[str List[InstValue]])
     List::new(List[InstValue])
@@ -87,7 +91,9 @@ fn test_emit_data {
     "hello" strings.push
     "world" strings.push
 
-    0 0 strings
+    0 0
+    List::new(List[StaticArray])
+    strings
     Map::new(Map[str List[InstValue]])
     List::new(List[InstValue])
     Program = program
@@ -111,7 +117,7 @@ fn test_emit_push {
     List::new(List[InstValue]) = bytecode
     42 InstValue::Push bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -128,7 +134,7 @@ fn test_emit_push_str {
     List::new(List[str]) = strings
     "test" strings.push
 
-    0 0 strings
+    0 0 List::new(List[StaticArray]) strings
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -142,7 +148,7 @@ fn test_emit_add {
     List::new(List[InstValue]) = bytecode
     InstValue::Add bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -157,7 +163,7 @@ fn test_emit_label_and_jump {
     7 InstValue::Label bytecode.push
     7 InstValue::Jump bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -177,7 +183,7 @@ fn test_emit_fn_call {
     Map::new(Map[str List[InstValue]]) = functions
     fn_bytecode "my_func" functions.set = functions
 
-    0 0 List::new(List[str]) functions bytecode Program = program
+    0 0 List::new(List[StaticArray]) List::new(List[str]) functions bytecode Program = program
     program emit = result
     "has jmp fn_my_func" result "jmp fn_my_func" assert_contains
     "has fn_my_func label" result "fn_my_func:" assert_contains
@@ -192,7 +198,7 @@ fn test_emit_fn_call_sanitized {
     Map::new(Map[str List[InstValue]]) = functions
     fn_bytecode "Foo::bar" functions.set = functions
 
-    0 0 List::new(List[str]) functions bytecode Program = program
+    0 0 List::new(List[StaticArray]) List::new(List[str]) functions bytecode Program = program
     program emit = result
     "has jmp fn_Foo__bar" result "jmp fn_Foo__bar" assert_contains
     "has fn_Foo__bar label" result "fn_Foo__bar:" assert_contains
@@ -220,7 +226,7 @@ fn test_emit_comparison {
     List::new(List[InstValue]) = bytecode
     InstValue::Eq bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -235,7 +241,7 @@ fn test_emit_syscall {
     List::new(List[InstValue]) = bytecode
     InstValue::Syscall3 bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -257,7 +263,7 @@ fn test_emit_local_ops {
     1 InstValue::LocalSet bytecode.push
     3 InstValue::LocalsUninit bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -276,7 +282,7 @@ fn test_emit_global_ops {
     2 InstValue::GlobalGet bytecode.push
     3 InstValue::GlobalSet bytecode.push
 
-    5 0 List::new(List[str])
+    5 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -292,7 +298,7 @@ fn test_emit_memory_ops {
     InstValue::Load64 bytecode.push
     InstValue::Store64 bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -308,7 +314,7 @@ fn test_emit_full_program {
     List::new(List[InstValue]) = bytecode
     99 InstValue::Push bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -329,7 +335,7 @@ fn test_emit_drop {
     List::new(List[InstValue]) = bytecode
     InstValue::Drop bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -343,7 +349,7 @@ fn test_emit_dup {
     List::new(List[InstValue]) = bytecode
     InstValue::Dup bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -357,7 +363,7 @@ fn test_emit_swap {
     List::new(List[InstValue]) = bytecode
     InstValue::Swap bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -374,7 +380,7 @@ fn test_emit_over {
     List::new(List[InstValue]) = bytecode
     InstValue::Over bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -388,7 +394,7 @@ fn test_emit_rot {
     List::new(List[InstValue]) = bytecode
     InstValue::Rot bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -411,7 +417,7 @@ fn test_emit_push_char {
     List::new(List[InstValue]) = bytecode
     97 InstValue::PushChar bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -425,7 +431,7 @@ fn test_emit_push_large_int {
     List::new(List[InstValue]) = bytecode
     4294967296 InstValue::Push bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -439,7 +445,7 @@ fn test_emit_push_negative_int {
     List::new(List[InstValue]) = bytecode
     0 42 - InstValue::Push bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -457,7 +463,7 @@ fn test_emit_sub {
     List::new(List[InstValue]) = bytecode
     InstValue::Sub bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -471,7 +477,7 @@ fn test_emit_mul {
     List::new(List[InstValue]) = bytecode
     InstValue::Mul bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -485,7 +491,7 @@ fn test_emit_div {
     List::new(List[InstValue]) = bytecode
     InstValue::Div bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -499,7 +505,7 @@ fn test_emit_mod {
     List::new(List[InstValue]) = bytecode
     InstValue::Mod bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -518,7 +524,7 @@ fn test_emit_shl {
     List::new(List[InstValue]) = bytecode
     InstValue::Shl bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -532,7 +538,7 @@ fn test_emit_shr {
     List::new(List[InstValue]) = bytecode
     InstValue::Shr bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -550,7 +556,7 @@ fn test_emit_bit_and {
     List::new(List[InstValue]) = bytecode
     InstValue::BitAnd bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -564,7 +570,7 @@ fn test_emit_bit_or {
     List::new(List[InstValue]) = bytecode
     InstValue::BitOr bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -578,7 +584,7 @@ fn test_emit_bit_xor {
     List::new(List[InstValue]) = bytecode
     InstValue::BitXor bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -592,7 +598,7 @@ fn test_emit_bit_not {
     List::new(List[InstValue]) = bytecode
     InstValue::BitNot bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -610,7 +616,7 @@ fn test_emit_bool_and {
     List::new(List[InstValue]) = bytecode
     InstValue::And bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -624,7 +630,7 @@ fn test_emit_bool_or {
     List::new(List[InstValue]) = bytecode
     InstValue::Or bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -638,7 +644,7 @@ fn test_emit_bool_not {
     List::new(List[InstValue]) = bytecode
     InstValue::Not bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -656,7 +662,7 @@ fn test_emit_ne {
     List::new(List[InstValue]) = bytecode
     InstValue::Ne bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -671,7 +677,7 @@ fn test_emit_lt {
     List::new(List[InstValue]) = bytecode
     InstValue::Lt bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -685,7 +691,7 @@ fn test_emit_le {
     List::new(List[InstValue]) = bytecode
     InstValue::Le bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -699,7 +705,7 @@ fn test_emit_gt {
     List::new(List[InstValue]) = bytecode
     InstValue::Gt bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -713,7 +719,7 @@ fn test_emit_ge {
     List::new(List[InstValue]) = bytecode
     InstValue::Ge bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -731,7 +737,7 @@ fn test_emit_heap_alloc {
     List::new(List[InstValue]) = bytecode
     InstValue::HeapAlloc bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -746,7 +752,7 @@ fn test_emit_load8 {
     List::new(List[InstValue]) = bytecode
     InstValue::Load8 bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -760,7 +766,7 @@ fn test_emit_load16 {
     List::new(List[InstValue]) = bytecode
     InstValue::Load16 bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -774,7 +780,7 @@ fn test_emit_load32 {
     List::new(List[InstValue]) = bytecode
     InstValue::Load32 bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -788,7 +794,7 @@ fn test_emit_store8 {
     List::new(List[InstValue]) = bytecode
     InstValue::Store8 bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -802,7 +808,7 @@ fn test_emit_store16 {
     List::new(List[InstValue]) = bytecode
     InstValue::Store16 bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -816,7 +822,7 @@ fn test_emit_store32 {
     List::new(List[InstValue]) = bytecode
     InstValue::Store32 bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -834,7 +840,7 @@ fn test_emit_syscall0 {
     List::new(List[InstValue]) = bytecode
     InstValue::Syscall0 bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -850,7 +856,7 @@ fn test_emit_syscall1 {
     List::new(List[InstValue]) = bytecode
     InstValue::Syscall1 bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -867,7 +873,7 @@ fn test_emit_syscall2 {
     List::new(List[InstValue]) = bytecode
     InstValue::Syscall2 bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -885,7 +891,7 @@ fn test_emit_syscall4 {
     List::new(List[InstValue]) = bytecode
     InstValue::Syscall4 bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -905,7 +911,7 @@ fn test_emit_syscall5 {
     List::new(List[InstValue]) = bytecode
     InstValue::Syscall5 bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -926,7 +932,7 @@ fn test_emit_syscall6 {
     List::new(List[InstValue]) = bytecode
     InstValue::Syscall6 bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -959,7 +965,7 @@ fn test_emit_fn_return {
     Map::new(Map[str List[InstValue]]) = functions
     fn_bytecode "test_fn" functions.set = functions
 
-    0 0 List::new(List[str]) functions bytecode Program = program
+    0 0 List::new(List[StaticArray]) List::new(List[str]) functions bytecode Program = program
     program emit = result
     "has jmpq *(%r14)" result "jmpq *(%r14)" assert_contains
 }
@@ -969,7 +975,7 @@ fn test_emit_fn_exec {
     List::new(List[InstValue]) = bytecode
     InstValue::FnExec bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -987,7 +993,7 @@ fn test_emit_fn_push {
     Map::new(Map[str List[InstValue]]) = functions
     fn_bytecode "my_lambda" functions.set = functions
 
-    0 0 List::new(List[str]) functions bytecode Program = program
+    0 0 List::new(List[StaticArray]) List::new(List[str]) functions bytecode Program = program
     program emit = result
     "has leaq fn_my_lambda" result "leaq fn_my_lambda" assert_contains
 }
@@ -1001,7 +1007,7 @@ fn test_emit_print_int {
     List::new(List[InstValue]) = bytecode
     InstValue::PrintInt bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -1015,7 +1021,7 @@ fn test_emit_print_str {
     List::new(List[InstValue]) = bytecode
     InstValue::PrintStr bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -1029,7 +1035,7 @@ fn test_emit_print_bool {
     List::new(List[InstValue]) = bytecode
     InstValue::PrintBool bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -1044,7 +1050,7 @@ fn test_emit_print_char {
     List::new(List[InstValue]) = bytecode
     InstValue::PrintChar bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -1058,7 +1064,7 @@ fn test_emit_print_cstr {
     List::new(List[InstValue]) = bytecode
     InstValue::PrintCstr bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -1076,7 +1082,7 @@ fn test_emit_str_eq {
     List::new(List[InstValue]) = bytecode
     InstValue::StrEq bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -1090,7 +1096,7 @@ fn test_emit_fstring_concat {
     List::new(List[InstValue]) = bytecode
     3 InstValue::FstringConcat bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -1109,7 +1115,7 @@ fn test_emit_constant_load {
     List::new(List[InstValue]) = bytecode
     0 InstValue::ConstantLoad bytecode.push
 
-    0 1 List::new(List[str])
+    0 1 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -1123,7 +1129,7 @@ fn test_emit_constant_store {
     List::new(List[InstValue]) = bytecode
     1 InstValue::ConstantStore bytecode.push
 
-    0 2 List::new(List[str])
+    0 2 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -1141,7 +1147,7 @@ fn test_emit_jump_ne {
     List::new(List[InstValue]) = bytecode
     5 InstValue::JumpNe bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -1160,7 +1166,7 @@ fn test_emit_argc {
     List::new(List[InstValue]) = bytecode
     InstValue::Argc bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -1174,7 +1180,7 @@ fn test_emit_argv {
     List::new(List[InstValue]) = bytecode
     InstValue::Argv bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -1204,7 +1210,7 @@ fn test_emit_globals_init {
     5 InstValue::GlobalsInit bytecode.push
     42 InstValue::Push bytecode.push
 
-    0 5 List::new(List[str])
+    0 5 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -1230,7 +1236,7 @@ fn test_emit_while_loop_pattern {
     10 InstValue::Jump bytecode.push
     11 InstValue::Label bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -1252,7 +1258,7 @@ fn test_emit_data_escape_sequences {
     "hello\nworld" strings.push
     "col1\tcol2" strings.push
 
-    0 0 strings
+    0 0 List::new(List[StaticArray]) strings
     Map::new(Map[str List[InstValue]])
     List::new(List[InstValue])
     Program = program
@@ -1275,7 +1281,7 @@ fn test_emit_locals_rep_stosq {
     4 InstValue::LocalsInit bytecode.push
     4 InstValue::LocalsUninit bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -1295,7 +1301,7 @@ fn test_emit_load64 {
     List::new(List[InstValue]) = bytecode
     InstValue::Load64 bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -1315,7 +1321,7 @@ fn test_emit_store64 {
     List::new(List[InstValue]) = bytecode
     InstValue::Store64 bytecode.push
 
-    0 0 List::new(List[str])
+    0 0 List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -1346,7 +1352,7 @@ fn test_emit_fn_with_body {
     Map::new(Map[str List[InstValue]]) = functions
     fn_bytecode "adder" functions.set = functions
 
-    0 0 List::new(List[str]) functions bytecode Program = program
+    0 0 List::new(List[StaticArray]) List::new(List[str]) functions bytecode Program = program
     program emit = result
     "has fn label" result "fn_adder:" assert_contains
     "has locals init" result "rep stosq" assert_contains
@@ -1374,7 +1380,7 @@ fn test_emit_multiple_functions {
     alpha_bytecode "alpha" functions.set = functions
     beta_bytecode "beta" functions.set = functions
 
-    0 0 List::new(List[str]) functions bytecode Program = program
+    0 0 List::new(List[StaticArray]) List::new(List[str]) functions bytecode Program = program
     program emit = result
     "has fn_alpha label" result "fn_alpha:" assert_contains
     "has fn_beta label" result "fn_beta:" assert_contains


### PR DESCRIPTION
## Summary

- Array literals with all compile-time constant elements (literals, `const` values, folded `const fn` results) are now emitted into `.data` as a static struct (header + elements) instead of heap-allocated at runtime
- At runtime the array is a single `leaq` — zero allocation cost, unblocking `["a", "b"].contains` patterns (#217)
- Arrays containing variables or non-const expressions remain heap-allocated via the existing bump allocator path

## Design decisions

See ADR-0006. Key trade-off: `.data` (writable, shared) over `.rodata` (segfault on mutation) and copy-on-use (complexity for no practical benefit).

## Test plan

- [x] Int, string, and empty array literals emit `static_array_N` labels in `.data`
- [x] Variable arrays still heap-allocate (`HeapAlloc` present, no `PushStaticArray`)
- [x] All 47 example programs pass (runtime correctness)
- [x] All 55 compiler unit tests pass
- [x] Bootstrap: self-compilation and fixed-point verified

Closes #235