### PR TITLE
refactor: extract compiler test helpers from lib/test.casa

### DIFF
--- a/lib/test.casa
+++ b/lib/test.casa
@@ -1,22 +1,10 @@
 # Test assertion library for Casa unit tests.
 #
-# Provides assertion functions and test result tracking, along with
-# compiler-specific helpers for error and global state testing.
-#
 # Usage:
 #   "test_name" test_start
 #   condition "message" assert_true
 #   actual expected "message" assert_eq
 #   test_summary
-#
-# Compiler-specific helpers (require the compiler modules to be included
-# in the host test file):
-#   enable_test_mode / disable_test_mode
-#   clear_errors / clear_warnings
-#   assert_has_errors / assert_no_errors / assert_error_count
-#   assert_error_contains / assert_error_kind
-#   assert_warning_count / assert_warning_contains
-#   clear_global_state
 import "std"
 
 0 = test_pass_count
@@ -63,96 +51,4 @@ fn test_summary {
     if 0 test_fail_count > then
         1 exit
     fi
-}
-
-# ---------------------------------------------------------------------------
-# Compiler test helpers
-#
-# These require the host test file to have already included the relevant
-# compiler modules (error.casa, parser.casa) so that TEST_MODE, ERRORS,
-# WARNINGS, CasaError, CasaWarning, and related symbols are in scope.
-# ---------------------------------------------------------------------------
-
-fn enable_test_mode {
-    global TEST_MODE
-    true = TEST_MODE
-}
-
-fn disable_test_mode {
-    global TEST_MODE
-    false = TEST_MODE
-}
-
-fn clear_errors {
-    global ERRORS
-    List::new(List[CasaError]) = ERRORS
-}
-
-fn clear_warnings {
-    global WARNINGS
-    List::new(List[CasaWarning]) = WARNINGS
-}
-
-fn assert_has_errors message:str {
-    message 0 ERRORS.length != assert_true
-}
-
-fn assert_no_errors message:str {
-    message 0 ERRORS.length == assert_true
-}
-
-fn assert_error_count expected:int message:str {
-    message expected ERRORS.length assert_eq
-}
-
-fn assert_error_contains needle:str message:str {
-    false = error_found
-    for error in ERRORS.iter do
-        error CasaError::message = error_message
-        error_message needle str::find = match_pos
-        if 0 match_pos >= then
-            true = error_found
-        fi
-    done
-    message error_found assert_true
-}
-
-fn assert_error_kind expected_kind:ErrorKind message:str {
-    false = kind_found
-    for error in ERRORS.iter do
-        if expected_kind error CasaError::kind == then
-            true = kind_found
-        fi
-    done
-    message kind_found assert_true
-}
-
-fn assert_warning_count expected:int message:str {
-    message expected WARNINGS.length assert_eq
-}
-
-fn assert_warning_contains needle:str message:str {
-    false = warning_found
-    for warning in WARNINGS.iter do
-        warning CasaWarning::message = warning_message
-        warning_message needle str::find = match_pos
-        if 0 match_pos >= then
-            true = warning_found
-        fi
-    done
-    message warning_found assert_true
-}
-
-fn clear_global_state {
-    global SOURCE_CACHE
-    global ERRORS
-    global WARNINGS
-    Map::new(Map[str str]) = SOURCE_CACHE
-    List::new(List[CasaError]) = ERRORS
-    List::new(List[CasaWarning]) = WARNINGS
-}
-
-fn parse_resolve_test_source code:str -> ParseResolveResult {
-    "test" code lex_source = tokens
-    List::new(List[str]) tokens parse_and_resolve
 }

