### PR TITLE
feat: support all expression types in array literals

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -49,7 +49,7 @@ The shared representation and flow for compiler diagnostics across lexer, parser
 _Avoid_: Typechecker-only diagnostics refactor, phase-local error schema
 
 **Array literal**:
-A bracket-delimited list of values (`[1, 2, 3]`, `["a", "b"]`) that produces a fixed-size `array[T]`. When all elements are compile-time constants, the compiler emits the data into `.data` as a static struct; otherwise the array is heap-allocated at runtime.
+A bracket-delimited list of values (`[1, 2, 3]`, `["a", "b"]`, `[[1], [2]]`, `[my_fn]`) that produces a fixed-size `array[T]`. Elements may be primitive literals, enum variants, nested array literals, function references, lambda expressions, or struct literals. When all elements are statically emittable (compile-time constants, payload-free enum ordinals, zero-capture function pointers, or recursively static nested arrays), the compiler emits the data into `.data`; otherwise the array is heap-allocated at runtime.
 _Avoid_: Static array, const array, inline array
 
 ### Type representation
@@ -170,7 +170,7 @@ _Avoid_: Release lint, tag lint
 - The **Default parser** should trend toward zero use as explicit pass boundaries mature; if a slice can remove it fully, it should.
 - A **Typecheck result** may return the same **SymbolStore** reference it received, as long as mutations are represented at the pass boundary.
 - The **Compiler diagnostics schema** should be refactored once across the compiler, not as part of the first **Typecheck result** boundary.
-- An **Array literal** is determined at bytecode compilation time: if all element ops are literal push values, the array qualifies. `const` values and `const fn` calls are already folded to literals during parsing, so they qualify automatically.
+- An **Array literal**'s emission path is determined at bytecode compilation time. An element qualifies as statically emittable if it is a primitive literal, a payload-free enum variant, a zero-capture function reference, or a nested **Array literal** whose own elements are all statically emittable. `const` values and `const fn` calls are already folded to literals during parsing, so they qualify automatically.
 - Multiple uses of the same **Array literal** contents produce separate `static_array_N` labels; no deduplication is performed.
 - An **Array literal** lives in `.data` (writable), not `.rodata`. Multiple references to the same literal share the same pointer; mutation through one reference is visible to others — consistent with how string literals behave.
 - The **Documentation glossary** names project concepts that prevent drift; language keywords and ordinary programming concepts belong in reference docs.

