### PR TITLE
feat: static emission for struct literals in array literals

### DIFF
--- a/compiler/bytecode.casa
+++ b/compiler/bytecode.casa
@@ -52,11 +52,13 @@ struct BytecodeCompiler {
     string_table:    List[str]
     constants_table: List[str]
     static_arrays:   List[StaticArray]
+    static_structs:  List[StaticStruct]
     store:           SymbolStore
 }
 
 fn make_compiler store:SymbolStore ops:List[Op] -> BytecodeCompiler {
     store
+    List::new(List[StaticStruct])
     List::new(List[StaticArray])
     List::new(List[str])
     List::new(List[str])
@@ -73,8 +75,10 @@ fn make_compiler_with_tables
     string_table:List[str]
     constants_table:List[str]
     static_arrays:List[StaticArray]
+    static_structs:List[StaticStruct]
 -> BytecodeCompiler {
     store
+    static_structs
     static_arrays
     constants_table
     string_table
@@ -765,27 +769,75 @@ fn compile_static_array_fns compiler:BytecodeCompiler items:List[Op] {
     done
 }
 
+fn compile_static_element compiler:BytecodeCompiler op:Op -> StaticArrayElement {
+    op Op::value match
+        OpValue::PushInt(val) => { val StaticArrayElement::Imm return }
+        OpValue::PushStr(val) => { val compiler intern_string = str_idx f"str_{str_idx}" StaticArrayElement::Label return }
+        OpValue::PushBool(val) => { val StaticArrayElement::Imm return }
+        OpValue::PushChar(val) => { val StaticArrayElement::Imm return }
+        OpValue::PushEnumVariant(ev) => { ev EnumVariant::ordinal.unwrap StaticArrayElement::Imm return }
+        OpValue::FnPush(fn_name) => {
+            fn_name sanitize_fn_name = sanitized_fn
+            f"closure_{sanitized_fn}" StaticArrayElement::Label return
+        }
+        _ => {
+            "Internal error: compile_static_element called on non-static op\n" eprint
+            1 exit
+            0 StaticArrayElement::Imm return
+        }
+    end
+    0 StaticArrayElement::Imm
+}
+
+fn compile_static_struct compiler:BytecodeCompiler group_ops:List[Op] -> str {
+    group_ops.length 1 - group_ops.get Op::value = last_val
+    if last_val OpValue::StructLiteral(literal) is ! then
+        "Internal error: compile_static_struct called on non-struct ExprGroup\n" eprint
+        1 exit
+        "" return
+    fi
+    literal StructLiteral::struct_name = struct_name
+    literal StructLiteral::field_order = field_order
+    struct_name compiler.store.structs.get.unwrap = casa_struct
+
+    List::new(List[StaticArrayElement]) = ordered_elems
+    0 = i
+    while i field_order.length > do
+        i group_ops.get compiler compile_static_element ordered_elems.push
+        1 += i
+    done
+
+    # Reorder to match struct member definition order
+    List::new(List[StaticArrayElement]) = fields
+    0 = mi
+    while mi casa_struct CasaStruct::members.length > do
+        mi casa_struct CasaStruct::members.get Member::name = member_name
+        member_name field_order string_list_index = fo_idx
+        fo_idx ordered_elems.get fields.push
+        1 += mi
+    done
+
+    compiler.static_structs.length = struct_index
+    fields StaticStruct compiler.static_structs.push
+    f"static_struct_{struct_index}"
+}
+
 fn compile_static_array compiler:BytecodeCompiler items:List[Op] bytecode:List[InstValue] {
     items compiler compile_static_array_fns
     List::new(List[StaticArrayElement]) = elements
     for item in items.iter do
         item Op::value match
-            OpValue::PushInt(val) => { val StaticArrayElement::Imm elements.push }
-            OpValue::PushStr(val) => { val compiler intern_string = str_idx f"str_{str_idx}" StaticArrayElement::Label elements.push }
-            OpValue::PushBool(val) => { val StaticArrayElement::Imm elements.push }
-            OpValue::PushChar(val) => { val StaticArrayElement::Imm elements.push }
-            OpValue::PushEnumVariant(ev) => { ev EnumVariant::ordinal.unwrap StaticArrayElement::Imm elements.push }
-            OpValue::FnPush(fn_name) => {
-                fn_name sanitize_fn_name = sanitized_fn
-                f"closure_{sanitized_fn}" StaticArrayElement::Label elements.push
-            }
             OpValue::PushArray(inner_items) => {
                 List::new(List[InstValue]) = discard_bytecode
                 discard_bytecode inner_items compiler compile_static_array
                 compiler.static_arrays.length 1 - = inner_idx
                 f"static_array_{inner_idx}" StaticArrayElement::Label elements.push
             }
-            _ => { }
+            OpValue::ExprGroup(group_ops) => {
+                group_ops compiler compile_static_struct = struct_label
+                struct_label StaticArrayElement::Label elements.push
+            }
+            _ => { item compiler compile_static_element elements.push }
         end
     done
     compiler.static_arrays.length = array_index
@@ -883,7 +935,7 @@ fn compile_function compiler:BytecodeCompiler function:Function op:Op {
     function Function::name COMPILED_FUNCTIONS.add = COMPILED_FUNCTIONS
 
     List::new(List[InstValue]) = function_bytecode
-    compiler.static_arrays compiler.constants_table compiler.string_table function Option::Some ops compiler.store make_compiler_with_tables = function_compiler
+    compiler.static_structs compiler.static_arrays compiler.constants_table compiler.string_table function Option::Some ops compiler.store make_compiler_with_tables = function_compiler
     function_bytecode function_compiler compile_ops
 
     # Handle locals
@@ -1194,6 +1246,7 @@ fn compile_bytecode store:SymbolStore ops:List[Op] -> Program {
 
     compiler.constants_table.length
     compiler.store.variables.length
+    compiler.static_structs
     compiler.static_arrays
     compiler.string_table
     functions

--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -421,6 +421,10 @@ struct StaticArray {
     elements: List[StaticArrayElement]
 }
 
+struct StaticStruct {
+    fields: List[StaticArrayElement]
+}
+
 struct Constant {
     name:     str
     value:    ConstantValue
@@ -676,9 +680,36 @@ fn op_int_value op:Op -> int {
     0
 }
 
+fn op_is_static_struct_literal group_ops:List[Op] -> bool {
+    if 0 group_ops.length == then false return fi
+    group_ops.length 1 - group_ops.get = last_op
+    if last_op Op::value OpValue::StructLiteral is ! then false return fi
+    0 = i
+    while i group_ops.length 1 - > do
+        if i group_ops.get op_is_static ! then false return fi
+        1 += i
+    done
+    true
+}
+
+fn op_is_static_struct_literal_with_store store:SymbolStore group_ops:List[Op] -> bool {
+    if 0 group_ops.length == then false return fi
+    group_ops.length 1 - group_ops.get = last_op
+    if last_op Op::value OpValue::StructLiteral is ! then false return fi
+    0 = i
+    while i group_ops.length 1 - > do
+        if i group_ops.get store op_is_static_with_store ! then false return fi
+        1 += i
+    done
+    true
+}
+
 fn op_is_static op:Op -> bool {
     if op.value OpValue::PushArray(inner) is then
         inner op_is_static_array return
+    fi
+    if op.value OpValue::ExprGroup(group_ops) is then
+        group_ops op_is_static_struct_literal return
     fi
     op.value OpValue::PushInt is
     op.value OpValue::PushStr is ||
@@ -694,6 +725,9 @@ fn op_is_static_with_store store:SymbolStore op:Op -> bool {
             0 fn_opt.unwrap Function::captures.length == return
         fi
         false return
+    fi
+    if op.value OpValue::ExprGroup(group_ops) is then
+        group_ops store op_is_static_struct_literal_with_store return
     fi
     op op_is_static
 }
@@ -895,6 +929,7 @@ struct Program {
     functions:       Map[str List[InstValue]]
     strings:         List[str]
     static_arrays:   List[StaticArray]
+    static_structs:  List[StaticStruct]
     globals_count:   int
     constants_count: int
 }

--- a/compiler/emitter.casa
+++ b/compiler/emitter.casa
@@ -175,6 +175,22 @@ fn emit_data asm:StringBuilder program:Program {
         1 += sa_index
     done
 
+    # Static struct literals
+    0 = ss_index
+    while ss_index program Program::static_structs.length > do
+        ss_index program Program::static_structs.get = ss
+        ss StaticStruct::fields = fields
+        ".align 8" asm emit_line
+        f"static_struct_{ss_index}:" asm emit_line
+        for field in fields.iter do
+            field match
+                StaticArrayElement::Imm(v) => { f".quad {v}" asm emit_line }
+                StaticArrayElement::Label(lbl) => { f".quad {lbl}" asm emit_line }
+            end
+        done
+        1 += ss_index
+    done
+
     "" asm emit_line
 }
 

--- a/tests/compiler/test_array_methods.casa
+++ b/tests/compiler/test_array_methods.casa
@@ -183,9 +183,37 @@ fn test_enum_variant_array_emits_static {
     "has static_array label" asm "static_array_0:" assert_contains
 }
 
-fn test_struct_array_uses_heap {
-    "struct_array_uses_heap" test_start
-    "struct Point { x: int y: int }\n[Point { x: 1, y: 2 }] drop" compile_am = prog
+fn test_struct_array_emits_static {
+    "struct_array_emits_static" test_start
+    "struct Point { x: int y: int }\n[Point { x: 1, y: 2 }] drop" emit_am = asm
+    "has static_array label" asm "static_array_0:" assert_contains
+    "has static_struct label" asm "static_struct_0:" assert_contains
+}
+
+fn test_struct_array_multi_emits_static {
+    "struct_array_multi_emits_static" test_start
+    "struct Point { x: int y: int }\n[Point { x: 1, y: 2 }, Point { x: 3, y: 4 }] drop" emit_am = asm
+    "has static_struct_0" asm "static_struct_0:" assert_contains
+    "has static_struct_1" asm "static_struct_1:" assert_contains
+}
+
+fn test_struct_array_field_reorder_emits_static {
+    "struct_array_field_reorder_emits_static" test_start
+    "struct Pair { a: int b: int }\n[Pair { b: 20, a: 10 }] drop" emit_am = asm
+    "has static_struct" asm "static_struct_0:" assert_contains
+    "field a first" asm ".quad 10\n.quad 20" assert_contains
+}
+
+fn test_struct_array_string_field_emits_static {
+    "struct_array_string_field_emits_static" test_start
+    "struct Named { name: str val: int }\n[Named { name: \"hello\", val: 42 }] drop" emit_am = asm
+    "has static_struct" asm "static_struct_0:" assert_contains
+    "has string ref" asm "str_" assert_contains
+}
+
+fn test_struct_array_non_literal_uses_heap {
+    "struct_array_non_literal_uses_heap" test_start
+    "struct Point { x: int y: int }\n42 = n\n[Point { x: n, y: 2 }] drop" compile_am = prog
     false = has_static
     false = has_heap
     for inst in prog Program::bytecode.iter do
@@ -284,7 +312,11 @@ test_lambda_in_array_type
 test_struct_in_array_type
 test_struct_in_array_with_var
 test_enum_variant_array_emits_static
-test_struct_array_uses_heap
+test_struct_array_emits_static
+test_struct_array_multi_emits_static
+test_struct_array_field_reorder_emits_static
+test_struct_array_string_field_emits_static
+test_struct_array_non_literal_uses_heap
 test_fn_ptr_in_array_type
 test_fn_ptr_array_emits_static
 test_lambda_type

--- a/tests/compiler/test_bytecode.casa
+++ b/tests/compiler/test_bytecode.casa
@@ -195,7 +195,7 @@ fn test_compile_local_variable {
     "y" make_variable func Function::variables.push
 
     List::new(List[InstValue]) = bytecode
-    List::new(List[StaticArray]) List::new(List[str]) List::new(List[str]) func Option::Some fn_ops TEST_STORE make_compiler_with_tables = compiler
+    List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str]) List::new(List[str]) func Option::Some fn_ops TEST_STORE make_compiler_with_tables = compiler
     bytecode compiler compile_ops
 
     # Index 0 is label, 1 is LOCAL_SET, 2 is LOCAL_GET

--- a/tests/compiler/test_emitter.casa
+++ b/tests/compiler/test_emitter.casa
@@ -19,6 +19,7 @@ fn assert_contains needle:str haystack:str msg:str {
 
 fn make_empty_program -> Program {
     0 0
+    List::new(List[StaticStruct])
     List::new(List[StaticArray])
     List::new(List[str])
     Map::new(Map[str List[InstValue]])
@@ -34,6 +35,7 @@ fn make_simple_program
     constants:int
 -> Program {
     constants globals
+    List::new(List[StaticStruct])
     List::new(List[StaticArray])
     strings
     Map::new(Map[str List[InstValue]])
@@ -64,6 +66,7 @@ fn test_emit_bss {
     3 = globals
     2 = constants
     constants globals
+    List::new(List[StaticStruct])
     List::new(List[StaticArray])
     List::new(List[str])
     Map::new(Map[str List[InstValue]])
@@ -92,6 +95,7 @@ fn test_emit_data {
     "world" strings.push
 
     0 0
+    List::new(List[StaticStruct])
     List::new(List[StaticArray])
     strings
     Map::new(Map[str List[InstValue]])
@@ -117,7 +121,7 @@ fn test_emit_push {
     List::new(List[InstValue]) = bytecode
     42 InstValue::Push bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -134,7 +138,7 @@ fn test_emit_push_str {
     List::new(List[str]) = strings
     "test" strings.push
 
-    0 0 List::new(List[StaticArray]) strings
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) strings
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -148,7 +152,7 @@ fn test_emit_add {
     List::new(List[InstValue]) = bytecode
     InstValue::Add bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -163,7 +167,7 @@ fn test_emit_label_and_jump {
     7 InstValue::Label bytecode.push
     7 InstValue::Jump bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -183,7 +187,7 @@ fn test_emit_fn_call {
     Map::new(Map[str List[InstValue]]) = functions
     fn_bytecode "my_func" functions.set = functions
 
-    0 0 List::new(List[StaticArray]) List::new(List[str]) functions bytecode Program = program
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str]) functions bytecode Program = program
     program emit = result
     "has jmp fn_my_func" result "jmp fn_my_func" assert_contains
     "has fn_my_func label" result "fn_my_func:" assert_contains
@@ -198,7 +202,7 @@ fn test_emit_fn_call_sanitized {
     Map::new(Map[str List[InstValue]]) = functions
     fn_bytecode "Foo::bar" functions.set = functions
 
-    0 0 List::new(List[StaticArray]) List::new(List[str]) functions bytecode Program = program
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str]) functions bytecode Program = program
     program emit = result
     "has jmp fn_Foo__bar" result "jmp fn_Foo__bar" assert_contains
     "has fn_Foo__bar label" result "fn_Foo__bar:" assert_contains
@@ -226,7 +230,7 @@ fn test_emit_comparison {
     List::new(List[InstValue]) = bytecode
     InstValue::Eq bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -241,7 +245,7 @@ fn test_emit_syscall {
     List::new(List[InstValue]) = bytecode
     InstValue::Syscall3 bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -263,7 +267,7 @@ fn test_emit_local_ops {
     1 InstValue::LocalSet bytecode.push
     3 InstValue::LocalsUninit bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -282,7 +286,7 @@ fn test_emit_global_ops {
     2 InstValue::GlobalGet bytecode.push
     3 InstValue::GlobalSet bytecode.push
 
-    5 0 List::new(List[StaticArray]) List::new(List[str])
+    5 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -298,7 +302,7 @@ fn test_emit_memory_ops {
     InstValue::Load64 bytecode.push
     InstValue::Store64 bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -314,7 +318,7 @@ fn test_emit_full_program {
     List::new(List[InstValue]) = bytecode
     99 InstValue::Push bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -335,7 +339,7 @@ fn test_emit_drop {
     List::new(List[InstValue]) = bytecode
     InstValue::Drop bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -349,7 +353,7 @@ fn test_emit_dup {
     List::new(List[InstValue]) = bytecode
     InstValue::Dup bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -363,7 +367,7 @@ fn test_emit_swap {
     List::new(List[InstValue]) = bytecode
     InstValue::Swap bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -380,7 +384,7 @@ fn test_emit_over {
     List::new(List[InstValue]) = bytecode
     InstValue::Over bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -394,7 +398,7 @@ fn test_emit_rot {
     List::new(List[InstValue]) = bytecode
     InstValue::Rot bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -417,7 +421,7 @@ fn test_emit_push_char {
     List::new(List[InstValue]) = bytecode
     97 InstValue::PushChar bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -431,7 +435,7 @@ fn test_emit_push_large_int {
     List::new(List[InstValue]) = bytecode
     4294967296 InstValue::Push bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -445,7 +449,7 @@ fn test_emit_push_negative_int {
     List::new(List[InstValue]) = bytecode
     0 42 - InstValue::Push bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -463,7 +467,7 @@ fn test_emit_sub {
     List::new(List[InstValue]) = bytecode
     InstValue::Sub bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -477,7 +481,7 @@ fn test_emit_mul {
     List::new(List[InstValue]) = bytecode
     InstValue::Mul bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -491,7 +495,7 @@ fn test_emit_div {
     List::new(List[InstValue]) = bytecode
     InstValue::Div bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -505,7 +509,7 @@ fn test_emit_mod {
     List::new(List[InstValue]) = bytecode
     InstValue::Mod bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -524,7 +528,7 @@ fn test_emit_shl {
     List::new(List[InstValue]) = bytecode
     InstValue::Shl bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -538,7 +542,7 @@ fn test_emit_shr {
     List::new(List[InstValue]) = bytecode
     InstValue::Shr bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -556,7 +560,7 @@ fn test_emit_bit_and {
     List::new(List[InstValue]) = bytecode
     InstValue::BitAnd bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -570,7 +574,7 @@ fn test_emit_bit_or {
     List::new(List[InstValue]) = bytecode
     InstValue::BitOr bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -584,7 +588,7 @@ fn test_emit_bit_xor {
     List::new(List[InstValue]) = bytecode
     InstValue::BitXor bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -598,7 +602,7 @@ fn test_emit_bit_not {
     List::new(List[InstValue]) = bytecode
     InstValue::BitNot bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -616,7 +620,7 @@ fn test_emit_bool_and {
     List::new(List[InstValue]) = bytecode
     InstValue::And bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -630,7 +634,7 @@ fn test_emit_bool_or {
     List::new(List[InstValue]) = bytecode
     InstValue::Or bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -644,7 +648,7 @@ fn test_emit_bool_not {
     List::new(List[InstValue]) = bytecode
     InstValue::Not bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -662,7 +666,7 @@ fn test_emit_ne {
     List::new(List[InstValue]) = bytecode
     InstValue::Ne bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -677,7 +681,7 @@ fn test_emit_lt {
     List::new(List[InstValue]) = bytecode
     InstValue::Lt bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -691,7 +695,7 @@ fn test_emit_le {
     List::new(List[InstValue]) = bytecode
     InstValue::Le bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -705,7 +709,7 @@ fn test_emit_gt {
     List::new(List[InstValue]) = bytecode
     InstValue::Gt bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -719,7 +723,7 @@ fn test_emit_ge {
     List::new(List[InstValue]) = bytecode
     InstValue::Ge bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -737,7 +741,7 @@ fn test_emit_heap_alloc {
     List::new(List[InstValue]) = bytecode
     InstValue::HeapAlloc bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -752,7 +756,7 @@ fn test_emit_load8 {
     List::new(List[InstValue]) = bytecode
     InstValue::Load8 bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -766,7 +770,7 @@ fn test_emit_load16 {
     List::new(List[InstValue]) = bytecode
     InstValue::Load16 bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -780,7 +784,7 @@ fn test_emit_load32 {
     List::new(List[InstValue]) = bytecode
     InstValue::Load32 bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -794,7 +798,7 @@ fn test_emit_store8 {
     List::new(List[InstValue]) = bytecode
     InstValue::Store8 bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -808,7 +812,7 @@ fn test_emit_store16 {
     List::new(List[InstValue]) = bytecode
     InstValue::Store16 bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -822,7 +826,7 @@ fn test_emit_store32 {
     List::new(List[InstValue]) = bytecode
     InstValue::Store32 bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -840,7 +844,7 @@ fn test_emit_syscall0 {
     List::new(List[InstValue]) = bytecode
     InstValue::Syscall0 bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -856,7 +860,7 @@ fn test_emit_syscall1 {
     List::new(List[InstValue]) = bytecode
     InstValue::Syscall1 bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -873,7 +877,7 @@ fn test_emit_syscall2 {
     List::new(List[InstValue]) = bytecode
     InstValue::Syscall2 bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -891,7 +895,7 @@ fn test_emit_syscall4 {
     List::new(List[InstValue]) = bytecode
     InstValue::Syscall4 bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -911,7 +915,7 @@ fn test_emit_syscall5 {
     List::new(List[InstValue]) = bytecode
     InstValue::Syscall5 bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -932,7 +936,7 @@ fn test_emit_syscall6 {
     List::new(List[InstValue]) = bytecode
     InstValue::Syscall6 bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -965,7 +969,7 @@ fn test_emit_fn_return {
     Map::new(Map[str List[InstValue]]) = functions
     fn_bytecode "test_fn" functions.set = functions
 
-    0 0 List::new(List[StaticArray]) List::new(List[str]) functions bytecode Program = program
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str]) functions bytecode Program = program
     program emit = result
     "has jmpq *(%r14)" result "jmpq *(%r14)" assert_contains
 }
@@ -975,7 +979,7 @@ fn test_emit_fn_exec {
     List::new(List[InstValue]) = bytecode
     InstValue::FnExec bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -993,7 +997,7 @@ fn test_emit_fn_push {
     Map::new(Map[str List[InstValue]]) = functions
     fn_bytecode "my_lambda" functions.set = functions
 
-    0 0 List::new(List[StaticArray]) List::new(List[str]) functions bytecode Program = program
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str]) functions bytecode Program = program
     program emit = result
     "has leaq fn_my_lambda" result "leaq fn_my_lambda" assert_contains
 }
@@ -1007,7 +1011,7 @@ fn test_emit_print_int {
     List::new(List[InstValue]) = bytecode
     InstValue::PrintInt bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -1021,7 +1025,7 @@ fn test_emit_print_str {
     List::new(List[InstValue]) = bytecode
     InstValue::PrintStr bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -1035,7 +1039,7 @@ fn test_emit_print_bool {
     List::new(List[InstValue]) = bytecode
     InstValue::PrintBool bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -1050,7 +1054,7 @@ fn test_emit_print_char {
     List::new(List[InstValue]) = bytecode
     InstValue::PrintChar bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -1064,7 +1068,7 @@ fn test_emit_print_cstr {
     List::new(List[InstValue]) = bytecode
     InstValue::PrintCstr bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -1082,7 +1086,7 @@ fn test_emit_str_eq {
     List::new(List[InstValue]) = bytecode
     InstValue::StrEq bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -1096,7 +1100,7 @@ fn test_emit_fstring_concat {
     List::new(List[InstValue]) = bytecode
     3 InstValue::FstringConcat bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -1115,7 +1119,7 @@ fn test_emit_constant_load {
     List::new(List[InstValue]) = bytecode
     0 InstValue::ConstantLoad bytecode.push
 
-    0 1 List::new(List[StaticArray]) List::new(List[str])
+    0 1 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -1129,7 +1133,7 @@ fn test_emit_constant_store {
     List::new(List[InstValue]) = bytecode
     1 InstValue::ConstantStore bytecode.push
 
-    0 2 List::new(List[StaticArray]) List::new(List[str])
+    0 2 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -1147,7 +1151,7 @@ fn test_emit_jump_ne {
     List::new(List[InstValue]) = bytecode
     5 InstValue::JumpNe bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -1166,7 +1170,7 @@ fn test_emit_argc {
     List::new(List[InstValue]) = bytecode
     InstValue::Argc bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -1180,7 +1184,7 @@ fn test_emit_argv {
     List::new(List[InstValue]) = bytecode
     InstValue::Argv bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -1210,7 +1214,7 @@ fn test_emit_globals_init {
     5 InstValue::GlobalsInit bytecode.push
     42 InstValue::Push bytecode.push
 
-    0 5 List::new(List[StaticArray]) List::new(List[str])
+    0 5 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -1236,7 +1240,7 @@ fn test_emit_while_loop_pattern {
     10 InstValue::Jump bytecode.push
     11 InstValue::Label bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -1258,7 +1262,7 @@ fn test_emit_data_escape_sequences {
     "hello\nworld" strings.push
     "col1\tcol2" strings.push
 
-    0 0 List::new(List[StaticArray]) strings
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) strings
     Map::new(Map[str List[InstValue]])
     List::new(List[InstValue])
     Program = program
@@ -1281,7 +1285,7 @@ fn test_emit_locals_rep_stosq {
     4 InstValue::LocalsInit bytecode.push
     4 InstValue::LocalsUninit bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -1301,7 +1305,7 @@ fn test_emit_load64 {
     List::new(List[InstValue]) = bytecode
     InstValue::Load64 bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -1321,7 +1325,7 @@ fn test_emit_store64 {
     List::new(List[InstValue]) = bytecode
     InstValue::Store64 bytecode.push
 
-    0 0 List::new(List[StaticArray]) List::new(List[str])
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str])
     Map::new(Map[str List[InstValue]])
     bytecode
     Program = program
@@ -1352,7 +1356,7 @@ fn test_emit_fn_with_body {
     Map::new(Map[str List[InstValue]]) = functions
     fn_bytecode "adder" functions.set = functions
 
-    0 0 List::new(List[StaticArray]) List::new(List[str]) functions bytecode Program = program
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str]) functions bytecode Program = program
     program emit = result
     "has fn label" result "fn_adder:" assert_contains
     "has locals init" result "rep stosq" assert_contains
@@ -1380,7 +1384,7 @@ fn test_emit_multiple_functions {
     alpha_bytecode "alpha" functions.set = functions
     beta_bytecode "beta" functions.set = functions
 
-    0 0 List::new(List[StaticArray]) List::new(List[str]) functions bytecode Program = program
+    0 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str]) functions bytecode Program = program
     program emit = result
     "has fn_alpha label" result "fn_alpha:" assert_contains
     "has fn_beta label" result "fn_beta:" assert_contains


### PR DESCRIPTION
## Summary

- Struct literals with all-constant fields in array literals now emit as static `.data` blocks instead of heap-allocating at runtime
- Extends `op_is_static` / `op_is_static_with_store` to recognize `ExprGroup` containing struct literals with constant fields
- Adds `StaticStruct` type, `compile_static_struct` for field reordering and emission, and `.data` section output
- Updates `Program` and `BytecodeCompiler` to carry `static_structs` alongside `static_arrays`

## Test plan

- [x] `test_struct_array_emits_static` — single struct emits static
- [x] `test_struct_array_multi_emits_static` — multiple structs get separate labels
- [x] `test_struct_array_field_reorder_emits_static` — field order != member order emits correctly
- [x] `test_struct_array_string_field_emits_static` — string fields use label refs
- [x] `test_struct_array_non_literal_uses_heap` — variable field falls back to heap
- [x] Full compiler test suite (55/55), examples (47/47), bootstrap (2/2)
- [x] Runtime verified: struct field access through `nth` returns correct values

Closes #240