--- a/tests/compiler/helpers.casa
+++ b/tests/compiler/helpers.casa
@@ -1,0 +1,101 @@
+# Compiler-specific test helpers.
+#
+# Wraps compiler globals (TEST_MODE, ERRORS, WARNINGS, SOURCE_CACHE)
+# so test files can toggle test mode, inspect diagnostics, and reset
+# state between test cases.
+#
+# Usage:
+#   enable_test_mode
+#   clear_global_state
+#   "some source" parse_resolve_test_source = result
+#   1 "expected one error" assert_error_count
+#   "msg" "should contain msg" assert_error_contains
+import "../../compiler/common.casa"
+import "../../compiler/error.casa"
+import "../../compiler/lexer.casa"
+import "../../compiler/syntax.casa"
+import "../../lib/test.casa"
+
+fn enable_test_mode {
+    global TEST_MODE
+    true = TEST_MODE
+}
+
+fn disable_test_mode {
+    global TEST_MODE
+    false = TEST_MODE
+}
+
+fn clear_errors {
+    global ERRORS
+    List::new(List[CasaError]) = ERRORS
+}
+
+fn clear_warnings {
+    global WARNINGS
+    List::new(List[CasaWarning]) = WARNINGS
+}
+
+fn assert_has_errors message:str {
+    message 0 ERRORS.length != assert_true
+}
+
+fn assert_no_errors message:str {
+    message 0 ERRORS.length == assert_true
+}
+
+fn assert_error_count expected:int message:str {
+    message expected ERRORS.length assert_eq
+}
+
+fn assert_error_contains needle:str message:str {
+    false = error_found
+    for error in ERRORS.iter do
+        error CasaError::message = error_message
+        error_message needle str::find = match_pos
+        if 0 match_pos >= then
+            true = error_found
+        fi
+    done
+    message error_found assert_true
+}
+
+fn assert_error_kind expected_kind:ErrorKind message:str {
+    false = kind_found
+    for error in ERRORS.iter do
+        if expected_kind error CasaError::kind == then
+            true = kind_found
+        fi
+    done
+    message kind_found assert_true
+}
+
+fn assert_warning_count expected:int message:str {
+    message expected WARNINGS.length assert_eq
+}
+
+fn assert_warning_contains needle:str message:str {
+    false = warning_found
+    for warning in WARNINGS.iter do
+        warning CasaWarning::message = warning_message
+        warning_message needle str::find = match_pos
+        if 0 match_pos >= then
+            true = warning_found
+        fi
+    done
+    message warning_found assert_true
+}
+
+fn clear_global_state {
+    global SOURCE_CACHE
+    global ERRORS
+    global WARNINGS
+    Map::new(Map[str str]) = SOURCE_CACHE
+    List::new(List[CasaError]) = ERRORS
+    List::new(List[CasaWarning]) = WARNINGS
+}
+
+fn parse_resolve_test_source code:str -> ParseResolveResult {
+    "test" code lex_source = tokens
+    List::new(List[str]) tokens parse_and_resolve
+}

--- a/tests/compiler/helpers.casa
+++ b/tests/compiler/helpers.casa
@@ -74,18 +74,6 @@ fn assert_warning_count expected:int message:str {
     message expected WARNINGS.length assert_eq
 }
 