--- a/compiler/bytecode.casa
+++ b/compiler/bytecode.casa
@@ -733,21 +733,58 @@ fn compile_struct_literal compiler:BytecodeCompiler op:Op bytecode:List[InstValu
 # Compile push array
 # ============================================================================
 
-fn is_all_literal_array items:List[Op] -> bool {
-    for item in items.iter do
-        if item op_is_literal ! then false return fi
+fn sanitize_fn_name name:str -> str {
+    StringBuilder::new = sb
+    0 = si
+    while si name.length > do
+        si name.at = ch
+        if ':' ch == then
+            if name.length si 1 + < then
+                if ':' si 1 + name.at == then
+                    '_' sb.append_char
+                    '_' sb.append_char
+                    2 += si
+                    continue
+                fi
+            fi
+        fi
+        ch sb.append_char
+        1 += si
     done
-    true
+    sb.build
+}
+
+fn compile_static_array_fns compiler:BytecodeCompiler items:List[Op] {
+    for item in items.iter do
+        if item Op::value OpValue::FnPush(fn_name) is then
+            fn_name compiler.store.functions.get = csa_fn_opt
+            if csa_fn_opt.is_some then
+                item csa_fn_opt.unwrap compiler compile_function
+            fi
+        fi
+    done
 }
 
 fn compile_static_array compiler:BytecodeCompiler items:List[Op] bytecode:List[InstValue] {
+    items compiler compile_static_array_fns
     List::new(List[StaticArrayElement]) = elements
     for item in items.iter do
         item Op::value match
-            OpValue::PushInt(val) => { val StaticArrayElement::Int elements.push }
-            OpValue::PushStr(val) => { val compiler intern_string StaticArrayElement::Str elements.push }
-            OpValue::PushBool(val) => { val StaticArrayElement::Bool elements.push }
-            OpValue::PushChar(val) => { val StaticArrayElement::Char elements.push }
+            OpValue::PushInt(val) => { val StaticArrayElement::Imm elements.push }
+            OpValue::PushStr(val) => { val compiler intern_string = str_idx f"str_{str_idx}" StaticArrayElement::Label elements.push }
+            OpValue::PushBool(val) => { val StaticArrayElement::Imm elements.push }
+            OpValue::PushChar(val) => { val StaticArrayElement::Imm elements.push }
+            OpValue::PushEnumVariant(ev) => { ev EnumVariant::ordinal.unwrap StaticArrayElement::Imm elements.push }
+            OpValue::FnPush(fn_name) => {
+                fn_name sanitize_fn_name = sanitized_fn
+                f"closure_{sanitized_fn}" StaticArrayElement::Label elements.push
+            }
+            OpValue::PushArray(inner_items) => {
+                List::new(List[InstValue]) = discard_bytecode
+                discard_bytecode inner_items compiler compile_static_array
+                compiler.static_arrays.length 1 - = inner_idx
+                f"static_array_{inner_idx}" StaticArrayElement::Label elements.push
+            }
             _ => { }
         end
     done
@@ -760,7 +797,7 @@ fn compile_push_array compiler:BytecodeCompiler op:Op bytecode:List[InstValue] {
     if op.value OpValue::PushArray(items) is ! then return fi
     items.length = length
 
-    if items is_all_literal_array then
+    if compiler.store items op_is_static_array_with_store then
         bytecode items compiler compile_static_array
         return
     fi
@@ -1055,6 +1092,12 @@ fn compile_op compiler:BytecodeCompiler op:Op op_index:int bytecode:List[InstVal
         InstValue::PrintStr bytecode.push
     elif op_value OpValue::PushArray is then
         bytecode op compiler compile_push_array
+    elif op_value OpValue::ExprGroup(group_ops) is then
+        0 = grp_idx
+        while grp_idx group_ops.length > do
+            bytecode grp_idx grp_idx group_ops.get compiler compile_op
+            1 += grp_idx
+        done
     elif op_value OpValue::PushBool(bool_value) is then
         bool_value InstValue::Push bytecode.push
     elif op_value OpValue::PushChar(char_value) is then

--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -413,10 +413,8 @@ enum ConstantValue {
 }
 
 enum StaticArrayElement {
-    Int (int)
-    Str (int)
-    Bool (int)
-    Char (int)
+    Imm (int)
+    Label (str)
 }
 
 struct StaticArray {
@@ -640,6 +638,8 @@ enum OpValue {
     Argc
     Argv
     Envp
+    # Expression group (multi-op element in array literals)
+    ExprGroup (List[Op])
     # Identifier (resolved by parser)
     Identifier (str)
 }
@@ -676,11 +676,40 @@ fn op_int_value op:Op -> int {
     0
 }
 
-fn op_is_literal op:Op -> bool {
+fn op_is_static op:Op -> bool {
+    if op.value OpValue::PushArray(inner) is then
+        inner op_is_static_array return
+    fi
     op.value OpValue::PushInt is
     op.value OpValue::PushStr is ||
     op.value OpValue::PushBool is ||
     op.value OpValue::PushChar is ||
+    op.value OpValue::PushEnumVariant is ||
+}
+
+fn op_is_static_with_store store:SymbolStore op:Op -> bool {
+    if op.value OpValue::FnPush(fn_name) is then
+        fn_name store.functions.get = fn_opt
+        if fn_opt.is_some then
+            0 fn_opt.unwrap Function::captures.length == return
+        fi
+        false return
+    fi
+    op op_is_static
+}
+
+fn op_is_static_array items:List[Op] -> bool {
+    for item in items.iter do
+        if item op_is_static ! then false return fi
+    done
+    true
+}
+
+fn op_is_static_array_with_store items:List[Op] store:SymbolStore -> bool {
+    for item in items.iter do
+        if item store op_is_static_with_store ! then false return fi
+    done
+    true
 }
 
 fn enum_variant_of op:Op -> EnumVariant {

--- a/compiler/emitter.casa
+++ b/compiler/emitter.casa
@@ -168,10 +168,8 @@ fn emit_data asm:StringBuilder program:Program {
         f".quad {elems.length}" asm emit_line
         for elem in elems.iter do
             elem match
-                StaticArrayElement::Int(v) => { f".quad {v}" asm emit_line }
-                StaticArrayElement::Str(si) => { f".quad str_{si}" asm emit_line }
-                StaticArrayElement::Bool(v) => { f".quad {v}" asm emit_line }
-                StaticArrayElement::Char(v) => { f".quad {v}" asm emit_line }
+                StaticArrayElement::Imm(v) => { f".quad {v}" asm emit_line }
+                StaticArrayElement::Label(lbl) => { f".quad {lbl}" asm emit_line }
             end
         done
         1 += sa_index

--- a/compiler/syntax.casa
+++ b/compiler/syntax.casa
@@ -3105,6 +3105,15 @@ fn resolve_array_identifiers
                 rai_name OpValue::PushCapture rai_item Op::set_value
             elif rai_name store.variables.get.is_some then
                 rai_name OpValue::PushVar rai_item Op::set_value
+            elif rai_name store.constants.get = rai_const_opt rai_const_opt.is_some then
+                rai_const_opt.unwrap Constant::value = rai_const_value
+                rai_const_value match
+                    ConstantValue::Int(rai_const_int) => { rai_const_int OpValue::PushInt rai_item Op::set_value }
+                    ConstantValue::Str(rai_const_str) => { rai_const_str OpValue::PushStr rai_item Op::set_value }
+                    ConstantValue::Bool(rai_const_bool) => { rai_const_bool OpValue::PushBool rai_item Op::set_value }
+                    ConstantValue::Char(rai_const_char) => { rai_const_char OpValue::PushChar rai_item Op::set_value }
+                end
+            elif errors rai_name rai_item store try_resolve_enum_variant_ident then
             else
                 rai_item Op::location f"Identifier `{rai_name}` is not defined" ErrorKind::UndefinedName make_error errors.push
             fi

--- a/compiler/syntax.casa
+++ b/compiler/syntax.casa
@@ -421,15 +421,41 @@ fn get_op_operator token:Token cursor:TokenCursor function_name:str -> Op {
 # get_op_array - parse [item1, item2] array literal
 # ============================================================================
 
-fn get_op_array cursor:TokenCursor -> Op {
+fn parse_array_struct_literal
+    parser:Parser
+    function_name:str
+    cursor:TokenCursor
+    name_token:Token
+    items:List[Op]
+{
+    function_name cursor name_token parser parse_struct_literal = struct_ops
+    name_token Token::location struct_ops OpValue::ExprGroup make_op items.push
+}
+
+fn parse_array_lambda
+    parser:Parser
+    function_name:str
+    cursor:TokenCursor
+    brace_token:Token
+    items:List[Op]
+{
+    cursor.retreat
+    f"lambda__{function_name}_o{brace_token Token::location Location::span Span::offset}" = arr_lam_name
+    arr_lam_name cursor parser parse_block_ops = arr_lam_ops
+    brace_token Token::location arr_lam_ops arr_lam_name make_function = arr_lam_fn
+    arr_lam_fn arr_lam_name parser.store.functions.set drop
+    brace_token Token::location arr_lam_name OpValue::FnPush make_op items.push
+}
+
+fn get_op_array parser:Parser function_name:str cursor:TokenCursor -> Op {
     "[" cursor expect_token_value = open_token
     List::new(List[Op]) = items
     while "]" cursor expect_delimiter ! do
         cursor.peek = next_opt
         if next_opt.is_some then
             if "[" next_opt.unwrap Token::value == then
-                cursor get_op_array items.push
-                "]" cursor expect_delimiter drop
+                cursor function_name parser get_op_array items.push
+                "," cursor expect_delimiter drop
                 continue
             fi
         fi
@@ -438,10 +464,21 @@ fn get_op_array cursor:TokenCursor -> Op {
             open_token Token::location "Unexpected end of input in array literal" ErrorKind::UnexpectedToken raise_error
         fi
         value_opt.unwrap = value_token
-        if TokenKind::Literal value_token Token::kind == then
+        if "{" value_token Token::value == then
+            items value_token cursor function_name parser parse_array_lambda
+        elif TokenKind::Literal value_token Token::kind == then
             value_token get_op_literal items.push
         elif TokenKind::Identifier value_token Token::kind == then
-            value_token Token::location value_token Token::value OpValue::Identifier make_op items.push
+            cursor.peek = struct_peek_opt
+            if struct_peek_opt.is_some then
+                if "{" struct_peek_opt.unwrap Token::value == then
+                    items value_token cursor function_name parser parse_array_struct_literal
+                else
+                    value_token Token::location value_token Token::value OpValue::Identifier make_op items.push
+                fi
+            else
+                value_token Token::location value_token Token::value OpValue::Identifier make_op items.push
+            fi
         else
             value_token Token::location "Unexpected token in array literal" ErrorKind::UnexpectedToken raise_error
         fi
@@ -572,7 +609,7 @@ fn get_op_delimiter parser:Parser token:Token cursor:TokenCursor function_name:s
     # Open bracket [ -> array literal
     if "[" value == then
         cursor.retreat
-        cursor get_op_array ops.push
+        cursor function_name parser get_op_array ops.push
         return
     fi
 
@@ -3098,6 +3135,8 @@ fn resolve_array_identifiers
     for rai_item in items.iter do
         if rai_item.value OpValue::PushArray(inner_items) is then
             errors function inner_items store resolve_array_identifiers
+        elif rai_item.value OpValue::ExprGroup(group_inner) is then
+            function group_inner store resolve_identifiers drop
         elif rai_item.value OpValue::Identifier(rai_name) is then
             if rai_name function Function::variables variable_list_contains then
                 rai_name OpValue::PushVar rai_item Op::set_value
@@ -3114,6 +3153,9 @@ fn resolve_array_identifiers
                     ConstantValue::Char(rai_const_char) => { rai_const_char OpValue::PushChar rai_item Op::set_value }
                 end
             elif errors rai_name rai_item store try_resolve_enum_variant_ident then
+            elif rai_name store.functions.get.is_some then
+                rai_name OpValue::FnPush rai_item Op::set_value
+                true rai_name store.functions.get.unwrap Function::set_is_used
             else
                 rai_item Op::location f"Identifier `{rai_name}` is not defined" ErrorKind::UndefinedName make_error errors.push
             fi
@@ -3265,6 +3307,11 @@ fn resolve_identifiers store:SymbolStore ops:List[Op] function:Function -> List[
 
         if current_op.value OpValue::PushArray(items_inner) is then
             resolve_errors function items_inner store resolve_array_identifiers
+            continue
+        fi
+
+        if current_op.value OpValue::ExprGroup(group_inner) is then
+            function group_inner store resolve_identifiers drop
             continue
         fi
 

--- a/compiler/typechecker.casa
+++ b/compiler/typechecker.casa
@@ -1695,6 +1695,8 @@ fn check_literals tc:TypeChecker op:Op function_opt:Option[Function] {
             elem_type_t item_params.push
             item_params "array" GenericType Type::Generic tc stack_push_type
         fi
+    elif literal_value OpValue::ExprGroup(group_ops) is then
+        function_opt group_ops tc run_type_check_ops
     elif literal_value OpValue::FstringConcat(count) is then
         0 = index
         while index count > do
@@ -2596,6 +2598,7 @@ fn run_type_check_ops checker:TypeChecker ops:List[Op] function_opt:Option[Funct
         op_value OpValue::PushBool is ||
         op_value OpValue::PushChar is ||
         op_value OpValue::PushArray is ||
+        op_value OpValue::ExprGroup is ||
         op_value OpValue::FstringConcat is ||
         then
             function_opt current_op checker check_literals

--- a/docs/types-and-literals.md
+++ b/docs/types-and-literals.md
@@ -186,11 +186,15 @@ Fixed-size, statically typed array literal. The element type `T` is inferred fro
 [true, false]       # type: array[bool]
 ```
 
-Array items can be literals or variables:
+Array items can be literals, variables, enum variants, function references, lambdas, or struct literals:
 
 ```casa
 42 = x
-[x, 2, 3]          # type: array[int]
+[x, 2, 3]                            # type: array[int]
+[Color::Red, Color::Blue]            # type: array[Color]
+[double, triple]                      # type: array[fn[int -> int]]
+[{ 1 + }]                            # type: array[fn[int -> int]]
+[Point { x: 1, y: 2 }]              # type: array[Point]
 ```
 
 All items must have the same type. Heterogeneous arrays are compile-time errors:

--- a/tests/compiler/test_array_methods.casa
+++ b/tests/compiler/test_array_methods.casa
@@ -142,6 +142,73 @@ fn test_bool_array_emits_static {
 }
 
 # ============================================================================
+# Nested array tests
+# ============================================================================
+
+fn test_nested_array_type {
+    "nested_array_type" test_start
+    "[[1, 2], [3, 4]] drop" tc_am = sig
+    "no stack effect" 0 sig StackEffect::return_types.length assert_eq
+}
+
+fn test_nested_array_emits_static {
+    "nested_array_emits_static" test_start
+    "[[1, 2], [3, 4]] drop" emit_am = asm
+    "inner array 0" asm "static_array_0:" assert_contains
+    "inner array 1" asm "static_array_1:" assert_contains
+    "outer array" asm "static_array_2:" assert_contains
+}
+
+fn test_lambda_in_array_type {
+    "lambda_in_array_type" test_start
+    "[{ 1 + }] drop" tc_am = sig
+    "no stack effect" 0 sig StackEffect::return_types.length assert_eq
+}
+
+fn test_struct_in_array_type {
+    "struct_in_array_type" test_start
+    "struct Point { x: int y: int }\n[Point { x: 1, y: 2 }] drop" tc_am = sig
+    "no stack effect" 0 sig StackEffect::return_types.length assert_eq
+}
+
+fn test_struct_in_array_with_var {
+    "struct_in_array_with_var" test_start
+    "struct Point { x: int y: int }\n42 = v [Point { x: v, y: 2 }] drop" tc_am = sig
+    "no stack effect" 0 sig StackEffect::return_types.length assert_eq
+}
+
+fn test_enum_variant_array_emits_static {
+    "enum_variant_array_emits_static" test_start
+    "enum Color { Red Green Blue }\n[Color::Red, Color::Blue] drop" emit_am = asm
+    "has static_array label" asm "static_array_0:" assert_contains
+}
+
+fn test_struct_array_uses_heap {
+    "struct_array_uses_heap" test_start
+    "struct Point { x: int y: int }\n[Point { x: 1, y: 2 }] drop" compile_am = prog
+    false = has_static
+    false = has_heap
+    for inst in prog Program::bytecode.iter do
+        if inst InstValue::PushStaticArray is then true = has_static fi
+        if inst InstValue::HeapAlloc is then true = has_heap fi
+    done
+    "no static array" has_static ! assert_true
+    "uses heap alloc" has_heap assert_true
+}
+
+fn test_fn_ptr_in_array_type {
+    "fn_ptr_in_array_type" test_start
+    "fn double x:int -> int { x 2 * }\n[double] drop" tc_am = sig
+    "no stack effect" 0 sig StackEffect::return_types.length assert_eq
+}
+
+fn test_fn_ptr_array_emits_static {
+    "fn_ptr_array_emits_static" test_start
+    "fn double x:int -> int { x 2 * }\n[double] drop" emit_am = asm
+    "has static_array label" asm "static_array_0:" assert_contains
+}
+
+# ============================================================================
 # Lambda tests (used by map/filter/reduce)
 # ============================================================================
 
@@ -211,6 +278,15 @@ test_enum_variant_array_emits
 test_constant_array_emits_static
 test_char_array_emits_static
 test_bool_array_emits_static
+test_nested_array_type
+test_nested_array_emits_static
+test_lambda_in_array_type
+test_struct_in_array_type
+test_struct_in_array_with_var
+test_enum_variant_array_emits_static
+test_struct_array_uses_heap
+test_fn_ptr_in_array_type
+test_fn_ptr_array_emits_static
 test_lambda_type
 test_lambda_compiles
 test_lambda_emits

--- a/tests/compiler/test_array_methods.casa
+++ b/tests/compiler/test_array_methods.casa
@@ -105,6 +105,42 @@ fn test_non_literal_array_heap_allocates {
     "uses heap alloc" has_heap assert_true
 }
 
+fn test_enum_variant_array_type {
+    "enum_variant_array_type" test_start
+    "enum Color { Red Green Blue }\n[Color::Red, Color::Green] drop" tc_am = sig
+    "no stack effect" 0 sig StackEffect::return_types.length assert_eq
+}
+
+fn test_enum_variant_array_compiles {
+    "enum_variant_array_compiles" test_start
+    "enum Color { Red Green Blue }\n[Color::Red, Color::Blue] drop" compile_am = prog
+    "has bytecode" 0 prog Program::bytecode.length != assert_true
+}
+
+fn test_enum_variant_array_emits {
+    "enum_variant_array_emits" test_start
+    "enum Color { Red Green Blue }\n[Color::Red, Color::Blue] drop" emit_am = asm
+    "has _start" asm "_start:" assert_contains
+}
+
+fn test_constant_array_emits_static {
+    "constant_array_emits_static" test_start
+    "const X 10\nconst Y 20\n[X, Y] drop" emit_am = asm
+    "has static_array label" asm "static_array_0:" assert_contains
+}
+
+fn test_char_array_emits_static {
+    "char_array_emits_static" test_start
+    "['a', 'b', 'c'] drop" emit_am = asm
+    "has static_array label" asm "static_array_0:" assert_contains
+}
+
+fn test_bool_array_emits_static {
+    "bool_array_emits_static" test_start
+    "[true, false] drop" emit_am = asm
+    "has static_array label" asm "static_array_0:" assert_contains
+}
+
 # ============================================================================
 # Lambda tests (used by map/filter/reduce)
 # ============================================================================
@@ -169,6 +205,12 @@ test_int_array_literal_emits_static
 test_str_array_literal_emits_static
 test_empty_array_literal_emits_static
 test_non_literal_array_heap_allocates
+test_enum_variant_array_type
+test_enum_variant_array_compiles
+test_enum_variant_array_emits
+test_constant_array_emits_static
+test_char_array_emits_static
+test_bool_array_emits_static
 test_lambda_type
 test_lambda_compiles
 test_lambda_emits


### PR DESCRIPTION
## Summary

- Extend array literal parser to accept nested arrays (`[[1, 2], [3, 4]]`), lambda expressions (`[{ 1 + }]`), struct literals (`[Point { x: 1, y: 2 }]`), and function references (`[double, triple]`)
- Static emission for enum variants (as ordinals), zero-capture function pointers (as closure labels), and recursively static nested arrays (as label references)
- Non-static elements (struct literals, capturing lambdas, variables) use the heap allocation path
- Fix nested array parser delimiter bug (was consuming `]` instead of `,`)

## Test plan

- [x] Unit tests: 39 array method tests covering parse, typecheck, compile, and emit for all new element types
- [x] Static vs heap: enum variants, fn pointers, nested arrays emit static; struct literals, variables emit heap
- [x] End-to-end: compiled program produces correct values for nested arrays, fn pointer calls, struct field access
- [x] Regression: all 55 compiler tests, 47 examples, bootstrap self-compilation + fixed point pass