-fn assert_warning_contains needle:str message:str {
-    false = warning_found
-    for warning in WARNINGS.iter do
-        warning CasaWarning::message = warning_message
-        warning_message needle str::find = match_pos
-        if 0 match_pos >= then
-            true = warning_found
-        fi
-    done
-    message warning_found assert_true
-}
-
 fn clear_global_state {
     global SOURCE_CACHE
     global ERRORS

--- a/tests/compiler/test_argv.casa
+++ b/tests/compiler/test_argv.casa
@@ -1,11 +1,6 @@
-import "../../compiler/common.casa"
-import "../../compiler/error.casa"
-import "../../compiler/lexer.casa"
-import "../../compiler/syntax.casa"
 import "../../compiler/typechecker.casa"
 import "../../compiler/bytecode.casa"
 import "../../compiler/emitter.casa"
-import "../../lib/test.casa"
 import "helpers.casa"
 
 # ============================================================================

--- a/tests/compiler/test_argv.casa
+++ b/tests/compiler/test_argv.casa
@@ -6,6 +6,7 @@ import "../../compiler/typechecker.casa"
 import "../../compiler/bytecode.casa"
 import "../../compiler/emitter.casa"
 import "../../lib/test.casa"
+import "helpers.casa"
 
 # ============================================================================
 # Helpers

--- a/tests/compiler/test_array_methods.casa
+++ b/tests/compiler/test_array_methods.casa
@@ -6,6 +6,7 @@ import "../../compiler/typechecker.casa"
 import "../../compiler/bytecode.casa"
 import "../../compiler/emitter.casa"
 import "../../lib/test.casa"
+import "helpers.casa"
 
 # ============================================================================
 # Array method tests

--- a/tests/compiler/test_array_methods.casa
+++ b/tests/compiler/test_array_methods.casa
@@ -1,11 +1,6 @@
-import "../../compiler/common.casa"
-import "../../compiler/error.casa"
-import "../../compiler/lexer.casa"
-import "../../compiler/syntax.casa"
 import "../../compiler/typechecker.casa"
 import "../../compiler/bytecode.casa"
 import "../../compiler/emitter.casa"
-import "../../lib/test.casa"
 import "helpers.casa"
 
 # ============================================================================

--- a/tests/compiler/test_compare.casa
+++ b/tests/compiler/test_compare.casa
@@ -1,9 +1,4 @@
-import "../../compiler/common.casa"
-import "../../compiler/error.casa"
-import "../../compiler/lexer.casa"
-import "../../compiler/syntax.casa"
 import "../../compiler/typechecker.casa"
-import "../../lib/test.casa"
 import "helpers.casa"
 
 # ============================================================================

--- a/tests/compiler/test_compare.casa
+++ b/tests/compiler/test_compare.casa
@@ -4,6 +4,7 @@ import "../../compiler/lexer.casa"
 import "../../compiler/syntax.casa"
 import "../../compiler/typechecker.casa"
 import "../../lib/test.casa"
+import "helpers.casa"
 
 # ============================================================================
 # Constants

--- a/tests/compiler/test_display.casa
+++ b/tests/compiler/test_display.casa
@@ -1,9 +1,4 @@
-import "../../compiler/common.casa"
-import "../../compiler/error.casa"
-import "../../compiler/lexer.casa"
-import "../../compiler/syntax.casa"
 import "../../compiler/typechecker.casa"
-import "../../lib/test.casa"
 import "helpers.casa"
 
 # ============================================================================

--- a/tests/compiler/test_display.casa
+++ b/tests/compiler/test_display.casa
@@ -4,6 +4,7 @@ import "../../compiler/lexer.casa"
 import "../../compiler/syntax.casa"
 import "../../compiler/typechecker.casa"
 import "../../lib/test.casa"
+import "helpers.casa"
 
 # ============================================================================
 # Constants

--- a/tests/compiler/test_enum.casa
+++ b/tests/compiler/test_enum.casa
@@ -1,11 +1,6 @@
-import "../../compiler/common.casa"
-import "../../compiler/error.casa"
-import "../../compiler/lexer.casa"
-import "../../compiler/syntax.casa"
 import "../../compiler/typechecker.casa"
 import "../../compiler/bytecode.casa"
 import "../../compiler/emitter.casa"
-import "../../lib/test.casa"
 import "helpers.casa"
 
 # ============================================================================

--- a/tests/compiler/test_enum.casa
+++ b/tests/compiler/test_enum.casa
@@ -6,6 +6,7 @@ import "../../compiler/typechecker.casa"
 import "../../compiler/bytecode.casa"
 import "../../compiler/emitter.casa"
 import "../../lib/test.casa"
+import "helpers.casa"
 
 # ============================================================================
 # Constants

--- a/tests/compiler/test_enum_variant_hint.casa
+++ b/tests/compiler/test_enum_variant_hint.casa
@@ -1,9 +1,4 @@
-import "../../compiler/common.casa"
-import "../../compiler/error.casa"
-import "../../compiler/lexer.casa"
-import "../../compiler/syntax.casa"
 import "../../compiler/typechecker.casa"
-import "../../lib/test.casa"
 import "helpers.casa"
 
 "enum Color { Red Green Blue }\n" = EVH_COLOR_ENUM

--- a/tests/compiler/test_enum_variant_hint.casa
+++ b/tests/compiler/test_enum_variant_hint.casa
@@ -4,6 +4,7 @@ import "../../compiler/lexer.casa"
 import "../../compiler/syntax.casa"
 import "../../compiler/typechecker.casa"
 import "../../lib/test.casa"
+import "helpers.casa"
 
 "enum Color { Red Green Blue }\n" = EVH_COLOR_ENUM
 "enum Direction { North South East West }\n" = EVH_DIRECTION_ENUM

--- a/tests/compiler/test_generic_structs.casa
+++ b/tests/compiler/test_generic_structs.casa
@@ -1,11 +1,6 @@
-import "../../compiler/common.casa"
-import "../../compiler/error.casa"
-import "../../compiler/lexer.casa"
-import "../../compiler/syntax.casa"
 import "../../compiler/typechecker.casa"
 import "../../compiler/bytecode.casa"
 import "../../compiler/emitter.casa"
-import "../../lib/test.casa"
 import "helpers.casa"
 
 # ============================================================================

--- a/tests/compiler/test_generic_structs.casa
+++ b/tests/compiler/test_generic_structs.casa
@@ -6,6 +6,7 @@ import "../../compiler/typechecker.casa"
 import "../../compiler/bytecode.casa"
 import "../../compiler/emitter.casa"
 import "../../lib/test.casa"
+import "helpers.casa"
 
 # ============================================================================
 # Helpers

--- a/tests/compiler/test_global_keyword.casa
+++ b/tests/compiler/test_global_keyword.casa
@@ -1,9 +1,4 @@
-import "../../compiler/common.casa"
-import "../../compiler/error.casa"
-import "../../compiler/lexer.casa"
-import "../../compiler/syntax.casa"
 import "../../compiler/typechecker.casa"
-import "../../lib/test.casa"
 import "helpers.casa"
 
 # ============================================================================

--- a/tests/compiler/test_global_keyword.casa
+++ b/tests/compiler/test_global_keyword.casa
@@ -4,6 +4,7 @@ import "../../compiler/lexer.casa"
 import "../../compiler/syntax.casa"
 import "../../compiler/typechecker.casa"
 import "../../lib/test.casa"
+import "helpers.casa"
 
 # ============================================================================
 # Helpers

--- a/tests/compiler/test_match_underflow.casa
+++ b/tests/compiler/test_match_underflow.casa
@@ -1,9 +1,4 @@
-import "../../compiler/common.casa"
-import "../../compiler/error.casa"
-import "../../compiler/lexer.casa"
-import "../../compiler/syntax.casa"
 import "../../compiler/typechecker.casa"
-import "../../lib/test.casa"
 import "helpers.casa"
 
 # ============================================================================

--- a/tests/compiler/test_match_underflow.casa
+++ b/tests/compiler/test_match_underflow.casa
@@ -4,6 +4,7 @@ import "../../compiler/lexer.casa"
 import "../../compiler/syntax.casa"
 import "../../compiler/typechecker.casa"
 import "../../lib/test.casa"
+import "helpers.casa"
 
 # ============================================================================
 # Helper: lex + parse + resolve + typecheck a source string

--- a/tests/compiler/test_pattern.casa
+++ b/tests/compiler/test_pattern.casa
@@ -6,6 +6,7 @@ import "../../compiler/typechecker.casa"
 import "../../compiler/bytecode.casa"
 import "../../compiler/pattern.casa"
 import "../../lib/test.casa"
+import "helpers.casa"
 
 # ============================================================================
 # Helpers for building match-arm ops for tests

--- a/tests/compiler/test_pattern.casa
+++ b/tests/compiler/test_pattern.casa
@@ -1,11 +1,6 @@
-import "../../compiler/common.casa"
-import "../../compiler/error.casa"
-import "../../compiler/lexer.casa"
-import "../../compiler/syntax.casa"
 import "../../compiler/typechecker.casa"
 import "../../compiler/bytecode.casa"
 import "../../compiler/pattern.casa"
-import "../../lib/test.casa"
 import "helpers.casa"
 
 # ============================================================================

--- a/tests/compiler/test_struct_literal.casa
+++ b/tests/compiler/test_struct_literal.casa
@@ -1,10 +1,5 @@
-import "../../compiler/common.casa"
-import "../../compiler/error.casa"
-import "../../compiler/lexer.casa"
-import "../../compiler/syntax.casa"
 import "../../compiler/typechecker.casa"
 import "../../compiler/bytecode.casa"
-import "../../lib/test.casa"
 import "helpers.casa"
 
 # ============================================================================

--- a/tests/compiler/test_struct_literal.casa
+++ b/tests/compiler/test_struct_literal.casa
@@ -5,6 +5,7 @@ import "../../compiler/syntax.casa"
 import "../../compiler/typechecker.casa"
 import "../../compiler/bytecode.casa"
 import "../../lib/test.casa"
+import "helpers.casa"
 
 # ============================================================================
 # Constants

--- a/tests/compiler/test_traits.casa
+++ b/tests/compiler/test_traits.casa
@@ -1,9 +1,4 @@
-import "../../compiler/common.casa"
-import "../../compiler/error.casa"
-import "../../compiler/lexer.casa"
-import "../../compiler/syntax.casa"
 import "../../compiler/typechecker.casa"
-import "../../lib/test.casa"
 import "helpers.casa"
 
 # ============================================================================

--- a/tests/compiler/test_traits.casa
+++ b/tests/compiler/test_traits.casa
@@ -4,6 +4,7 @@ import "../../compiler/lexer.casa"
 import "../../compiler/syntax.casa"
 import "../../compiler/typechecker.casa"
 import "../../lib/test.casa"
+import "helpers.casa"
 
 # ============================================================================
 # Constants

--- a/tests/compiler/test_type_annotations.casa
+++ b/tests/compiler/test_type_annotations.casa
@@ -1,9 +1,4 @@
-import "../../compiler/common.casa"
-import "../../compiler/error.casa"
-import "../../compiler/lexer.casa"
-import "../../compiler/syntax.casa"
 import "../../compiler/typechecker.casa"
-import "../../lib/test.casa"
 import "helpers.casa"
 
 # ============================================================================

--- a/tests/compiler/test_type_annotations.casa
+++ b/tests/compiler/test_type_annotations.casa
@@ -4,6 +4,7 @@ import "../../compiler/lexer.casa"
 import "../../compiler/syntax.casa"
 import "../../compiler/typechecker.casa"
 import "../../lib/test.casa"
+import "helpers.casa"
 
 # ============================================================================
 # Constants

--- a/tests/compiler/test_typechecker.casa
+++ b/tests/compiler/test_typechecker.casa
@@ -1,9 +1,4 @@
-import "../../compiler/common.casa"
-import "../../compiler/error.casa"
-import "../../compiler/lexer.casa"
-import "../../compiler/syntax.casa"
 import "../../compiler/typechecker.casa"
-import "../../lib/test.casa"
 import "helpers.casa"
 
 # ============================================================================

--- a/tests/compiler/test_typechecker.casa
+++ b/tests/compiler/test_typechecker.casa
@@ -4,6 +4,7 @@ import "../../compiler/lexer.casa"
 import "../../compiler/syntax.casa"
 import "../../compiler/typechecker.casa"
 import "../../lib/test.casa"
+import "helpers.casa"
 
 # ============================================================================
 # Helper: create ops list and type check it

--- a/tests/compiler/test_typeof.casa
+++ b/tests/compiler/test_typeof.casa
@@ -1,11 +1,6 @@
-import "../../compiler/common.casa"
-import "../../compiler/error.casa"
-import "../../compiler/lexer.casa"
-import "../../compiler/syntax.casa"
 import "../../compiler/typechecker.casa"
 import "../../compiler/bytecode.casa"
 import "../../compiler/emitter.casa"
-import "../../lib/test.casa"
 import "helpers.casa"
 
 # ============================================================================

--- a/tests/compiler/test_typeof.casa
+++ b/tests/compiler/test_typeof.casa
@@ -6,6 +6,7 @@ import "../../compiler/typechecker.casa"
 import "../../compiler/bytecode.casa"
 import "../../compiler/emitter.casa"
 import "../../lib/test.casa"
+import "helpers.casa"
 
 # ============================================================================
 # Helpers

--- a/tests/compiler/test_underflow_messages.casa
+++ b/tests/compiler/test_underflow_messages.casa
@@ -1,9 +1,4 @@
-import "../../compiler/common.casa"
-import "../../compiler/error.casa"
-import "../../compiler/lexer.casa"
-import "../../compiler/syntax.casa"
 import "../../compiler/typechecker.casa"
-import "../../lib/test.casa"
 import "helpers.casa"
 
 # ============================================================================

--- a/tests/compiler/test_underflow_messages.casa
+++ b/tests/compiler/test_underflow_messages.casa
@@ -4,6 +4,7 @@ import "../../compiler/lexer.casa"
 import "../../compiler/syntax.casa"
 import "../../compiler/typechecker.casa"
 import "../../lib/test.casa"
+import "helpers.casa"
 
 # ============================================================================
 # Helper: lex + parse + resolve + typecheck a source string


### PR DESCRIPTION
## Summary

- Move compiler-specific test helpers (`enable_test_mode`, `clear_errors`, `assert_error_contains`, `clear_global_state`, `parse_resolve_test_source`, etc.) from `lib/test.casa` into `tests/compiler/helpers.casa`
- `lib/test.casa` becomes a generic assertion library usable by any Casa program without compiler dependencies
- Remove redundant imports from 16 test files — `helpers.casa` transitively provides `common`, `error`, `lexer`, `syntax`, and `test` modules
- Remove unused `assert_warning_contains`

## Test plan

- [x] `tests/test_compiler.sh` — 55/55
- [x] `tests/test_examples.sh` — 47/47