### PR TITLE
refactor: align compiler conventions

### DIFF
--- a/compiler/bytecode.casa
+++ b/compiler/bytecode.casa
@@ -25,45 +25,36 @@ struct BytecodeCompiler {
     compiled_functions: Set[str]
 }
 
-fn make_compiler store:SymbolStore ops:List[Op] -> BytecodeCompiler {
-    Set::new(Set[str])
-    Map::new(Map[Op int])
-    0
-    store
-    List::new(List[StaticStruct])
-    List::new(List[StaticArray])
-    List::new(List[str])
-    List::new(List[str])
-    0
-    Option::None(Option[Function])
-    ops
-    BytecodeCompiler
-}
+impl BytecodeCompiler {
+    fn new store:SymbolStore ops:List[Op] -> BytecodeCompiler {
+        Set::new(Set[str])
+        Map::new(Map[Op int])
+        0
+        store
+        List::new(List[StaticStruct])
+        List::new(List[StaticArray])
+        List::new(List[str])
+        List::new(List[str])
+        0
+        Option::None(Option[Function])
+        ops
+        BytecodeCompiler
+    }
 
-fn make_compiler_with_tables
-    store:SymbolStore
-    ops:List[Op]
-    function:Option[Function]
-    string_table:List[str]
-    constants_table:List[str]
-    static_arrays:List[StaticArray]
-    static_structs:List[StaticStruct]
-    label_counter:int
-    op_label_map:Map[Op int]
-    compiled_functions:Set[str]
--> BytecodeCompiler {
-    compiled_functions
-    op_label_map
-    label_counter
-    store
-    static_structs
-    static_arrays
-    constants_table
-    string_table
-    0
-    function
-    ops
-    BytecodeCompiler
+    fn child self:BytecodeCompiler function:Function ops:List[Op] -> BytecodeCompiler {
+        self.compiled_functions
+        self.op_label_map
+        self.label_counter
+        self.store
+        self.static_structs
+        self.static_arrays
+        self.constants_table
+        self.string_table
+        0
+        function Option::Some
+        ops
+        BytecodeCompiler
+    }
 }
 
 # ============================================================================
@@ -235,7 +226,7 @@ fn require_matching
 -> int {
     backward target_values boundary_value op_index ops compiler find_matching_label = result
     if result.is_none then
-        location message ErrorKind::UnmatchedBlock make_error ERRORS.push
+        location message ErrorKind::UnmatchedBlock CasaError::new ERRORS.push
         0
     else
         result.unwrap
@@ -930,7 +921,7 @@ fn compile_function compiler:BytecodeCompiler function:Function op:Op {
     function Function::name compiler.compiled_functions.add drop
 
     List::new(List[InstValue]) = function_bytecode
-    compiler.compiled_functions compiler.op_label_map compiler.label_counter compiler.static_structs compiler.static_arrays compiler.constants_table compiler.string_table function Option::Some ops compiler.store make_compiler_with_tables = function_compiler
+    ops function compiler.child = function_compiler
     function_bytecode function_compiler compile_ops
     function_compiler.label_counter compiler->label_counter
 
@@ -972,7 +963,7 @@ fn compile_function_ops compiler:BytecodeCompiler op:Op bytecode:List[InstValue]
         OpValue::FnPush => {
             name compiler.store.functions.get = function_opt
             if function_opt.is_none then
-                op Op::location f"Function `{name}` is not defined" ErrorKind::UndefinedName make_error ERRORS.push
+                op Op::location f"Function `{name}` is not defined" ErrorKind::UndefinedName CasaError::new ERRORS.push
                 return
             fi
             function_opt.unwrap = lambda
@@ -1207,7 +1198,7 @@ fn compile_ops compiler:BytecodeCompiler bytecode:List[InstValue] {
 
 fn compile_bytecode store:SymbolStore ops:List[Op] -> Program {
     List::new(List[InstValue]) = bytecode
-    ops store make_compiler = compiler
+    ops store BytecodeCompiler::new = compiler
 
     # Emit globals init if needed
     if 0 compiler.store.variables.length != then

--- a/compiler/bytecode.casa
+++ b/compiler/bytecode.casa
@@ -105,10 +105,6 @@ fn intern_string compiler:BytecodeCompiler value:str -> int {
     value compiler.string_table intern_table
 }
 
-fn intern_constant compiler:BytecodeCompiler name:str -> int {
-    name compiler.constants_table intern_table
-}
-
 # ============================================================================
 # Variable resolution
 # ============================================================================

--- a/compiler/bytecode.casa
+++ b/compiler/bytecode.casa
@@ -245,8 +245,12 @@ impl BytecodeCompiler {
         if result.is_none then
             location message ErrorKind::UnmatchedBlock CasaError::new ERRORS.push
             0
+        elif result Option::Some(label) is then
+            label
         else
-            result.unwrap
+            location "Expected matching block label" ErrorKind::UnmatchedBlock raise_error
+            1 exit
+            0
         fi
     }
 }
@@ -399,7 +403,11 @@ impl BytecodeCompiler {
         struct_pattern:StructPattern
         bytecode:List[InstValue]
     {
-        struct_pattern StructPattern::struct_name compiler.store.structs.get.unwrap = casa_struct
+        if struct_pattern StructPattern::struct_name compiler.store.structs.get Option::Some(casa_struct) is then
+        else
+            empty_location "Expected option value while unwrapping struct_pattern StructPattern::struct_name compiler.store.structs.get" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         0 = index
         while index casa_struct CasaStruct::members.length > do
             index casa_struct CasaStruct::members.get Member::name = field_name
@@ -424,6 +432,15 @@ fn emit_int_eq value:int bytecode:List[InstValue] {
     InstValue::Eq bytecode.push
 }
 
+fn enum_variant_ordinal variant:EnumVariant -> int {
+    if variant EnumVariant::ordinal Option::Some(ordinal) is then
+        ordinal return
+    fi
+    empty_location "Expected enum variant ordinal during bytecode compilation" ErrorKind::Syntax raise_error
+    1 exit
+    0
+}
+
 impl BytecodeCompiler {
     fn emit_literal_arm
         compiler:BytecodeCompiler
@@ -444,7 +461,12 @@ impl BytecodeCompiler {
             LiteralValue::Char(char_value) => { bytecode char_value emit_int_eq }
             LiteralValue::Bool(bool_value) => { bytecode bool_value (int) emit_int_eq }
         end
-        next_arm.unwrap InstValue::JumpNe bytecode.push
+        if next_arm Option::Some(label) is then
+            label InstValue::JumpNe bytecode.push
+        else
+            empty_location "Expected next match arm label" ErrorKind::Syntax raise_error
+            1 exit
+        fi
     }
 }
 
@@ -460,14 +482,23 @@ impl BytecodeCompiler {
         if is_wildcard then return fi
         variant EnumVariant::enum_name = enum_name
         if "" enum_name != enum_name compiler.store.enums.has && then
-            enum_name compiler.store.enums.get.unwrap = casa_enum
+            if enum_name compiler.store.enums.get Option::Some(casa_enum) is then
+            else
+                empty_location "Expected option value while unwrapping enum_name compiler.store.enums.get" ErrorKind::Syntax raise_error
+                1 exit
+            fi
             if casa_enum has_inner_values then
                 if is_last ! then
                     InstValue::Dup bytecode.push
                     InstValue::Load64 bytecode.push
-                    variant EnumVariant::ordinal.unwrap InstValue::Push bytecode.push
+                    variant enum_variant_ordinal InstValue::Push bytecode.push
                     InstValue::Eq bytecode.push
-                    next_arm.unwrap InstValue::JumpNe bytecode.push
+                    if next_arm Option::Some(label) is then
+                        label InstValue::JumpNe bytecode.push
+                    else
+                        empty_location "Expected next match arm label" ErrorKind::Syntax raise_error
+                        1 exit
+                    fi
                 fi
                 variant bytecode compiler.emit_enum_arm_bindings
                 return
@@ -476,9 +507,14 @@ impl BytecodeCompiler {
 
         if is_last then return fi
         InstValue::Dup bytecode.push
-        variant EnumVariant::ordinal.unwrap InstValue::Push bytecode.push
+        variant enum_variant_ordinal InstValue::Push bytecode.push
         InstValue::Eq bytecode.push
-        next_arm.unwrap InstValue::JumpNe bytecode.push
+        if next_arm Option::Some(label) is then
+            label InstValue::JumpNe bytecode.push
+        else
+            empty_location "Expected next match arm label" ErrorKind::Syntax raise_error
+            1 exit
+        fi
     }
 }
 
@@ -536,8 +572,8 @@ impl BytecodeCompiler {
             # does not cover its pattern, so a non-guarded fallback is
             # required). Codegen may still run in RESILIENT_MODE after such
             # an error, so skip the fail-jump rather than unwrapping None.
-            if next_arm.is_some then
-                next_arm.unwrap InstValue::JumpNe bytecode.push
+            if next_arm Option::Some(label) is then
+                label InstValue::JumpNe bytecode.push
             else
                 InstValue::Drop bytecode.push
             fi
@@ -564,7 +600,12 @@ impl BytecodeCompiler {
 
             if is_first ! then
                 end_label InstValue::Jump bytecode.push
-                existing.unwrap InstValue::Label bytecode.push
+                if existing Option::Some(label) is then
+                    label InstValue::Label bytecode.push
+                else
+                    empty_location "Expected existing match arm label" ErrorKind::Syntax raise_error
+                    1 exit
+                fi
             fi
 
             op_index ops compiler.find_next_match_arm_or_end = next_arm
@@ -616,8 +657,8 @@ impl BytecodeCompiler {
         variant EnumVariant::variant_name = variant_name
         variant_name casa_enum CasaEnum::variant_types.get = types_opt
         0 = inner_count
-        if types_opt.is_some then
-            types_opt.unwrap.length = inner_count
+        if types_opt Option::Some(types) is then
+            types.length = inner_count
         fi
         inner_count 1 + = slot_count
 
@@ -640,7 +681,7 @@ impl BytecodeCompiler {
         ptr_local InstValue::LocalSet bytecode.push
 
         # Store ordinal at offset 0
-        variant EnumVariant::ordinal.unwrap InstValue::Push bytecode.push
+        variant enum_variant_ordinal InstValue::Push bytecode.push
         ptr_local InstValue::LocalGet bytecode.push
         InstValue::Store64 bytecode.push
 
@@ -673,11 +714,15 @@ impl BytecodeCompiler {
     fn compile_is_check compiler:BytecodeCompiler op:Op bytecode:List[InstValue] {
         if op.value OpValue::IsCheck(variant) is ! then return fi
         variant EnumVariant::enum_name = enum_name
-        enum_name compiler.store.enums.get.unwrap = casa_enum
+        if enum_name compiler.store.enums.get Option::Some(casa_enum) is then
+        else
+            empty_location "Expected option value while unwrapping enum_name compiler.store.enums.get" ErrorKind::Syntax raise_error
+            1 exit
+        fi
 
         if casa_enum has_inner_values ! then
             # Plain enum: compare ordinal directly
-            variant EnumVariant::ordinal.unwrap InstValue::Push bytecode.push
+            variant enum_variant_ordinal InstValue::Push bytecode.push
             InstValue::Eq bytecode.push
             return
         fi
@@ -685,7 +730,7 @@ impl BytecodeCompiler {
         if 0 variant EnumVariant::bindings.length == then
             # Data-carrying enum, no bindings: load ordinal and compare
             InstValue::Load64 bytecode.push
-            variant EnumVariant::ordinal.unwrap InstValue::Push bytecode.push
+            variant enum_variant_ordinal InstValue::Push bytecode.push
             InstValue::Eq bytecode.push
             return
         fi
@@ -702,7 +747,7 @@ impl BytecodeCompiler {
         # Load ordinal and compare
         temp_ptr InstValue::LocalGet bytecode.push
         InstValue::Load64 bytecode.push
-        variant EnumVariant::ordinal.unwrap InstValue::Push bytecode.push
+        variant enum_variant_ordinal InstValue::Push bytecode.push
         InstValue::Eq bytecode.push
 
         # Duplicate bool
@@ -734,7 +779,11 @@ impl BytecodeCompiler {
 impl BytecodeCompiler {
     fn compile_struct_literal compiler:BytecodeCompiler op:Op bytecode:List[InstValue] {
         if op.value OpValue::StructLiteral(literal) is ! then return fi
-        literal StructLiteral::struct_name compiler.store.structs.get.unwrap = casa_struct
+        if literal StructLiteral::struct_name compiler.store.structs.get Option::Some(casa_struct) is then
+        else
+            empty_location "Expected option value while unwrapping literal StructLiteral::struct_name compiler.store.structs.get" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         casa_struct CasaStruct::members.length = count
 
         # Store all field values into temp locals (top of stack = last in field_order)
@@ -764,7 +813,12 @@ impl BytecodeCompiler {
                 member_offset InstValue::Push bytecode.push
                 InstValue::Add bytecode.push
             fi
-            member_name temp_locals.get.unwrap InstValue::LocalGet bytecode.push
+            if member_name temp_locals.get Option::Some(temp_local) is then
+                temp_local InstValue::LocalGet bytecode.push
+            else
+                empty_location "Expected struct literal temp local" ErrorKind::Syntax raise_error
+                1 exit
+            fi
             InstValue::Swap bytecode.push
             InstValue::Store64 bytecode.push
             1 += member_index
@@ -802,8 +856,8 @@ impl BytecodeCompiler {
         for item in items.iter do
             if item Op::value OpValue::FnPush(fn_name) is then
                 fn_name compiler.store.functions.get = csa_fn_opt
-                if csa_fn_opt.is_some then
-                    item csa_fn_opt.unwrap compiler.compile_function
+                if csa_fn_opt Option::Some(csa_fn) is then
+                    item csa_fn compiler.compile_function
                 fi
             fi
         done
@@ -817,7 +871,7 @@ impl BytecodeCompiler {
             OpValue::PushStr(val) => { val compiler.intern_string = str_idx f"str_{str_idx}" StaticArrayElement::Label return }
             OpValue::PushBool(val) => { val StaticArrayElement::Imm return }
             OpValue::PushChar(val) => { val StaticArrayElement::Imm return }
-            OpValue::PushEnumVariant(ev) => { ev EnumVariant::ordinal.unwrap StaticArrayElement::Imm return }
+            OpValue::PushEnumVariant(ev) => { ev enum_variant_ordinal StaticArrayElement::Imm return }
             OpValue::FnPush(fn_name) => {
                 fn_name sanitize_fn_name = sanitized_fn
                 f"closure_{sanitized_fn}" StaticArrayElement::Label return
@@ -842,7 +896,11 @@ impl BytecodeCompiler {
         fi
         literal StructLiteral::struct_name = struct_name
         literal StructLiteral::field_order = field_order
-        struct_name compiler.store.structs.get.unwrap = casa_struct
+        if struct_name compiler.store.structs.get Option::Some(casa_struct) is then
+        else
+            empty_location "Expected option value while unwrapping struct_name compiler.store.structs.get" ErrorKind::Syntax raise_error
+            1 exit
+        fi
 
         List::new(List[StaticArrayElement]) = ordered_elems
         0 = i
@@ -1021,7 +1079,11 @@ impl BytecodeCompiler {
 
         op.value match
             OpValue::FnCall => {
-                name compiler.store.functions.get.unwrap = function
+                if name compiler.store.functions.get Option::Some(function) is then
+                else
+                    empty_location "Expected option value while unwrapping name compiler.store.functions.get" ErrorKind::Syntax raise_error
+                    1 exit
+                fi
                 op function compiler.compile_function
                 name InstValue::FnCall bytecode.push
             }
@@ -1031,7 +1093,11 @@ impl BytecodeCompiler {
                     op Op::location f"Function `{name}` is not defined" ErrorKind::UndefinedName CasaError::new ERRORS.push
                     return
                 fi
-                function_opt.unwrap = lambda
+                if function_opt Option::Some(lambda) is then
+                else
+                    empty_location "Expected option value while unwrapping function_opt" ErrorKind::Syntax raise_error
+                    1 exit
+                fi
                 op lambda compiler.compile_function
 
                 # Zero-capture closures share a single static record so trait
@@ -1093,7 +1159,7 @@ impl BytecodeCompiler {
         fi
 
         # Check direct op-to-inst mapping first
-        if direct_inst_opt.is_some then
+        if direct_inst_opt Option::Some(direct_inst) is then
             # Data-carrying enum comparison
             if
             op_value OpValue::Eq is
@@ -1105,7 +1171,7 @@ impl BytecodeCompiler {
             has_type_hint &&
             type_hint_name compiler.store.enums.has &&
             then
-                bytecode direct_inst_opt.unwrap compiler.compile_enum_comparison
+                bytecode direct_inst compiler.compile_enum_comparison
                 return
             fi
             # String content comparison
@@ -1126,7 +1192,7 @@ impl BytecodeCompiler {
                 InstValue::PrintInt bytecode.push
                 return
             fi
-            direct_inst_opt.unwrap bytecode.push
+            direct_inst bytecode.push
             return
         fi
 
@@ -1146,7 +1212,11 @@ impl BytecodeCompiler {
             if op_value OpValue::FnPush(fn_push_name) is then
                 fn_push_name compiler.store.functions.get = function_opt
                 if function_opt.is_some then
-                    function_opt.unwrap = function_check
+                    if function_opt Option::Some(function_check) is then
+                    else
+                        empty_location "Expected option value while unwrapping function_opt" ErrorKind::Syntax raise_error
+                        1 exit
+                    fi
                     if function_check Function::has_deferred_methods then
                         0 InstValue::Push bytecode.push
                         return
@@ -1168,11 +1238,15 @@ impl BytecodeCompiler {
         elif op_value OpValue::ImportFile is op_value OpValue::TypeCast is || op_value OpValue::DeclareGlobal is || then
             # No instruction emitted
         elif op_value OpValue::PushEnumVariant(variant) is then
-            variant EnumVariant::enum_name compiler.store.enums.get.unwrap = casa_enum
+            if variant EnumVariant::enum_name compiler.store.enums.get Option::Some(casa_enum) is then
+            else
+                empty_location "Expected option value while unwrapping variant EnumVariant::enum_name compiler.store.enums.get" ErrorKind::Syntax raise_error
+                1 exit
+            fi
             if casa_enum has_inner_values then
                 bytecode casa_enum variant compiler.compile_enum_variant
             else
-                variant EnumVariant::ordinal.unwrap InstValue::Push bytecode.push
+                variant enum_variant_ordinal InstValue::Push bytecode.push
             fi
         elif op_value OpValue::IsCheck is then
             bytecode op compiler.compile_is_check

--- a/compiler/bytecode.casa
+++ b/compiler/bytecode.casa
@@ -61,20 +61,24 @@ impl BytecodeCompiler {
 # Label management
 # ============================================================================
 
-fn new_label compiler:BytecodeCompiler -> int {
-    compiler.label_counter = value
-    compiler.label_counter 1 + compiler->label_counter
-    value
+impl BytecodeCompiler {
+    fn new_label compiler:BytecodeCompiler -> int {
+        compiler.label_counter = value
+        compiler.label_counter 1 + compiler->label_counter
+        value
+    }
 }
 
-fn op_to_label compiler:BytecodeCompiler op:Op -> int {
-    if op compiler.op_label_map.get Option::Some(existing) is then
-        existing
-    else
-        compiler new_label = label
-        label op compiler.op_label_map.set drop
-        label
-    fi
+impl BytecodeCompiler {
+    fn op_to_label compiler:BytecodeCompiler op:Op -> int {
+        if op compiler.op_label_map.get Option::Some(existing) is then
+            existing
+        else
+            compiler.new_label = label
+            label op compiler.op_label_map.set drop
+            label
+        fi
+    }
 }
 
 # ============================================================================
@@ -92,30 +96,34 @@ fn intern_table table:List[str] value:str -> int {
     fi
 }
 
-fn intern_string compiler:BytecodeCompiler value:str -> int {
-    value compiler.string_table intern_table
+impl BytecodeCompiler {
+    fn intern_string compiler:BytecodeCompiler value:str -> int {
+        value compiler.string_table intern_table
+    }
 }
 
 # ============================================================================
 # Variable resolution
 # ============================================================================
 
-fn resolve_variable compiler:BytecodeCompiler variable_name:str -> ResolvedVariable {
-    if compiler.function Option::Some(function) is then
-        variable_name function Function::variables variable_list_contains = is_local
-        if is_local then
-            variable_name function Function::variables variable_list_index = local_index
-            local_index ResolvedVariable::Local return
+impl BytecodeCompiler {
+    fn resolve_variable compiler:BytecodeCompiler variable_name:str -> ResolvedVariable {
+        if compiler.function Option::Some(function) is then
+            variable_name function Function::variables variable_list_contains = is_local
+            if is_local then
+                variable_name function Function::variables variable_list_index = local_index
+                local_index ResolvedVariable::Local return
+            fi
         fi
-    fi
-    variable_name compiler.store.variables.has = is_global
-    if is_global then
-        variable_name compiler.store.variables.keys string_list_index = global_index
-        global_index ResolvedVariable::Global return
-    fi
-    f"Variable `{variable_name}` is not defined\n" eprint
-    1 exit
-    0 ResolvedVariable::Local
+        variable_name compiler.store.variables.has = is_global
+        if is_global then
+            variable_name compiler.store.variables.keys string_list_index = global_index
+            global_index ResolvedVariable::Global return
+        fi
+        f"Variable `{variable_name}` is not defined\n" eprint
+        1 exit
+        0 ResolvedVariable::Local
+    }
 }
 
 # ============================================================================
@@ -138,41 +146,43 @@ fn is_block_end_value op_value:OpValue -> bool {
 # opening/closing variant at which to give up (end variant going forward,
 # start variant going backward).
 
-fn find_matching_label
-    compiler:BytecodeCompiler
-    ops:List[Op]
-    op_index:int
-    boundary_value:OpValue
-    target_values:List[OpValue]
-    backward:bool
--> Option[int] {
-    if backward then -1 else 1 fi = step
-    0 step - = neg_step
-    1 = depth
-    op_index step + = index
-    while
-    if backward then 0 index >= else index ops.length > fi
-    do
-        index ops.get = other_op
-        other_op.value = other_value
-        if 1 depth <= then
-            if other_value target_values op_value_list_contains then
-                index ops.get compiler op_to_label Option::Some return
+impl BytecodeCompiler {
+    fn find_matching_label
+        compiler:BytecodeCompiler
+        ops:List[Op]
+        op_index:int
+        boundary_value:OpValue
+        target_values:List[OpValue]
+        backward:bool
+    -> Option[int] {
+        if backward then -1 else 1 fi = step
+        0 step - = neg_step
+        1 = depth
+        op_index step + = index
+        while
+        if backward then 0 index >= else index ops.length > fi
+        do
+            index ops.get = other_op
+            other_op.value = other_value
+            if 1 depth <= then
+                if other_value target_values op_value_list_contains then
+                    index ops.get compiler.op_to_label Option::Some return
+                fi
             fi
-        fi
-        if other_value is_block_start_value then
-            step += depth
-        elif other_value is_block_end_value then
-            neg_step += depth
-        fi
-        if 1 depth < then
-            if boundary_value other_value == then
-                Option::None return
+            if other_value is_block_start_value then
+                step += depth
+            elif other_value is_block_end_value then
+                neg_step += depth
             fi
-        fi
-        step += index
-    done
-    Option::None
+            if 1 depth < then
+                if boundary_value other_value == then
+                    Option::None return
+                fi
+            fi
+            step += index
+        done
+        Option::None
+    }
 }
 
 fn op_value_list_contains items:List[OpValue] value:OpValue -> bool {
@@ -188,178 +198,192 @@ fn op_value_list_contains items:List[OpValue] value:OpValue -> bool {
 # tag-only equality. This forward scan tracks depth and returns the label
 # of the next OpMatchArm or None on OpMatchEnd at depth 0.
 
-fn find_next_match_arm_or_end compiler:BytecodeCompiler ops:List[Op] op_index:int -> Option[int] {
-    1 = depth
-    op_index 1 + = index
-    while index ops.length > do
-        index ops.get = other_op
-        other_op.value = other_value
-        if 1 depth <= then
-            if other_value OpValue::MatchArm is then
-                index ops.get compiler op_to_label Option::Some return
+impl BytecodeCompiler {
+    fn find_next_match_arm_or_end
+        compiler:BytecodeCompiler
+        ops:List[Op]
+        op_index:int
+    -> Option[int] {
+        1 = depth
+        op_index 1 + = index
+        while index ops.length > do
+            index ops.get = other_op
+            other_op.value = other_value
+            if 1 depth <= then
+                if other_value OpValue::MatchArm is then
+                    index ops.get compiler.op_to_label Option::Some return
+                fi
             fi
-        fi
-        if other_value is_block_start_value then
-            1 += depth
-        elif other_value is_block_end_value then
-            -1 += depth
-        fi
-        if 1 depth < then
-            if other_value OpValue::MatchEnd is then
-                Option::None return
+            if other_value is_block_start_value then
+                1 += depth
+            elif other_value is_block_end_value then
+                -1 += depth
             fi
-        fi
-        1 += index
-    done
-    Option::None
+            if 1 depth < then
+                if other_value OpValue::MatchEnd is then
+                    Option::None return
+                fi
+            fi
+            1 += index
+        done
+        Option::None
+    }
 }
 
-fn require_matching
-    compiler:BytecodeCompiler
-    ops:List[Op]
-    op_index:int
-    boundary_value:OpValue
-    target_values:List[OpValue]
-    location:Location
-    message:str
-    backward:bool
--> int {
-    backward target_values boundary_value op_index ops compiler find_matching_label = result
-    if result.is_none then
-        location message ErrorKind::UnmatchedBlock CasaError::new ERRORS.push
-        0
-    else
-        result.unwrap
-    fi
+impl BytecodeCompiler {
+    fn require_matching
+        compiler:BytecodeCompiler
+        ops:List[Op]
+        op_index:int
+        boundary_value:OpValue
+        target_values:List[OpValue]
+        location:Location
+        message:str
+        backward:bool
+    -> int {
+        backward target_values boundary_value op_index ops compiler.find_matching_label = result
+        if result.is_none then
+            location message ErrorKind::UnmatchedBlock CasaError::new ERRORS.push
+            0
+        else
+            result.unwrap
+        fi
+    }
 }
 
 # ============================================================================
 # Compile assignment
 # ============================================================================
 
-fn compile_assignment compiler:BytecodeCompiler op:Op bytecode:List[InstValue] {
-    op op_str_value = name
-    name compiler resolve_variable = resolved
+impl BytecodeCompiler {
+    fn compile_assignment compiler:BytecodeCompiler op:Op bytecode:List[InstValue] {
+        op op_str_value = name
+        name compiler.resolve_variable = resolved
 
-    op.value match
-        OpValue::AssignDec => {
-            bytecode resolved.emit_get
-            InstValue::Swap bytecode.push
-            InstValue::Sub bytecode.push
-            bytecode resolved.emit_set
-        }
-        OpValue::AssignInc => {
-            bytecode resolved.emit_get
-            InstValue::Add bytecode.push
-            bytecode resolved.emit_set
-        }
-        OpValue::AssignVar => bytecode resolved.emit_set
-        _ => {
-            "Internal error: compile_assignment called with non-assignment OpValue\n" eprint
-            1 exit
-        }
-    end
+        op.value match
+            OpValue::AssignDec => {
+                bytecode resolved.emit_get
+                InstValue::Swap bytecode.push
+                InstValue::Sub bytecode.push
+                bytecode resolved.emit_set
+            }
+            OpValue::AssignInc => {
+                bytecode resolved.emit_get
+                InstValue::Add bytecode.push
+                bytecode resolved.emit_set
+            }
+            OpValue::AssignVar => bytecode resolved.emit_set
+            _ => {
+                "Internal error: compile_assignment called with non-assignment OpValue\n" eprint
+                1 exit
+            }
+        end
+    }
 }
 
 # ============================================================================
 # Compile if block
 # ============================================================================
 
-fn compile_if_block compiler:BytecodeCompiler op:Op op_index:int bytecode:List[InstValue] {
-    compiler.ops = ops
-    op Op::location = loc
+impl BytecodeCompiler {
+    fn compile_if_block compiler:BytecodeCompiler op:Op op_index:int bytecode:List[InstValue] {
+        compiler.ops = ops
+        op Op::location = loc
 
-    List::new(List[OpValue]) = start_targets
-    OpValue::IfStart start_targets.push
+        List::new(List[OpValue]) = start_targets
+        OpValue::IfStart start_targets.push
 
-    List::new(List[OpValue]) = elif_else_end
-    OpValue::IfElif elif_else_end.push
-    OpValue::IfElse elif_else_end.push
-    OpValue::IfEnd elif_else_end.push
+        List::new(List[OpValue]) = elif_else_end
+        OpValue::IfElif elif_else_end.push
+        OpValue::IfElse elif_else_end.push
+        OpValue::IfEnd elif_else_end.push
 
-    List::new(List[OpValue]) = end_targets
-    OpValue::IfEnd end_targets.push
+        List::new(List[OpValue]) = end_targets
+        OpValue::IfEnd end_targets.push
 
-    List::new(List[OpValue]) = else_targets
-    OpValue::IfElse else_targets.push
+        List::new(List[OpValue]) = else_targets
+        OpValue::IfElse else_targets.push
 
-    op.value match
-        OpValue::IfCondition => {
-            true "`then` without matching `if`" loc start_targets OpValue::IfStart op_index ops compiler require_matching drop
-            false "`then` without matching `fi`" loc elif_else_end OpValue::IfEnd op_index ops compiler require_matching = end_label
-            end_label InstValue::JumpNe bytecode.push
-        }
-        OpValue::IfElif => {
-            true "`elif` without parent `if`" loc start_targets OpValue::IfStart op_index ops compiler require_matching drop
-            op_index compiler.ops.get compiler op_to_label = elif_label
-            false "`elif` without matching `fi`" loc end_targets OpValue::IfEnd op_index ops compiler require_matching = end_label_2
-            end_label_2 InstValue::Jump bytecode.push
-            elif_label InstValue::Label bytecode.push
-        }
-        OpValue::IfElse => {
-            true "`else` without parent `if`" loc start_targets OpValue::IfStart op_index ops compiler require_matching drop
-            op_index compiler.ops.get compiler op_to_label = else_label
-            false "`else` without matching `fi`" loc end_targets OpValue::IfEnd op_index ops compiler require_matching = end_label_3
-            end_label_3 InstValue::Jump bytecode.push
-            else_label InstValue::Label bytecode.push
-        }
-        OpValue::IfEnd => {
-            true "`fi` without parent `if`" loc start_targets OpValue::IfStart op_index ops compiler require_matching drop
-            op_index compiler.ops.get compiler op_to_label = fi_label
-            fi_label InstValue::Label bytecode.push
-        }
-        OpValue::IfStart => false "`if` without matching `fi`" loc end_targets OpValue::IfEnd op_index ops compiler require_matching drop
-        _ => {
-            "Internal error: compile_if_block called with non-if OpValue\n" eprint
-            1 exit
-        }
-    end
+        op.value match
+            OpValue::IfCondition => {
+                true "`then` without matching `if`" loc start_targets OpValue::IfStart op_index ops compiler.require_matching drop
+                false "`then` without matching `fi`" loc elif_else_end OpValue::IfEnd op_index ops compiler.require_matching = end_label
+                end_label InstValue::JumpNe bytecode.push
+            }
+            OpValue::IfElif => {
+                true "`elif` without parent `if`" loc start_targets OpValue::IfStart op_index ops compiler.require_matching drop
+                op_index compiler.ops.get compiler.op_to_label = elif_label
+                false "`elif` without matching `fi`" loc end_targets OpValue::IfEnd op_index ops compiler.require_matching = end_label_2
+                end_label_2 InstValue::Jump bytecode.push
+                elif_label InstValue::Label bytecode.push
+            }
+            OpValue::IfElse => {
+                true "`else` without parent `if`" loc start_targets OpValue::IfStart op_index ops compiler.require_matching drop
+                op_index compiler.ops.get compiler.op_to_label = else_label
+                false "`else` without matching `fi`" loc end_targets OpValue::IfEnd op_index ops compiler.require_matching = end_label_3
+                end_label_3 InstValue::Jump bytecode.push
+                else_label InstValue::Label bytecode.push
+            }
+            OpValue::IfEnd => {
+                true "`fi` without parent `if`" loc start_targets OpValue::IfStart op_index ops compiler.require_matching drop
+                op_index compiler.ops.get compiler.op_to_label = fi_label
+                fi_label InstValue::Label bytecode.push
+            }
+            OpValue::IfStart => false "`if` without matching `fi`" loc end_targets OpValue::IfEnd op_index ops compiler.require_matching drop
+            _ => {
+                "Internal error: compile_if_block called with non-if OpValue\n" eprint
+                1 exit
+            }
+        end
+    }
 }
 
 # ============================================================================
 # Compile while block
 # ============================================================================
 
-fn compile_while_block compiler:BytecodeCompiler op:Op op_index:int bytecode:List[InstValue] {
-    compiler.ops = ops
-    op Op::location = loc
+impl BytecodeCompiler {
+    fn compile_while_block compiler:BytecodeCompiler op:Op op_index:int bytecode:List[InstValue] {
+        compiler.ops = ops
+        op Op::location = loc
 
-    List::new(List[OpValue]) = start_targets
-    OpValue::WhileStart start_targets.push
+        List::new(List[OpValue]) = start_targets
+        OpValue::WhileStart start_targets.push
 
-    List::new(List[OpValue]) = end_targets
-    OpValue::WhileEnd end_targets.push
+        List::new(List[OpValue]) = end_targets
+        OpValue::WhileEnd end_targets.push
 
-    op.value match
-        OpValue::WhileBreak => {
-            true "`break` without parent `while`" loc start_targets OpValue::WhileStart op_index ops compiler require_matching drop
-            false "`break` without matching `done`" loc end_targets OpValue::WhileEnd op_index ops compiler require_matching = end_label
-            end_label InstValue::Jump bytecode.push
-        }
-        OpValue::WhileCondition => {
-            true "`do` without parent `while`" loc start_targets OpValue::WhileStart op_index ops compiler require_matching drop
-            false "`do` without matching `done`" loc end_targets OpValue::WhileEnd op_index ops compiler require_matching = end_label_2
-            end_label_2 InstValue::JumpNe bytecode.push
-        }
-        OpValue::WhileContinue => {
-            true "`continue` without parent `while`" loc start_targets OpValue::WhileStart op_index ops compiler require_matching = continue_target
-            continue_target InstValue::Jump bytecode.push
-        }
-        OpValue::WhileEnd => {
-            op_index compiler.ops.get compiler op_to_label = while_label
-            true "`done` without parent `while`" loc start_targets OpValue::WhileStart op_index ops compiler require_matching = loop_start
-            loop_start InstValue::Jump bytecode.push
-            while_label InstValue::Label bytecode.push
-        }
-        OpValue::WhileStart => {
-            op_index compiler.ops.get compiler op_to_label = start_label
-            start_label InstValue::Label bytecode.push
-        }
-        _ => {
-            "Internal error: compile_while_block called with non-while OpValue\n" eprint
-            1 exit
-        }
-    end
+        op.value match
+            OpValue::WhileBreak => {
+                true "`break` without parent `while`" loc start_targets OpValue::WhileStart op_index ops compiler.require_matching drop
+                false "`break` without matching `done`" loc end_targets OpValue::WhileEnd op_index ops compiler.require_matching = end_label
+                end_label InstValue::Jump bytecode.push
+            }
+            OpValue::WhileCondition => {
+                true "`do` without parent `while`" loc start_targets OpValue::WhileStart op_index ops compiler.require_matching drop
+                false "`do` without matching `done`" loc end_targets OpValue::WhileEnd op_index ops compiler.require_matching = end_label_2
+                end_label_2 InstValue::JumpNe bytecode.push
+            }
+            OpValue::WhileContinue => {
+                true "`continue` without parent `while`" loc start_targets OpValue::WhileStart op_index ops compiler.require_matching = continue_target
+                continue_target InstValue::Jump bytecode.push
+            }
+            OpValue::WhileEnd => {
+                op_index compiler.ops.get compiler.op_to_label = while_label
+                true "`done` without parent `while`" loc start_targets OpValue::WhileStart op_index ops compiler.require_matching = loop_start
+                loop_start InstValue::Jump bytecode.push
+                while_label InstValue::Label bytecode.push
+            }
+            OpValue::WhileStart => {
+                op_index compiler.ops.get compiler.op_to_label = start_label
+                start_label InstValue::Label bytecode.push
+            }
+            _ => {
+                "Internal error: compile_while_block called with non-while OpValue\n" eprint
+                1 exit
+            }
+        end
+    }
 }
 
 # ============================================================================
@@ -369,24 +393,30 @@ fn compile_while_block compiler:BytecodeCompiler op:Op op_index:int bytecode:Lis
 # Replaces the three former compile_match_arm_* helpers and consolidates
 # literal / enum / struct emission behind a single pattern-driven function.
 
-fn emit_struct_arm compiler:BytecodeCompiler struct_pattern:StructPattern bytecode:List[InstValue] {
-    struct_pattern StructPattern::struct_name compiler.store.structs.get.unwrap = casa_struct
-    0 = index
-    while index casa_struct CasaStruct::members.length > do
-        index casa_struct CasaStruct::members.get Member::name = field_name
-        index WORD_SIZE * = offset
-        if field_name struct_pattern StructPattern::bindings.get Option::Some(var_name) is then
-            InstValue::Dup bytecode.push
-            if 0 offset > then
-                offset InstValue::Push bytecode.push
-                InstValue::Add bytecode.push
+impl BytecodeCompiler {
+    fn emit_struct_arm
+        compiler:BytecodeCompiler
+        struct_pattern:StructPattern
+        bytecode:List[InstValue]
+    {
+        struct_pattern StructPattern::struct_name compiler.store.structs.get.unwrap = casa_struct
+        0 = index
+        while index casa_struct CasaStruct::members.length > do
+            index casa_struct CasaStruct::members.get Member::name = field_name
+            index WORD_SIZE * = offset
+            if field_name struct_pattern StructPattern::bindings.get Option::Some(var_name) is then
+                InstValue::Dup bytecode.push
+                if 0 offset > then
+                    offset InstValue::Push bytecode.push
+                    InstValue::Add bytecode.push
+                fi
+                InstValue::Load64 bytecode.push
+                var_name compiler.resolve_variable = resolved
+                bytecode resolved.emit_set
             fi
-            InstValue::Load64 bytecode.push
-            var_name compiler resolve_variable = resolved
-            bytecode resolved.emit_set
-        fi
-        1 += index
-    done
+            1 += index
+        done
+    }
 }
 
 fn emit_int_eq value:int bytecode:List[InstValue] {
@@ -394,330 +424,352 @@ fn emit_int_eq value:int bytecode:List[InstValue] {
     InstValue::Eq bytecode.push
 }
 
-fn emit_literal_arm
-    compiler:BytecodeCompiler
-    literal_pattern:LiteralPattern
-    is_last:bool
-    next_arm:Option[int]
-    bytecode:List[InstValue]
-{
-    if is_last then return fi
-    InstValue::Dup bytecode.push
-    literal_pattern.value match
-        LiteralValue::Str(str_value) => {
-            str_value compiler intern_string = str_index
-            str_index InstValue::PushStr bytecode.push
-            InstValue::StrEq bytecode.push
-        }
-        LiteralValue::Int(int_value) => { bytecode int_value emit_int_eq }
-        LiteralValue::Char(char_value) => { bytecode char_value emit_int_eq }
-        LiteralValue::Bool(bool_value) => { bytecode bool_value (int) emit_int_eq }
-    end
-    next_arm.unwrap InstValue::JumpNe bytecode.push
-}
-
-fn emit_enum_arm
-    compiler:BytecodeCompiler
-    variant:EnumVariant
-    is_wildcard:bool
-    is_last:bool
-    next_arm:Option[int]
-    bytecode:List[InstValue]
-{
-    if is_wildcard then return fi
-    variant EnumVariant::enum_name = enum_name
-    if "" enum_name != enum_name compiler.store.enums.has && then
-        enum_name compiler.store.enums.get.unwrap = casa_enum
-        if casa_enum has_inner_values then
-            if is_last ! then
-                InstValue::Dup bytecode.push
-                InstValue::Load64 bytecode.push
-                variant EnumVariant::ordinal.unwrap InstValue::Push bytecode.push
-                InstValue::Eq bytecode.push
-                next_arm.unwrap InstValue::JumpNe bytecode.push
-            fi
-            variant bytecode compiler emit_enum_arm_bindings
-            return
-        fi
-    fi
-
-    if is_last then return fi
-    InstValue::Dup bytecode.push
-    variant EnumVariant::ordinal.unwrap InstValue::Push bytecode.push
-    InstValue::Eq bytecode.push
-    next_arm.unwrap InstValue::JumpNe bytecode.push
-}
-
-fn emit_enum_arm_bindings compiler:BytecodeCompiler bytecode:List[InstValue] variant:EnumVariant {
-    0 = index
-    while index variant EnumVariant::bindings.length > do
-        index 1 + WORD_SIZE * = offset
+impl BytecodeCompiler {
+    fn emit_literal_arm
+        compiler:BytecodeCompiler
+        literal_pattern:LiteralPattern
+        is_last:bool
+        next_arm:Option[int]
+        bytecode:List[InstValue]
+    {
+        if is_last then return fi
         InstValue::Dup bytecode.push
-        offset InstValue::Push bytecode.push
-        InstValue::Add bytecode.push
-        InstValue::Load64 bytecode.push
-        index variant EnumVariant::bindings.get = var_name
-        var_name compiler resolve_variable = resolved
-        bytecode resolved.emit_set
-        1 += index
-    done
+        literal_pattern.value match
+            LiteralValue::Str(str_value) => {
+                str_value compiler.intern_string = str_index
+                str_index InstValue::PushStr bytecode.push
+                InstValue::StrEq bytecode.push
+            }
+            LiteralValue::Int(int_value) => { bytecode int_value emit_int_eq }
+            LiteralValue::Char(char_value) => { bytecode char_value emit_int_eq }
+            LiteralValue::Bool(bool_value) => { bytecode bool_value (int) emit_int_eq }
+        end
+        next_arm.unwrap InstValue::JumpNe bytecode.push
+    }
 }
 
-fn compile_match_op
-    compiler:BytecodeCompiler
-    op:Op
-    is_last:bool
-    next_arm:Option[int]
-    bytecode:List[InstValue]
-{
-    if op.value OpValue::MatchArm(arm) is ! then return fi
-    arm.pattern_value match
-        PatternValue::Struct(struct_pattern) => {
-            bytecode struct_pattern compiler emit_struct_arm
-        }
-        PatternValue::Literal(literal_pattern) => {
-            bytecode next_arm is_last literal_pattern compiler emit_literal_arm
-        }
-        PatternValue::EnumVariant(variant) => {
-            op pattern_is_wildcard = is_wildcard
-            bytecode next_arm is_last is_wildcard variant compiler emit_enum_arm
-        }
-    end
-    arm.guard_ops = guard_ops
-    if guard_ops.length 0 != then
-        0 = guard_index
-        while guard_index guard_ops.length > do
-            guard_index guard_ops.get = guard_op
-            bytecode guard_index guard_op compiler compile_op
-            1 += guard_index
+impl BytecodeCompiler {
+    fn emit_enum_arm
+        compiler:BytecodeCompiler
+        variant:EnumVariant
+        is_wildcard:bool
+        is_last:bool
+        next_arm:Option[int]
+        bytecode:List[InstValue]
+    {
+        if is_wildcard then return fi
+        variant EnumVariant::enum_name = enum_name
+        if "" enum_name != enum_name compiler.store.enums.has && then
+            enum_name compiler.store.enums.get.unwrap = casa_enum
+            if casa_enum has_inner_values then
+                if is_last ! then
+                    InstValue::Dup bytecode.push
+                    InstValue::Load64 bytecode.push
+                    variant EnumVariant::ordinal.unwrap InstValue::Push bytecode.push
+                    InstValue::Eq bytecode.push
+                    next_arm.unwrap InstValue::JumpNe bytecode.push
+                fi
+                variant bytecode compiler.emit_enum_arm_bindings
+                return
+            fi
+        fi
+
+        if is_last then return fi
+        InstValue::Dup bytecode.push
+        variant EnumVariant::ordinal.unwrap InstValue::Push bytecode.push
+        InstValue::Eq bytecode.push
+        next_arm.unwrap InstValue::JumpNe bytecode.push
+    }
+}
+
+impl BytecodeCompiler {
+    fn emit_enum_arm_bindings
+        compiler:BytecodeCompiler
+        bytecode:List[InstValue]
+        variant:EnumVariant
+    {
+        0 = index
+        while index variant EnumVariant::bindings.length > do
+            index 1 + WORD_SIZE * = offset
+            InstValue::Dup bytecode.push
+            offset InstValue::Push bytecode.push
+            InstValue::Add bytecode.push
+            InstValue::Load64 bytecode.push
+            index variant EnumVariant::bindings.get = var_name
+            var_name compiler.resolve_variable = resolved
+            bytecode resolved.emit_set
+            1 += index
         done
-        # Guarded last-arm is rejected by the typechecker (a guarded arm
-        # does not cover its pattern, so a non-guarded fallback is
-        # required). Codegen may still run in RESILIENT_MODE after such
-        # an error, so skip the fail-jump rather than unwrapping None.
-        if next_arm.is_some then
-            next_arm.unwrap InstValue::JumpNe bytecode.push
-        else
-            InstValue::Drop bytecode.push
-        fi
-    fi
-    InstValue::Drop bytecode.push
+    }
 }
 
-fn compile_match_block compiler:BytecodeCompiler op:Op op_index:int bytecode:List[InstValue] {
-    compiler.ops = ops
-    op.value = match_value
-
-    if match_value OpValue::MatchArm is then
-        op Op::location = loc
-
-        List::new(List[OpValue]) = end_targets
-        OpValue::MatchEnd end_targets.push
-
-        false "`match` arm without matching `end`" loc end_targets OpValue::MatchEnd op_index ops compiler require_matching = end_label
-
-        op_index ops.get compiler.op_label_map.get = existing
-        existing.is_some ! = is_first
-
-        if is_first ! then
-            end_label InstValue::Jump bytecode.push
-            existing.unwrap InstValue::Label bytecode.push
+impl BytecodeCompiler {
+    fn compile_match_op
+        compiler:BytecodeCompiler
+        op:Op
+        is_last:bool
+        next_arm:Option[int]
+        bytecode:List[InstValue]
+    {
+        if op.value OpValue::MatchArm(arm) is ! then return fi
+        arm.pattern_value match
+            PatternValue::Struct(struct_pattern) => {
+                bytecode struct_pattern compiler.emit_struct_arm
+            }
+            PatternValue::Literal(literal_pattern) => {
+                bytecode next_arm is_last literal_pattern compiler.emit_literal_arm
+            }
+            PatternValue::EnumVariant(variant) => {
+                op pattern_is_wildcard = is_wildcard
+                bytecode next_arm is_last is_wildcard variant compiler.emit_enum_arm
+            }
+        end
+        arm.guard_ops = guard_ops
+        if guard_ops.length 0 != then
+            0 = guard_index
+            while guard_index guard_ops.length > do
+                guard_index guard_ops.get = guard_op
+                bytecode guard_index guard_op compiler.compile_op
+                1 += guard_index
+            done
+            # Guarded last-arm is rejected by the typechecker (a guarded arm
+            # does not cover its pattern, so a non-guarded fallback is
+            # required). Codegen may still run in RESILIENT_MODE after such
+            # an error, so skip the fail-jump rather than unwrapping None.
+            if next_arm.is_some then
+                next_arm.unwrap InstValue::JumpNe bytecode.push
+            else
+                InstValue::Drop bytecode.push
+            fi
         fi
+        InstValue::Drop bytecode.push
+    }
+}
 
-        op_index ops compiler find_next_match_arm_or_end = next_arm
-        next_arm.is_none = is_last
+impl BytecodeCompiler {
+    fn compile_match_block compiler:BytecodeCompiler op:Op op_index:int bytecode:List[InstValue] {
+        compiler.ops = ops
+        op.value = match_value
 
-        bytecode next_arm is_last op compiler compile_match_op
-    elif match_value OpValue::MatchEnd is then
-        op_index compiler.ops.get compiler op_to_label = end_match_label
-        end_match_label InstValue::Label bytecode.push
-    fi
+        if match_value OpValue::MatchArm is then
+            op Op::location = loc
+
+            List::new(List[OpValue]) = end_targets
+            OpValue::MatchEnd end_targets.push
+
+            false "`match` arm without matching `end`" loc end_targets OpValue::MatchEnd op_index ops compiler.require_matching = end_label
+
+            op_index ops.get compiler.op_label_map.get = existing
+            existing.is_some ! = is_first
+
+            if is_first ! then
+                end_label InstValue::Jump bytecode.push
+                existing.unwrap InstValue::Label bytecode.push
+            fi
+
+            op_index ops compiler.find_next_match_arm_or_end = next_arm
+            next_arm.is_none = is_last
+
+            bytecode next_arm is_last op compiler.compile_match_op
+        elif match_value OpValue::MatchEnd is then
+            op_index compiler.ops.get compiler.op_to_label = end_match_label
+            end_match_label InstValue::Label bytecode.push
+        fi
+    }
 }
 
 # ============================================================================
 # Compile struct new
 # ============================================================================
 
-fn compile_struct_new compiler:BytecodeCompiler op:Op bytecode:List[InstValue] {
-    if op.value OpValue::StructNew(casa_struct) is ! then return fi
-    casa_struct CasaStruct::members.length = count
-    count WORD_SIZE * InstValue::Push bytecode.push
-    InstValue::HeapAlloc bytecode.push
-    0 = index
-    while index count > do
-        InstValue::Swap bytecode.push
-        InstValue::Over bytecode.push
-        if 0 index > then
-            index WORD_SIZE * InstValue::Push bytecode.push
-            InstValue::Add bytecode.push
-        fi
-        InstValue::Store64 bytecode.push
-        1 += index
-    done
+impl BytecodeCompiler {
+    fn compile_struct_new compiler:BytecodeCompiler op:Op bytecode:List[InstValue] {
+        if op.value OpValue::StructNew(casa_struct) is ! then return fi
+        casa_struct CasaStruct::members.length = count
+        count WORD_SIZE * InstValue::Push bytecode.push
+        InstValue::HeapAlloc bytecode.push
+        0 = index
+        while index count > do
+            InstValue::Swap bytecode.push
+            InstValue::Over bytecode.push
+            if 0 index > then
+                index WORD_SIZE * InstValue::Push bytecode.push
+                InstValue::Add bytecode.push
+            fi
+            InstValue::Store64 bytecode.push
+            1 += index
+        done
+    }
 }
 
 # ============================================================================
 # Compile enum variant
 # ============================================================================
 
-fn compile_enum_variant
-    compiler:BytecodeCompiler
-    variant:EnumVariant
-    casa_enum:CasaEnum
-    bytecode:List[InstValue]
-{
-    variant EnumVariant::variant_name = variant_name
-    variant_name casa_enum CasaEnum::variant_types.get = types_opt
-    0 = inner_count
-    if types_opt.is_some then
-        types_opt.unwrap.length = inner_count
-    fi
-    inner_count 1 + = slot_count
+impl BytecodeCompiler {
+    fn compile_enum_variant
+        compiler:BytecodeCompiler
+        variant:EnumVariant
+        casa_enum:CasaEnum
+        bytecode:List[InstValue]
+    {
+        variant EnumVariant::variant_name = variant_name
+        variant_name casa_enum CasaEnum::variant_types.get = types_opt
+        0 = inner_count
+        if types_opt.is_some then
+            types_opt.unwrap.length = inner_count
+        fi
+        inner_count 1 + = slot_count
 
-    # Store inner values from stack into temp locals
-    List::new(List[int]) = temps
-    0 = index
-    while index inner_count > do
-        compiler.locals_count = local_index
+        # Store inner values from stack into temp locals
+        List::new(List[int]) = temps
+        0 = index
+        while index inner_count > do
+            compiler.locals_count = local_index
+            compiler.locals_count 1 + compiler->locals_count
+            local_index temps.push
+            local_index InstValue::LocalSet bytecode.push
+            1 += index
+        done
+
+        # Allocate heap
+        compiler.locals_count = ptr_local
         compiler.locals_count 1 + compiler->locals_count
-        local_index temps.push
-        local_index InstValue::LocalSet bytecode.push
-        1 += index
-    done
+        slot_count WORD_SIZE * InstValue::Push bytecode.push
+        InstValue::HeapAlloc bytecode.push
+        ptr_local InstValue::LocalSet bytecode.push
 
-    # Allocate heap
-    compiler.locals_count = ptr_local
-    compiler.locals_count 1 + compiler->locals_count
-    slot_count WORD_SIZE * InstValue::Push bytecode.push
-    InstValue::HeapAlloc bytecode.push
-    ptr_local InstValue::LocalSet bytecode.push
-
-    # Store ordinal at offset 0
-    variant EnumVariant::ordinal.unwrap InstValue::Push bytecode.push
-    ptr_local InstValue::LocalGet bytecode.push
-    InstValue::Store64 bytecode.push
-
-    # Store inner values at offsets 8, 16, ...
-    # Reversed temp_locals
-    0 = inner_index
-    while inner_index inner_count > do
-        inner_count 1 - inner_index - = reverse_index
-        inner_index 1 + WORD_SIZE * = offset
+        # Store ordinal at offset 0
+        variant EnumVariant::ordinal.unwrap InstValue::Push bytecode.push
         ptr_local InstValue::LocalGet bytecode.push
-        offset InstValue::Push bytecode.push
-        InstValue::Add bytecode.push
-        reverse_index temps.get = temp_local
-        temp_local InstValue::LocalGet bytecode.push
-        InstValue::Swap bytecode.push
         InstValue::Store64 bytecode.push
-        1 += inner_index
-    done
 
-    # Push pointer
-    ptr_local InstValue::LocalGet bytecode.push
+        # Store inner values at offsets 8, 16, ...
+        # Reversed temp_locals
+        0 = inner_index
+        while inner_index inner_count > do
+            inner_count 1 - inner_index - = reverse_index
+            inner_index 1 + WORD_SIZE * = offset
+            ptr_local InstValue::LocalGet bytecode.push
+            offset InstValue::Push bytecode.push
+            InstValue::Add bytecode.push
+            reverse_index temps.get = temp_local
+            temp_local InstValue::LocalGet bytecode.push
+            InstValue::Swap bytecode.push
+            InstValue::Store64 bytecode.push
+            1 += inner_index
+        done
+
+        # Push pointer
+        ptr_local InstValue::LocalGet bytecode.push
+    }
 }
 
 # ============================================================================
 # Compile is check
 # ============================================================================
 
-fn compile_is_check compiler:BytecodeCompiler op:Op bytecode:List[InstValue] {
-    if op.value OpValue::IsCheck(variant) is ! then return fi
-    variant EnumVariant::enum_name = enum_name
-    enum_name compiler.store.enums.get.unwrap = casa_enum
+impl BytecodeCompiler {
+    fn compile_is_check compiler:BytecodeCompiler op:Op bytecode:List[InstValue] {
+        if op.value OpValue::IsCheck(variant) is ! then return fi
+        variant EnumVariant::enum_name = enum_name
+        enum_name compiler.store.enums.get.unwrap = casa_enum
 
-    if casa_enum has_inner_values ! then
-        # Plain enum: compare ordinal directly
-        variant EnumVariant::ordinal.unwrap InstValue::Push bytecode.push
-        InstValue::Eq bytecode.push
-        return
-    fi
+        if casa_enum has_inner_values ! then
+            # Plain enum: compare ordinal directly
+            variant EnumVariant::ordinal.unwrap InstValue::Push bytecode.push
+            InstValue::Eq bytecode.push
+            return
+        fi
 
-    if 0 variant EnumVariant::bindings.length == then
-        # Data-carrying enum, no bindings: load ordinal and compare
-        InstValue::Load64 bytecode.push
-        variant EnumVariant::ordinal.unwrap InstValue::Push bytecode.push
-        InstValue::Eq bytecode.push
-        return
-    fi
+        if 0 variant EnumVariant::bindings.length == then
+            # Data-carrying enum, no bindings: load ordinal and compare
+            InstValue::Load64 bytecode.push
+            variant EnumVariant::ordinal.unwrap InstValue::Push bytecode.push
+            InstValue::Eq bytecode.push
+            return
+        fi
 
-    # Data-carrying enum with bindings
-    compiler.locals_count = temp_ptr
-    compiler.locals_count 1 + compiler->locals_count
+        # Data-carrying enum with bindings
+        compiler.locals_count = temp_ptr
+        compiler.locals_count 1 + compiler->locals_count
 
-    compiler new_label = skip_bindings
+        compiler.new_label = skip_bindings
 
-    # Save enum pointer
-    temp_ptr InstValue::LocalSet bytecode.push
+        # Save enum pointer
+        temp_ptr InstValue::LocalSet bytecode.push
 
-    # Load ordinal and compare
-    temp_ptr InstValue::LocalGet bytecode.push
-    InstValue::Load64 bytecode.push
-    variant EnumVariant::ordinal.unwrap InstValue::Push bytecode.push
-    InstValue::Eq bytecode.push
-
-    # Duplicate bool
-    InstValue::Dup bytecode.push
-    skip_bindings InstValue::JumpNe bytecode.push
-
-    # Extract bindings
-    0 = index
-    while index variant EnumVariant::bindings.length > do
-        index 1 + WORD_SIZE * = offset
+        # Load ordinal and compare
         temp_ptr InstValue::LocalGet bytecode.push
-        offset InstValue::Push bytecode.push
-        InstValue::Add bytecode.push
         InstValue::Load64 bytecode.push
-        index variant EnumVariant::bindings.get = var_name
-        var_name compiler resolve_variable = resolved
-        bytecode resolved.emit_set
-        1 += index
-    done
+        variant EnumVariant::ordinal.unwrap InstValue::Push bytecode.push
+        InstValue::Eq bytecode.push
 
-    skip_bindings InstValue::Label bytecode.push
+        # Duplicate bool
+        InstValue::Dup bytecode.push
+        skip_bindings InstValue::JumpNe bytecode.push
+
+        # Extract bindings
+        0 = index
+        while index variant EnumVariant::bindings.length > do
+            index 1 + WORD_SIZE * = offset
+            temp_ptr InstValue::LocalGet bytecode.push
+            offset InstValue::Push bytecode.push
+            InstValue::Add bytecode.push
+            InstValue::Load64 bytecode.push
+            index variant EnumVariant::bindings.get = var_name
+            var_name compiler.resolve_variable = resolved
+            bytecode resolved.emit_set
+            1 += index
+        done
+
+        skip_bindings InstValue::Label bytecode.push
+    }
 }
 
 # ============================================================================
 # Compile struct literal
 # ============================================================================
 
-fn compile_struct_literal compiler:BytecodeCompiler op:Op bytecode:List[InstValue] {
-    if op.value OpValue::StructLiteral(literal) is ! then return fi
-    literal StructLiteral::struct_name compiler.store.structs.get.unwrap = casa_struct
-    casa_struct CasaStruct::members.length = count
+impl BytecodeCompiler {
+    fn compile_struct_literal compiler:BytecodeCompiler op:Op bytecode:List[InstValue] {
+        if op.value OpValue::StructLiteral(literal) is ! then return fi
+        literal StructLiteral::struct_name compiler.store.structs.get.unwrap = casa_struct
+        casa_struct CasaStruct::members.length = count
 
-    # Store all field values into temp locals (top of stack = last in field_order)
-    # Iterate field_order in reverse
-    literal StructLiteral::field_order.length 1 - = field_index
-    Map::new(Map[str int]) = temp_locals
-    while 0 field_index >= do
-        compiler.locals_count = local_index
-        compiler.locals_count 1 + compiler->locals_count
-        field_index literal StructLiteral::field_order.get = field_name
-        local_index field_name temp_locals.set = temp_locals
-        local_index InstValue::LocalSet bytecode.push
-        field_index 1 - = field_index
-    done
+        # Store all field values into temp locals (top of stack = last in field_order)
+        # Iterate field_order in reverse
+        literal StructLiteral::field_order.length 1 - = field_index
+        Map::new(Map[str int]) = temp_locals
+        while 0 field_index >= do
+            compiler.locals_count = local_index
+            compiler.locals_count 1 + compiler->locals_count
+            field_index literal StructLiteral::field_order.get = field_name
+            local_index field_name temp_locals.set = temp_locals
+            local_index InstValue::LocalSet bytecode.push
+            field_index 1 - = field_index
+        done
 
-    # Allocate struct on heap
-    count WORD_SIZE * InstValue::Push bytecode.push
-    InstValue::HeapAlloc bytecode.push
+        # Allocate struct on heap
+        count WORD_SIZE * InstValue::Push bytecode.push
+        InstValue::HeapAlloc bytecode.push
 
-    # Store each field at its correct offset
-    0 = member_index
-    while member_index casa_struct CasaStruct::members.length > do
-        member_index casa_struct CasaStruct::members.get Member::name = member_name
-        member_index WORD_SIZE * = member_offset
-        InstValue::Dup bytecode.push
-        if 0 member_offset > then
-            member_offset InstValue::Push bytecode.push
-            InstValue::Add bytecode.push
-        fi
-        member_name temp_locals.get.unwrap InstValue::LocalGet bytecode.push
-        InstValue::Swap bytecode.push
-        InstValue::Store64 bytecode.push
-        1 += member_index
-    done
+        # Store each field at its correct offset
+        0 = member_index
+        while member_index casa_struct CasaStruct::members.length > do
+            member_index casa_struct CasaStruct::members.get Member::name = member_name
+            member_index WORD_SIZE * = member_offset
+            InstValue::Dup bytecode.push
+            if 0 member_offset > then
+                member_offset InstValue::Push bytecode.push
+                InstValue::Add bytecode.push
+            fi
+            member_name temp_locals.get.unwrap InstValue::LocalGet bytecode.push
+            InstValue::Swap bytecode.push
+            InstValue::Store64 bytecode.push
+            1 += member_index
+        done
+    }
 }
 
 # ============================================================================
@@ -745,451 +797,471 @@ fn sanitize_fn_name name:str -> str {
     sb.build
 }
 
-fn compile_static_array_fns compiler:BytecodeCompiler items:List[Op] {
-    for item in items.iter do
-        if item Op::value OpValue::FnPush(fn_name) is then
-            fn_name compiler.store.functions.get = csa_fn_opt
-            if csa_fn_opt.is_some then
-                item csa_fn_opt.unwrap compiler compile_function
+impl BytecodeCompiler {
+    fn compile_static_array_fns compiler:BytecodeCompiler items:List[Op] {
+        for item in items.iter do
+            if item Op::value OpValue::FnPush(fn_name) is then
+                fn_name compiler.store.functions.get = csa_fn_opt
+                if csa_fn_opt.is_some then
+                    item csa_fn_opt.unwrap compiler.compile_function
+                fi
             fi
-        fi
-    done
+        done
+    }
 }
 
-fn compile_static_element compiler:BytecodeCompiler op:Op -> StaticArrayElement {
-    op Op::value match
-        OpValue::PushInt(val) => { val StaticArrayElement::Imm return }
-        OpValue::PushStr(val) => { val compiler intern_string = str_idx f"str_{str_idx}" StaticArrayElement::Label return }
-        OpValue::PushBool(val) => { val StaticArrayElement::Imm return }
-        OpValue::PushChar(val) => { val StaticArrayElement::Imm return }
-        OpValue::PushEnumVariant(ev) => { ev EnumVariant::ordinal.unwrap StaticArrayElement::Imm return }
-        OpValue::FnPush(fn_name) => {
-            fn_name sanitize_fn_name = sanitized_fn
-            f"closure_{sanitized_fn}" StaticArrayElement::Label return
-        }
-        _ => {
-            "Internal error: compile_static_element called on non-static op\n" eprint
-            1 exit
-            0 StaticArrayElement::Imm return
-        }
-    end
-    0 StaticArrayElement::Imm
-}
-
-fn compile_static_struct compiler:BytecodeCompiler group_ops:List[Op] -> str {
-    group_ops.length 1 - group_ops.get Op::value = last_val
-    if last_val OpValue::StructLiteral(literal) is ! then
-        "Internal error: compile_static_struct called on non-struct ExprGroup\n" eprint
-        1 exit
-        "" return
-    fi
-    literal StructLiteral::struct_name = struct_name
-    literal StructLiteral::field_order = field_order
-    struct_name compiler.store.structs.get.unwrap = casa_struct
-
-    List::new(List[StaticArrayElement]) = ordered_elems
-    0 = i
-    while i field_order.length > do
-        i group_ops.get compiler compile_static_element ordered_elems.push
-        1 += i
-    done
-
-    # Reorder to match struct member definition order
-    List::new(List[StaticArrayElement]) = fields
-    0 = mi
-    while mi casa_struct CasaStruct::members.length > do
-        mi casa_struct CasaStruct::members.get Member::name = member_name
-        member_name field_order string_list_index = fo_idx
-        fo_idx ordered_elems.get fields.push
-        1 += mi
-    done
-
-    compiler.static_structs.length = struct_index
-    fields StaticStruct compiler.static_structs.push
-    f"static_struct_{struct_index}"
-}
-
-fn compile_static_array compiler:BytecodeCompiler items:List[Op] bytecode:List[InstValue] {
-    items compiler compile_static_array_fns
-    List::new(List[StaticArrayElement]) = elements
-    for item in items.iter do
-        item Op::value match
-            OpValue::PushArray(inner_items) => {
-                List::new(List[InstValue]) = discard_bytecode
-                discard_bytecode inner_items compiler compile_static_array
-                compiler.static_arrays.length 1 - = inner_idx
-                f"static_array_{inner_idx}" StaticArrayElement::Label elements.push
+impl BytecodeCompiler {
+    fn compile_static_element compiler:BytecodeCompiler op:Op -> StaticArrayElement {
+        op Op::value match
+            OpValue::PushInt(val) => { val StaticArrayElement::Imm return }
+            OpValue::PushStr(val) => { val compiler.intern_string = str_idx f"str_{str_idx}" StaticArrayElement::Label return }
+            OpValue::PushBool(val) => { val StaticArrayElement::Imm return }
+            OpValue::PushChar(val) => { val StaticArrayElement::Imm return }
+            OpValue::PushEnumVariant(ev) => { ev EnumVariant::ordinal.unwrap StaticArrayElement::Imm return }
+            OpValue::FnPush(fn_name) => {
+                fn_name sanitize_fn_name = sanitized_fn
+                f"closure_{sanitized_fn}" StaticArrayElement::Label return
             }
-            OpValue::ExprGroup(group_ops) => {
-                group_ops compiler compile_static_struct = struct_label
-                struct_label StaticArrayElement::Label elements.push
+            _ => {
+                "Internal error: compile_static_element called on non-static op\n" eprint
+                1 exit
+                0 StaticArrayElement::Imm return
             }
-            _ => { item compiler compile_static_element elements.push }
         end
-    done
-    compiler.static_arrays.length = array_index
-    elements StaticArray compiler.static_arrays.push
-    array_index InstValue::PushStaticArray bytecode.push
+        0 StaticArrayElement::Imm
+    }
 }
 
-fn compile_push_array compiler:BytecodeCompiler op:Op bytecode:List[InstValue] {
-    if op.value OpValue::PushArray(items) is ! then return fi
-    items.length = length
+impl BytecodeCompiler {
+    fn compile_static_struct compiler:BytecodeCompiler group_ops:List[Op] -> str {
+        group_ops.length 1 - group_ops.get Op::value = last_val
+        if last_val OpValue::StructLiteral(literal) is ! then
+            "Internal error: compile_static_struct called on non-struct ExprGroup\n" eprint
+            1 exit
+            "" return
+        fi
+        literal StructLiteral::struct_name = struct_name
+        literal StructLiteral::field_order = field_order
+        struct_name compiler.store.structs.get.unwrap = casa_struct
 
-    if compiler.store items op_is_static_array_with_store then
-        bytecode items compiler compile_static_array
-        return
-    fi
+        List::new(List[StaticArrayElement]) = ordered_elems
+        0 = i
+        while i field_order.length > do
+            i group_ops.get compiler.compile_static_element ordered_elems.push
+            1 += i
+        done
 
-    # Compile items in reverse order
-    length 1 - = reverse_index
-    while 0 reverse_index >= do
-        reverse_index items.get = item
-        bytecode reverse_index item compiler compile_op
-        reverse_index 1 - = reverse_index
-    done
+        # Reorder to match struct member definition order
+        List::new(List[StaticArrayElement]) = fields
+        0 = mi
+        while mi casa_struct CasaStruct::members.length > do
+            mi casa_struct CasaStruct::members.get Member::name = member_name
+            member_name field_order string_list_index = fo_idx
+            fo_idx ordered_elems.get fields.push
+            1 += mi
+        done
 
-    # Allocate memory: header (data_ptr + length) + elements
-    compiler.locals_count = list_local
-    compiler.locals_count 1 + compiler->locals_count
-    length 2 + WORD_SIZE * InstValue::Push bytecode.push
-    InstValue::HeapAlloc bytecode.push
-    list_local InstValue::LocalSet bytecode.push
+        compiler.static_structs.length = struct_index
+        fields StaticStruct compiler.static_structs.push
+        f"static_struct_{struct_index}"
+    }
+}
 
-    # Store data_ptr (allocation + 16) at offset 0
-    list_local InstValue::LocalGet bytecode.push
-    16 InstValue::Push bytecode.push
-    InstValue::Add bytecode.push
-    list_local InstValue::LocalGet bytecode.push
-    InstValue::Store64 bytecode.push
+impl BytecodeCompiler {
+    fn compile_static_array compiler:BytecodeCompiler items:List[Op] bytecode:List[InstValue] {
+        items compiler.compile_static_array_fns
+        List::new(List[StaticArrayElement]) = elements
+        for item in items.iter do
+            item Op::value match
+                OpValue::PushArray(inner_items) => {
+                    List::new(List[InstValue]) = discard_bytecode
+                    discard_bytecode inner_items compiler.compile_static_array
+                    compiler.static_arrays.length 1 - = inner_idx
+                    f"static_array_{inner_idx}" StaticArrayElement::Label elements.push
+                }
+                OpValue::ExprGroup(group_ops) => {
+                    group_ops compiler.compile_static_struct = struct_label
+                    struct_label StaticArrayElement::Label elements.push
+                }
+                _ => { item compiler.compile_static_element elements.push }
+            end
+        done
+        compiler.static_arrays.length = array_index
+        elements StaticArray compiler.static_arrays.push
+        array_index InstValue::PushStaticArray bytecode.push
+    }
+}
 
-    # Store length at offset WORD_SIZE
-    length InstValue::Push bytecode.push
-    list_local InstValue::LocalGet bytecode.push
-    WORD_SIZE InstValue::Push bytecode.push
-    InstValue::Add bytecode.push
-    InstValue::Store64 bytecode.push
+impl BytecodeCompiler {
+    fn compile_push_array compiler:BytecodeCompiler op:Op bytecode:List[InstValue] {
+        if op.value OpValue::PushArray(items) is ! then return fi
+        items.length = length
 
-    # Store elements starting at offset 16
-    compiler.locals_count = index_local
-    compiler.locals_count 1 + compiler->locals_count
-    16 InstValue::Push bytecode.push
-    index_local InstValue::LocalSet bytecode.push
+        if compiler.store items op_is_static_array_with_store then
+            bytecode items compiler.compile_static_array
+            return
+        fi
 
-    compiler new_label = start_label
-    compiler new_label = end_label
+        # Compile items in reverse order
+        length 1 - = reverse_index
+        while 0 reverse_index >= do
+            reverse_index items.get = item
+            bytecode reverse_index item compiler.compile_op
+            reverse_index 1 - = reverse_index
+        done
 
-    # while index limit > do
-    start_label InstValue::Label bytecode.push
-    index_local InstValue::LocalGet bytecode.push
-    length 2 + WORD_SIZE * InstValue::Push bytecode.push
-    InstValue::Gt bytecode.push
-    end_label InstValue::JumpNe bytecode.push
+        # Allocate memory: header (data_ptr + length) + elements
+        compiler.locals_count = list_local
+        compiler.locals_count 1 + compiler->locals_count
+        length 2 + WORD_SIZE * InstValue::Push bytecode.push
+        InstValue::HeapAlloc bytecode.push
+        list_local InstValue::LocalSet bytecode.push
 
-    # list index + store64
-    list_local InstValue::LocalGet bytecode.push
-    index_local InstValue::LocalGet bytecode.push
-    InstValue::Add bytecode.push
-    InstValue::Store64 bytecode.push
+        # Store data_ptr (allocation + 16) at offset 0
+        list_local InstValue::LocalGet bytecode.push
+        16 InstValue::Push bytecode.push
+        InstValue::Add bytecode.push
+        list_local InstValue::LocalGet bytecode.push
+        InstValue::Store64 bytecode.push
 
-    # WORD_SIZE += index
-    index_local InstValue::LocalGet bytecode.push
-    WORD_SIZE InstValue::Push bytecode.push
-    InstValue::Add bytecode.push
-    index_local InstValue::LocalSet bytecode.push
+        # Store length at offset WORD_SIZE
+        length InstValue::Push bytecode.push
+        list_local InstValue::LocalGet bytecode.push
+        WORD_SIZE InstValue::Push bytecode.push
+        InstValue::Add bytecode.push
+        InstValue::Store64 bytecode.push
 
-    # done
-    start_label InstValue::Jump bytecode.push
-    end_label InstValue::Label bytecode.push
+        # Store elements starting at offset 16
+        compiler.locals_count = index_local
+        compiler.locals_count 1 + compiler->locals_count
+        16 InstValue::Push bytecode.push
+        index_local InstValue::LocalSet bytecode.push
 
-    # Push array pointer
-    list_local InstValue::LocalGet bytecode.push
+        compiler.new_label = start_label
+        compiler.new_label = end_label
+
+        # while index limit > do
+        start_label InstValue::Label bytecode.push
+        index_local InstValue::LocalGet bytecode.push
+        length 2 + WORD_SIZE * InstValue::Push bytecode.push
+        InstValue::Gt bytecode.push
+        end_label InstValue::JumpNe bytecode.push
+
+        # list index + store64
+        list_local InstValue::LocalGet bytecode.push
+        index_local InstValue::LocalGet bytecode.push
+        InstValue::Add bytecode.push
+        InstValue::Store64 bytecode.push
+
+        # WORD_SIZE += index
+        index_local InstValue::LocalGet bytecode.push
+        WORD_SIZE InstValue::Push bytecode.push
+        InstValue::Add bytecode.push
+        index_local InstValue::LocalSet bytecode.push
+
+        # done
+        start_label InstValue::Jump bytecode.push
+        end_label InstValue::Label bytecode.push
+
+        # Push array pointer
+        list_local InstValue::LocalGet bytecode.push
+    }
 }
 
 # ============================================================================
 # Compile function call
 # ============================================================================
 
-fn compile_function compiler:BytecodeCompiler function:Function op:Op {
-    # Compile a function if not already compiled.
-    if function Function::name compiler.compiled_functions.has then
-        return
-    fi
-    function Function::ops = ops
+impl BytecodeCompiler {
+    fn compile_function compiler:BytecodeCompiler function:Function op:Op {
+        # Compile a function if not already compiled.
+        if function Function::name compiler.compiled_functions.has then
+            return
+        fi
+        function Function::ops = ops
 
-    # Mark as being compiled to prevent infinite recursion on recursive calls
-    function Function::name compiler.compiled_functions.add drop
+        # Mark as being compiled to prevent infinite recursion on recursive calls
+        function Function::name compiler.compiled_functions.add drop
 
-    List::new(List[InstValue]) = function_bytecode
-    ops function compiler.child = function_compiler
-    function_bytecode function_compiler compile_ops
-    function_compiler.label_counter compiler->label_counter
+        List::new(List[InstValue]) = function_bytecode
+        ops function compiler.child = function_compiler
+        function_bytecode function_compiler.compile_ops
+        function_compiler.label_counter compiler->label_counter
 
-    # Handle locals
-    function_compiler.locals_count = locals_count
-    if locals_count 0 < then
-        # Build new list with LOCALS_INIT at front
-        List::new(List[InstValue]) = final_bytecode
-        locals_count InstValue::LocalsInit final_bytecode.push
+        # Handle locals
+        function_compiler.locals_count = locals_count
+        if locals_count 0 < then
+            # Build new list with LOCALS_INIT at front
+            List::new(List[InstValue]) = final_bytecode
+            locals_count InstValue::LocalsInit final_bytecode.push
 
+            for inst in function_bytecode.iter do
+                if inst InstValue::FnReturn is then
+                    locals_count InstValue::LocalsUninit final_bytecode.push
+                fi
+                inst final_bytecode.push
+            done
+            locals_count InstValue::LocalsUninit final_bytecode.push
+            InstValue::FnReturn final_bytecode.push
+            final_bytecode = function_bytecode
+        else
+            InstValue::FnReturn function_bytecode.push
+        fi
+
+        # Store bytecode on the function
         for inst in function_bytecode.iter do
-            if inst InstValue::FnReturn is then
-                locals_count InstValue::LocalsUninit final_bytecode.push
-            fi
-            inst final_bytecode.push
+            inst function Function::bytecode.push
         done
-        locals_count InstValue::LocalsUninit final_bytecode.push
-        InstValue::FnReturn final_bytecode.push
-        final_bytecode = function_bytecode
-    else
-        InstValue::FnReturn function_bytecode.push
-    fi
-
-    # Store bytecode on the function
-    for inst in function_bytecode.iter do
-        inst function Function::bytecode.push
-    done
+    }
 }
 
-fn compile_function_ops compiler:BytecodeCompiler op:Op bytecode:List[InstValue] {
-    op op_str_value = name
+impl BytecodeCompiler {
+    fn compile_function_ops compiler:BytecodeCompiler op:Op bytecode:List[InstValue] {
+        op op_str_value = name
 
-    op.value match
-        OpValue::FnCall => {
-            name compiler.store.functions.get.unwrap = function
-            op function compiler compile_function
-            name InstValue::FnCall bytecode.push
-        }
-        OpValue::FnPush => {
-            name compiler.store.functions.get = function_opt
-            if function_opt.is_none then
-                op Op::location f"Function `{name}` is not defined" ErrorKind::UndefinedName CasaError::new ERRORS.push
-                return
-            fi
-            function_opt.unwrap = lambda
-            op lambda compiler compile_function
+        op.value match
+            OpValue::FnCall => {
+                name compiler.store.functions.get.unwrap = function
+                op function compiler.compile_function
+                name InstValue::FnCall bytecode.push
+            }
+            OpValue::FnPush => {
+                name compiler.store.functions.get = function_opt
+                if function_opt.is_none then
+                    op Op::location f"Function `{name}` is not defined" ErrorKind::UndefinedName CasaError::new ERRORS.push
+                    return
+                fi
+                function_opt.unwrap = lambda
+                op lambda compiler.compile_function
 
-            # Zero-capture closures share a single static record so trait
-            # dispatch and named-function pushes do not allocate per call.
-            if 0 lambda Function::captures.length == then
-                name InstValue::FnPushStatic bytecode.push
-            else
-                # Captures are pushed before the function pointer so InstClosureRecord
-                # pops fn_ptr first into record[0] and then captures into record[1..].
-                for capture in lambda Function::captures.iter do
-                    capture Variable::name compiler resolve_variable = capture_resolved
-                    bytecode capture_resolved.emit_get
-                done
-                name InstValue::FnPush bytecode.push
-                lambda Function::captures.length InstValue::ClosureRecord bytecode.push
-            fi
-        }
-        _ => {
-            "Internal error: compile_function_ops called with non-function OpValue\n" eprint
-            1 exit
-        }
-    end
+                # Zero-capture closures share a single static record so trait
+                # dispatch and named-function pushes do not allocate per call.
+                if 0 lambda Function::captures.length == then
+                    name InstValue::FnPushStatic bytecode.push
+                else
+                    # Captures are pushed before the function pointer so InstClosureRecord
+                    # pops fn_ptr first into record[0] and then captures into record[1..].
+                    for capture in lambda Function::captures.iter do
+                        capture Variable::name compiler.resolve_variable = capture_resolved
+                        bytecode capture_resolved.emit_get
+                    done
+                    name InstValue::FnPush bytecode.push
+                    lambda Function::captures.length InstValue::ClosureRecord bytecode.push
+                fi
+            }
+            _ => {
+                "Internal error: compile_function_ops called with non-function OpValue\n" eprint
+                1 exit
+            }
+        end
+    }
 }
 
 # ============================================================================
 # Compile enum comparison (data-carrying enums)
 # ============================================================================
 
-fn compile_enum_comparison
-    compiler:BytecodeCompiler
-    compare_value:InstValue
-    bytecode:List[InstValue]
-{
-    compiler.locals_count = local_a
-    compiler.locals_count 1 + compiler->locals_count
-    local_a InstValue::LocalSet bytecode.push
-    InstValue::Load64 bytecode.push
-    local_a InstValue::LocalGet bytecode.push
-    InstValue::Load64 bytecode.push
-    compare_value bytecode.push
+impl BytecodeCompiler {
+    fn compile_enum_comparison
+        compiler:BytecodeCompiler
+        compare_value:InstValue
+        bytecode:List[InstValue]
+    {
+        compiler.locals_count = local_a
+        compiler.locals_count 1 + compiler->locals_count
+        local_a InstValue::LocalSet bytecode.push
+        InstValue::Load64 bytecode.push
+        local_a InstValue::LocalGet bytecode.push
+        InstValue::Load64 bytecode.push
+        compare_value bytecode.push
+    }
 }
 
 # ============================================================================
 # Compile single op
 # ============================================================================
 
-fn compile_op compiler:BytecodeCompiler op:Op op_index:int bytecode:List[InstValue] {
-    op.value = op_value
-    op_value direct_op_to_inst = direct_inst_opt
-    false = has_type_hint
-    "" = type_hint_name
-    if op Op::type_hint Option::Some(type_hint) is then
-        true = has_type_hint
-        type_hint.format = type_hint_name
-    fi
-
-    # Check direct op-to-inst mapping first
-    if direct_inst_opt.is_some then
-        # Data-carrying enum comparison
-        if
-        op_value OpValue::Eq is
-        op_value OpValue::Ne is ||
-        op_value OpValue::Lt is ||
-        op_value OpValue::Le is ||
-        op_value OpValue::Gt is ||
-        op_value OpValue::Ge is ||
-        has_type_hint &&
-        type_hint_name compiler.store.enums.has &&
-        then
-            bytecode direct_inst_opt.unwrap compiler compile_enum_comparison
-            return
+impl BytecodeCompiler {
+    fn compile_op compiler:BytecodeCompiler op:Op op_index:int bytecode:List[InstValue] {
+        op.value = op_value
+        op_value direct_op_to_inst = direct_inst_opt
+        false = has_type_hint
+        "" = type_hint_name
+        if op Op::type_hint Option::Some(type_hint) is then
+            true = has_type_hint
+            type_hint.format = type_hint_name
         fi
-        # String content comparison
-        if
-        op_value OpValue::Eq is
-        op_value OpValue::Ne is ||
-        "str" type_hint_name == &&
-        then
-            InstValue::StrEq bytecode.push
-            if op_value OpValue::Ne is then
-                InstValue::Not bytecode.push
+
+        # Check direct op-to-inst mapping first
+        if direct_inst_opt.is_some then
+            # Data-carrying enum comparison
+            if
+            op_value OpValue::Eq is
+            op_value OpValue::Ne is ||
+            op_value OpValue::Lt is ||
+            op_value OpValue::Le is ||
+            op_value OpValue::Gt is ||
+            op_value OpValue::Ge is ||
+            has_type_hint &&
+            type_hint_name compiler.store.enums.has &&
+            then
+                bytecode direct_inst_opt.unwrap compiler.compile_enum_comparison
+                return
             fi
+            # String content comparison
+            if
+            op_value OpValue::Eq is
+            op_value OpValue::Ne is ||
+            "str" type_hint_name == &&
+            then
+                InstValue::StrEq bytecode.push
+                if op_value OpValue::Ne is then
+                    InstValue::Not bytecode.push
+                fi
+                return
+            fi
+            # Data-carrying enum print
+            if op_value OpValue::PrintInt is has_type_hint && then
+                InstValue::Load64 bytecode.push
+                InstValue::PrintInt bytecode.push
+                return
+            fi
+            direct_inst_opt.unwrap bytecode.push
             return
         fi
-        # Data-carrying enum print
-        if op_value OpValue::PrintInt is has_type_hint && then
-            InstValue::Load64 bytecode.push
-            InstValue::PrintInt bytecode.push
-            return
-        fi
-        direct_inst_opt.unwrap bytecode.push
-        return
-    fi
 
-    # Non-direct ops
-    if
-    op_value OpValue::AssignDec is
-    op_value OpValue::AssignInc is ||
-    op_value OpValue::AssignVar is ||
-    then
-        bytecode op compiler compile_assignment
-    elif op_value OpValue::FstringConcat(fstring_count) is then
-        fstring_count InstValue::FstringConcat bytecode.push
-    elif op_value OpValue::FstringToStr is then
-        # Identity no-op: str expression already left on stack by the preceding lambda.
-        # Non-str cases are rewritten to OpMethodCall during type checking.
-    elif op_value OpValue::FnCall is op_value OpValue::FnPush is || then
-        if op_value OpValue::FnPush(fn_push_name) is then
-            fn_push_name compiler.store.functions.get = function_opt
-            if function_opt.is_some then
-                function_opt.unwrap = function_check
-                if function_check Function::has_deferred_methods then
-                    0 InstValue::Push bytecode.push
-                    return
+        # Non-direct ops
+        if
+        op_value OpValue::AssignDec is
+        op_value OpValue::AssignInc is ||
+        op_value OpValue::AssignVar is ||
+        then
+            bytecode op compiler.compile_assignment
+        elif op_value OpValue::FstringConcat(fstring_count) is then
+            fstring_count InstValue::FstringConcat bytecode.push
+        elif op_value OpValue::FstringToStr is then
+            # Identity no-op: str expression already left on stack by the preceding lambda.
+            # Non-str cases are rewritten to OpMethodCall during type checking.
+        elif op_value OpValue::FnCall is op_value OpValue::FnPush is || then
+            if op_value OpValue::FnPush(fn_push_name) is then
+                fn_push_name compiler.store.functions.get = function_opt
+                if function_opt.is_some then
+                    function_opt.unwrap = function_check
+                    if function_check Function::has_deferred_methods then
+                        0 InstValue::Push bytecode.push
+                        return
+                    fi
                 fi
             fi
+            bytecode op compiler.compile_function_ops
+        elif op_value OpValue::Identifier(ident_name) is then
+            f"Identifier `{ident_name}` should be resolved by the parser\n" eprint
+            1 exit
+        elif
+        op_value OpValue::IfCondition is
+        op_value OpValue::IfElif is ||
+        op_value OpValue::IfElse is ||
+        op_value OpValue::IfEnd is ||
+        op_value OpValue::IfStart is ||
+        then
+            bytecode op_index op compiler.compile_if_block
+        elif op_value OpValue::ImportFile is op_value OpValue::TypeCast is || op_value OpValue::DeclareGlobal is || then
+            # No instruction emitted
+        elif op_value OpValue::PushEnumVariant(variant) is then
+            variant EnumVariant::enum_name compiler.store.enums.get.unwrap = casa_enum
+            if casa_enum has_inner_values then
+                bytecode casa_enum variant compiler.compile_enum_variant
+            else
+                variant EnumVariant::ordinal.unwrap InstValue::Push bytecode.push
+            fi
+        elif op_value OpValue::IsCheck is then
+            bytecode op compiler.compile_is_check
+        elif
+        op_value OpValue::MatchStart is
+        op_value OpValue::MatchArm is ||
+        op_value OpValue::MatchEnd is ||
+        then
+            bytecode op_index op compiler.compile_match_block
+        elif op_value OpValue::MethodCall is then
+            "Method call should be transpiled to function call during type checking\n" eprint
+            1 exit
+        elif op_value OpValue::TraitMethodCall(trait_hidden_var) is then
+            trait_hidden_var compiler.resolve_variable = trait_resolved
+            bytecode trait_resolved.emit_get
+            InstValue::FnExec bytecode.push
+        elif op_value OpValue::Print is then
+            "PRINT should be resolved by type checker\n" eprint
+            1 exit
+        elif op_value OpValue::Typeof is then
+            type_hint_name = type_name
+            type_name compiler.intern_string = typeof_index
+            InstValue::Drop bytecode.push
+            typeof_index InstValue::PushStr bytecode.push
+            InstValue::PrintStr bytecode.push
+        elif op_value OpValue::PushArray is then
+            bytecode op compiler.compile_push_array
+        elif op_value OpValue::ExprGroup(group_ops) is then
+            0 = grp_idx
+            while grp_idx group_ops.length > do
+                bytecode grp_idx grp_idx group_ops.get compiler.compile_op
+                1 += grp_idx
+            done
+        elif op_value OpValue::PushBool(bool_value) is then
+            bool_value InstValue::Push bytecode.push
+        elif op_value OpValue::PushChar(char_value) is then
+            char_value InstValue::PushChar bytecode.push
+        elif op_value OpValue::PushCapture(capture_name) is then
+            if compiler.function Option::Some(function) is then
+                capture_name function Function::captures variable_list_index = capture_index
+                capture_index InstValue::CaptureLoad bytecode.push
+            fi
+        elif op_value OpValue::PushInt(int_value) is then
+            int_value InstValue::Push bytecode.push
+        elif op_value OpValue::PushStr(str_value) is then
+            str_value compiler.intern_string = string_index
+            string_index InstValue::PushStr bytecode.push
+        elif op_value OpValue::PushVar(var_name) is then
+            var_name compiler.resolve_variable = var_resolved
+            bytecode var_resolved.emit_get
+        elif op_value OpValue::StructNew is then
+            bytecode op compiler.compile_struct_new
+        elif op_value OpValue::StructLiteral is then
+            bytecode op compiler.compile_struct_literal
+        elif
+        op_value OpValue::WhileBreak is
+        op_value OpValue::WhileCondition is ||
+        op_value OpValue::WhileContinue is ||
+        op_value OpValue::WhileEnd is ||
+        op_value OpValue::WhileStart is ||
+        then
+            bytecode op_index op compiler.compile_while_block
         fi
-        bytecode op compiler compile_function_ops
-    elif op_value OpValue::Identifier(ident_name) is then
-        f"Identifier `{ident_name}` should be resolved by the parser\n" eprint
-        1 exit
-    elif
-    op_value OpValue::IfCondition is
-    op_value OpValue::IfElif is ||
-    op_value OpValue::IfElse is ||
-    op_value OpValue::IfEnd is ||
-    op_value OpValue::IfStart is ||
-    then
-        bytecode op_index op compiler compile_if_block
-    elif op_value OpValue::ImportFile is op_value OpValue::TypeCast is || op_value OpValue::DeclareGlobal is || then
-        # No instruction emitted
-    elif op_value OpValue::PushEnumVariant(variant) is then
-        variant EnumVariant::enum_name compiler.store.enums.get.unwrap = casa_enum
-        if casa_enum has_inner_values then
-            bytecode casa_enum variant compiler compile_enum_variant
-        else
-            variant EnumVariant::ordinal.unwrap InstValue::Push bytecode.push
-        fi
-    elif op_value OpValue::IsCheck is then
-        bytecode op compiler compile_is_check
-    elif
-    op_value OpValue::MatchStart is
-    op_value OpValue::MatchArm is ||
-    op_value OpValue::MatchEnd is ||
-    then
-        bytecode op_index op compiler compile_match_block
-    elif op_value OpValue::MethodCall is then
-        "Method call should be transpiled to function call during type checking\n" eprint
-        1 exit
-    elif op_value OpValue::TraitMethodCall(trait_hidden_var) is then
-        trait_hidden_var compiler resolve_variable = trait_resolved
-        bytecode trait_resolved.emit_get
-        InstValue::FnExec bytecode.push
-    elif op_value OpValue::Print is then
-        "PRINT should be resolved by type checker\n" eprint
-        1 exit
-    elif op_value OpValue::Typeof is then
-        type_hint_name = type_name
-        type_name compiler intern_string = typeof_index
-        InstValue::Drop bytecode.push
-        typeof_index InstValue::PushStr bytecode.push
-        InstValue::PrintStr bytecode.push
-    elif op_value OpValue::PushArray is then
-        bytecode op compiler compile_push_array
-    elif op_value OpValue::ExprGroup(group_ops) is then
-        0 = grp_idx
-        while grp_idx group_ops.length > do
-            bytecode grp_idx grp_idx group_ops.get compiler compile_op
-            1 += grp_idx
-        done
-    elif op_value OpValue::PushBool(bool_value) is then
-        bool_value InstValue::Push bytecode.push
-    elif op_value OpValue::PushChar(char_value) is then
-        char_value InstValue::PushChar bytecode.push
-    elif op_value OpValue::PushCapture(capture_name) is then
-        if compiler.function Option::Some(function) is then
-            capture_name function Function::captures variable_list_index = capture_index
-            capture_index InstValue::CaptureLoad bytecode.push
-        fi
-    elif op_value OpValue::PushInt(int_value) is then
-        int_value InstValue::Push bytecode.push
-    elif op_value OpValue::PushStr(str_value) is then
-        str_value compiler intern_string = string_index
-        string_index InstValue::PushStr bytecode.push
-    elif op_value OpValue::PushVar(var_name) is then
-        var_name compiler resolve_variable = var_resolved
-        bytecode var_resolved.emit_get
-    elif op_value OpValue::StructNew is then
-        bytecode op compiler compile_struct_new
-    elif op_value OpValue::StructLiteral is then
-        bytecode op compiler compile_struct_literal
-    elif
-    op_value OpValue::WhileBreak is
-    op_value OpValue::WhileCondition is ||
-    op_value OpValue::WhileContinue is ||
-    op_value OpValue::WhileEnd is ||
-    op_value OpValue::WhileStart is ||
-    then
-        bytecode op_index op compiler compile_while_block
-    fi
+    }
 }
 
 # ============================================================================
 # Compile ops list
 # ============================================================================
 
-fn compile_ops compiler:BytecodeCompiler bytecode:List[InstValue] {
-    # Set locals_count from function variables
-    if compiler.function Option::Some(function) is then
-        function Function::variables.length = var_count
-        var_count compiler->locals_count
-    fi
+impl BytecodeCompiler {
+    fn compile_ops compiler:BytecodeCompiler bytecode:List[InstValue] {
+        # Set locals_count from function variables
+        if compiler.function Option::Some(function) is then
+            function Function::variables.length = var_count
+            var_count compiler->locals_count
+        fi
 
-    # Function label
-    compiler new_label = function_label
-    function_label InstValue::Label bytecode.push
+        # Function label
+        compiler.new_label = function_label
+        function_label InstValue::Label bytecode.push
 
-    0 = index
-    while index compiler.ops.length > do
-        index compiler.ops.get = op
-        bytecode index op compiler compile_op
-        1 += index
-    done
+        0 = index
+        while index compiler.ops.length > do
+            index compiler.ops.get = op
+            bytecode index op compiler.compile_op
+            1 += index
+        done
+    }
 }
 
 # ============================================================================
@@ -1205,7 +1277,7 @@ fn compile_bytecode store:SymbolStore ops:List[Op] -> Program {
         compiler.store.variables.length InstValue::GlobalsInit bytecode.push
     fi
 
-    bytecode compiler compile_ops
+    bytecode compiler.compile_ops
 
     # Handle locals for global scope
     compiler.locals_count = locals_count

--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -730,8 +730,8 @@ fn op_is_static op:Op -> bool {
 fn op_is_static_with_store store:SymbolStore op:Op -> bool {
     if op.value OpValue::FnPush(fn_name) is then
         fn_name store.functions.get = fn_opt
-        if fn_opt.is_some then
-            0 fn_opt.unwrap Function::captures.length == return
+        if fn_opt Option::Some(function) is then
+            0 function Function::captures.length == return
         fi
         false return
     fi
@@ -1497,28 +1497,11 @@ fn split_type_tokens s:str -> List[str] {
     tokens
 }
 
-fn build_parameterized_type base:str params:List[str] -> str {
-    " " params.join = args_str
-    f"{base}[{args_str}]"
+fn build_parameterized_type base:str params:List[str] -> Type {
+    Map::new(Map[str Type]) params base build_resolved_type
 }
 
-fn build_parameterized_type_t base:str params:List[str] -> Type {
-    Map::new(Map[str Type]) params base build_resolved_type_t
-}
-
-fn build_resolved_type base:str type_vars:List[str] bindings:Map[str str] -> str {
-    List::new(List[str]) = params
-    for type_var in type_vars.iter do
-        if type_var bindings.get Option::Some(bound) is then
-            bound params.push
-        else
-            type_var params.push
-        fi
-    done
-    params base build_parameterized_type
-}
-
-fn build_resolved_type_t base:str type_vars:List[str] bindings:Map[str Type] -> Type {
+fn build_resolved_type base:str type_vars:List[str] bindings:Map[str Type] -> Type {
     List::new(List[Type]) = params
     for type_var in type_vars.iter do
         if type_var bindings.get Option::Some(bound) is then

--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -326,10 +326,6 @@ struct Op {
 fn make_op value:OpValue location:Location -> Op {
     value Option::None(Option[Type]) Option::None(Option[Type]) location Op
 }
-
-fn make_op_with_type_hint value:OpValue location:Location type_hint:Type -> Op {
-    value Option::None(Option[Type]) type_hint Option::Some location Op
-}
 # Op identity is its heap address: two Op values compare equal iff the same
 # allocation. Required so labels map by Op identity (Map[Op int]), not by an
 # int reinterpretation of an Op pointer at every read site.
@@ -851,10 +847,6 @@ struct HiddenTraitMethod {
 struct TraitBound {
     name:      str
     type_args: List[str]
-}
-
-fn make_simple_trait_bound name:str -> TraitBound {
-    List::new(List[str]) name TraitBound
 }
 
 fn trait_bound_to_str bound:TraitBound -> str {
@@ -1570,47 +1562,6 @@ fn function_type_to_stack_effect fn_type:FunctionType -> StackEffect {
         "" param_type Parameter params.push
     done
     fn_type FunctionType::return_types params make_stack_effect
-}
-
-fn stack_effect_from_str effect_str:str -> StackEffect {
-    # Parse "param1 param2 -> ret1 ret2" into StackEffect.
-    effect_str split_type_tokens = tokens
-
-    # Find the -> separator
-    -1 = arrow_index
-    0 = index
-    while index tokens.length > do
-        if "->" index tokens.get == then
-            index = arrow_index
-            break
-        fi
-        1 += index
-    done
-
-    List::new(List[Parameter]) = params
-    List::new(List[Type]) = returns
-
-    # Parameters: tokens before ->
-    0 = index
-    while index arrow_index > do
-        index tokens.get = token
-        if "None" token != then
-            token make_param params.push
-        fi
-        1 += index
-    done
-
-    # Return types: tokens after ->
-    arrow_index 1 + = index
-    while index tokens.length > do
-        index tokens.get = token
-        if "None" token != then
-            token parse_type_str returns.push
-        fi
-        1 += index
-    done
-
-    returns params make_stack_effect
 }
 
 fn stack_effect_type_param_matches expected:Type actual:Type type_vars:Set[str] -> bool {

--- a/compiler/common.casa
+++ b/compiler/common.casa
@@ -289,8 +289,10 @@ struct Location {
     span: Span
 }
 
-fn make_location file:str offset:int length:int -> Location {
-    length offset Span file Location
+impl Location {
+    fn new file:str offset:int length:int -> Location {
+        length offset Span file Location
+    }
 }
 
 fn empty_location -> Location {
@@ -303,8 +305,10 @@ struct Token {
     location: Location
 }
 
-fn make_token value:str kind:TokenKind location:Location -> Token {
-    location kind value Token
+impl Token {
+    fn new value:str kind:TokenKind location:Location -> Token {
+        location kind value Token
+    }
 }
 
 # ============================================================================
@@ -323,14 +327,15 @@ struct Op {
     value:                OpValue
 }
 
-fn make_op value:OpValue location:Location -> Op {
-    value Option::None(Option[Type]) Option::None(Option[Type]) location Op
-}
 # Op identity is its heap address: two Op values compare equal iff the same
 # allocation. Required so labels map by Op identity (Map[Op int]), not by an
 # int reinterpretation of an Op pointer at every read site.
 
 impl Op {
+    fn new value:OpValue location:Location -> Op {
+        value Option::None(Option[Type]) Option::None(Option[Type]) location Op
+    }
+
     fn hash self:Op -> int { self (int) int_hash }
     fn eq self:Op other:Op -> bool { self (int) other (int) == }
 }
@@ -366,12 +371,14 @@ struct Parameter {
     name: str
 }
 
-fn make_param typ:str -> Parameter {
-    "" typ parse_type_str Parameter
-}
+impl Parameter {
+    fn new typ:str -> Parameter {
+        "" typ parse_type_str Parameter
+    }
 
-fn make_named_param typ:Type name:str -> Parameter {
-    name typ Parameter
+    fn named typ:Type name:str -> Parameter {
+        name typ Parameter
+    }
 }
 
 struct StackEffect {
@@ -389,12 +396,14 @@ fn empty_stack_effect -> StackEffect {
     StackEffect
 }
 
-fn make_stack_effect params:List[Parameter] returns:List[Type] -> StackEffect {
-    Map::new(Map[str TraitBound])
-    Set::new(Set[str])
-    returns
-    params
-    StackEffect
+impl StackEffect {
+    fn new params:List[Parameter] returns:List[Type] -> StackEffect {
+        Map::new(Map[str TraitBound])
+        Set::new(Set[str])
+        returns
+        params
+        StackEffect
+    }
 }
 
 # ============================================================================
@@ -432,8 +441,10 @@ struct Variable {
     typ:  Type
 }
 
-fn make_variable name:str -> Variable {
-    Type::Unknown name Variable
+impl Variable {
+    fn new name:str -> Variable {
+        Type::Unknown name Variable
+    }
 }
 
 enum ResolvedVariable {
@@ -481,8 +492,10 @@ struct EnumVariant {
     bindings:     List[str]
 }
 
-fn make_enum_variant enum_name:str variant_name:str ordinal:Option[int] -> EnumVariant {
-    List::new(List[str]) ordinal variant_name enum_name EnumVariant
+impl EnumVariant {
+    fn new enum_name:str variant_name:str ordinal:Option[int] -> EnumVariant {
+        List::new(List[str]) ordinal variant_name enum_name EnumVariant
+    }
 }
 
 struct StructLiteral {
@@ -747,7 +760,7 @@ fn enum_variant_of op:Op -> EnumVariant {
     if op.value OpValue::IsCheck(variant) is then variant return fi
     "Internal error: enum_variant_of called on non-EnumVariant op\n" eprint
     1 exit
-    Option::None(Option[int]) "" "" make_enum_variant
+    Option::None(Option[int]) "" "" EnumVariant::new
 }
 # MatchArm — wrapper stored on OpValue::MatchArm. Carries the pattern payload
 # (typed via PatternValue) and an optional guard expression. `guard_ops` is
@@ -760,8 +773,10 @@ struct MatchArm {
     guard_ops:     List[Op]
 }
 
-fn make_match_arm pattern_value:PatternValue guard_ops:List[Op] -> MatchArm {
-    guard_ops pattern_value MatchArm
+impl MatchArm {
+    fn new pattern_value:PatternValue guard_ops:List[Op] -> MatchArm {
+        guard_ops pattern_value MatchArm
+    }
 }
 
 fn pattern_value_of op:Op -> PatternValue {
@@ -899,17 +914,14 @@ struct Function {
     is_const_fn:          bool
 }
 
-fn make_function name:str ops:List[Op] location:Location -> Function {
-    false false List::new(List[Variable]) List::new(List[Variable]) false false List::new(List[InstValue]) empty_stack_effect location ops name Function
-}
+impl Function {
+    fn new name:str ops:List[Op] location:Location -> Function {
+        false false List::new(List[Variable]) List::new(List[Variable]) false false List::new(List[InstValue]) empty_stack_effect location ops name Function
+    }
 
-fn make_function_with_stack_effect
-    name:str
-    ops:List[Op]
-    location:Location
-    effect:StackEffect
--> Function {
-    false false List::new(List[Variable]) List::new(List[Variable]) false false List::new(List[InstValue]) effect location ops name Function
+    fn with_stack_effect name:str ops:List[Op] location:Location effect:StackEffect -> Function {
+        false false List::new(List[Variable]) List::new(List[Variable]) false false List::new(List[InstValue]) effect location ops name Function
+    }
 }
 
 # ============================================================================
@@ -983,6 +995,12 @@ fn builtin_from_str source:str -> Option[BuiltinType] {
 struct GenericType {
     base:   str
     params: List[Type]
+}
+
+impl GenericType {
+    fn new name:str -> GenericType {
+        List::new(List[Type]) name GenericType
+    }
 }
 
 struct FunctionType {
@@ -1376,10 +1394,6 @@ fn canonicalize_stack_effect_type_vars effect:StackEffect type_vars:Set[str] {
     done
 }
 
-fn make_named_type name:str -> Type {
-    List::new(List[Type]) name GenericType Type::Generic
-}
-
 fn parse_type_str source:str -> Type {
     if "" source == then Type::Unknown return fi
     if source builtin_from_str Option::Some(builtin) is then
@@ -1561,7 +1575,7 @@ fn function_type_to_stack_effect fn_type:FunctionType -> StackEffect {
     for param_type in fn_type FunctionType::parameters.iter do
         "" param_type Parameter params.push
     done
-    fn_type FunctionType::return_types params make_stack_effect
+    fn_type FunctionType::return_types params StackEffect::new
 }
 
 fn stack_effect_type_param_matches expected:Type actual:Type type_vars:Set[str] -> bool {
@@ -1679,13 +1693,13 @@ fn apply_type_subs_to_stack_effect effect:StackEffect subs:Map[str Type] -> Stac
     List::new(List[Parameter]) = params
     for param in effect StackEffect::parameters.iter do
         subs param Parameter::typ.substitute_t = new_typ
-        param Parameter::name new_typ make_named_param params.push
+        param Parameter::name new_typ Parameter::named params.push
     done
     List::new(List[Type]) = returns
     for return_type in effect StackEffect::return_types.iter do
         subs return_type.substitute_t returns.push
     done
-    returns params make_stack_effect
+    returns params StackEffect::new
 }
 
 fn resolve_trait_stack_effect effect:StackEffect type_var:str -> StackEffect {
@@ -1698,7 +1712,7 @@ fn resolve_trait_stack_effect effect:StackEffect type_var:str -> StackEffect {
         else
             param Parameter::typ
         fi = new_typ
-        param Parameter::name new_typ make_named_param params.push
+        param Parameter::name new_typ Parameter::named params.push
     done
 
     List::new(List[Type]) = returns
@@ -1710,7 +1724,7 @@ fn resolve_trait_stack_effect effect:StackEffect type_var:str -> StackEffect {
         fi
     done
 
-    returns params make_stack_effect
+    returns params StackEffect::new
 }
 
 # ============================================================================

--- a/compiler/emitter.casa
+++ b/compiler/emitter.casa
@@ -11,28 +11,38 @@ import "common"
 1073741824 = HEAP_SIZE
 
 # ============================================================================
-# Label counter (global mutable state)
+# Emitter state
 # ============================================================================
-0 = emit_label_counter
 
-fn emit_uid -> int {
-    1 += emit_label_counter
-    emit_label_counter
+struct Emitter {
+    asm:           StringBuilder
+    label_counter: int
+    program:       Program
 }
 
-# ============================================================================
-# Helper: write a line to the assembly buffer
-# ============================================================================
+impl Emitter {
+    fn new program:Program -> Emitter {
+        program
+        0
+        StringBuilder::new
+        Emitter
+    }
 
-fn emit_line asm:StringBuilder text:str {
-    text asm.append
-    '\n' asm.append_char
-}
+    fn emit_uid self:Emitter -> int {
+        self.label_counter 1 + self->label_counter
+        self.label_counter
+    }
 
-fn emit_indent asm:StringBuilder text:str {
-    "    " asm.append
-    text asm.append
-    '\n' asm.append_char
+    fn line self:Emitter text:str {
+        text self.asm.append
+        '\n' self.asm.append_char
+    }
+
+    fn indent self:Emitter text:str {
+        "    " self.asm.append
+        text self.asm.append
+        '\n' self.asm.append_char
+    }
 }
 
 # ============================================================================
@@ -109,841 +119,841 @@ fn escape_string s:str -> str {
 # BSS section
 # ============================================================================
 
-fn emit_bss asm:StringBuilder program:Program {
-    ".section .bss" asm emit_line
-    if 0 program Program::globals_count > then
-        f"globals: .skip {program Program::globals_count WORD_SIZE *}" asm emit_line
-    fi
-    if 0 program Program::constants_count > then
-        f"constants: .skip {program Program::constants_count WORD_SIZE *}" asm emit_line
-    fi
-    f"return_stack: .skip {RETURN_STACK_SIZE}" asm emit_line
-    f"env_stack: .skip {RETURN_STACK_SIZE}" asm emit_line
-    "env_sp: .skip 8" asm emit_line
-    "current_env: .skip 8" asm emit_line
-    f"heap: .skip {HEAP_SIZE}" asm emit_line
-    "heap_ptr: .skip 8" asm emit_line
-    "__argc: .skip 8" asm emit_line
-    "__argv: .skip 8" asm emit_line
-    "__envp: .skip 8" asm emit_line
-    "print_buf: .skip 32" asm emit_line
-    "" asm emit_line
-}
+impl Emitter {
+    fn emit_bss self:Emitter {
+        ".section .bss" self.line
+        if 0 self.program.globals_count > then
+            f"globals: .skip {self.program.globals_count WORD_SIZE *}" self.line
+        fi
+        if 0 self.program.constants_count > then
+            f"constants: .skip {self.program.constants_count WORD_SIZE *}" self.line
+        fi
+        f"return_stack: .skip {RETURN_STACK_SIZE}" self.line
+        f"env_stack: .skip {RETURN_STACK_SIZE}" self.line
+        "env_sp: .skip 8" self.line
+        "current_env: .skip 8" self.line
+        f"heap: .skip {HEAP_SIZE}" self.line
+        "heap_ptr: .skip 8" self.line
+        "__argc: .skip 8" self.line
+        "__argv: .skip 8" self.line
+        "__envp: .skip 8" self.line
+        "print_buf: .skip 32" self.line
+        "" self.line
+    }
 
-# ============================================================================
-# DATA section
-# ============================================================================
+    # ============================================================================
+    # DATA section
+    # ============================================================================
 
-fn emit_data asm:StringBuilder program:Program {
-    ".section .data" asm emit_line
-    0 = index
-    while index program Program::strings.length > do
-        index program Program::strings.get = value
-        value escape_string = escaped
-        ".align 8" asm emit_line
-        f"str_{index}:" asm emit_line
-        f".quad {value.length}" asm emit_line
-        f".asciz \"{escaped}\"" asm emit_line
-        1 += index
-    done
-    "bool_true: .ascii \"true\"" asm emit_line
-    "bool_false: .ascii \"false\"" asm emit_line
-    "env_stack_overflow_msg: .ascii \"error: env stack overflow\\n\"" asm emit_line
-    ".equ env_stack_overflow_msg_len, . - env_stack_overflow_msg" asm emit_line
-    # Static closure record per function
-    for name in program Program::functions.keys.iter do
-        name sanitize_name = label
-        ".align 8" asm emit_line
-        f"closure_{label}: .quad fn_{label}" asm emit_line
-    done
-
-    # Static array literals
-    0 = sa_index
-    while sa_index program Program::static_arrays.length > do
-        sa_index program Program::static_arrays.get = sa
-        sa StaticArray::elements = elems
-        ".align 8" asm emit_line
-        f"static_array_{sa_index}:" asm emit_line
-        f".quad static_array_{sa_index} + 16" asm emit_line
-        f".quad {elems.length}" asm emit_line
-        for elem in elems.iter do
-            elem match
-                StaticArrayElement::Imm(v) => { f".quad {v}" asm emit_line }
-                StaticArrayElement::Label(lbl) => { f".quad {lbl}" asm emit_line }
-            end
+    fn emit_data self:Emitter {
+        ".section .data" self.line
+        0 = index
+        while index self.program.strings.length > do
+            index self.program.strings.get = value
+            value escape_string = escaped
+            ".align 8" self.line
+            f"str_{index}:" self.line
+            f".quad {value.length}" self.line
+            f".asciz \"{escaped}\"" self.line
+            1 += index
         done
-        1 += sa_index
-    done
-
-    # Static struct literals
-    0 = ss_index
-    while ss_index program Program::static_structs.length > do
-        ss_index program Program::static_structs.get = ss
-        ss StaticStruct::fields = fields
-        ".align 8" asm emit_line
-        f"static_struct_{ss_index}:" asm emit_line
-        for field in fields.iter do
-            field match
-                StaticArrayElement::Imm(v) => { f".quad {v}" asm emit_line }
-                StaticArrayElement::Label(lbl) => { f".quad {lbl}" asm emit_line }
-            end
+        "bool_true: .ascii \"true\"" self.line
+        "bool_false: .ascii \"false\"" self.line
+        "env_stack_overflow_msg: .ascii \"error: env stack overflow\\n\"" self.line
+        ".equ env_stack_overflow_msg_len, . - env_stack_overflow_msg" self.line
+        # Static closure record per function
+        for name in self.program.functions.keys.iter do
+            name sanitize_name = label
+            ".align 8" self.line
+            f"closure_{label}: .quad fn_{label}" self.line
         done
-        1 += ss_index
-    done
 
-    "" asm emit_line
-}
-
-# ============================================================================
-# TEXT section
-# ============================================================================
-
-fn emit_text asm:StringBuilder program:Program {
-    ".section .text" asm emit_line
-    asm emit_helpers
-    program asm emit_functions
-    program asm emit_start
-}
-
-# ============================================================================
-# Helper subroutines
-# ============================================================================
-
-fn emit_helpers asm:StringBuilder {
-    # print_int: value in %rdi, returns via r14
-    "print_int:" asm emit_line
-    "movq %rdi, %rax" asm emit_indent
-    "leaq print_buf+32(%rip), %rsi" asm emit_indent
-    "testq %rax, %rax" asm emit_indent
-    "jnz .Lpi_nonzero" asm emit_indent
-    "decq %rsi" asm emit_indent
-    "movb $48, (%rsi)" asm emit_indent
-    "jmp .Lpi_write" asm emit_indent
-    ".Lpi_nonzero:" asm emit_line
-    "movq %rax, %r15" asm emit_indent
-    "jns .Lpi_abs" asm emit_indent
-    "negq %rax" asm emit_indent
-    ".Lpi_abs:" asm emit_line
-    "movq $10, %rcx" asm emit_indent
-    ".Lpi_digit_loop:" asm emit_line
-    "decq %rsi" asm emit_indent
-    "xorq %rdx, %rdx" asm emit_indent
-    "divq %rcx" asm emit_indent
-    "addb $48, %dl" asm emit_indent
-    "movb %dl, (%rsi)" asm emit_indent
-    "testq %rax, %rax" asm emit_indent
-    "jnz .Lpi_digit_loop" asm emit_indent
-    "testq %r15, %r15" asm emit_indent
-    "jns .Lpi_write" asm emit_indent
-    "decq %rsi" asm emit_indent
-    "movb $45, (%rsi)" asm emit_indent
-    ".Lpi_write:" asm emit_line
-    "leaq print_buf+32(%rip), %rdx" asm emit_indent
-    "subq %rsi, %rdx" asm emit_indent
-    "movq $1, %rax" asm emit_indent
-    "movq $1, %rdi" asm emit_indent
-    "syscall" asm emit_indent
-    "subq $8, %r14" asm emit_indent
-    "jmpq *(%r14)" asm emit_indent
-    "" asm emit_line
-
-    # print_str: string pointer in %rdi (points to length prefix), returns via r14
-    "print_str:" asm emit_line
-    "movq (%rdi), %rdx" asm emit_indent
-    "leaq 8(%rdi), %rsi" asm emit_indent
-    "movq $1, %rdi" asm emit_indent
-    "movq $1, %rax" asm emit_indent
-    "syscall" asm emit_indent
-    "subq $8, %r14" asm emit_indent
-    "jmpq *(%r14)" asm emit_indent
-    "" asm emit_line
-
-    # str_concat: %rdi = part count (N), N string pointers on data stack
-    "str_concat:" asm emit_line
-    "movq %rdi, %r8" asm emit_indent
-    "movq %rsp, %r9" asm emit_indent
-    "xorq %r10, %r10" asm emit_indent
-    "xorq %rcx, %rcx" asm emit_indent
-    ".Lsc_len_loop:" asm emit_line
-    "cmpq %r8, %rcx" asm emit_indent
-    "jge .Lsc_len_done" asm emit_indent
-    "movq (%r9, %rcx, 8), %rax" asm emit_indent
-    "addq (%rax), %r10" asm emit_indent
-    "incq %rcx" asm emit_indent
-    "jmp .Lsc_len_loop" asm emit_indent
-    ".Lsc_len_done:" asm emit_line
-    "leaq heap(%rip), %r11" asm emit_indent
-    "movq heap_ptr(%rip), %r12" asm emit_indent
-    "leaq (%r11, %r12), %r13" asm emit_indent
-    "leaq 9(%r10, %r12), %rax" asm emit_indent
-    "movq %rax, heap_ptr(%rip)" asm emit_indent
-    "movq %r10, (%r13)" asm emit_indent
-    "leaq 8(%r13), %rdi" asm emit_indent
-    "movq %r8, %rcx" asm emit_indent
-    "decq %rcx" asm emit_indent
-    ".Lsc_copy_loop:" asm emit_line
-    "cmpq $0, %rcx" asm emit_indent
-    "jl .Lsc_copy_done" asm emit_indent
-    "movq (%r9, %rcx, 8), %rsi" asm emit_indent
-    "movq (%rsi), %rdx" asm emit_indent
-    "addq $8, %rsi" asm emit_indent
-    "pushq %rcx" asm emit_indent
-    "movq %rdx, %rcx" asm emit_indent
-    "rep movsb" asm emit_indent
-    "popq %rcx" asm emit_indent
-    "decq %rcx" asm emit_indent
-    "jmp .Lsc_copy_loop" asm emit_indent
-    ".Lsc_copy_done:" asm emit_line
-    "movb $0, (%rdi)" asm emit_indent
-    "leaq (%r9, %r8, 8), %rsp" asm emit_indent
-    "pushq %r13" asm emit_indent
-    "subq $8, %r14" asm emit_indent
-    "jmpq *(%r14)" asm emit_indent
-    "" asm emit_line
-
-    # env_stack overflow handler: write error to fd 2 and exit(1).
-    "env_stack_overflow:" asm emit_line
-    "leaq env_stack_overflow_msg(%rip), %rsi" asm emit_indent
-    "movq $env_stack_overflow_msg_len, %rdx" asm emit_indent
-    "movq $2, %rdi" asm emit_indent
-    "movq $1, %rax" asm emit_indent
-    "syscall" asm emit_indent
-    "movq $1, %rdi" asm emit_indent
-    "movq $60, %rax" asm emit_indent
-    "syscall" asm emit_indent
-    "" asm emit_line
-}
-
-# ============================================================================
-# Emit user functions
-# ============================================================================
-
-fn emit_functions asm:StringBuilder program:Program {
-    for pair in program Program::functions.iter do
-        pair.first = name
-        pair.second = bytecode
-        name sanitize_name = label
-        f"fn_{label}:" asm emit_line
-        false bytecode asm emit_bytecode
-        "" asm emit_line
-    done
-}
-
-# ============================================================================
-# Emit _start entry point
-# ============================================================================
-
-fn emit_start asm:StringBuilder program:Program {
-    ".globl _start" asm emit_line
-    "_start:" asm emit_line
-    "leaq return_stack(%rip), %r14" asm emit_indent
-    "movq (%rsp), %rax" asm emit_indent
-    "movq %rax, __argc(%rip)" asm emit_indent
-    "leaq 8(%rsp), %rax" asm emit_indent
-    "movq %rax, __argv(%rip)" asm emit_indent
-    "movq (%rsp), %rcx" asm emit_indent
-    "addq $1, %rcx" asm emit_indent
-    "leaq 8(%rsp,%rcx,8), %rax" asm emit_indent
-    "movq %rax, __envp(%rip)" asm emit_indent
-    true program Program::bytecode asm emit_bytecode
-    "movq $60, %rax" asm emit_indent
-    "xorq %rdi, %rdi" asm emit_indent
-    "syscall" asm emit_indent
-    "" asm emit_line
-}
-
-# ============================================================================
-# Emit bytecode sequence
-# ============================================================================
-
-fn emit_bytecode asm:StringBuilder bytecode:List[InstValue] is_global:bool {
-    for inst in bytecode.iter do
-        is_global inst asm emit_inst
-    done
-}
-
-# ============================================================================
-# Emit comparison helper
-# ============================================================================
-
-fn emit_comparison setcc:str asm:StringBuilder {
-    "popq %rax" asm emit_indent
-    "cmpq (%rsp), %rax" asm emit_indent
-    f"{setcc} %al" asm emit_indent
-    "movzbq %al, %rax" asm emit_indent
-    "movq %rax, (%rsp)" asm emit_indent
-}
-
-# ============================================================================
-# Emit syscall helper
-# ============================================================================
-
-fn emit_syscall arg_count:int asm:StringBuilder {
-    "popq %rax" asm emit_indent
-    ["%rdi", "%rsi", "%rdx", "%r10", "%r8", "%r9"] = syscall_regs
-    0 = index
-    while index arg_count > do
-        f"popq {index syscall_regs array::nth(str)}" asm emit_indent
-        1 += index
-    done
-    "syscall" asm emit_indent
-    "pushq %rax" asm emit_indent
-}
-
-# ============================================================================
-# Emit call-via-return-stack: push a return address onto r14, jump to target,
-# then emit the return label. Shared by FnCall, PrintInt, PrintStr, and
-# FstringConcat (all of which funnel into a shared asm subroutine).
-# ============================================================================
-
-fn emit_call_via_return_stack asm:StringBuilder jump_target:str label_prefix:str {
-    emit_uid = uid
-    f"leaq .L{label_prefix}_{uid}(%rip), %rax" asm emit_indent
-    "movq %rax, (%r14)" asm emit_indent
-    "addq $8, %r14" asm emit_indent
-    f"jmp {jump_target}" asm emit_indent
-    f".L{label_prefix}_{uid}:" asm emit_line
-}
-
-# ============================================================================
-# Emit memory load/store shared helpers
-# ============================================================================
-
-fn emit_load asm:StringBuilder mov_op:str dst_reg:str {
-    "popq %rax" asm emit_indent
-    f"{mov_op} (%rax), {dst_reg}" asm emit_indent
-    "pushq %rax" asm emit_indent
-}
-
-fn emit_store asm:StringBuilder mov_op:str src_reg:str {
-    "popq %rax" asm emit_indent
-    "popq %rbx" asm emit_indent
-    f"{mov_op} {src_reg}, (%rax)" asm emit_indent
-}
-
-# ============================================================================
-# Emit stack operations
-# ============================================================================
-
-fn emit_stack_ops asm:StringBuilder inst:InstValue {
-    inst match
-        InstValue::Push(value) => {
-            if
-            INT32_MIN value >=
-            INT32_MAX value <= &&
-            then
-                f"pushq ${value}" asm emit_indent
-            else
-                f"movabsq ${value}, %rax" asm emit_indent
-                "pushq %rax" asm emit_indent
-            fi
-        }
-        InstValue::PushStr(str_index) => {
-            f"leaq str_{str_index}(%rip), %rax" asm emit_indent
-            "pushq %rax" asm emit_indent
-        }
-        InstValue::PushStaticArray(array_index) => {
-            f"leaq static_array_{array_index}(%rip), %rax" asm emit_indent
-            "pushq %rax" asm emit_indent
-        }
-        InstValue::PushChar(char_value) => f"pushq ${char_value}" asm emit_indent
-        InstValue::Drop => "addq $8, %rsp" asm emit_indent
-        InstValue::Dup => "pushq (%rsp)" asm emit_indent
-        InstValue::Swap => {
-            "popq %rax" asm emit_indent
-            "popq %rbx" asm emit_indent
-            "pushq %rax" asm emit_indent
-            "pushq %rbx" asm emit_indent
-        }
-        InstValue::Over => "pushq 8(%rsp)" asm emit_indent
-        InstValue::Rot => {
-            "popq %rax" asm emit_indent
-            "popq %rbx" asm emit_indent
-            "popq %rcx" asm emit_indent
-            "pushq %rbx" asm emit_indent
-            "pushq %rax" asm emit_indent
-            "pushq %rcx" asm emit_indent
-        }
-        _ => {
-            "Internal error: emit_stack_ops called with non-stack InstValue\n" eprint
-            1 exit
-        }
-    end
-}
-
-# ============================================================================
-# Emit arithmetic / bitwise / boolean / comparison operations
-# ============================================================================
-
-fn emit_arithmetic asm:StringBuilder inst:InstValue {
-    inst match
-        InstValue::Add => {
-            "popq %rax" asm emit_indent
-            "addq %rax, (%rsp)" asm emit_indent
-        }
-        InstValue::Sub => {
-            "popq %rax" asm emit_indent
-            "subq %rax, (%rsp)" asm emit_indent
-        }
-        InstValue::Mul => {
-            "popq %rax" asm emit_indent
-            "imulq (%rsp), %rax" asm emit_indent
-            "movq %rax, (%rsp)" asm emit_indent
-        }
-        InstValue::Div => {
-            "popq %rbx" asm emit_indent
-            "popq %rax" asm emit_indent
-            "cqto" asm emit_indent
-            "idivq %rbx" asm emit_indent
-            "pushq %rax" asm emit_indent
-        }
-        InstValue::Mod => {
-            "popq %rbx" asm emit_indent
-            "popq %rax" asm emit_indent
-            "cqto" asm emit_indent
-            "idivq %rbx" asm emit_indent
-            "pushq %rdx" asm emit_indent
-        }
-        InstValue::Shl => {
-            "popq %rcx" asm emit_indent
-            "shlq %cl, (%rsp)" asm emit_indent
-        }
-        InstValue::Shr => {
-            "popq %rcx" asm emit_indent
-            "sarq %cl, (%rsp)" asm emit_indent
-        }
-        InstValue::BitAnd => {
-            "popq %rax" asm emit_indent
-            "andq %rax, (%rsp)" asm emit_indent
-        }
-        InstValue::BitOr => {
-            "popq %rax" asm emit_indent
-            "orq %rax, (%rsp)" asm emit_indent
-        }
-        InstValue::BitXor => {
-            "popq %rax" asm emit_indent
-            "xorq %rax, (%rsp)" asm emit_indent
-        }
-        InstValue::BitNot => "notq (%rsp)" asm emit_indent
-        InstValue::And => {
-            "popq %rax" asm emit_indent
-            "testq %rax, %rax" asm emit_indent
-            "setne %al" asm emit_indent
-            "cmpq $0, (%rsp)" asm emit_indent
-            "setne %cl" asm emit_indent
-            "andb %cl, %al" asm emit_indent
-            "movzbq %al, %rax" asm emit_indent
-            "movq %rax, (%rsp)" asm emit_indent
-        }
-        InstValue::Or => {
-            "popq %rax" asm emit_indent
-            "orq %rax, (%rsp)" asm emit_indent
-            "setne %al" asm emit_indent
-            "movzbq %al, %rax" asm emit_indent
-            "movq %rax, (%rsp)" asm emit_indent
-        }
-        InstValue::Not => {
-            "cmpq $0, (%rsp)" asm emit_indent
-            "sete %al" asm emit_indent
-            "movzbq %al, %rax" asm emit_indent
-            "movq %rax, (%rsp)" asm emit_indent
-        }
-        InstValue::Eq => asm "sete" emit_comparison
-        InstValue::Ne => asm "setne" emit_comparison
-        InstValue::Lt => asm "setl" emit_comparison
-        InstValue::Le => asm "setle" emit_comparison
-        InstValue::Gt => asm "setg" emit_comparison
-        InstValue::Ge => asm "setge" emit_comparison
-        _ => {
-            "Internal error: emit_arithmetic called with non-arithmetic InstValue\n" eprint
-            1 exit
-        }
-    end
-}
-
-# ============================================================================
-# Emit control flow / variable / function operations
-# ============================================================================
-
-fn emit_control_flow asm:StringBuilder inst:InstValue is_global:bool {
-    inst match
-        InstValue::Label(label) => f".L{label}:" asm emit_line
-        InstValue::Jump(label) => f"jmp .L{label}" asm emit_indent
-        InstValue::JumpNe(label) => {
-            "popq %rax" asm emit_indent
-            "testq %rax, %rax" asm emit_indent
-            f"jz .L{label}" asm emit_indent
-        }
-        InstValue::GlobalsInit => {
-            # Nothing needed, BSS handles it
-        }
-        InstValue::GlobalGet(global_index) => {
-            global_index WORD_SIZE * = offset
-            f"movq globals+{offset}(%rip), %rax" asm emit_indent
-            "pushq %rax" asm emit_indent
-        }
-        InstValue::GlobalSet(global_index) => {
-            global_index WORD_SIZE * = offset
-            "popq %rax" asm emit_indent
-            f"movq %rax, globals+{offset}(%rip)" asm emit_indent
-        }
-        InstValue::LocalsInit(count) => {
-            if 0 count != then
-                "movq %r14, %rdi" asm emit_indent
-                f"movq ${count}, %rcx" asm emit_indent
-                "xorq %rax, %rax" asm emit_indent
-                "rep stosq" asm emit_indent
-                f"addq ${count WORD_SIZE *}, %r14" asm emit_indent
-            fi
-        }
-        InstValue::LocalsUninit(count) => {
-            if 0 count != then
-                f"subq ${count WORD_SIZE *}, %r14" asm emit_indent
-            fi
-        }
-        InstValue::LocalGet(local_index) => {
-            local_index 1 + WORD_SIZE * = offset
-            f"movq -{offset}(%r14), %rax" asm emit_indent
-            "pushq %rax" asm emit_indent
-        }
-        InstValue::LocalSet(local_index) => {
-            local_index 1 + WORD_SIZE * = offset
-            "popq %rax" asm emit_indent
-            f"movq %rax, -{offset}(%r14)" asm emit_indent
-        }
-        InstValue::ConstantLoad(constant_index) => {
-            constant_index WORD_SIZE * = offset
-            f"movq constants+{offset}(%rip), %rax" asm emit_indent
-            "pushq %rax" asm emit_indent
-        }
-        InstValue::ConstantStore(constant_index) => {
-            constant_index WORD_SIZE * = offset
-            "popq %rax" asm emit_indent
-            f"movq %rax, constants+{offset}(%rip)" asm emit_indent
-        }
-        InstValue::FnCall(fn_name) => {
-            fn_name sanitize_name = fn_label
-            "ret" f"fn_{fn_label}" asm emit_call_via_return_stack
-        }
-        InstValue::FnExec => {
-            emit_uid = uid
-            # Save the caller's active closure env on the env stack and switch
-            # current_env to the popped closure record so its body can access
-            # captured values via InstCaptureLoad. After the callee returns,
-            # restore the previous env.
-            "popq %rax" asm emit_indent
-            "movq current_env(%rip), %rbx" asm emit_indent
-            "movq env_sp(%rip), %rcx" asm emit_indent
-            f"cmpq ${RETURN_STACK_SIZE}, %rcx" asm emit_indent
-            "jge env_stack_overflow" asm emit_indent
-            "movq %rbx, env_stack(%rcx)" asm emit_indent
-            "addq $8, %rcx" asm emit_indent
-            "movq %rcx, env_sp(%rip)" asm emit_indent
-            "movq %rax, current_env(%rip)" asm emit_indent
-            f"leaq .Lret_{uid}(%rip), %rcx" asm emit_indent
-            "movq %rcx, (%r14)" asm emit_indent
-            "addq $8, %r14" asm emit_indent
-            "movq (%rax), %rax" asm emit_indent
-            "jmpq *%rax" asm emit_indent
-            f".Lret_{uid}:" asm emit_line
-            "movq env_sp(%rip), %rcx" asm emit_indent
-            "subq $8, %rcx" asm emit_indent
-            "movq %rcx, env_sp(%rip)" asm emit_indent
-            "movq env_stack(%rcx), %rax" asm emit_indent
-            "movq %rax, current_env(%rip)" asm emit_indent
-        }
-        InstValue::CaptureLoad(capture_index) => {
-            capture_index 1 + WORD_SIZE * = offset
-            "movq current_env(%rip), %rax" asm emit_indent
-            f"movq {offset}(%rax), %rax" asm emit_indent
-            "pushq %rax" asm emit_indent
-        }
-        InstValue::ClosureRecord(capture_count) => {
-            capture_count 1 + WORD_SIZE * = record_size
-            # Bump-allocate the record from the heap.
-            "leaq heap(%rip), %rbx" asm emit_indent
-            "movq heap_ptr(%rip), %rcx" asm emit_indent
-            "leaq (%rbx,%rcx), %rdx" asm emit_indent
-            f"addq ${record_size}, %rcx" asm emit_indent
-            "movq %rcx, heap_ptr(%rip)" asm emit_indent
-            # Stack top is the function pointer; store it at offset 0.
-            "popq %rax" asm emit_indent
-            "movq %rax, (%rdx)" asm emit_indent
-            # Captures were pushed in order 0..N-1, so the top of the stack is
-            # capture N-1. Pop them in reverse to fill record[N], record[N-1],
-            # ..., record[1].
-            capture_count = capture_remaining
-            while 0 capture_remaining > do
-                capture_remaining WORD_SIZE * = field_offset
-                "popq %rax" asm emit_indent
-                f"movq %rax, {field_offset}(%rdx)" asm emit_indent
-                capture_remaining 1 - = capture_remaining
+        # Static array literals
+        0 = sa_index
+        while sa_index self.program.static_arrays.length > do
+            sa_index self.program.static_arrays.get = sa
+            sa StaticArray::elements = elems
+            ".align 8" self.line
+            f"static_array_{sa_index}:" self.line
+            f".quad static_array_{sa_index} + 16" self.line
+            f".quad {elems.length}" self.line
+            for elem in elems.iter do
+                elem match
+                    StaticArrayElement::Imm(v) => { f".quad {v}" self.line }
+                    StaticArrayElement::Label(lbl) => { f".quad {lbl}" self.line }
+                end
             done
-            "pushq %rdx" asm emit_indent
-        }
-        InstValue::FnPush(fn_name) => {
-            fn_name sanitize_name = fn_label
-            f"leaq fn_{fn_label}(%rip), %rax" asm emit_indent
-            "pushq %rax" asm emit_indent
-        }
-        InstValue::FnPushStatic(fn_name) => {
-            fn_name sanitize_name = fn_label
-            f"leaq closure_{fn_label}(%rip), %rax" asm emit_indent
-            "pushq %rax" asm emit_indent
-        }
-        InstValue::FnReturn => {
-            if is_global then
-                "movq $60, %rax" asm emit_indent
-                "xorq %rdi, %rdi" asm emit_indent
-                "syscall" asm emit_indent
-            else
-                "subq $8, %r14" asm emit_indent
-                "jmpq *(%r14)" asm emit_indent
-            fi
-        }
-        _ => {
-            "Internal error: emit_control_flow called with non-control-flow InstValue\n" eprint
-            1 exit
-        }
-    end
+            1 += sa_index
+        done
+
+        # Static struct literals
+        0 = ss_index
+        while ss_index self.program.static_structs.length > do
+            ss_index self.program.static_structs.get = ss
+            ss StaticStruct::fields = fields
+            ".align 8" self.line
+            f"static_struct_{ss_index}:" self.line
+            for field in fields.iter do
+                field match
+                    StaticArrayElement::Imm(v) => { f".quad {v}" self.line }
+                    StaticArrayElement::Label(lbl) => { f".quad {lbl}" self.line }
+                end
+            done
+            1 += ss_index
+        done
+
+        "" self.line
+    }
+
+    # ============================================================================
+    # TEXT section
+    # ============================================================================
+
+    fn emit_text self:Emitter {
+        ".section .text" self.line
+        self.emit_helpers
+        self.emit_functions
+        self.emit_start
+    }
+
+    # ============================================================================
+    # Helper subroutines
+    # ============================================================================
+
+    fn emit_helpers self:Emitter {
+        # print_int: value in %rdi, returns via r14
+        "print_int:" self.line
+        "movq %rdi, %rax" self.indent
+        "leaq print_buf+32(%rip), %rsi" self.indent
+        "testq %rax, %rax" self.indent
+        "jnz .Lpi_nonzero" self.indent
+        "decq %rsi" self.indent
+        "movb $48, (%rsi)" self.indent
+        "jmp .Lpi_write" self.indent
+        ".Lpi_nonzero:" self.line
+        "movq %rax, %r15" self.indent
+        "jns .Lpi_abs" self.indent
+        "negq %rax" self.indent
+        ".Lpi_abs:" self.line
+        "movq $10, %rcx" self.indent
+        ".Lpi_digit_loop:" self.line
+        "decq %rsi" self.indent
+        "xorq %rdx, %rdx" self.indent
+        "divq %rcx" self.indent
+        "addb $48, %dl" self.indent
+        "movb %dl, (%rsi)" self.indent
+        "testq %rax, %rax" self.indent
+        "jnz .Lpi_digit_loop" self.indent
+        "testq %r15, %r15" self.indent
+        "jns .Lpi_write" self.indent
+        "decq %rsi" self.indent
+        "movb $45, (%rsi)" self.indent
+        ".Lpi_write:" self.line
+        "leaq print_buf+32(%rip), %rdx" self.indent
+        "subq %rsi, %rdx" self.indent
+        "movq $1, %rax" self.indent
+        "movq $1, %rdi" self.indent
+        "syscall" self.indent
+        "subq $8, %r14" self.indent
+        "jmpq *(%r14)" self.indent
+        "" self.line
+
+        # print_str: string pointer in %rdi (points to length prefix), returns via r14
+        "print_str:" self.line
+        "movq (%rdi), %rdx" self.indent
+        "leaq 8(%rdi), %rsi" self.indent
+        "movq $1, %rdi" self.indent
+        "movq $1, %rax" self.indent
+        "syscall" self.indent
+        "subq $8, %r14" self.indent
+        "jmpq *(%r14)" self.indent
+        "" self.line
+
+        # str_concat: %rdi = part count (N), N string pointers on data stack
+        "str_concat:" self.line
+        "movq %rdi, %r8" self.indent
+        "movq %rsp, %r9" self.indent
+        "xorq %r10, %r10" self.indent
+        "xorq %rcx, %rcx" self.indent
+        ".Lsc_len_loop:" self.line
+        "cmpq %r8, %rcx" self.indent
+        "jge .Lsc_len_done" self.indent
+        "movq (%r9, %rcx, 8), %rax" self.indent
+        "addq (%rax), %r10" self.indent
+        "incq %rcx" self.indent
+        "jmp .Lsc_len_loop" self.indent
+        ".Lsc_len_done:" self.line
+        "leaq heap(%rip), %r11" self.indent
+        "movq heap_ptr(%rip), %r12" self.indent
+        "leaq (%r11, %r12), %r13" self.indent
+        "leaq 9(%r10, %r12), %rax" self.indent
+        "movq %rax, heap_ptr(%rip)" self.indent
+        "movq %r10, (%r13)" self.indent
+        "leaq 8(%r13), %rdi" self.indent
+        "movq %r8, %rcx" self.indent
+        "decq %rcx" self.indent
+        ".Lsc_copy_loop:" self.line
+        "cmpq $0, %rcx" self.indent
+        "jl .Lsc_copy_done" self.indent
+        "movq (%r9, %rcx, 8), %rsi" self.indent
+        "movq (%rsi), %rdx" self.indent
+        "addq $8, %rsi" self.indent
+        "pushq %rcx" self.indent
+        "movq %rdx, %rcx" self.indent
+        "rep movsb" self.indent
+        "popq %rcx" self.indent
+        "decq %rcx" self.indent
+        "jmp .Lsc_copy_loop" self.indent
+        ".Lsc_copy_done:" self.line
+        "movb $0, (%rdi)" self.indent
+        "leaq (%r9, %r8, 8), %rsp" self.indent
+        "pushq %r13" self.indent
+        "subq $8, %r14" self.indent
+        "jmpq *(%r14)" self.indent
+        "" self.line
+
+        # env_stack overflow handler: write error to fd 2 and exit(1).
+        "env_stack_overflow:" self.line
+        "leaq env_stack_overflow_msg(%rip), %rsi" self.indent
+        "movq $env_stack_overflow_msg_len, %rdx" self.indent
+        "movq $2, %rdi" self.indent
+        "movq $1, %rax" self.indent
+        "syscall" self.indent
+        "movq $1, %rdi" self.indent
+        "movq $60, %rax" self.indent
+        "syscall" self.indent
+        "" self.line
+    }
+
+    # ============================================================================
+    # Emit user functions
+    # ============================================================================
+
+    fn emit_functions self:Emitter {
+        for pair in self.program.functions.iter do
+            pair.first = name
+            pair.second = bytecode
+            name sanitize_name = label
+            f"fn_{label}:" self.line
+            false bytecode self.emit_bytecode
+            "" self.line
+        done
+    }
+
+    # ============================================================================
+    # Emit _start entry point
+    # ============================================================================
+
+    fn emit_start self:Emitter {
+        ".globl _start" self.line
+        "_start:" self.line
+        "leaq return_stack(%rip), %r14" self.indent
+        "movq (%rsp), %rax" self.indent
+        "movq %rax, __argc(%rip)" self.indent
+        "leaq 8(%rsp), %rax" self.indent
+        "movq %rax, __argv(%rip)" self.indent
+        "movq (%rsp), %rcx" self.indent
+        "addq $1, %rcx" self.indent
+        "leaq 8(%rsp,%rcx,8), %rax" self.indent
+        "movq %rax, __envp(%rip)" self.indent
+        true self.program.bytecode self.emit_bytecode
+        "movq $60, %rax" self.indent
+        "xorq %rdi, %rdi" self.indent
+        "syscall" self.indent
+        "" self.line
+    }
+
+    # ============================================================================
+    # Emit bytecode sequence
+    # ============================================================================
+
+    fn emit_bytecode self:Emitter bytecode:List[InstValue] is_global:bool {
+        for inst in bytecode.iter do
+            is_global inst self.emit_inst
+        done
+    }
+
+    # ============================================================================
+    # Emit comparison helper
+    # ============================================================================
+
+    fn emit_comparison self:Emitter setcc:str {
+        "popq %rax" self.indent
+        "cmpq (%rsp), %rax" self.indent
+        f"{setcc} %al" self.indent
+        "movzbq %al, %rax" self.indent
+        "movq %rax, (%rsp)" self.indent
+    }
+
+    # ============================================================================
+    # Emit syscall helper
+    # ============================================================================
+
+    fn emit_syscall self:Emitter arg_count:int {
+        "popq %rax" self.indent
+        ["%rdi", "%rsi", "%rdx", "%r10", "%r8", "%r9"] = syscall_regs
+        0 = index
+        while index arg_count > do
+            f"popq {index syscall_regs array::nth(str)}" self.indent
+            1 += index
+        done
+        "syscall" self.indent
+        "pushq %rax" self.indent
+    }
+
+    # ============================================================================
+    # Emit call-via-return-stack: push a return address onto r14, jump to target,
+    # then emit the return label. Shared by FnCall, PrintInt, PrintStr, and
+    # FstringConcat (all of which funnel into a shared asm subroutine).
+    # ============================================================================
+
+    fn emit_call_via_return_stack self:Emitter jump_target:str label_prefix:str {
+        self.emit_uid = uid
+        f"leaq .L{label_prefix}_{uid}(%rip), %rax" self.indent
+        "movq %rax, (%r14)" self.indent
+        "addq $8, %r14" self.indent
+        f"jmp {jump_target}" self.indent
+        f".L{label_prefix}_{uid}:" self.line
+    }
+
+    # ============================================================================
+    # Emit memory load/store shared helpers
+    # ============================================================================
+
+    fn emit_load self:Emitter mov_op:str dst_reg:str {
+        "popq %rax" self.indent
+        f"{mov_op} (%rax), {dst_reg}" self.indent
+        "pushq %rax" self.indent
+    }
+
+    fn emit_store self:Emitter mov_op:str src_reg:str {
+        "popq %rax" self.indent
+        "popq %rbx" self.indent
+        f"{mov_op} {src_reg}, (%rax)" self.indent
+    }
+
+    # ============================================================================
+    # Emit stack operations
+    # ============================================================================
+
+    fn emit_stack_ops self:Emitter inst:InstValue {
+        inst match
+            InstValue::Push(value) => {
+                if
+                INT32_MIN value >=
+                INT32_MAX value <= &&
+                then
+                    f"pushq ${value}" self.indent
+                else
+                    f"movabsq ${value}, %rax" self.indent
+                    "pushq %rax" self.indent
+                fi
+            }
+            InstValue::PushStr(str_index) => {
+                f"leaq str_{str_index}(%rip), %rax" self.indent
+                "pushq %rax" self.indent
+            }
+            InstValue::PushStaticArray(array_index) => {
+                f"leaq static_array_{array_index}(%rip), %rax" self.indent
+                "pushq %rax" self.indent
+            }
+            InstValue::PushChar(char_value) => f"pushq ${char_value}" self.indent
+            InstValue::Drop => "addq $8, %rsp" self.indent
+            InstValue::Dup => "pushq (%rsp)" self.indent
+            InstValue::Swap => {
+                "popq %rax" self.indent
+                "popq %rbx" self.indent
+                "pushq %rax" self.indent
+                "pushq %rbx" self.indent
+            }
+            InstValue::Over => "pushq 8(%rsp)" self.indent
+            InstValue::Rot => {
+                "popq %rax" self.indent
+                "popq %rbx" self.indent
+                "popq %rcx" self.indent
+                "pushq %rbx" self.indent
+                "pushq %rax" self.indent
+                "pushq %rcx" self.indent
+            }
+            _ => {
+                "Internal error: emit_stack_ops called with non-stack InstValue\n" eprint
+                1 exit
+            }
+        end
+    }
+
+    # ============================================================================
+    # Emit arithmetic / bitwise / boolean / comparison operations
+    # ============================================================================
+
+    fn emit_arithmetic self:Emitter inst:InstValue {
+        inst match
+            InstValue::Add => {
+                "popq %rax" self.indent
+                "addq %rax, (%rsp)" self.indent
+            }
+            InstValue::Sub => {
+                "popq %rax" self.indent
+                "subq %rax, (%rsp)" self.indent
+            }
+            InstValue::Mul => {
+                "popq %rax" self.indent
+                "imulq (%rsp), %rax" self.indent
+                "movq %rax, (%rsp)" self.indent
+            }
+            InstValue::Div => {
+                "popq %rbx" self.indent
+                "popq %rax" self.indent
+                "cqto" self.indent
+                "idivq %rbx" self.indent
+                "pushq %rax" self.indent
+            }
+            InstValue::Mod => {
+                "popq %rbx" self.indent
+                "popq %rax" self.indent
+                "cqto" self.indent
+                "idivq %rbx" self.indent
+                "pushq %rdx" self.indent
+            }
+            InstValue::Shl => {
+                "popq %rcx" self.indent
+                "shlq %cl, (%rsp)" self.indent
+            }
+            InstValue::Shr => {
+                "popq %rcx" self.indent
+                "sarq %cl, (%rsp)" self.indent
+            }
+            InstValue::BitAnd => {
+                "popq %rax" self.indent
+                "andq %rax, (%rsp)" self.indent
+            }
+            InstValue::BitOr => {
+                "popq %rax" self.indent
+                "orq %rax, (%rsp)" self.indent
+            }
+            InstValue::BitXor => {
+                "popq %rax" self.indent
+                "xorq %rax, (%rsp)" self.indent
+            }
+            InstValue::BitNot => "notq (%rsp)" self.indent
+            InstValue::And => {
+                "popq %rax" self.indent
+                "testq %rax, %rax" self.indent
+                "setne %al" self.indent
+                "cmpq $0, (%rsp)" self.indent
+                "setne %cl" self.indent
+                "andb %cl, %al" self.indent
+                "movzbq %al, %rax" self.indent
+                "movq %rax, (%rsp)" self.indent
+            }
+            InstValue::Or => {
+                "popq %rax" self.indent
+                "orq %rax, (%rsp)" self.indent
+                "setne %al" self.indent
+                "movzbq %al, %rax" self.indent
+                "movq %rax, (%rsp)" self.indent
+            }
+            InstValue::Not => {
+                "cmpq $0, (%rsp)" self.indent
+                "sete %al" self.indent
+                "movzbq %al, %rax" self.indent
+                "movq %rax, (%rsp)" self.indent
+            }
+            InstValue::Eq => "sete" self.emit_comparison
+            InstValue::Ne => "setne" self.emit_comparison
+            InstValue::Lt => "setl" self.emit_comparison
+            InstValue::Le => "setle" self.emit_comparison
+            InstValue::Gt => "setg" self.emit_comparison
+            InstValue::Ge => "setge" self.emit_comparison
+            _ => {
+                "Internal error: emit_arithmetic called with non-arithmetic InstValue\n" eprint
+                1 exit
+            }
+        end
+    }
+
+    # ============================================================================
+    # Emit control flow / variable / function operations
+    # ============================================================================
+
+    fn emit_control_flow self:Emitter inst:InstValue is_global:bool {
+        inst match
+            InstValue::Label(label) => f".L{label}:" self.line
+            InstValue::Jump(label) => f"jmp .L{label}" self.indent
+            InstValue::JumpNe(label) => {
+                "popq %rax" self.indent
+                "testq %rax, %rax" self.indent
+                f"jz .L{label}" self.indent
+            }
+            InstValue::GlobalsInit => {
+                # Nothing needed, BSS handles it
+            }
+            InstValue::GlobalGet(global_index) => {
+                global_index WORD_SIZE * = offset
+                f"movq globals+{offset}(%rip), %rax" self.indent
+                "pushq %rax" self.indent
+            }
+            InstValue::GlobalSet(global_index) => {
+                global_index WORD_SIZE * = offset
+                "popq %rax" self.indent
+                f"movq %rax, globals+{offset}(%rip)" self.indent
+            }
+            InstValue::LocalsInit(count) => {
+                if 0 count != then
+                    "movq %r14, %rdi" self.indent
+                    f"movq ${count}, %rcx" self.indent
+                    "xorq %rax, %rax" self.indent
+                    "rep stosq" self.indent
+                    f"addq ${count WORD_SIZE *}, %r14" self.indent
+                fi
+            }
+            InstValue::LocalsUninit(count) => {
+                if 0 count != then
+                    f"subq ${count WORD_SIZE *}, %r14" self.indent
+                fi
+            }
+            InstValue::LocalGet(local_index) => {
+                local_index 1 + WORD_SIZE * = offset
+                f"movq -{offset}(%r14), %rax" self.indent
+                "pushq %rax" self.indent
+            }
+            InstValue::LocalSet(local_index) => {
+                local_index 1 + WORD_SIZE * = offset
+                "popq %rax" self.indent
+                f"movq %rax, -{offset}(%r14)" self.indent
+            }
+            InstValue::ConstantLoad(constant_index) => {
+                constant_index WORD_SIZE * = offset
+                f"movq constants+{offset}(%rip), %rax" self.indent
+                "pushq %rax" self.indent
+            }
+            InstValue::ConstantStore(constant_index) => {
+                constant_index WORD_SIZE * = offset
+                "popq %rax" self.indent
+                f"movq %rax, constants+{offset}(%rip)" self.indent
+            }
+            InstValue::FnCall(fn_name) => {
+                fn_name sanitize_name = fn_label
+                "ret" f"fn_{fn_label}" self.emit_call_via_return_stack
+            }
+            InstValue::FnExec => {
+                self.emit_uid = uid
+                # Save the caller's active closure env on the env stack and switch
+                # current_env to the popped closure record so its body can access
+                # captured values via InstCaptureLoad. After the callee returns,
+                # restore the previous env.
+                "popq %rax" self.indent
+                "movq current_env(%rip), %rbx" self.indent
+                "movq env_sp(%rip), %rcx" self.indent
+                f"cmpq ${RETURN_STACK_SIZE}, %rcx" self.indent
+                "jge env_stack_overflow" self.indent
+                "movq %rbx, env_stack(%rcx)" self.indent
+                "addq $8, %rcx" self.indent
+                "movq %rcx, env_sp(%rip)" self.indent
+                "movq %rax, current_env(%rip)" self.indent
+                f"leaq .Lret_{uid}(%rip), %rcx" self.indent
+                "movq %rcx, (%r14)" self.indent
+                "addq $8, %r14" self.indent
+                "movq (%rax), %rax" self.indent
+                "jmpq *%rax" self.indent
+                f".Lret_{uid}:" self.line
+                "movq env_sp(%rip), %rcx" self.indent
+                "subq $8, %rcx" self.indent
+                "movq %rcx, env_sp(%rip)" self.indent
+                "movq env_stack(%rcx), %rax" self.indent
+                "movq %rax, current_env(%rip)" self.indent
+            }
+            InstValue::CaptureLoad(capture_index) => {
+                capture_index 1 + WORD_SIZE * = offset
+                "movq current_env(%rip), %rax" self.indent
+                f"movq {offset}(%rax), %rax" self.indent
+                "pushq %rax" self.indent
+            }
+            InstValue::ClosureRecord(capture_count) => {
+                capture_count 1 + WORD_SIZE * = record_size
+                # Bump-allocate the record from the heap.
+                "leaq heap(%rip), %rbx" self.indent
+                "movq heap_ptr(%rip), %rcx" self.indent
+                "leaq (%rbx,%rcx), %rdx" self.indent
+                f"addq ${record_size}, %rcx" self.indent
+                "movq %rcx, heap_ptr(%rip)" self.indent
+                # Stack top is the function pointer; store it at offset 0.
+                "popq %rax" self.indent
+                "movq %rax, (%rdx)" self.indent
+                # Captures were pushed in order 0..N-1, so the top of the stack is
+                # capture N-1. Pop them in reverse to fill record[N], record[N-1],
+                # ..., record[1].
+                capture_count = capture_remaining
+                while 0 capture_remaining > do
+                    capture_remaining WORD_SIZE * = field_offset
+                    "popq %rax" self.indent
+                    f"movq %rax, {field_offset}(%rdx)" self.indent
+                    capture_remaining 1 - = capture_remaining
+                done
+                "pushq %rdx" self.indent
+            }
+            InstValue::FnPush(fn_name) => {
+                fn_name sanitize_name = fn_label
+                f"leaq fn_{fn_label}(%rip), %rax" self.indent
+                "pushq %rax" self.indent
+            }
+            InstValue::FnPushStatic(fn_name) => {
+                fn_name sanitize_name = fn_label
+                f"leaq closure_{fn_label}(%rip), %rax" self.indent
+                "pushq %rax" self.indent
+            }
+            InstValue::FnReturn => {
+                if is_global then
+                    "movq $60, %rax" self.indent
+                    "xorq %rdi, %rdi" self.indent
+                    "syscall" self.indent
+                else
+                    "subq $8, %r14" self.indent
+                    "jmpq *(%r14)" self.indent
+                fi
+            }
+            _ => {
+                "Internal error: emit_control_flow called with non-control-flow InstValue\n" eprint
+                1 exit
+            }
+        end
+    }
+
+    # ============================================================================
+    # Emit memory operations
+    # ============================================================================
+
+    fn emit_memory self:Emitter inst:InstValue {
+        inst match
+            InstValue::HeapAlloc => {
+                "popq %rax" self.indent
+                "leaq heap(%rip), %rbx" self.indent
+                "movq heap_ptr(%rip), %rcx" self.indent
+                "leaq (%rbx,%rcx), %rdx" self.indent
+                "pushq %rdx" self.indent
+                "addq %rax, %rcx" self.indent
+                "movq %rcx, heap_ptr(%rip)" self.indent
+            }
+            InstValue::Load8 => "%eax" "movzbl" self.emit_load
+            InstValue::Load16 => "%eax" "movzwl" self.emit_load
+            InstValue::Load32 => "%eax" "movl" self.emit_load
+            InstValue::Load64 => "%rax" "movq" self.emit_load
+            InstValue::Store8 => "%bl" "movb" self.emit_store
+            InstValue::Store16 => "%bx" "movw" self.emit_store
+            InstValue::Store32 => "%ebx" "movl" self.emit_store
+            InstValue::Store64 => "%rbx" "movq" self.emit_store
+            _ => {
+                "Internal error: emit_memory called with non-memory InstValue\n" eprint
+                1 exit
+            }
+        end
+    }
+
+    # ============================================================================
+    # Emit IO operations
+    # ============================================================================
+
+    fn emit_io_ops self:Emitter inst:InstValue {
+        inst match
+            InstValue::PrintInt => {
+                "popq %rdi" self.indent
+                "print_done" "print_int" self.emit_call_via_return_stack
+            }
+            InstValue::PrintBool => {
+                self.emit_uid = uid
+                "popq %rax" self.indent
+                "testq %rax, %rax" self.indent
+                f"jz .Lpb_false_{uid}" self.indent
+                "leaq bool_true(%rip), %rsi" self.indent
+                "movq $4, %rdx" self.indent
+                f"jmp .Lpb_write_{uid}" self.indent
+                f".Lpb_false_{uid}:" self.line
+                "leaq bool_false(%rip), %rsi" self.indent
+                "movq $5, %rdx" self.indent
+                f".Lpb_write_{uid}:" self.line
+                "movq $1, %rdi" self.indent
+                "movq $1, %rax" self.indent
+                "syscall" self.indent
+            }
+            InstValue::PrintStr => {
+                "popq %rdi" self.indent
+                "print_done" "print_str" self.emit_call_via_return_stack
+            }
+            InstValue::PrintChar => {
+                "popq %rax" self.indent
+                "movb %al, -1(%rsp)" self.indent
+                "leaq -1(%rsp), %rsi" self.indent
+                "movq $1, %rdx" self.indent
+                "movq $1, %rdi" self.indent
+                "movq $1, %rax" self.indent
+                "syscall" self.indent
+            }
+            InstValue::PrintCstr => {
+                self.emit_uid = uid
+                "popq %rsi" self.indent
+                "movq %rsi, %rdi" self.indent
+                f".Lpc_scan_{uid}:" self.line
+                "cmpb $0, (%rsi)" self.indent
+                f"je .Lpc_done_{uid}" self.indent
+                "incq %rsi" self.indent
+                f"jmp .Lpc_scan_{uid}" self.indent
+                f".Lpc_done_{uid}:" self.line
+                "movq %rsi, %rdx" self.indent
+                "subq %rdi, %rdx" self.indent
+                "movq %rdi, %rsi" self.indent
+                "movq $1, %rdi" self.indent
+                "movq $1, %rax" self.indent
+                "syscall" self.indent
+            }
+            InstValue::FstringConcat(fstring_count) => {
+                f"movq ${fstring_count}, %rdi" self.indent
+                "concat_done" "str_concat" self.emit_call_via_return_stack
+            }
+            _ => {
+                "Internal error: emit_io_ops called with non-IO InstValue\n" eprint
+                1 exit
+            }
+        end
+    }
+
+    # ============================================================================
+    # Emit string equality
+    # ============================================================================
+
+    fn emit_str_eq self:Emitter {
+        self.emit_uid = uid
+        "popq %rsi" self.indent
+        "popq %rdi" self.indent
+        "movq (%rdi), %rcx" self.indent
+        "cmpq (%rsi), %rcx" self.indent
+        f"jne .Lstreq_ne_{uid}" self.indent
+        "leaq 8(%rdi), %rdi" self.indent
+        "leaq 8(%rsi), %rsi" self.indent
+        "repe cmpsb" self.indent
+        f"jne .Lstreq_ne_{uid}" self.indent
+        "pushq $1" self.indent
+        f"jmp .Lstreq_done_{uid}" self.indent
+        f".Lstreq_ne_{uid}:" self.line
+        "pushq $0" self.indent
+        f".Lstreq_done_{uid}:" self.line
+    }
+
+    # ============================================================================
+    # Emit single instruction (main dispatch)
+    # ============================================================================
+
+    fn emit_inst self:Emitter inst:InstValue is_global:bool {
+        inst match
+            # Stack operations
+            InstValue::Drop => inst self.emit_stack_ops
+            InstValue::Dup => inst self.emit_stack_ops
+            InstValue::Over => inst self.emit_stack_ops
+            InstValue::Push => inst self.emit_stack_ops
+            InstValue::PushChar => inst self.emit_stack_ops
+            InstValue::PushStr => inst self.emit_stack_ops
+            InstValue::PushStaticArray => inst self.emit_stack_ops
+            InstValue::Rot => inst self.emit_stack_ops
+            InstValue::Swap => inst self.emit_stack_ops
+
+            # Arithmetic / bitshift / bitwise / boolean / comparison
+            InstValue::Add => inst self.emit_arithmetic
+            InstValue::Sub => inst self.emit_arithmetic
+            InstValue::Mul => inst self.emit_arithmetic
+            InstValue::Div => inst self.emit_arithmetic
+            InstValue::Mod => inst self.emit_arithmetic
+            InstValue::Shl => inst self.emit_arithmetic
+            InstValue::Shr => inst self.emit_arithmetic
+            InstValue::BitAnd => inst self.emit_arithmetic
+            InstValue::BitOr => inst self.emit_arithmetic
+            InstValue::BitXor => inst self.emit_arithmetic
+            InstValue::BitNot => inst self.emit_arithmetic
+            InstValue::And => inst self.emit_arithmetic
+            InstValue::Or => inst self.emit_arithmetic
+            InstValue::Not => inst self.emit_arithmetic
+            InstValue::Eq => inst self.emit_arithmetic
+            InstValue::Ne => inst self.emit_arithmetic
+            InstValue::Lt => inst self.emit_arithmetic
+            InstValue::Le => inst self.emit_arithmetic
+            InstValue::Gt => inst self.emit_arithmetic
+            InstValue::Ge => inst self.emit_arithmetic
+
+            # Control flow / variables / functions
+            InstValue::Label => is_global inst self.emit_control_flow
+            InstValue::Jump => is_global inst self.emit_control_flow
+            InstValue::JumpNe => is_global inst self.emit_control_flow
+            InstValue::GlobalsInit => is_global inst self.emit_control_flow
+            InstValue::GlobalGet => is_global inst self.emit_control_flow
+            InstValue::GlobalSet => is_global inst self.emit_control_flow
+            InstValue::LocalsInit => is_global inst self.emit_control_flow
+            InstValue::LocalsUninit => is_global inst self.emit_control_flow
+            InstValue::LocalGet => is_global inst self.emit_control_flow
+            InstValue::LocalSet => is_global inst self.emit_control_flow
+            InstValue::ConstantLoad => is_global inst self.emit_control_flow
+            InstValue::ConstantStore => is_global inst self.emit_control_flow
+            InstValue::CaptureLoad => is_global inst self.emit_control_flow
+            InstValue::ClosureRecord => is_global inst self.emit_control_flow
+            InstValue::FnCall => is_global inst self.emit_control_flow
+            InstValue::FnExec => is_global inst self.emit_control_flow
+            InstValue::FnPush => is_global inst self.emit_control_flow
+            InstValue::FnPushStatic => is_global inst self.emit_control_flow
+            InstValue::FnReturn => is_global inst self.emit_control_flow
+
+            # Memory operations
+            InstValue::HeapAlloc => inst self.emit_memory
+            InstValue::Load8 => inst self.emit_memory
+            InstValue::Load16 => inst self.emit_memory
+            InstValue::Load32 => inst self.emit_memory
+            InstValue::Load64 => inst self.emit_memory
+            InstValue::Store8 => inst self.emit_memory
+            InstValue::Store16 => inst self.emit_memory
+            InstValue::Store32 => inst self.emit_memory
+            InstValue::Store64 => inst self.emit_memory
+
+            # IO operations
+            InstValue::PrintInt => inst self.emit_io_ops
+            InstValue::PrintBool => inst self.emit_io_ops
+            InstValue::PrintStr => inst self.emit_io_ops
+            InstValue::PrintChar => inst self.emit_io_ops
+            InstValue::PrintCstr => inst self.emit_io_ops
+            InstValue::FstringConcat => inst self.emit_io_ops
+
+            # String equality
+            InstValue::StrEq => self.emit_str_eq
+
+            # Syscalls
+            InstValue::Syscall0 => 0 self.emit_syscall
+            InstValue::Syscall1 => 1 self.emit_syscall
+            InstValue::Syscall2 => 2 self.emit_syscall
+            InstValue::Syscall3 => 3 self.emit_syscall
+            InstValue::Syscall4 => 4 self.emit_syscall
+            InstValue::Syscall5 => 5 self.emit_syscall
+            InstValue::Syscall6 => 6 self.emit_syscall
+
+            # argc / argv
+            InstValue::Argc => {
+                "movq __argc(%rip), %rax" self.indent
+                "pushq %rax" self.indent
+            }
+            InstValue::Argv => {
+                "movq __argv(%rip), %rax" self.indent
+                "pushq %rax" self.indent
+            }
+            InstValue::Envp => {
+                "movq __envp(%rip), %rax" self.indent
+                "pushq %rax" self.indent
+            }
+        end
+    }
+
+    # ============================================================================
+    # Main emit function
+    # ============================================================================
 }
-
-# ============================================================================
-# Emit memory operations
-# ============================================================================
-
-fn emit_memory asm:StringBuilder inst:InstValue {
-    inst match
-        InstValue::HeapAlloc => {
-            "popq %rax" asm emit_indent
-            "leaq heap(%rip), %rbx" asm emit_indent
-            "movq heap_ptr(%rip), %rcx" asm emit_indent
-            "leaq (%rbx,%rcx), %rdx" asm emit_indent
-            "pushq %rdx" asm emit_indent
-            "addq %rax, %rcx" asm emit_indent
-            "movq %rcx, heap_ptr(%rip)" asm emit_indent
-        }
-        InstValue::Load8 => "%eax" "movzbl" asm emit_load
-        InstValue::Load16 => "%eax" "movzwl" asm emit_load
-        InstValue::Load32 => "%eax" "movl" asm emit_load
-        InstValue::Load64 => "%rax" "movq" asm emit_load
-        InstValue::Store8 => "%bl" "movb" asm emit_store
-        InstValue::Store16 => "%bx" "movw" asm emit_store
-        InstValue::Store32 => "%ebx" "movl" asm emit_store
-        InstValue::Store64 => "%rbx" "movq" asm emit_store
-        _ => {
-            "Internal error: emit_memory called with non-memory InstValue\n" eprint
-            1 exit
-        }
-    end
-}
-
-# ============================================================================
-# Emit IO operations
-# ============================================================================
-
-fn emit_io_ops asm:StringBuilder inst:InstValue {
-    inst match
-        InstValue::PrintInt => {
-            "popq %rdi" asm emit_indent
-            "print_done" "print_int" asm emit_call_via_return_stack
-        }
-        InstValue::PrintBool => {
-            emit_uid = uid
-            "popq %rax" asm emit_indent
-            "testq %rax, %rax" asm emit_indent
-            f"jz .Lpb_false_{uid}" asm emit_indent
-            "leaq bool_true(%rip), %rsi" asm emit_indent
-            "movq $4, %rdx" asm emit_indent
-            f"jmp .Lpb_write_{uid}" asm emit_indent
-            f".Lpb_false_{uid}:" asm emit_line
-            "leaq bool_false(%rip), %rsi" asm emit_indent
-            "movq $5, %rdx" asm emit_indent
-            f".Lpb_write_{uid}:" asm emit_line
-            "movq $1, %rdi" asm emit_indent
-            "movq $1, %rax" asm emit_indent
-            "syscall" asm emit_indent
-        }
-        InstValue::PrintStr => {
-            "popq %rdi" asm emit_indent
-            "print_done" "print_str" asm emit_call_via_return_stack
-        }
-        InstValue::PrintChar => {
-            "popq %rax" asm emit_indent
-            "movb %al, -1(%rsp)" asm emit_indent
-            "leaq -1(%rsp), %rsi" asm emit_indent
-            "movq $1, %rdx" asm emit_indent
-            "movq $1, %rdi" asm emit_indent
-            "movq $1, %rax" asm emit_indent
-            "syscall" asm emit_indent
-        }
-        InstValue::PrintCstr => {
-            emit_uid = uid
-            "popq %rsi" asm emit_indent
-            "movq %rsi, %rdi" asm emit_indent
-            f".Lpc_scan_{uid}:" asm emit_line
-            "cmpb $0, (%rsi)" asm emit_indent
-            f"je .Lpc_done_{uid}" asm emit_indent
-            "incq %rsi" asm emit_indent
-            f"jmp .Lpc_scan_{uid}" asm emit_indent
-            f".Lpc_done_{uid}:" asm emit_line
-            "movq %rsi, %rdx" asm emit_indent
-            "subq %rdi, %rdx" asm emit_indent
-            "movq %rdi, %rsi" asm emit_indent
-            "movq $1, %rdi" asm emit_indent
-            "movq $1, %rax" asm emit_indent
-            "syscall" asm emit_indent
-        }
-        InstValue::FstringConcat(fstring_count) => {
-            f"movq ${fstring_count}, %rdi" asm emit_indent
-            "concat_done" "str_concat" asm emit_call_via_return_stack
-        }
-        _ => {
-            "Internal error: emit_io_ops called with non-IO InstValue\n" eprint
-            1 exit
-        }
-    end
-}
-
-# ============================================================================
-# Emit string equality
-# ============================================================================
-
-fn emit_str_eq asm:StringBuilder {
-    emit_uid = uid
-    "popq %rsi" asm emit_indent
-    "popq %rdi" asm emit_indent
-    "movq (%rdi), %rcx" asm emit_indent
-    "cmpq (%rsi), %rcx" asm emit_indent
-    f"jne .Lstreq_ne_{uid}" asm emit_indent
-    "leaq 8(%rdi), %rdi" asm emit_indent
-    "leaq 8(%rsi), %rsi" asm emit_indent
-    "repe cmpsb" asm emit_indent
-    f"jne .Lstreq_ne_{uid}" asm emit_indent
-    "pushq $1" asm emit_indent
-    f"jmp .Lstreq_done_{uid}" asm emit_indent
-    f".Lstreq_ne_{uid}:" asm emit_line
-    "pushq $0" asm emit_indent
-    f".Lstreq_done_{uid}:" asm emit_line
-}
-
-# ============================================================================
-# Emit single instruction (main dispatch)
-# ============================================================================
-
-fn emit_inst asm:StringBuilder inst:InstValue is_global:bool {
-    inst match
-        # Stack operations
-        InstValue::Drop => inst asm emit_stack_ops
-        InstValue::Dup => inst asm emit_stack_ops
-        InstValue::Over => inst asm emit_stack_ops
-        InstValue::Push => inst asm emit_stack_ops
-        InstValue::PushChar => inst asm emit_stack_ops
-        InstValue::PushStr => inst asm emit_stack_ops
-        InstValue::PushStaticArray => inst asm emit_stack_ops
-        InstValue::Rot => inst asm emit_stack_ops
-        InstValue::Swap => inst asm emit_stack_ops
-
-        # Arithmetic / bitshift / bitwise / boolean / comparison
-        InstValue::Add => inst asm emit_arithmetic
-        InstValue::Sub => inst asm emit_arithmetic
-        InstValue::Mul => inst asm emit_arithmetic
-        InstValue::Div => inst asm emit_arithmetic
-        InstValue::Mod => inst asm emit_arithmetic
-        InstValue::Shl => inst asm emit_arithmetic
-        InstValue::Shr => inst asm emit_arithmetic
-        InstValue::BitAnd => inst asm emit_arithmetic
-        InstValue::BitOr => inst asm emit_arithmetic
-        InstValue::BitXor => inst asm emit_arithmetic
-        InstValue::BitNot => inst asm emit_arithmetic
-        InstValue::And => inst asm emit_arithmetic
-        InstValue::Or => inst asm emit_arithmetic
-        InstValue::Not => inst asm emit_arithmetic
-        InstValue::Eq => inst asm emit_arithmetic
-        InstValue::Ne => inst asm emit_arithmetic
-        InstValue::Lt => inst asm emit_arithmetic
-        InstValue::Le => inst asm emit_arithmetic
-        InstValue::Gt => inst asm emit_arithmetic
-        InstValue::Ge => inst asm emit_arithmetic
-
-        # Control flow / variables / functions
-        InstValue::Label => is_global inst asm emit_control_flow
-        InstValue::Jump => is_global inst asm emit_control_flow
-        InstValue::JumpNe => is_global inst asm emit_control_flow
-        InstValue::GlobalsInit => is_global inst asm emit_control_flow
-        InstValue::GlobalGet => is_global inst asm emit_control_flow
-        InstValue::GlobalSet => is_global inst asm emit_control_flow
-        InstValue::LocalsInit => is_global inst asm emit_control_flow
-        InstValue::LocalsUninit => is_global inst asm emit_control_flow
-        InstValue::LocalGet => is_global inst asm emit_control_flow
-        InstValue::LocalSet => is_global inst asm emit_control_flow
-        InstValue::ConstantLoad => is_global inst asm emit_control_flow
-        InstValue::ConstantStore => is_global inst asm emit_control_flow
-        InstValue::CaptureLoad => is_global inst asm emit_control_flow
-        InstValue::ClosureRecord => is_global inst asm emit_control_flow
-        InstValue::FnCall => is_global inst asm emit_control_flow
-        InstValue::FnExec => is_global inst asm emit_control_flow
-        InstValue::FnPush => is_global inst asm emit_control_flow
-        InstValue::FnPushStatic => is_global inst asm emit_control_flow
-        InstValue::FnReturn => is_global inst asm emit_control_flow
-
-        # Memory operations
-        InstValue::HeapAlloc => inst asm emit_memory
-        InstValue::Load8 => inst asm emit_memory
-        InstValue::Load16 => inst asm emit_memory
-        InstValue::Load32 => inst asm emit_memory
-        InstValue::Load64 => inst asm emit_memory
-        InstValue::Store8 => inst asm emit_memory
-        InstValue::Store16 => inst asm emit_memory
-        InstValue::Store32 => inst asm emit_memory
-        InstValue::Store64 => inst asm emit_memory
-
-        # IO operations
-        InstValue::PrintInt => inst asm emit_io_ops
-        InstValue::PrintBool => inst asm emit_io_ops
-        InstValue::PrintStr => inst asm emit_io_ops
-        InstValue::PrintChar => inst asm emit_io_ops
-        InstValue::PrintCstr => inst asm emit_io_ops
-        InstValue::FstringConcat => inst asm emit_io_ops
-
-        # String equality
-        InstValue::StrEq => asm emit_str_eq
-
-        # Syscalls
-        InstValue::Syscall0 => asm 0 emit_syscall
-        InstValue::Syscall1 => asm 1 emit_syscall
-        InstValue::Syscall2 => asm 2 emit_syscall
-        InstValue::Syscall3 => asm 3 emit_syscall
-        InstValue::Syscall4 => asm 4 emit_syscall
-        InstValue::Syscall5 => asm 5 emit_syscall
-        InstValue::Syscall6 => asm 6 emit_syscall
-
-        # argc / argv
-        InstValue::Argc => {
-            "movq __argc(%rip), %rax" asm emit_indent
-            "pushq %rax" asm emit_indent
-        }
-        InstValue::Argv => {
-            "movq __argv(%rip), %rax" asm emit_indent
-            "pushq %rax" asm emit_indent
-        }
-        InstValue::Envp => {
-            "movq __envp(%rip), %rax" asm emit_indent
-            "pushq %rax" asm emit_indent
-        }
-    end
-}
-
-# ============================================================================
-# Main emit function
-# ============================================================================
 
 fn emit program:Program -> str {
-    # Reset label counter for each emission
-    0 = emit_label_counter
-    StringBuilder::new = asm
-    program asm emit_bss
-    program asm emit_data
-    program asm emit_text
-    asm.build
+    program Emitter::new = emitter
+    emitter.emit_bss
+    emitter.emit_data
+    emitter.emit_text
+    emitter.asm.build
 }

--- a/compiler/error.casa
+++ b/compiler/error.casa
@@ -220,13 +220,8 @@ fn format_error error:CasaError -> str {
     # Source context if location has a file
     if "" error CasaError::location Location::file != then
         error CasaError::location Location::file SOURCE_CACHE.get = source_opt
-        if source_opt.is_some then
+        if source_opt Option::Some(source) is then
             "\n" builder.append
-            if source_opt Option::Some(source) is then
-            else
-                empty_location "Expected option value while unwrapping source_opt" ErrorKind::Syntax raise_error
-                1 exit
-            fi
             error CasaError::location Location::span Span::length
             error CasaError::location Location::span Span::offset
             source

--- a/compiler/error.casa
+++ b/compiler/error.casa
@@ -32,18 +32,20 @@ struct CasaError {
     notes:     List[CasaNote]
 }
 
-fn make_error kind:ErrorKind message:str location:Location -> CasaError {
-    List::new(List[CasaNote]) "Got" Option::None Option::None location message kind CasaError
-}
+impl CasaError {
+    fn new kind:ErrorKind message:str location:Location -> CasaError {
+        List::new(List[CasaNote]) "Got" Option::None Option::None location message kind CasaError
+    }
 
-fn make_error_expected
-    kind:ErrorKind
-    message:str
-    location:Location
-    expected:str
-    got:str
--> CasaError {
-    List::new(List[CasaNote]) "Got" got Option::Some expected Option::Some location message kind CasaError
+    fn with_expected
+        kind:ErrorKind
+        message:str
+        location:Location
+        expected:str
+        got:str
+    -> CasaError {
+        List::new(List[CasaNote]) "Got" got Option::Some expected Option::Some location message kind CasaError
+    }
 }
 
 # ============================================================================
@@ -230,9 +232,9 @@ fn format_error error:CasaError -> str {
     fi
 
     # Expected/Got
-    if error CasaError::expected.is_some then
+    if error.expected.is_some then
         "\n  Expected: " builder.append
-        error CasaError::expected.unwrap builder.append
+        error.expected.unwrap builder.append
     fi
     if error CasaError::got.is_some then
         "\n  " builder.append
@@ -292,15 +294,15 @@ fn report_warnings {
 # ============================================================================
 
 fn add_error kind:ErrorKind message:str location:Location {
-    location message kind make_error ERRORS.push
+    location message kind CasaError::new ERRORS.push
 }
 
 fn add_error_expected kind:ErrorKind message:str location:Location expected:str got:str {
-    got expected location message kind make_error_expected ERRORS.push
+    got expected location message kind CasaError::with_expected ERRORS.push
 }
 
 fn raise_error kind:ErrorKind message:str location:Location {
-    location message kind make_error ERRORS.push
+    location message kind CasaError::new ERRORS.push
     if TEST_MODE ! RESILIENT_MODE ! && then
         ERRORS report_errors
         1 exit
@@ -308,7 +310,7 @@ fn raise_error kind:ErrorKind message:str location:Location {
 }
 
 fn raise_error_expected kind:ErrorKind message:str location:Location expected:str got:str {
-    got expected location message kind make_error_expected ERRORS.push
+    got expected location message kind CasaError::with_expected ERRORS.push
     if TEST_MODE ! RESILIENT_MODE ! && then
         ERRORS report_errors
         1 exit

--- a/compiler/error.casa
+++ b/compiler/error.casa
@@ -222,7 +222,11 @@ fn format_error error:CasaError -> str {
         error CasaError::location Location::file SOURCE_CACHE.get = source_opt
         if source_opt.is_some then
             "\n" builder.append
-            source_opt.unwrap = source
+            if source_opt Option::Some(source) is then
+            else
+                empty_location "Expected option value while unwrapping source_opt" ErrorKind::Syntax raise_error
+                1 exit
+            fi
             error CasaError::location Location::span Span::length
             error CasaError::location Location::span Span::offset
             source
@@ -232,15 +236,15 @@ fn format_error error:CasaError -> str {
     fi
 
     # Expected/Got
-    if error.expected.is_some then
+    if error.expected Option::Some(expected) is then
         "\n  Expected: " builder.append
-        error.expected.unwrap builder.append
+        expected builder.append
     fi
-    if error CasaError::got.is_some then
+    if error CasaError::got Option::Some(got) is then
         "\n  " builder.append
         error CasaError::got_label builder.append
         ": " builder.append
-        error CasaError::got.unwrap builder.append
+        got builder.append
     fi
 
     # Notes
@@ -249,11 +253,11 @@ fn format_error error:CasaError -> str {
         note CasaNote::message builder.append
         if "" note CasaNote::location Location::file != then
             note CasaNote::location Location::file SOURCE_CACHE.get = note_source
-            if note_source.is_some then
+            if note_source Option::Some(source) is then
                 "\n" builder.append
                 note CasaNote::location Location::span Span::length
                 note CasaNote::location Location::span Span::offset
-                note_source.unwrap
+                source
                 note CasaNote::location Location::file
                 format_source_context builder.append
             fi

--- a/compiler/lexer.casa
+++ b/compiler/lexer.casa
@@ -40,7 +40,7 @@ impl Lexer {
     }
 
     fn loc self:Lexer offset:int length:int -> Location {
-        length offset self Lexer::file make_location
+        length offset self Lexer::file Location::new
     }
 
     fn cur_loc self:Lexer length:int -> Location {
@@ -74,7 +74,7 @@ impl Lexer {
     }
 
     fn add_error self:Lexer kind:ErrorKind message:str location:Location {
-        location message kind make_error self Lexer::errors.push
+        location message kind CasaError::new self Lexer::errors.push
     }
 
     fn lex_integer self:Lexer -> Token {
@@ -88,7 +88,7 @@ impl Lexer {
             self Lexer::cursor.advance drop
         done
         self Lexer::cursor Cursor::pos start - start self.loc = loc
-        loc TokenKind::Literal builder.build make_token
+        loc TokenKind::Literal builder.build Token::new
     }
 
     fn parse_hex_escape self:Lexer -> Option[str] {
@@ -174,7 +174,7 @@ impl Lexer {
         if next_opt.is_none then
             self Lexer::cursor Cursor::pos start - start self.loc = error_loc
             error_loc "Unclosed char literal" ErrorKind::Syntax self.add_error
-            error_loc TokenKind::Literal "'\0'" make_token return
+            error_loc TokenKind::Literal "'\0'" Token::new return
         fi
         next_opt.unwrap = next_char
         "" = char_value
@@ -183,13 +183,13 @@ impl Lexer {
             self.parse_escape = escape
             if escape.is_none then
                 self Lexer::cursor Cursor::pos start - start self.loc = error_loc2
-                error_loc2 TokenKind::Literal "'\0'" make_token return
+                error_loc2 TokenKind::Literal "'\0'" Token::new return
             fi
             escape.unwrap = char_value
         elif '\'' next_char == then
             self Lexer::cursor Cursor::pos start - start self.loc = error_loc3
             error_loc3 "Empty char literal" ErrorKind::Syntax self.add_error
-            error_loc3 TokenKind::Literal "'\0'" make_token return
+            error_loc3 TokenKind::Literal "'\0'" Token::new return
         else
             StringBuilder::new = char_builder
             next_char char_builder.append_char
@@ -211,7 +211,7 @@ impl Lexer {
         '\'' result.append_char
         char_value result.append
         '\'' result.append_char
-        final_loc TokenKind::Literal result.build make_token
+        final_loc TokenKind::Literal result.build Token::new
     }
 
     fn peek_word self:Lexer -> Option[str] {
@@ -253,7 +253,7 @@ impl Lexer {
         if "\"" self.startswith then
             self.parse_string = str_value
             self Lexer::cursor Cursor::pos start - start self.loc = str_loc
-            str_loc TokenKind::Literal str_value make_token Option::Some return
+            str_loc TokenKind::Literal str_value Token::new Option::Some return
         fi
 
         self.peek_word ? = value
@@ -269,27 +269,27 @@ impl Lexer {
 
         # Negative integer literal
         if value is_negative_integer_literal prev_digit ! && then
-            loc TokenKind::Literal value make_token Option::Some return
+            loc TokenKind::Literal value Token::new Option::Some return
         fi
         # Boolean literals
         if "true" value == "false" value == || then
-            loc TokenKind::Literal value make_token Option::Some return
+            loc TokenKind::Literal value Token::new Option::Some return
         fi
         # Delimiter
         if value delimiter_from_str.is_some then
-            loc TokenKind::Delimiter value make_token Option::Some return
+            loc TokenKind::Delimiter value Token::new Option::Some return
         fi
         # Intrinsic
         if value intrinsic_from_str.is_some then
-            loc TokenKind::Intrinsic value make_token Option::Some return
+            loc TokenKind::Intrinsic value Token::new Option::Some return
         fi
         # Keyword
         if value keyword_from_str.is_some then
-            loc TokenKind::Keyword value make_token Option::Some return
+            loc TokenKind::Keyword value Token::new Option::Some return
         fi
         # Operator
         if value operator_from_str.is_some then
-            loc TokenKind::Operator value make_token Option::Some return
+            loc TokenKind::Operator value Token::new Option::Some return
         fi
         # :: chaining
         if "::" self.startswith then
@@ -297,15 +297,15 @@ impl Lexer {
             self.lex_multichar = method_opt
             if method_opt.is_none then
                 loc "Expected method name after `::`" ErrorKind::Syntax self.add_error
-                loc TokenKind::Identifier value make_token Option::Some return
+                loc TokenKind::Identifier value Token::new Option::Some return
             fi
             method_opt.unwrap Token::value = method_name
             f"{value}::{method_name}" = full_name
             full_name.length start self.loc = full_loc
-            full_loc TokenKind::Identifier full_name make_token Option::Some return
+            full_loc TokenKind::Identifier full_name Token::new Option::Some return
         fi
         # Identifier
-        loc TokenKind::Identifier value make_token Option::Some
+        loc TokenKind::Identifier value Token::new Option::Some
     }
 
     fn lex_fstring_expr self:Lexer tokens:List[Token] {
@@ -322,7 +322,7 @@ impl Lexer {
             # Closing }
             if '}' character == 0 depth == && then
                 1 self.cur_loc = end_loc
-                end_loc TokenKind::FstringExprEnd "}" make_token tokens.push
+                end_loc TokenKind::FstringExprEnd "}" Token::new tokens.push
                 self Lexer::cursor.advance drop
                 return
             fi
@@ -345,7 +345,7 @@ impl Lexer {
         2 start self.loc = start_loc
         self Lexer::cursor Cursor::pos 2 + self Lexer::cursor Cursor::set_pos
 
-        start_loc TokenKind::FstringStart "" make_token tokens.push
+        start_loc TokenKind::FstringStart "" Token::new tokens.push
         StringBuilder::new = text
         self Lexer::cursor Cursor::pos = text_start
 
@@ -363,11 +363,11 @@ impl Lexer {
             if '{' character == then
                 if 0 text.length != then
                     self Lexer::cursor Cursor::pos text_start - text_start self.loc = text_loc
-                    text_loc TokenKind::FstringText text.build make_token tokens.push
+                    text_loc TokenKind::FstringText text.build Token::new tokens.push
                     StringBuilder::new = text
                 fi
                 1 self Lexer::cursor Cursor::pos self.loc = expr_loc
-                expr_loc TokenKind::FstringExprStart "{" make_token tokens.push
+                expr_loc TokenKind::FstringExprStart "{" Token::new tokens.push
                 self Lexer::cursor.advance drop
                 tokens self.lex_fstring_expr
                 self Lexer::cursor Cursor::pos = text_start
@@ -377,11 +377,11 @@ impl Lexer {
             if '"' character == then
                 if 0 text.length != then
                     self Lexer::cursor Cursor::pos text_start - text_start self.loc = text_loc2
-                    text_loc2 TokenKind::FstringText text.build make_token tokens.push
+                    text_loc2 TokenKind::FstringText text.build Token::new tokens.push
                 fi
                 self Lexer::cursor.advance drop
                 1 self Lexer::cursor Cursor::pos 1 - self.loc = end_loc
-                end_loc TokenKind::FstringEnd "" make_token tokens.push
+                end_loc TokenKind::FstringEnd "" Token::new tokens.push
                 return
             fi
             character text.append_char
@@ -408,7 +408,7 @@ impl Lexer {
                     self Lexer::cursor.advance drop
                 done
                 self Lexer::cursor Cursor::pos comment_start - comment_start self.loc = comment_loc
-                comment_loc TokenKind::Comment comment_builder.build make_token Option::Some return
+                comment_loc TokenKind::Comment comment_builder.build Token::new Option::Some return
             fi
             self.skip_line
             Option::None return
@@ -423,7 +423,7 @@ impl Lexer {
             StringBuilder::new = builder
             character builder.append_char
             1 position self.loc = loc
-            loc TokenKind::Delimiter builder.build make_token Option::Some
+            loc TokenKind::Delimiter builder.build Token::new Option::Some
             self Lexer::cursor.advance drop
             return
         fi
@@ -447,7 +447,7 @@ impl Lexer {
                     if '\n' nl_opt.unwrap == then
                         self Lexer::cursor Cursor::pos = nl_pos
                         1 nl_pos self.loc = nl_loc
-                        nl_loc TokenKind::Newline "\n" make_token tokens.push
+                        nl_loc TokenKind::Newline "\n" Token::new tokens.push
                         self Lexer::cursor.advance drop
                         continue
                     fi
@@ -462,7 +462,7 @@ impl Lexer {
                 token_opt.unwrap tokens.push
             fi
         done
-        0 self.cur_loc TokenKind::Eof "" make_token tokens.push
+        0 self.cur_loc TokenKind::Eof "" Token::new tokens.push
         if 0 self Lexer::errors.length != then
             if RESILIENT_MODE then
                 for error in self Lexer::errors.iter do

--- a/compiler/lexer.casa
+++ b/compiler/lexer.casa
@@ -51,7 +51,11 @@ impl Lexer {
         while self Lexer::cursor.is_eof ! do
             self Lexer::cursor.peek = char_opt
             if char_opt.is_none then break fi
-            char_opt.unwrap = ch
+            if char_opt Option::Some(ch) is then
+            else
+                empty_location "Expected option value while unwrapping char_opt" ErrorKind::Syntax raise_error
+                1 exit
+            fi
             if FMT_LEXER_MODE then
                 if ch ' ' == ch '\t' == || ! then break fi
             else
@@ -65,7 +69,9 @@ impl Lexer {
         while self Lexer::cursor.is_eof ! do
             self Lexer::cursor.advance = char_opt
             if char_opt.is_none then break fi
-            if '\n' char_opt.unwrap == then break fi
+            if char_opt Option::Some(ch) is then
+                if '\n' ch == then break fi
+            fi
         done
     }
 
@@ -83,8 +89,10 @@ impl Lexer {
         while self Lexer::cursor.is_eof ! do
             self Lexer::cursor.peek = char_opt
             if char_opt.is_none then break fi
-            if char_opt.unwrap.is_digit ! then break fi
-            char_opt.unwrap builder.append_char
+            if char_opt Option::Some(ch) is then
+                if ch.is_digit ! then break fi
+                ch builder.append_char
+            fi
             self Lexer::cursor.advance drop
         done
         self Lexer::cursor Cursor::pos start - start self.loc = loc
@@ -98,7 +106,12 @@ impl Lexer {
             loc "Expected two hex digits after \\x" ErrorKind::Syntax self.add_error
             "" Option::Some return
         fi
-        high_opt.unwrap hex_digit_value = high_value
+        if high_opt Option::Some(high) is then
+            high hex_digit_value = high_value
+        else
+            empty_location "Expected high hex digit" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         if 0 high_value < then
             3 self Lexer::cursor Cursor::pos 3 - self.loc = loc
             loc "Invalid hex digit in \\x escape" ErrorKind::Syntax self.add_error
@@ -110,7 +123,12 @@ impl Lexer {
             loc "Expected two hex digits after \\x" ErrorKind::Syntax self.add_error
             "" Option::Some return
         fi
-        low_opt.unwrap hex_digit_value = low_value
+        if low_opt Option::Some(low) is then
+            low hex_digit_value = low_value
+        else
+            empty_location "Expected low hex digit" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         if 0 low_value < then
             4 self Lexer::cursor Cursor::pos 4 - self.loc = loc
             loc "Invalid hex digit in \\x escape" ErrorKind::Syntax self.add_error
@@ -145,11 +163,17 @@ impl Lexer {
         while self Lexer::cursor.is_eof ! do
             self Lexer::cursor.advance = char_opt
             if char_opt.is_none then break fi
-            char_opt.unwrap = character
+            if char_opt Option::Some(character) is then
+            else
+                empty_location "Expected option value while unwrapping char_opt" ErrorKind::Syntax raise_error
+                1 exit
+            fi
             if '\\' character == then
                 self.parse_escape = escape
                 if escape.is_none then break fi
-                escape.unwrap builder.append
+                if escape Option::Some(escaped) is then
+                    escaped builder.append
+                fi
                 continue
             fi
             if '"' character == then
@@ -176,7 +200,11 @@ impl Lexer {
             error_loc "Unclosed char literal" ErrorKind::Syntax self.add_error
             error_loc TokenKind::Literal "'\0'" Token::new return
         fi
-        next_opt.unwrap = next_char
+        if next_opt Option::Some(next_char) is then
+        else
+            empty_location "Expected option value while unwrapping next_opt" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         "" = char_value
 
         if '\\' next_char == then
@@ -185,7 +213,11 @@ impl Lexer {
                 self Lexer::cursor Cursor::pos start - start self.loc = error_loc2
                 error_loc2 TokenKind::Literal "'\0'" Token::new return
             fi
-            escape.unwrap = char_value
+            if escape Option::Some(char_value) is then
+            else
+                empty_location "Expected option value while unwrapping escape" ErrorKind::Syntax raise_error
+                1 exit
+            fi
         elif '\'' next_char == then
             self Lexer::cursor Cursor::pos start - start self.loc = error_loc3
             error_loc3 "Empty char literal" ErrorKind::Syntax self.add_error
@@ -201,9 +233,13 @@ impl Lexer {
         if closing.is_none then
             self Lexer::cursor Cursor::pos start - start self.loc = error_loc4
             error_loc4 "Unclosed char literal" ErrorKind::Syntax self.add_error
-        elif '\'' closing.unwrap != then
-            self Lexer::cursor Cursor::pos start - start self.loc = error_loc5
-            error_loc5 "Unclosed char literal" ErrorKind::Syntax self.add_error
+        else
+            if closing Option::Some(closing_char) is then
+                if '\'' closing_char != then
+                    self Lexer::cursor Cursor::pos start - start self.loc = error_loc5
+                    error_loc5 "Unclosed char literal" ErrorKind::Syntax self.add_error
+                fi
+            fi
         fi
 
         self Lexer::cursor Cursor::pos start - start self.loc = final_loc
@@ -299,10 +335,12 @@ impl Lexer {
                 loc "Expected method name after `::`" ErrorKind::Syntax self.add_error
                 loc TokenKind::Identifier value Token::new Option::Some return
             fi
-            method_opt.unwrap Token::value = method_name
-            f"{value}::{method_name}" = full_name
-            full_name.length start self.loc = full_loc
-            full_loc TokenKind::Identifier full_name Token::new Option::Some return
+            if method_opt Option::Some(method_token) is then
+                method_token Token::value = method_name
+                f"{value}::{method_name}" = full_name
+                full_name.length start self.loc = full_loc
+                full_loc TokenKind::Identifier full_name Token::new Option::Some return
+            fi
         fi
         # Identifier
         loc TokenKind::Identifier value Token::new Option::Some
@@ -313,7 +351,11 @@ impl Lexer {
         while self Lexer::cursor.is_eof ! do
             self.skip_whitespace
             if self Lexer::cursor.is_eof then break fi
-            self Lexer::cursor.peek.unwrap = character
+            if self Lexer::cursor.peek Option::Some(character) is then
+            else
+                empty_location "Expected option value while unwrapping self Lexer::cursor.peek" ErrorKind::Syntax raise_error
+                1 exit
+            fi
             # Nested f-string
             if "f\"" self.startswith then
                 tokens self.lex_fstring
@@ -333,8 +375,8 @@ impl Lexer {
                 depth 1 - = depth
             fi
             self.parse_single_token = token_opt
-            if token_opt.is_some then
-                token_opt.unwrap tokens.push
+            if token_opt Option::Some(token) is then
+                token tokens.push
             fi
         done
         0 self.cur_loc "Unclosed f-string expression" ErrorKind::Syntax self.add_error
@@ -350,13 +392,19 @@ impl Lexer {
         self Lexer::cursor Cursor::pos = text_start
 
         while self Lexer::cursor.is_eof ! do
-            self Lexer::cursor.peek.unwrap = character
+            if self Lexer::cursor.peek Option::Some(character) is then
+            else
+                empty_location "Expected option value while unwrapping self Lexer::cursor.peek" ErrorKind::Syntax raise_error
+                1 exit
+            fi
             # Escape
             if '\\' character == then
                 self Lexer::cursor.advance drop
                 self.parse_escape = escape
                 if escape.is_none then break fi
-                escape.unwrap text.append
+                if escape Option::Some(escaped) is then
+                    escaped text.append
+                fi
                 continue
             fi
             # Expression
@@ -403,9 +451,11 @@ impl Lexer {
                 while self Lexer::cursor.is_eof ! do
                     self Lexer::cursor.peek = peek_opt
                     if peek_opt.is_none then break fi
-                    if '\n' peek_opt.unwrap == then break fi
-                    peek_opt.unwrap comment_builder.append_char
-                    self Lexer::cursor.advance drop
+                    if peek_opt Option::Some(peek_char) is then
+                        if '\n' peek_char == then break fi
+                        peek_char comment_builder.append_char
+                        self Lexer::cursor.advance drop
+                    fi
                 done
                 self Lexer::cursor Cursor::pos comment_start - comment_start self.loc = comment_loc
                 comment_loc TokenKind::Comment comment_builder.build Token::new Option::Some return
@@ -443,8 +493,8 @@ impl Lexer {
             # Emit newline tokens in formatter mode
             if FMT_LEXER_MODE then
                 self Lexer::cursor.peek = nl_opt
-                if nl_opt.is_some then
-                    if '\n' nl_opt.unwrap == then
+                if nl_opt Option::Some(nl_char) is then
+                    if '\n' nl_char == then
                         self Lexer::cursor Cursor::pos = nl_pos
                         1 nl_pos self.loc = nl_loc
                         nl_loc TokenKind::Newline "\n" Token::new tokens.push
@@ -458,8 +508,8 @@ impl Lexer {
                 continue
             fi
             self.parse_single_token = token_opt
-            if token_opt.is_some then
-                token_opt.unwrap tokens.push
+            if token_opt Option::Some(token) is then
+                token tokens.push
             fi
         done
         0 self.cur_loc TokenKind::Eof "" Token::new tokens.push
@@ -531,7 +581,11 @@ fn lex_file path:str -> List[Token] {
         f"error: cannot read {path}: {read_err.to_str}" eprintln
         1 exit
     fi
-    read_result.unwrap = code
+    if read_result Result::Ok(code) is then
+    else
+        empty_location "Expected option value while unwrapping read_result" ErrorKind::Syntax raise_error
+        1 exit
+    fi
     code path SOURCE_CACHE.set = SOURCE_CACHE
     path code Lexer::new.lex
 }

--- a/compiler/pattern.casa
+++ b/compiler/pattern.casa
@@ -282,7 +282,7 @@ fn typecheck_match_op tc:TypeChecker function_opt:Option[Function] op:Op {
 
         if op pattern_is_guarded then
             op pattern_guard_ops = guard_ops
-            tc.store make_typechecker = guard_checker
+            tc.store TypeChecker::new = guard_checker
             function_opt guard_ops guard_checker run_type_check_ops
             guard_checker.stack.types = guard_stack
             false = guard_ok

--- a/compiler/pattern.casa
+++ b/compiler/pattern.casa
@@ -60,7 +60,11 @@ fn pattern_bindings op:Op -> List[str] {
         PatternValue::Struct(struct_pat) => {
             struct_pat.bindings.keys = field_names
             for field_name in field_names.iter do
-                field_name struct_pat.bindings.get.unwrap = bound_name
+                if field_name struct_pat.bindings.get Option::Some(bound_name) is then
+                else
+                    empty_location "Expected option value while unwrapping field_name struct_pat.bindings.get" ErrorKind::Syntax raise_error
+                    1 exit
+                fi
                 bound_name out.push
             done
         }
@@ -158,10 +162,18 @@ fn register_struct_pattern_bindings
     function_opt:Option[Function]
     struct_pattern:StructPattern
 {
-    struct_pattern StructPattern::struct_name tc.store.structs.get.unwrap = matched_struct
+    if struct_pattern StructPattern::struct_name tc.store.structs.get Option::Some(matched_struct) is then
+    else
+        empty_location "Expected option value while unwrapping struct_pattern StructPattern::struct_name tc.store.structs.get" ErrorKind::Syntax raise_error
+        1 exit
+    fi
     struct_pattern StructPattern::bindings.keys = binding_keys
     for field_name in binding_keys.iter do
-        field_name struct_pattern StructPattern::bindings.get.unwrap = bound_var
+        if field_name struct_pattern StructPattern::bindings.get Option::Some(bound_var) is then
+        else
+            empty_location "Expected option value while unwrapping field_name struct_pattern StructPattern::bindings.get" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         tc.store function_opt bound_var field_name matched_struct assign_struct_binding_type
     done
 }

--- a/compiler/pattern.casa
+++ b/compiler/pattern.casa
@@ -120,19 +120,19 @@ fn unify_arm_stacks tc:TypeChecker match_ctx:MatchContext op:Op {
     match_ctx MatchContext::before = match_before
     match_ctx MatchContext::after = match_after
     if
-    match_before tc TypeChecker::live.equals
+    match_before tc.stack.equals
     match_after match_before.equals && !
     then
-        tc.store match_after tc TypeChecker::live.unify_types = unified
+        tc.store match_after tc.stack.unify_types = unified
         if 0 unified.length != match_after match_before.equals ! && then
-            unified match_after TypedStack::set_types
+            unified match_after->types
         elif match_after match_before.equals then
-            tc TypeChecker::live match_after.restore
+            tc.stack match_after.restore
         else
             op Op::location "Match arms have incompatible stack effects" ErrorKind::StackMismatch add_error
         fi
     fi
-    match_before tc TypeChecker::live.restore
+    match_before tc.stack.restore
 }
 
 # ============================================================================
@@ -255,8 +255,8 @@ fn register_pattern_bindings
 # function; start/end of the match block remain in check_match.
 
 fn typecheck_match_op tc:TypeChecker function_opt:Option[Function] op:Op {
-    if 0 tc TypeChecker::branched_stacks.length == then return fi
-    tc TypeChecker::branched_stacks.length 1 - tc TypeChecker::branched_stacks.get = top_frame
+    if 0 tc.branched_stacks.length == then return fi
+    tc.branched_stacks.length 1 - tc.branched_stacks.get = top_frame
     if top_frame BranchFrame::BranchMatch(match_ctx) is then
         match_ctx MatchContext::match_type = match_subject_type
         op pattern_covered_key = covered_key
@@ -274,8 +274,8 @@ fn typecheck_match_op tc:TypeChecker function_opt:Option[Function] op:Op {
             op match_ctx tc unify_arm_stacks
         else
             true match_ctx MatchContext::set_condition_present
-            tc TypeChecker::live match_ctx MatchContext::before.restore
-            tc TypeChecker::live match_ctx MatchContext::after.restore
+            tc.stack match_ctx MatchContext::before.restore
+            tc.stack match_ctx MatchContext::after.restore
         fi
 
         match_subject_type op function_opt tc register_pattern_bindings
@@ -284,7 +284,7 @@ fn typecheck_match_op tc:TypeChecker function_opt:Option[Function] op:Op {
             op pattern_guard_ops = guard_ops
             tc.store make_typechecker = guard_checker
             function_opt guard_ops guard_checker run_type_check_ops
-            guard_checker TypeChecker::live TypedStack::types = guard_stack
+            guard_checker.stack.types = guard_stack
             false = guard_ok
             if 1 guard_stack.length == then
                 if "bool" 0 guard_stack.get.format == then

--- a/compiler/pattern.casa
+++ b/compiler/pattern.casa
@@ -283,7 +283,7 @@ fn typecheck_match_op tc:TypeChecker function_opt:Option[Function] op:Op {
         if op pattern_is_guarded then
             op pattern_guard_ops = guard_ops
             tc.store TypeChecker::new = guard_checker
-            function_opt guard_ops guard_checker run_type_check_ops
+            function_opt guard_ops guard_checker.run_type_check_ops
             guard_checker.stack.types = guard_stack
             false = guard_ok
             if 1 guard_stack.length == then

--- a/compiler/syntax.casa
+++ b/compiler/syntax.casa
@@ -174,7 +174,11 @@ fn expect_token cursor:TokenCursor -> Token {
         # Return dummy token for resilient/test mode
         empty_location TokenKind::Eof "" Token::new return
     fi
-    result_opt.unwrap = token
+    if result_opt Option::Some(token) is then
+    else
+        empty_location "Expected option value while unwrapping result_opt" ErrorKind::Syntax raise_error
+        1 exit
+    fi
     if TokenKind::Eof token Token::kind == then
         token Token::location "Unexpected end of input" ErrorKind::UnexpectedToken raise_error
     fi
@@ -209,7 +213,11 @@ fn expect_token_kind cursor:TokenCursor expected_kind:TokenKind -> Token {
 fn expect_delimiter cursor:TokenCursor expected_value:str -> bool {
     cursor.peek = peek_opt
     if peek_opt.is_none then false return fi
-    peek_opt.unwrap = token
+    if peek_opt Option::Some(token) is then
+    else
+        empty_location "Expected option value while unwrapping peek_opt" ErrorKind::Syntax raise_error
+        1 exit
+    fi
     if expected_value token Token::value != then false return fi
     cursor.advance
     true
@@ -225,7 +233,11 @@ fn parse_type_ast cursor:TokenCursor -> Type {
         empty_location "Expected type" ErrorKind::UnexpectedToken raise_error
         Type::Unknown return
     fi
-    peek_opt.unwrap = peek
+    if peek_opt Option::Some(peek) is then
+    else
+        empty_location "Expected option value while unwrapping peek_opt" ErrorKind::Syntax raise_error
+        1 exit
+    fi
 
     if "fn" peek Token::value == then
         cursor.pop drop
@@ -240,7 +252,9 @@ fn parse_type_ast cursor:TokenCursor -> Type {
 
     cursor.peek = next_opt
     if next_opt.is_none then base parse_type_str return fi
-    if "[" next_opt.unwrap Token::value != then base parse_type_str return fi
+    if next_opt Option::Some(next) is then
+        if "[" next Token::value != then base parse_type_str return fi
+    fi
     cursor.advance # consume [
 
     if "fn" base == then
@@ -250,7 +264,11 @@ fn parse_type_ast cursor:TokenCursor -> Type {
         while cursor.is_finished ! do
             cursor.peek = inner_opt
             if inner_opt.is_none then break fi
-            inner_opt.unwrap Token::value = ival
+            if inner_opt Option::Some(inner) is then
+                inner Token::value = ival
+            else
+                break
+            fi
             if "]" ival == then
                 cursor.pop drop
                 break
@@ -273,8 +291,8 @@ fn parse_type_ast cursor:TokenCursor -> Type {
     List::new(List[Type]) = inner_types
     while true do
         cursor.peek = inner_opt
-        if inner_opt.is_some then
-            if "]" inner_opt.unwrap Token::value == then
+        if inner_opt Option::Some(inner) is then
+            if "]" inner Token::value == then
                 cursor.pop drop
                 break
             fi
@@ -353,12 +371,19 @@ fn get_op_intrinsic token:Token -> Op {
     if kind_opt.is_none then
         token Token::location f"Token `{token Token::value}` is not an intrinsic" ErrorKind::Syntax raise_error
     fi
-    kind_opt.unwrap = intrinsic_kind
+    if kind_opt Option::Some(intrinsic_kind) is then
+    else
+        empty_location "Expected option value while unwrapping kind_opt" ErrorKind::Syntax raise_error
+        1 exit
+    fi
     intrinsic_kind intrinsic_to_op_value = op_value_opt
     if op_value_opt.is_none then
         token Token::location f"No OpValue for intrinsic `{token Token::value}`" ErrorKind::Syntax raise_error
     fi
-    token Token::location op_value_opt.unwrap Op::new
+    if op_value_opt Option::Some(op_value) is then
+        token Token::location op_value Op::new return
+    fi
+    token Token::location 0 OpValue::PushInt Op::new
 }
 
 # ============================================================================
@@ -370,7 +395,11 @@ fn get_op_operator token:Token cursor:TokenCursor function_name:str -> Op {
     if kind_opt.is_none then
         token Token::location f"Token `{token Token::value}` is not an operator" ErrorKind::Syntax raise_error
     fi
-    kind_opt.unwrap = operator_kind
+    if kind_opt Option::Some(operator_kind) is then
+    else
+        empty_location "Expected option value while unwrapping kind_opt" ErrorKind::Syntax raise_error
+        1 exit
+    fi
 
     # Assignment: = varname
     if OperatorKind::Assign operator_kind == then
@@ -380,8 +409,8 @@ fn get_op_operator token:Token cursor:TokenCursor function_name:str -> Op {
         # Optional type annotation: = varname : type
         Option::None(Option[Type]) = type_hint
         cursor.peek = colon_opt
-        if colon_opt.is_some then
-            if ":" colon_opt.unwrap Token::value == then
+        if colon_opt Option::Some(colon) is then
+            if ":" colon Token::value == then
                 cursor.advance
                 cursor parse_type_ast Option::Some = type_hint
             fi
@@ -411,7 +440,10 @@ fn get_op_operator token:Token cursor:TokenCursor function_name:str -> Op {
     if op_value_opt.is_none then
         token Token::location f"No OpValue for operator `{token Token::value}`" ErrorKind::Syntax raise_error
     fi
-    token Token::location op_value_opt.unwrap Op::new
+    if op_value_opt Option::Some(op_value) is then
+        token Token::location op_value Op::new return
+    fi
+    token Token::location 0 OpValue::PushInt Op::new
 }
 
 # ============================================================================
@@ -454,8 +486,8 @@ fn get_op_array parser:Parser function_name:str cursor:TokenCursor -> Op {
     List::new(List[Op]) = items
     while "]" cursor expect_delimiter ! do
         cursor.peek = next_opt
-        if next_opt.is_some then
-            if "[" next_opt.unwrap Token::value == then
+        if next_opt Option::Some(next) is then
+            if "[" next Token::value == then
                 cursor function_name parser get_op_array items.push
                 "," cursor expect_delimiter drop
                 continue
@@ -465,15 +497,19 @@ fn get_op_array parser:Parser function_name:str cursor:TokenCursor -> Op {
         if value_opt.is_none then
             open_token Token::location "Unexpected end of input in array literal" ErrorKind::UnexpectedToken raise_error
         fi
-        value_opt.unwrap = value_token
+        if value_opt Option::Some(value_token) is then
+        else
+            empty_location "Expected option value while unwrapping value_opt" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         if "{" value_token Token::value == then
             items value_token cursor function_name parser parse_array_lambda
         elif TokenKind::Literal value_token Token::kind == then
             value_token get_op_literal items.push
         elif TokenKind::Identifier value_token Token::kind == then
             cursor.peek = struct_peek_opt
-            if struct_peek_opt.is_some then
-                if "{" struct_peek_opt.unwrap Token::value == then
+            if struct_peek_opt Option::Some(struct_peek) is then
+                if "{" struct_peek Token::value == then
                     items value_token cursor function_name parser parse_array_struct_literal
                 else
                     value_token Token::location value_token Token::value OpValue::Identifier Op::new items.push
@@ -501,7 +537,11 @@ fn parse_block_ops parser:Parser cursor:TokenCursor function_name:str -> List[Op
         if token_opt.is_none then
             open_token Token::location "Unclosed block" ErrorKind::UnmatchedBlock raise_error
         fi
-        token_opt.unwrap = token
+        if token_opt Option::Some(token) is then
+        else
+            empty_location "Expected option value while unwrapping token_opt" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         if TokenKind::Comment token Token::kind == then continue fi
         if TokenKind::Newline token Token::kind == then continue fi
         if "}" token Token::value == then
@@ -525,7 +565,11 @@ fn parse_fstring_expr parser:Parser cursor:TokenCursor function_name:str -> List
     while true do
         cursor.pop = token_opt
         if token_opt.is_none then break fi
-        token_opt.unwrap = token
+        if token_opt Option::Some(token) is then
+        else
+            empty_location "Expected option value while unwrapping token_opt" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         if TokenKind::FstringExprEnd token Token::kind == then
             break
         fi
@@ -549,7 +593,11 @@ fn handle_fstring
     while true do
         cursor.pop = token_opt
         if token_opt.is_none then break fi
-        token_opt.unwrap = token
+        if token_opt Option::Some(token) is then
+        else
+            empty_location "Expected option value while unwrapping token_opt" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         if TokenKind::FstringText token Token::kind == then
             token Token::location token Token::value OpValue::PushStr Op::new ops.push
             1 += part_count
@@ -645,7 +693,12 @@ fn try_parse_is_check token:Token cursor:TokenCursor -> Option[Op] {
                 saved_pos cursor.restore
                 Option::None return
             fi
-            if ")" inner_opt.unwrap Token::value == then
+            if inner_opt Option::Some(inner) is then
+            else
+                saved_pos cursor.restore
+                Option::None return
+            fi
+            if ")" inner Token::value == then
                 cursor.pop drop # consume )
                 if 0 bindings.length == then
                     saved_pos cursor.restore
@@ -653,12 +706,12 @@ fn try_parse_is_check token:Token cursor:TokenCursor -> Option[Op] {
                 fi
                 break
             fi
-            if TokenKind::Identifier inner_opt.unwrap Token::kind != then
+            if TokenKind::Identifier inner Token::kind != then
                 saved_pos cursor.restore
                 Option::None return
             fi
             cursor.pop drop
-            inner_opt.unwrap Token::value bindings.push
+            inner Token::value bindings.push
         done
     fi
 
@@ -668,9 +721,11 @@ fn try_parse_is_check token:Token cursor:TokenCursor -> Option[Op] {
         saved_pos cursor.restore
         Option::None return
     fi
-    if "is" is_opt.unwrap Token::value != then
-        saved_pos cursor.restore
-        Option::None return
+    if is_opt Option::Some(is_token) is then
+        if "is" is_token Token::value != then
+            saved_pos cursor.restore
+            Option::None return
+        fi
     fi
     cursor.pop drop # consume `is`
 
@@ -710,7 +765,9 @@ fn parse_bound_type_args cursor:TokenCursor trait_token:Token -> List[str] {
     List::new(List[str]) = bound_args
     cursor.peek = bracket_opt
     if bracket_opt.is_none then bound_args return fi
-    if "[" bracket_opt.unwrap Token::value != then bound_args return fi
+    if bracket_opt Option::Some(bracket) is then
+        if "[" bracket Token::value != then bound_args return fi
+    fi
     cursor.pop drop # consume [
     1 = pba_depth
     StringBuilder::new = pba_current
@@ -721,7 +778,11 @@ fn parse_bound_type_args cursor:TokenCursor trait_token:Token -> List[str] {
             trait_token Token::location "Unclosed trait bound type argument list" ErrorKind::Syntax raise_error
             bound_args return
         fi
-        arg_tok_opt.unwrap Token::value = arg_val
+        if arg_tok_opt Option::Some(arg_tok) is then
+            arg_tok Token::value = arg_val
+        else
+            bound_args return
+        fi
         if "[" arg_val == then
             1 += pba_depth
             arg_val pba_current.append
@@ -779,7 +840,11 @@ fn parse_type_vars parser:Parser cursor:TokenCursor -> List[str] {
         if token_opt.is_none then
             empty_location "Expected `]` to close type parameters" ErrorKind::Syntax raise_error
         fi
-        token_opt.unwrap = token
+        if token_opt Option::Some(token) is then
+        else
+            empty_location "Expected option value while unwrapping token_opt" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         if "]" token Token::value == then
             if 0 vars.length == then
                 token Token::location "Empty type parameter list `[]` is not allowed" ErrorKind::Syntax raise_error
@@ -798,8 +863,8 @@ fn parse_type_vars parser:Parser cursor:TokenCursor -> List[str] {
             token Token::value seen.add = seen
             # Check for trait bound: K: Hashable  or  K: Iterable[int]
             cursor.peek = colon_opt
-            if colon_opt.is_some then
-                if ":" colon_opt.unwrap Token::value == then
+            if colon_opt Option::Some(colon) is then
+                if ":" colon Token::value == then
                     cursor.pop drop # consume :
                     TokenKind::Identifier cursor expect_token_kind = trait_token
                     trait_token Token::value = bound_trait_name
@@ -808,9 +873,9 @@ fn parse_type_vars parser:Parser cursor:TokenCursor -> List[str] {
                         trait_token Token::location f"Trait `{bound_trait_name}` is not defined" ErrorKind::UndefinedName raise_error
                     fi
                     trait_token cursor parse_bound_type_args = bound_args
-                    if bound_trait_def_opt.is_some then
+                    if bound_trait_def_opt Option::Some(bound_trait_def) is then
                         # Arity check against trait's declared type_params
-                        bound_trait_def_opt.unwrap CasaTrait::type_params = declared_params
+                        bound_trait_def CasaTrait::type_params = declared_params
                         if bound_args.length declared_params.length != then
                             trait_token Token::location f"Trait `{bound_trait_name}` expects {declared_params.length} type argument(s), got {bound_args.length}" ErrorKind::Syntax raise_error
                         fi
@@ -851,7 +916,11 @@ fn parse_parameters cursor:TokenCursor -> List[Parameter] {
         if token_opt.is_none then
             empty_location "Unexpected end of input" ErrorKind::UnexpectedToken raise_error
         fi
-        token_opt.unwrap = token
+        if token_opt Option::Some(token) is then
+        else
+            empty_location "Expected option value while unwrapping token_opt" ErrorKind::Syntax raise_error
+            1 exit
+        fi
 
         # Stop at -> or {
         if "->" token Token::value == "{" token Token::value == || then
@@ -886,8 +955,10 @@ fn parse_return_types cursor:TokenCursor -> List[Type] {
         if peek_opt.is_none then
             empty_location "Unexpected end of input" ErrorKind::UnexpectedToken raise_error
         fi
-        if "{" peek_opt.unwrap Token::value == then
-            types return
+        if peek_opt Option::Some(peek) is then
+            if "{" peek Token::value == then
+                types return
+            fi
         fi
         cursor parse_type_ast types.push
     done
@@ -906,9 +977,11 @@ fn parse_stack_effect cursor:TokenCursor -> StackEffect {
     if next_opt.is_none then
         empty_location "Unexpected end of input" ErrorKind::UnexpectedToken raise_error
     fi
-    if "->" next_opt.unwrap Token::value == then
-        cursor.advance # consume ->
-        cursor parse_return_types = returns
+    if next_opt Option::Some(next) is then
+        if "->" next Token::value == then
+            cursor.advance # consume ->
+            cursor parse_return_types = returns
+        fi
     fi
     returns params StackEffect::new
 }
@@ -937,8 +1010,8 @@ fn collect_trait_methods_into
     done
     for ctm_super in trait_def CasaTrait::supertraits.iter do
         ctm_super TraitBound::name store.traits.get = ctm_super_opt
-        if ctm_super_opt.is_some then
-            ctm_super_opt.unwrap store result seen collect_trait_methods_into = seen
+        if ctm_super_opt Option::Some(ctm_super_trait) is then
+            ctm_super_trait store result seen collect_trait_methods_into = seen
         fi
     done
     seen
@@ -961,10 +1034,18 @@ fn build_hidden_trait_methods
     List::new(List[HiddenTraitMethod]) = result
     trait_bounds.keys = bound_keys
     for bound_type_var in bound_keys.iter do
-        bound_type_var trait_bounds.get.unwrap = bound
+        if bound_type_var trait_bounds.get Option::Some(bound) is then
+        else
+            empty_location "Expected option value while unwrapping bound_type_var trait_bounds.get" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         bound TraitBound::name parser.store.traits.get = bound_trait_opt
         if bound_trait_opt.is_some then
-            bound_trait_opt.unwrap = bound_trait
+            if bound_trait_opt Option::Some(bound_trait) is then
+            else
+                empty_location "Expected option value while unwrapping bound_trait_opt" ErrorKind::Syntax raise_error
+                1 exit
+            fi
             # Build substitution map from trait's declared type_params to the
             # concrete type_args carried on the bound.
             Map::new(Map[str Type]) = bound_subs
@@ -1022,8 +1103,12 @@ fn try_fold_const_fn_call
 -> int {
     fn_name store.functions.get = fold_fn_opt
     if fold_fn_opt.is_none then op_index return fi
-    if fold_fn_opt.unwrap Function::is_const_fn ! then op_index return fi
-    fold_fn_opt.unwrap Function::stack_effect StackEffect::parameters.length = fold_param_count
+    if fold_fn_opt Option::Some(fold_fn) is then
+    else
+        op_index return
+    fi
+    if fold_fn Function::is_const_fn ! then op_index return fi
+    fold_fn Function::stack_effect StackEffect::parameters.length = fold_param_count
     op_index 1 - = call_idx
     call_idx fold_param_count - = first_arg_idx
     if 0 first_arg_idx > then op_index return fi
@@ -1220,7 +1305,11 @@ fn eval_const_fn
     if fn_opt.is_none then
         location f"`{fn_name}` is not a const fn" ErrorKind::Syntax raise_error
     fi
-    fn_opt.unwrap = function
+    if fn_opt Option::Some(function) is then
+    else
+        empty_location "Expected option value while unwrapping fn_opt" ErrorKind::Syntax raise_error
+        1 exit
+    fi
     if function Function::is_const_fn ! then
         location f"`{fn_name}` is not a const fn" ErrorKind::Syntax raise_error
     fi
@@ -1259,8 +1348,8 @@ fn eval_const_fn
             continue
         fi
         op_value op_value_to_operator_kind = eval_op_kind_opt
-        if eval_op_kind_opt.is_some then
-            fn_op Op::location eval_op_kind_opt.unwrap fn_stack const_eval_apply_operator
+        if eval_op_kind_opt Option::Some(eval_op_kind) is then
+            fn_op Op::location eval_op_kind fn_stack const_eval_apply_operator
             continue
         fi
         if op_value OpValue::FnReturn is then
@@ -1278,31 +1367,31 @@ fn eval_const_fn
         fi
         if op_value OpValue::PushVar(var_name) is then
             var_name locals.get = local_opt
-            if local_opt.is_some then
-                local_opt.unwrap fn_stack.push
+            if local_opt Option::Some(local) is then
+                local fn_stack.push
                 continue
             fi
             var_name store.constants.get = inner_const_opt
-            if inner_const_opt.is_some then
-                inner_const_opt.unwrap Constant::value fn_stack.push
+            if inner_const_opt Option::Some(inner_const) is then
+                inner_const Constant::value fn_stack.push
                 continue
             fi
             fn_op Op::location f"Cannot use variable `{var_name}` in const fn evaluation" ErrorKind::Syntax raise_error
         fi
         if op_value OpValue::Identifier(ident_name) is then
             ident_name locals.get = local_opt
-            if local_opt.is_some then
-                local_opt.unwrap fn_stack.push
+            if local_opt Option::Some(local) is then
+                local fn_stack.push
                 continue
             fi
             ident_name store.constants.get = inner_const_opt
-            if inner_const_opt.is_some then
-                inner_const_opt.unwrap Constant::value fn_stack.push
+            if inner_const_opt Option::Some(inner_const) is then
+                inner_const Constant::value fn_stack.push
                 continue
             fi
             ident_name store.functions.get = inner_fn_opt
-            if inner_fn_opt.is_some then
-                if inner_fn_opt.unwrap Function::is_const_fn then
+            if inner_fn_opt Option::Some(inner_fn) is then
+                if inner_fn Function::is_const_fn then
                     eval_stack fn_op Op::location fn_stack ident_name store eval_const_fn
                     continue
                 fi
@@ -1327,7 +1416,11 @@ fn eval_const_block parser:Parser cursor:TokenCursor location:Location -> Consta
         if tok_opt.is_none then
             location "Unclosed const block expression" ErrorKind::Syntax raise_error
         fi
-        tok_opt.unwrap = tok
+        if tok_opt Option::Some(tok) is then
+        else
+            empty_location "Expected option value while unwrapping tok_opt" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         if "}" tok Token::value == then break fi
         if TokenKind::Comment tok Token::kind == then continue fi
         if TokenKind::Newline tok Token::kind == then continue fi
@@ -1337,21 +1430,21 @@ fn eval_const_block parser:Parser cursor:TokenCursor location:Location -> Consta
         fi
         if TokenKind::Operator tok Token::kind == then
             tok Token::value operator_from_str = op_kind_opt
-            if op_kind_opt.is_some then
-                tok Token::location op_kind_opt.unwrap stack const_eval_apply_operator
+            if op_kind_opt Option::Some(op_kind) is then
+                tok Token::location op_kind stack const_eval_apply_operator
             fi
             continue
         fi
         if TokenKind::Identifier tok Token::kind == then
             tok Token::value = ident
             ident parser.store.constants.get = c_opt
-            if c_opt.is_some then
-                c_opt.unwrap Constant::value stack.push
+            if c_opt Option::Some(casa_const) is then
+                casa_const Constant::value stack.push
                 continue
             fi
             ident parser.store.functions.get = f_opt
-            if f_opt.is_some then
-                if f_opt.unwrap Function::is_const_fn then
+            if f_opt Option::Some(function) is then
+                if function Function::is_const_fn then
                     eval_stack tok Token::location stack ident parser.store eval_const_fn
                     continue
                 fi
@@ -1380,8 +1473,8 @@ fn parse_function parser:Parser cursor:TokenCursor -> Function {
     # Parse optional type parameters
     List::new(List[str]) = type_vars
     cursor.peek = tvars_opt
-    if tvars_opt.is_some then
-        if "[" tvars_opt.unwrap Token::value == then
+    if tvars_opt Option::Some(tvars) is then
+        if "[" tvars Token::value == then
             cursor parser parse_type_vars = type_vars
         fi
     fi
@@ -1452,8 +1545,8 @@ fn parse_enum parser:Parser cursor:TokenCursor -> CasaEnum {
     # Parse optional type parameters
     List::new(List[str]) = type_vars
     cursor.peek = tvars_opt
-    if tvars_opt.is_some then
-        if "[" tvars_opt.unwrap Token::value == then
+    if tvars_opt Option::Some(tvars) is then
+        if "[" tvars Token::value == then
             cursor parser parse_type_vars = type_vars
         fi
     fi
@@ -1478,17 +1571,19 @@ fn parse_enum parser:Parser cursor:TokenCursor -> CasaEnum {
         # Parse optional inner types: Variant(type1 type2)
         List::new(List[Type]) = inner_types
         cursor.peek = paren_opt
-        if paren_opt.is_some then
-            if "(" paren_opt.unwrap Token::value == then
+        if paren_opt Option::Some(paren) is then
+            if "(" paren Token::value == then
                 cursor.pop drop # consume (
                 while true do
                     cursor.peek = inner_opt
                     if inner_opt.is_none then
                         variant_token Token::location "Unexpected end of input in variant inner types" ErrorKind::UnexpectedToken raise_error
                     fi
-                    if ")" inner_opt.unwrap Token::value == then
-                        cursor.pop drop # consume )
-                        break
+                    if inner_opt Option::Some(inner) is then
+                        if ")" inner Token::value == then
+                            cursor.pop drop # consume )
+                            break
+                        fi
                     fi
                     cursor parse_type_ast inner_types.push
                 done
@@ -1509,7 +1604,11 @@ fn parse_enum parser:Parser cursor:TokenCursor -> CasaEnum {
         for variant_name in variants.iter do
             variant_name variant_types.get = vt_opt
             if vt_opt.is_some then
-                vt_opt.unwrap = vt_inner
+                if vt_opt Option::Some(vt_inner) is then
+                else
+                    empty_location "Expected option value while unwrapping vt_opt" ErrorKind::Syntax raise_error
+                    1 exit
+                fi
                 0 = vt_index
                 while vt_index vt_inner.length > do
                     tv_set vt_index vt_inner.get canonicalize_type_var vt_index vt_inner.set
@@ -1585,7 +1684,7 @@ fn create_member_accessor
     struct_name = param_type
     type_vars string_list_to_set = effect_type_vars
     if 0 type_vars.length != then
-        type_vars struct_name build_parameterized_type = param_type
+        type_vars struct_name build_parameterized_type.format = param_type
     fi
 
     # Getter
@@ -1645,8 +1744,8 @@ fn parse_struct parser:Parser cursor:TokenCursor -> CasaStruct {
     # Parse optional type parameters
     List::new(List[str]) = type_vars
     cursor.peek = tvars_opt
-    if tvars_opt.is_some then
-        if "[" tvars_opt.unwrap Token::value == then
+    if tvars_opt Option::Some(tvars) is then
+        if "[" tvars Token::value == then
             cursor parser parse_type_vars = type_vars
             # Trait bounds are not allowed on struct definitions
             if 0 LAST_TRAIT_BOUNDS.keys.length != then
@@ -1692,7 +1791,11 @@ fn parse_trait_method_stack_effect cursor:TokenCursor -> StackEffect {
     while true do
         cursor.peek = peek_opt
         if peek_opt.is_none then break fi
-        peek_opt.unwrap = peek
+        if peek_opt Option::Some(peek) is then
+        else
+            empty_location "Expected option value while unwrapping peek_opt" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         if
         "->" peek Token::value ==
         "{" peek Token::value == ||
@@ -1715,16 +1818,20 @@ fn parse_trait_method_stack_effect cursor:TokenCursor -> StackEffect {
 
     List::new(List[Type]) = returns
     cursor.peek = arrow_opt
-    if arrow_opt.is_some then
-        if "->" arrow_opt.unwrap Token::value == then
+    if arrow_opt Option::Some(arrow) is then
+        if "->" arrow Token::value == then
             cursor.pop drop # consume ->
             while true do
                 cursor.peek = return_opt
                 if return_opt.is_none then break fi
+                if return_opt Option::Some(return_token) is then
+                else
+                    break
+                fi
                 if
-                "fn" return_opt.unwrap Token::value ==
-                "}" return_opt.unwrap Token::value == ||
-                "{" return_opt.unwrap Token::value == ||
+                "fn" return_token Token::value ==
+                "}" return_token Token::value == ||
+                "{" return_token Token::value == ||
                 then
                     break
                 fi
@@ -1750,7 +1857,11 @@ fn parse_simple_type_vars cursor:TokenCursor context:str -> List[str] {
             empty_location f"Unclosed {context} type parameter list" ErrorKind::UnmatchedBlock raise_error
             false = loop_flag
         else
-            token_opt.unwrap = token
+            if token_opt Option::Some(token) is then
+            else
+                empty_location "Expected option value while unwrapping token_opt" ErrorKind::Syntax raise_error
+                1 exit
+            fi
             if "]" token Token::value == then
                 cursor.pop drop
                 false = loop_flag
@@ -1789,8 +1900,8 @@ fn parse_trait parser:Parser cursor:TokenCursor -> CasaTrait {
                 super_token Token::location f"Supertrait `{super_name}` is not defined" ErrorKind::UndefinedName raise_error
             fi
             super_token cursor parse_bound_type_args = super_args
-            if super_def_opt.is_some then
-                super_def_opt.unwrap CasaTrait::type_params = super_params
+            if super_def_opt Option::Some(super_def) is then
+                super_def CasaTrait::type_params = super_params
                 if super_args.length super_params.length != then
                     super_token Token::location f"Supertrait `{super_name}` expects {super_params.length} type argument(s), got {super_args.length}" ErrorKind::Syntax raise_error
                 fi
@@ -1814,42 +1925,46 @@ fn parse_trait parser:Parser cursor:TokenCursor -> CasaTrait {
         if next_opt.is_none then
             name_token Token::location "Unclosed trait block" ErrorKind::UnmatchedBlock raise_error
             false = parse_trait_loop
-        elif "}" next_opt.unwrap Token::value == then
-            cursor.pop drop
-            false = parse_trait_loop
-        elif "fn" next_opt.unwrap Token::value != then
-            next_opt.unwrap Token::location "Expected method declaration in trait" ErrorKind::UnexpectedToken raise_error
-            false = parse_trait_loop
+        elif next_opt Option::Some(next) is then
+            if "}" next Token::value == then
+                cursor.pop drop
+                false = parse_trait_loop
+            elif "fn" next Token::value != then
+                next Token::location "Expected method declaration in trait" ErrorKind::UnexpectedToken raise_error
+                false = parse_trait_loop
+            else
+                cursor.pop drop # consume fn
+                TokenKind::Identifier cursor expect_token_kind = method_name
+
+                # Parse optional method-level type parameters (e.g., fn map[U])
+                List::new(List[str]) = method_type_vars
+                if cursor.peek Option::Some(mtv_bracket) is then
+                    if "[" mtv_bracket Token::value == then
+                        "trait method" cursor parse_simple_type_vars = method_type_vars
+                    fi
+                fi
+
+                cursor parse_trait_method_stack_effect = method_stack_effect
+
+                type_params string_list_to_set = trait_tv_set
+                TRAIT_SELF_TYPE trait_tv_set.add = trait_tv_set
+                for mtv in method_type_vars.iter do
+                    mtv trait_tv_set.add = trait_tv_set
+                done
+                trait_tv_set method_stack_effect canonicalize_stack_effect_type_vars
+
+                # Parse optional default method body
+                List::new(List[Op]) = default_ops
+                if cursor.peek Option::Some(body_peek) is then
+                    if "{" body_peek Token::value == then
+                        f"{name_token Token::value}::{method_name Token::value}" cursor parser parse_block_ops = default_ops
+                    fi
+                fi
+
+                method_type_vars default_ops method_stack_effect method_name Token::value TraitMethod methods.push
+            fi
         else
-            cursor.pop drop # consume fn
-            TokenKind::Identifier cursor expect_token_kind = method_name
-
-            # Parse optional method-level type parameters (e.g., fn map[U])
-            List::new(List[str]) = method_type_vars
-            if cursor.peek Option::Some(mtv_bracket) is then
-                if "[" mtv_bracket Token::value == then
-                    "trait method" cursor parse_simple_type_vars = method_type_vars
-                fi
-            fi
-
-            cursor parse_trait_method_stack_effect = method_stack_effect
-
-            type_params string_list_to_set = trait_tv_set
-            TRAIT_SELF_TYPE trait_tv_set.add = trait_tv_set
-            for mtv in method_type_vars.iter do
-                mtv trait_tv_set.add = trait_tv_set
-            done
-            trait_tv_set method_stack_effect canonicalize_stack_effect_type_vars
-
-            # Parse optional default method body
-            List::new(List[Op]) = default_ops
-            if cursor.peek Option::Some(body_peek) is then
-                if "{" body_peek Token::value == then
-                    f"{name_token Token::value}::{method_name Token::value}" cursor parser parse_block_ops = default_ops
-                fi
-            fi
-
-            method_type_vars default_ops method_stack_effect method_name Token::value TraitMethod methods.push
+            false = parse_trait_loop
         fi
     done
 
@@ -1879,8 +1994,10 @@ fn inject_impl_trait_params
     # Merge trait bounds
     trait_bounds.keys = bound_keys
     for bound_key in bound_keys.iter do
-        bound_key trait_bounds.get.unwrap bound_key effect StackEffect::trait_bounds.set = new_bounds
-        new_bounds effect StackEffect::set_trait_bounds
+        if bound_key trait_bounds.get Option::Some(bound) is then
+            bound bound_key effect StackEffect::trait_bounds.set = new_bounds
+            new_bounds effect StackEffect::set_trait_bounds
+        fi
     done
 
     # Inject hidden __trait_* parameters
@@ -1914,8 +2031,8 @@ fn parse_impl_block parser:Parser cursor:TokenCursor {
     List::new(List[str]) = type_vars
     Map::new(Map[str TraitBound]) = trait_bounds
     cursor.peek = tvars_opt
-    if tvars_opt.is_some then
-        if "[" tvars_opt.unwrap Token::value == then
+    if tvars_opt Option::Some(tvars) is then
+        if "[" tvars Token::value == then
             cursor parser parse_type_vars = type_vars
             LAST_TRAIT_BOUNDS = trait_bounds
         fi
@@ -1935,7 +2052,9 @@ fn parse_impl_block parser:Parser cursor:TokenCursor {
     while true do
         cursor.peek = fn_opt
         if fn_opt.is_none then break fi
-        if "fn" fn_opt.unwrap Token::value != then break fi
+        if fn_opt Option::Some(fn_token) is then
+            if "fn" fn_token Token::value != then break fi
+        fi
         cursor parser parse_function = function
         f"{base_type}::{function Function::name}" = fn_name
         fn_name function Function::set_name
@@ -2014,9 +2133,11 @@ fn parse_struct_match_pattern parser:Parser name_token:Token cursor:TokenCursor 
         if next_opt.is_none then
             name_token Token::location "Unexpected end of input in struct pattern" ErrorKind::UnexpectedToken raise_error
         fi
-        if "}" next_opt.unwrap Token::value == then
-            cursor.pop drop
-            break
+        if next_opt Option::Some(next) is then
+            if "}" next Token::value == then
+                cursor.pop drop
+                break
+            fi
         fi
         TokenKind::Identifier cursor expect_token_kind = field_token
         ":" cursor expect_token_value drop
@@ -2044,11 +2165,19 @@ fn parse_pattern_terminator parser:Parser cursor:TokenCursor function_name:str -
         while cursor.is_finished ! do
             cursor.peek = next_opt
             if next_opt.is_none then break fi
-            next_opt.unwrap Token::value = next_value
+            if next_opt Option::Some(next) is then
+                next Token::value = next_value
+            else
+                break
+            fi
             if "=>" next_value == 0 match_depth == && then break fi
             cursor.pop = guard_token_opt
             if guard_token_opt.is_none then break fi
-            guard_token_opt.unwrap = guard_token
+            if guard_token_opt Option::Some(guard_token) is then
+            else
+                empty_location "Expected option value while unwrapping guard_token_opt" ErrorKind::Syntax raise_error
+                1 exit
+            fi
             if "match" guard_token Token::value == then
                 1 += match_depth
             elif "end" guard_token Token::value == 0 match_depth != && then
@@ -2135,9 +2264,11 @@ fn parse_match_arm_pattern
                 if inner_opt.is_none then
                     arm_token Token::location "Unexpected end of input in match arm bindings" ErrorKind::UnexpectedToken raise_error
                 fi
-                if ")" inner_opt.unwrap Token::value == then
-                    cursor.pop drop
-                    break
+                if inner_opt Option::Some(inner) is then
+                    if ")" inner Token::value == then
+                        cursor.pop drop
+                        break
+                    fi
                 fi
                 TokenKind::Identifier cursor expect_token_kind = binding_token
                 binding_token Token::value bindings.push
@@ -2171,7 +2302,11 @@ fn parse_match_arm_body parser:Parser cursor:TokenCursor function_name:str ops:L
         fi
         cursor.pop = body_token_opt
         if body_token_opt.is_none then break fi
-        body_token_opt.unwrap = body_token
+        if body_token_opt Option::Some(body_token) is then
+        else
+            empty_location "Expected option value while unwrapping body_token_opt" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         if TokenKind::FstringStart body_token Token::kind == then
             ops function_name cursor body_token parser handle_fstring
             continue
@@ -2248,16 +2383,16 @@ fn is_path_specifier spec:str -> bool {
 }
 
 fn dir_of_path path:str -> str {
-    -1 = last_slash
+    Option::None(Option[int]) = last_slash
     0 = scan
     while scan path.length > do
         if '/' scan path.at == then
-            scan = last_slash
+            scan Option::Some = last_slash
         fi
         1 += scan
     done
-    if 0 last_slash >= then
-        path 0 last_slash 1 + str::substring
+    if last_slash Option::Some(index) is then
+        path 0 index 1 + str::substring
         return
     fi
     ""
@@ -2312,7 +2447,11 @@ fn parse_selective_import_symbols cursor:TokenCursor location:Location -> List[s
         if symbol_opt.is_none then
             location "Unclosed selective import list" ErrorKind::UnmatchedBlock raise_error
         fi
-        symbol_opt.unwrap = symbol_token
+        if symbol_opt Option::Some(symbol_token) is then
+        else
+            empty_location "Expected option value while unwrapping symbol_opt" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         if TokenKind::Comment symbol_token Token::kind == then continue fi
         if TokenKind::Newline symbol_token Token::kind == then continue fi
         if "}" symbol_token Token::value == then
@@ -2464,7 +2603,11 @@ fn selective_import_symbol
 
     symbol import_parser.store.functions.get = fn_opt
     if fn_opt.is_some then
-        fn_opt.unwrap = imported_fn
+        if fn_opt Option::Some(imported_fn) is then
+        else
+            empty_location "Expected option value while unwrapping fn_opt" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         if symbol parser.store.functions.has then
             location f"Imported symbol `{symbol}` conflicts with an existing function" ErrorKind::DuplicateName raise_error
         fi
@@ -2486,40 +2629,40 @@ fn selective_import_symbol
     fi
 
     symbol import_parser.store.constants.get = const_opt
-    if const_opt.is_some then
+    if const_opt Option::Some(imported_const) is then
         if symbol parser.store.constants.has then
             location f"Imported symbol `{symbol}` conflicts with an existing constant" ErrorKind::DuplicateName raise_error
         fi
-        const_opt.unwrap symbol parser.store.constants.set drop
+        imported_const symbol parser.store.constants.set drop
         return
     fi
 
     symbol import_parser.store.structs.get = struct_opt
-    if struct_opt.is_some then
+    if struct_opt Option::Some(imported_struct) is then
         if symbol parser.store.structs.has then
             location f"Imported symbol `{symbol}` conflicts with an existing struct" ErrorKind::DuplicateName raise_error
         fi
-        struct_opt.unwrap symbol parser.store.structs.set drop
+        imported_struct symbol parser.store.structs.set drop
         imported location symbol import_parser parser selective_import_methods
         return
     fi
 
     symbol import_parser.store.enums.get = enum_opt
-    if enum_opt.is_some then
+    if enum_opt Option::Some(imported_enum) is then
         if symbol parser.store.enums.has then
             location f"Imported symbol `{symbol}` conflicts with an existing enum" ErrorKind::DuplicateName raise_error
         fi
-        enum_opt.unwrap symbol parser.store.enums.set drop
+        imported_enum symbol parser.store.enums.set drop
         imported location symbol import_parser parser selective_import_methods
         return
     fi
 
     symbol import_parser.store.traits.get = trait_opt
-    if trait_opt.is_some then
+    if trait_opt Option::Some(imported_trait) is then
         if symbol parser.store.traits.has then
             location f"Imported symbol `{symbol}` conflicts with an existing trait" ErrorKind::DuplicateName raise_error
         fi
-        trait_opt.unwrap symbol parser.store.traits.set drop
+        imported_trait symbol parser.store.traits.set drop
         return
     fi
 
@@ -2577,8 +2720,8 @@ fn handle_question_operator parser:Parser token:Token function_name:str ops:List
     loc OpValue::IfCondition Op::new ops.push
 
     function_name parser.store.functions.get = fn_opt
-    if fn_opt.is_some then
-        fn_opt.unwrap Function::stack_effect StackEffect::return_types = ret_types
+    if fn_opt Option::Some(function) is then
+        function Function::stack_effect StackEffect::return_types = ret_types
         if 0 ret_types.length != then
             0 ret_types.get = ret_type
             loc ret_type OpValue::TypeCast Op::new ops.push
@@ -2637,7 +2780,11 @@ fn handle_keyword_for parser:Parser token:Token cursor:TokenCursor function_name
             for_loc "Unclosed `for` loop" ErrorKind::UnmatchedBlock raise_error
             return
         fi
-        peek_opt.unwrap = peeked_token
+        if peek_opt Option::Some(peeked_token) is then
+        else
+            empty_location "Expected option value while unwrapping peek_opt" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         if "do" peeked_token Token::value == 0 nesting_depth == && then
             cursor.pop drop
             break
@@ -2678,7 +2825,11 @@ fn handle_keyword_for parser:Parser token:Token cursor:TokenCursor function_name
             for_loc "Unclosed `for` loop body" ErrorKind::UnmatchedBlock raise_error
             return
         fi
-        body_peek_opt.unwrap = body_token
+        if body_peek_opt Option::Some(body_token) is then
+        else
+            empty_location "Expected option value while unwrapping body_peek_opt" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         if "done" body_token Token::value == 0 body_nesting_depth == && then
             cursor.pop drop
             body_token Token::location OpValue::WhileEnd Op::new ops.push
@@ -2708,12 +2859,16 @@ fn get_op_keyword parser:Parser token:Token cursor:TokenCursor function_name:str
     if keyword_opt.is_none then
         token Token::location f"Token `{token Token::value}` is not a keyword" ErrorKind::Syntax raise_error
     fi
-    keyword_opt.unwrap = keyword
+    if keyword_opt Option::Some(keyword) is then
+    else
+        empty_location "Expected option value while unwrapping keyword_opt" ErrorKind::Syntax raise_error
+        1 exit
+    fi
 
     # Simple keyword -> OpValue lookup
     keyword keyword_to_op_value = simple_opt
-    if simple_opt.is_some then
-        token Token::location simple_opt.unwrap Op::new ops.push
+    if simple_opt Option::Some(simple) is then
+        token Token::location simple Op::new ops.push
         return
     fi
 
@@ -2822,8 +2977,8 @@ fn get_op_keyword parser:Parser token:Token cursor:TokenCursor function_name:str
         token Token::location "Constants" function_name require_global_scope
         # const fn — compile-time evaluable function
         cursor.peek = const_next_opt
-        if const_next_opt.is_some then
-            if "fn" const_next_opt.unwrap Token::value == then
+        if const_next_opt Option::Some(const_next) is then
+            if "fn" const_next Token::value == then
                 cursor parser parse_function = function
                 true function Function::set_is_const_fn
                 function validate_const_fn_body
@@ -2855,7 +3010,11 @@ fn get_op_keyword parser:Parser token:Token cursor:TokenCursor function_name:str
         if const_value_token_opt.is_none then
             token Token::location "Expected a literal value, block expression, or constant name after constant name" ErrorKind::Syntax raise_error
         fi
-        const_value_token_opt.unwrap = const_value_token
+        if const_value_token_opt Option::Some(const_value_token) is then
+        else
+            empty_location "Expected option value while unwrapping const_value_token_opt" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         if "{" const_value_token Token::value == then
             cursor.retreat
             token Token::location cursor parser eval_const_block = const_block_val
@@ -2868,8 +3027,8 @@ fn get_op_keyword parser:Parser token:Token cursor:TokenCursor function_name:str
         elif TokenKind::Identifier const_value_token Token::kind == then
             const_value_token Token::value = const_ref_name
             const_ref_name parser.store.constants.get = const_ref_opt
-            if const_ref_opt.is_some then
-                token Token::location const_ref_opt.unwrap Constant::value const_name Constant = casa_const
+            if const_ref_opt Option::Some(const_ref) is then
+                token Token::location const_ref Constant::value const_name Constant = casa_const
                 casa_const const_name parser.store.constants.set drop
             elif const_ref_name parser.store.functions.get.is_some then
                 token Token::location f"Cannot use `{const_ref_name}` as a constant value; it is not a constant" ErrorKind::Syntax raise_error
@@ -2924,11 +3083,17 @@ fn parse_struct_field_value
     while cursor.is_finished ! do
         cursor.peek = peek_opt
         if peek_opt.is_none then break fi
-        if "}" peek_opt.unwrap Token::value == then break fi
+        if peek_opt Option::Some(peek) is then
+            if "}" peek Token::value == then break fi
+        fi
         if member_names cursor is_struct_field_boundary then break fi
         cursor.pop = value_opt
         if value_opt.is_none then break fi
-        value_opt.unwrap = value_token
+        if value_opt Option::Some(value_token) is then
+        else
+            empty_location "Expected option value while unwrapping value_opt" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         if TokenKind::FstringStart value_token Token::kind == then
             all_ops function_name cursor value_token parser handle_fstring
             continue
@@ -2944,7 +3109,11 @@ fn parse_struct_literal
     function_name:str
 -> List[Op] {
     "{" cursor expect_token_value drop
-    name_token Token::value parser.store.structs.get.unwrap = casa_struct
+    if name_token Token::value parser.store.structs.get Option::Some(casa_struct) is then
+    else
+        empty_location "Expected option value while unwrapping name_token Token::value parser.store.structs.get" ErrorKind::Syntax raise_error
+        1 exit
+    fi
     List::new(List[str]) = member_names
     for member in casa_struct CasaStruct::members.iter do
         member Member::name member_names.push
@@ -2959,9 +3128,11 @@ fn parse_struct_literal
         if next_opt.is_none then
             name_token Token::location "Unexpected end of input in struct literal" ErrorKind::UnexpectedToken raise_error
         fi
-        if "}" next_opt.unwrap Token::value == then
-            cursor.pop drop
-            break
+        if next_opt Option::Some(next) is then
+            if "}" next Token::value == then
+                cursor.pop drop
+                break
+            fi
         fi
 
         TokenKind::Identifier cursor expect_token_kind = field_token
@@ -3031,8 +3202,8 @@ fn token_to_op parser:Parser token:Token cursor:TokenCursor function_name:str op
     if TokenKind::Identifier kind == then
         # Check for struct literal: StructName { ... }
         cursor.peek = next_opt
-        if next_opt.is_some then
-            if "{" next_opt.unwrap Token::value == then
+        if next_opt Option::Some(next) is then
+            if "{" next Token::value == then
                 if token Token::value parser.store.structs.get.is_some then
                     function_name cursor token parser parse_struct_literal = struct_literal_ops
                     for struct_op in struct_literal_ops.iter do
@@ -3046,8 +3217,8 @@ fn token_to_op parser:Parser token:Token cursor:TokenCursor function_name:str op
         # Check for is check: Enum::Variant is
         if token Token::value "::" str::find 0 <= then
             cursor token try_parse_is_check = is_check_opt
-            if is_check_opt.is_some then
-                is_check_opt.unwrap ops.push
+            if is_check_opt Option::Some(is_check_op) is then
+                is_check_op ops.push
                 return
             fi
         fi
@@ -3079,7 +3250,11 @@ fn parse_ops parser:Parser tokens:List[Token] -> List[Op] {
     while cursor.is_finished ! do
         cursor.pop = token_opt
         if token_opt.is_none then break fi
-        token_opt.unwrap = token
+        if token_opt Option::Some(token) is then
+        else
+            empty_location "Expected option value while unwrapping token_opt" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         if TokenKind::Comment token Token::kind == then continue fi
         if TokenKind::Newline token Token::kind == then continue fi
         if TokenKind::FstringStart token Token::kind == then
@@ -3121,8 +3296,8 @@ fn gather_captures store:SymbolStore lambda_function:Function function:Function 
         if captured ! then
             # Check global variables
             name store.variables.get = global_var_opt
-            if global_var_opt.is_some then
-                global_var_opt.unwrap lambda_function Function::captures.push
+            if global_var_opt Option::Some(global_var) is then
+                global_var lambda_function Function::captures.push
             fi
         fi
     done
@@ -3146,8 +3321,8 @@ fn resolve_array_identifiers
                 rai_name OpValue::PushCapture rai_item Op::set_value
             elif rai_name store.variables.get.is_some then
                 rai_name OpValue::PushVar rai_item Op::set_value
-            elif rai_name store.constants.get = rai_const_opt rai_const_opt.is_some then
-                rai_const_opt.unwrap Constant::value = rai_const_value
+            elif rai_name store.constants.get = rai_const_opt rai_const_opt Option::Some(rai_const) is then
+                rai_const Constant::value = rai_const_value
                 rai_const_value match
                     ConstantValue::Int(rai_const_int) => { rai_const_int OpValue::PushInt rai_item Op::set_value }
                     ConstantValue::Str(rai_const_str) => { rai_const_str OpValue::PushStr rai_item Op::set_value }
@@ -3155,9 +3330,9 @@ fn resolve_array_identifiers
                     ConstantValue::Char(rai_const_char) => { rai_const_char OpValue::PushChar rai_item Op::set_value }
                 end
             elif errors rai_name rai_item store try_resolve_enum_variant_ident then
-            elif rai_name store.functions.get.is_some then
+            elif rai_name store.functions.get Option::Some(rai_fn) is then
                 rai_name OpValue::FnPush rai_item Op::set_value
-                true rai_name store.functions.get.unwrap Function::set_is_used
+                true rai_fn Function::set_is_used
             else
                 rai_item Op::location f"Identifier `{rai_name}` is not defined" ErrorKind::UndefinedName CasaError::new errors.push
             fi
@@ -3178,7 +3353,11 @@ fn resolve_enum_variant
         if rev_enum_opt.is_none then
             op Op::location f"Enum `{variant EnumVariant::enum_name}` is not defined" ErrorKind::UndefinedName CasaError::new errors.push
         else
-            rev_enum_opt.unwrap = rev_enum
+            if rev_enum_opt Option::Some(rev_enum) is then
+            else
+                empty_location "Expected option value while unwrapping rev_enum_opt" ErrorKind::Syntax raise_error
+                1 exit
+            fi
             variant EnumVariant::variant_name rev_enum CasaEnum::variants string_list_index = rev_ordinal
             if 0 rev_ordinal < then
                 op Op::location f"Variant `{variant EnumVariant::variant_name}` is not defined in enum `{variant EnumVariant::enum_name}`" ErrorKind::UndefinedName CasaError::new errors.push
@@ -3298,7 +3477,11 @@ fn resolve_identifiers store:SymbolStore ops:List[Op] function:Function -> List[
         if current_op.value OpValue::FnPush(fn_name) is then
             fn_name store.functions.get = lambda_opt
             if lambda_opt.is_some then
-                lambda_opt.unwrap = lambda
+                if lambda_opt Option::Some(lambda) is then
+                else
+                    empty_location "Expected option value while unwrapping lambda_opt" ErrorKind::Syntax raise_error
+                    1 exit
+                fi
                 true lambda Function::set_is_used
                 function lambda store gather_captures
                 lambda lambda Function::ops store resolve_identifiers = lambda_resolved
@@ -3373,7 +3556,11 @@ fn resolve_match_op store:SymbolStore function:Function op:Op errors:List[CasaEr
         PatternValue::Struct(struct_pattern) => {
             struct_pattern.bindings.keys = pattern_keys
             for pattern_key in pattern_keys.iter do
-                pattern_key struct_pattern.bindings.get.unwrap = binding_name
+                if pattern_key struct_pattern.bindings.get Option::Some(binding_name) is then
+                else
+                    empty_location "Expected option value while unwrapping pattern_key struct_pattern.bindings.get" ErrorKind::Syntax raise_error
+                    1 exit
+                fi
                 binding_name function store register_struct_pattern_binding
             done
         }
@@ -3416,9 +3603,9 @@ fn try_resolve_fn_ref
         fi
     fi
     ref_name store.functions.get = ref_fn_opt
-    if ref_fn_opt.is_some then
+    if ref_fn_opt Option::Some(ref_fn) is then
         ref_name OpValue::FnPush op Op::set_value
-        true ref_fn_opt.unwrap Function::set_is_used
+        true ref_fn Function::set_is_used
     else
         op Op::location f"Function `{ref_name}` is not defined" ErrorKind::UndefinedName CasaError::new resolve_errors.push
     fi
@@ -3439,7 +3626,11 @@ fn try_resolve_enum_variant_ident
     enum_name store.enums.get = enum_opt
     if enum_opt.is_none then false return fi
     ident separator 2 + ident.length separator - 2 - str::substring = binding_name
-    binding_name enum_opt.unwrap CasaEnum::variants string_list_index = ordinal
+    if enum_opt Option::Some(casa_enum) is then
+    else
+        false return
+    fi
+    binding_name casa_enum CasaEnum::variants string_list_index = ordinal
     if 0 ordinal < then
         op Op::location f"Variant `{binding_name}` is not defined in enum `{enum_name}`" ErrorKind::UndefinedName CasaError::new resolve_errors.push
     else
@@ -3480,9 +3671,9 @@ fn resolve_plain_identifier
     fi
 
     ident store.functions.get = generic_fn_opt
-    if generic_fn_opt.is_some then
+    if generic_fn_opt Option::Some(generic_fn) is then
         ident OpValue::FnCall op Op::set_value
-        true generic_fn_opt.unwrap Function::set_is_used
+        true generic_fn Function::set_is_used
         return
     fi
 
@@ -3497,8 +3688,8 @@ fn resolve_plain_identifier
     fi
 
     ident store.constants.get = const_opt
-    if const_opt.is_some then
-        const_opt.unwrap Constant::value = const_value
+    if const_opt Option::Some(casa_const) is then
+        casa_const Constant::value = const_value
         const_value match
             ConstantValue::Int(const_int) => {
                 const_int OpValue::PushInt op Op::set_value
@@ -3517,14 +3708,14 @@ fn resolve_plain_identifier
     fi
 
     ident store.structs.get = struct_opt
-    if struct_opt.is_some then
-        struct_opt.unwrap OpValue::StructNew op Op::set_value
+    if struct_opt Option::Some(casa_struct) is then
+        casa_struct OpValue::StructNew op Op::set_value
         return
     fi
 
     ident store.enums.get = resolved_enum_opt
-    if resolved_enum_opt.is_some then
-        resolved_enum_opt.unwrap CasaEnum::variants.length OpValue::PushInt op Op::set_value
+    if resolved_enum_opt Option::Some(resolved_enum) is then
+        resolved_enum CasaEnum::variants.length OpValue::PushInt op Op::set_value
         return
     fi
 

--- a/compiler/syntax.casa
+++ b/compiler/syntax.casa
@@ -26,11 +26,13 @@ struct ParseResolveResult {
     store: SymbolStore
 }
 
-fn make_parser store:SymbolStore -> Parser {
-    List::new(List[str])
-    Set::new(Set[str])
-    store
-    Parser
+impl Parser {
+    fn new store:SymbolStore -> Parser {
+        List::new(List[str])
+        Set::new(Set[str])
+        store
+        Parser
+    }
 }
 
 # ============================================================================
@@ -170,7 +172,7 @@ fn expect_token cursor:TokenCursor -> Token {
     if result_opt.is_none then
         empty_location "Unexpected end of input" ErrorKind::UnexpectedToken raise_error
         # Return dummy token for resilient/test mode
-        empty_location TokenKind::Eof "" make_token return
+        empty_location TokenKind::Eof "" Token::new return
     fi
     result_opt.unwrap = token
     if TokenKind::Eof token Token::kind == then
@@ -301,9 +303,9 @@ fn get_op_type_cast cursor:TokenCursor -> Op {
     open_token Token::location Location::span Span::offset = open_offset
     close_token Token::location Location::span Span::offset = close_offset
     close_offset open_offset - 1 + = length
-    length open_offset open_token Token::location Location::file make_location = loc
+    length open_offset open_token Token::location Location::file Location::new = loc
 
-    loc cast_type OpValue::TypeCast make_op
+    loc cast_type OpValue::TypeCast Op::new
 }
 
 # ============================================================================
@@ -313,15 +315,15 @@ fn get_op_type_cast cursor:TokenCursor -> Op {
 fn get_op_literal token:Token -> Op {
     token Token::value = value
     if "true" value == then
-        token Token::location 1 OpValue::PushBool make_op return
+        token Token::location 1 OpValue::PushBool Op::new return
     fi
     if "false" value == then
-        token Token::location 0 OpValue::PushBool make_op return
+        token Token::location 0 OpValue::PushBool Op::new return
     fi
     # Integer literal (positive or negative)
     if 0 value.at.is_digit value is_negative_integer_literal || then
         value str_to_int = int_value
-        token Token::location int_value OpValue::PushInt make_op return
+        token Token::location int_value OpValue::PushInt Op::new return
     fi
     # Char literal: 'X'
     if
@@ -330,16 +332,16 @@ fn get_op_literal token:Token -> Op {
     3 value.length == &&
     then
         1 value.at (int) = char_value
-        token Token::location char_value OpValue::PushChar make_op return
+        token Token::location char_value OpValue::PushChar Op::new return
     fi
     # String literal: "..."
     if '"' 0 value.at == '"' value.length 1 - value.at == && then
         value 1 value.length 2 - str::substring = str_value
-        token Token::location str_value OpValue::PushStr make_op return
+        token Token::location str_value OpValue::PushStr Op::new return
     fi
     token Token::location f"Token `{value}` is not a literal" ErrorKind::Syntax raise_error
     # Unreachable - raise_error exits
-    token Token::location 0 OpValue::PushInt make_op
+    token Token::location 0 OpValue::PushInt Op::new
 }
 
 # ============================================================================
@@ -356,7 +358,7 @@ fn get_op_intrinsic token:Token -> Op {
     if op_value_opt.is_none then
         token Token::location f"No OpValue for intrinsic `{token Token::value}`" ErrorKind::Syntax raise_error
     fi
-    token Token::location op_value_opt.unwrap make_op
+    token Token::location op_value_opt.unwrap Op::new
 }
 
 # ============================================================================
@@ -384,7 +386,7 @@ fn get_op_operator token:Token cursor:TokenCursor function_name:str -> Op {
                 cursor parse_type_ast Option::Some = type_hint
             fi
         fi
-        name_token Token::location var_name OpValue::AssignVar make_op = assign_op
+        name_token Token::location var_name OpValue::AssignVar Op::new = assign_op
         if type_hint Option::Some(hint) is then
             hint Option::Some assign_op->type_hint
         fi
@@ -395,13 +397,13 @@ fn get_op_operator token:Token cursor:TokenCursor function_name:str -> Op {
     # Compound assignment: += varname
     if OperatorKind::AssignInc operator_kind == then
         TokenKind::Identifier cursor expect_token_kind = inc_token
-        token Token::location inc_token Token::value OpValue::AssignInc make_op return
+        token Token::location inc_token Token::value OpValue::AssignInc Op::new return
     fi
 
     # Compound assignment: -= varname
     if OperatorKind::AssignDec operator_kind == then
         TokenKind::Identifier cursor expect_token_kind = dec_token
-        token Token::location dec_token Token::value OpValue::AssignDec make_op return
+        token Token::location dec_token Token::value OpValue::AssignDec Op::new return
     fi
 
     # Simple operator -> OpValue lookup
@@ -409,7 +411,7 @@ fn get_op_operator token:Token cursor:TokenCursor function_name:str -> Op {
     if op_value_opt.is_none then
         token Token::location f"No OpValue for operator `{token Token::value}`" ErrorKind::Syntax raise_error
     fi
-    token Token::location op_value_opt.unwrap make_op
+    token Token::location op_value_opt.unwrap Op::new
 }
 
 # ============================================================================
@@ -429,7 +431,7 @@ fn parse_array_struct_literal
     items:List[Op]
 {
     function_name cursor name_token parser parse_struct_literal = struct_ops
-    name_token Token::location struct_ops OpValue::ExprGroup make_op items.push
+    name_token Token::location struct_ops OpValue::ExprGroup Op::new items.push
 }
 
 fn parse_array_lambda
@@ -442,9 +444,9 @@ fn parse_array_lambda
     cursor.retreat
     f"lambda__{function_name}_o{brace_token Token::location Location::span Span::offset}" = arr_lam_name
     arr_lam_name cursor parser parse_block_ops = arr_lam_ops
-    brace_token Token::location arr_lam_ops arr_lam_name make_function = arr_lam_fn
+    brace_token Token::location arr_lam_ops arr_lam_name Function::new = arr_lam_fn
     arr_lam_fn arr_lam_name parser.store.functions.set drop
-    brace_token Token::location arr_lam_name OpValue::FnPush make_op items.push
+    brace_token Token::location arr_lam_name OpValue::FnPush Op::new items.push
 }
 
 fn get_op_array parser:Parser function_name:str cursor:TokenCursor -> Op {
@@ -474,17 +476,17 @@ fn get_op_array parser:Parser function_name:str cursor:TokenCursor -> Op {
                 if "{" struct_peek_opt.unwrap Token::value == then
                     items value_token cursor function_name parser parse_array_struct_literal
                 else
-                    value_token Token::location value_token Token::value OpValue::Identifier make_op items.push
+                    value_token Token::location value_token Token::value OpValue::Identifier Op::new items.push
                 fi
             else
-                value_token Token::location value_token Token::value OpValue::Identifier make_op items.push
+                value_token Token::location value_token Token::value OpValue::Identifier Op::new items.push
             fi
         else
             value_token Token::location "Unexpected token in array literal" ErrorKind::UnexpectedToken raise_error
         fi
         "," cursor expect_delimiter drop
     done
-    open_token Token::location items OpValue::PushArray make_op
+    open_token Token::location items OpValue::PushArray Op::new
 }
 
 # ============================================================================
@@ -549,27 +551,27 @@ fn handle_fstring
         if token_opt.is_none then break fi
         token_opt.unwrap = token
         if TokenKind::FstringText token Token::kind == then
-            token Token::location token Token::value OpValue::PushStr make_op ops.push
+            token Token::location token Token::value OpValue::PushStr Op::new ops.push
             1 += part_count
         elif TokenKind::FstringExprStart token Token::kind == then
             function_name cursor parser parse_fstring_expr = expr_ops
             f"lambda__{function_name}_o{token Token::location Location::span Span::offset}" = lambda_name
-            token Token::location expr_ops lambda_name make_function = lambda_function
+            token Token::location expr_ops lambda_name Function::new = lambda_function
             lambda_function lambda_name parser.store.functions.set drop
-            token Token::location lambda_name OpValue::FnPush make_op ops.push
-            token Token::location OpValue::FnExec make_op ops.push
-            token Token::location OpValue::FstringToStr make_op ops.push
+            token Token::location lambda_name OpValue::FnPush Op::new ops.push
+            token Token::location OpValue::FnExec Op::new ops.push
+            token Token::location OpValue::FstringToStr Op::new ops.push
             1 += part_count
         elif TokenKind::FstringEnd token Token::kind == then
             break
         fi
     done
     if 0 part_count == then
-        start_token Token::location "" OpValue::PushStr make_op ops.push
+        start_token Token::location "" OpValue::PushStr Op::new ops.push
         1 = part_count
     fi
     if 1 part_count > then
-        start_token Token::location part_count OpValue::FstringConcat make_op ops.push
+        start_token Token::location part_count OpValue::FstringConcat Op::new ops.push
     fi
 }
 
@@ -584,14 +586,14 @@ fn get_op_delimiter parser:Parser token:Token cursor:TokenCursor function_name:s
     if "->" value == then
         TokenKind::Identifier cursor expect_token_kind = member_token
         f"set_{member_token Token::value}" = god_setter_name
-        member_token Token::location god_setter_name OpValue::MethodCall make_op ops.push
+        member_token Token::location god_setter_name OpValue::MethodCall Op::new ops.push
         return
     fi
 
     # Dot . method
     if "." value == then
         TokenKind::Identifier cursor expect_token_kind = method_token
-        method_token Token::location method_token Token::value OpValue::MethodCall make_op ops.push
+        method_token Token::location method_token Token::value OpValue::MethodCall Op::new ops.push
         return
     fi
 
@@ -600,9 +602,9 @@ fn get_op_delimiter parser:Parser token:Token cursor:TokenCursor function_name:s
         cursor.retreat
         f"lambda__{function_name}_o{token Token::location Location::span Span::offset}" = lambda_name
         lambda_name cursor parser parse_block_ops = lambda_ops
-        token Token::location lambda_ops lambda_name make_function = lambda_function
+        token Token::location lambda_ops lambda_name Function::new = lambda_function
         lambda_function lambda_name parser.store.functions.set drop
-        token Token::location lambda_name OpValue::FnPush make_op ops.push
+        token Token::location lambda_name OpValue::FnPush Op::new ops.push
         return
     fi
 
@@ -677,9 +679,9 @@ fn try_parse_is_check token:Token cursor:TokenCursor -> Option[Op] {
     token Token::value 0 separator str::substring = enum_name
     token Token::value separator 2 + token Token::value.length separator - 2 - str::substring = variant_name
 
-    Option::None variant_name enum_name make_enum_variant = variant
+    Option::None variant_name enum_name EnumVariant::new = variant
     bindings variant EnumVariant::set_bindings
-    token Token::location variant OpValue::IsCheck make_op Option::Some
+    token Token::location variant OpValue::IsCheck Op::new Option::Some
 }
 
 # ============================================================================
@@ -836,10 +838,10 @@ fn parse_parameter_maybe_named cursor:TokenCursor token:Token -> Parameter {
     if { Token::value ":" == } next_opt.filter.is_some then
         cursor.advance # consume :
         cursor parse_type_ast = param_type
-        token Token::value param_type make_named_param return
+        token Token::value param_type Parameter::named return
     fi
     cursor.retreat
-    cursor parse_type make_param
+    cursor parse_type Parameter::new
 }
 
 fn parse_parameters cursor:TokenCursor -> List[Parameter] {
@@ -860,7 +862,7 @@ fn parse_parameters cursor:TokenCursor -> List[Parameter] {
         # Allow fn keyword as unnamed parameter type
         if "fn" token Token::value == then
             cursor.retreat
-            cursor parse_type make_param params.push
+            cursor parse_type Parameter::new params.push
             continue
         fi
 
@@ -908,7 +910,7 @@ fn parse_stack_effect cursor:TokenCursor -> StackEffect {
         cursor.advance # consume ->
         cursor parse_return_types = returns
     fi
-    returns params make_stack_effect
+    returns params StackEffect::new
 }
 
 # ============================================================================
@@ -1406,9 +1408,9 @@ fn parse_function parser:Parser cursor:TokenCursor -> Function {
         for hidden in hidden_methods.iter do
             hidden HiddenTraitMethod::var_name = hidden_name
             hidden HiddenTraitMethod::fn_type = hidden_type
-            hidden_name hidden_type make_named_param hidden_params.push
+            hidden_name hidden_type Parameter::named hidden_params.push
             hidden_type hidden_name Variable variables.push
-            name_token Token::location hidden_name OpValue::AssignVar make_op = hidden_assign
+            name_token Token::location hidden_name OpValue::AssignVar Op::new = hidden_assign
             hidden_type Option::Some hidden_assign Op::set_type_hint
             hidden_assign ops.push
         done
@@ -1424,7 +1426,7 @@ fn parse_function parser:Parser cursor:TokenCursor -> Function {
         if "" param Parameter::name != then
             if param Parameter::name "__trait_" str::starts_with ! then
                 param Parameter::typ param Parameter::name Variable variables.push
-                name_token Token::location param Parameter::name OpValue::AssignVar make_op ops.push
+                name_token Token::location param Parameter::name OpValue::AssignVar Op::new ops.push
             fi
         fi
     done
@@ -1434,7 +1436,7 @@ fn parse_function parser:Parser cursor:TokenCursor -> Function {
         body_op ops.push
     done
 
-    effect name_token Token::location ops name_token Token::value make_function_with_stack_effect = function
+    effect name_token Token::location ops name_token Token::value Function::with_stack_effect = function
     variables function Function::set_variables
     function
 }
@@ -1533,27 +1535,27 @@ fn synthesize_hashable_for_enum parser:Parser casa_enum:CasaEnum {
     f"{enum_name}::hash" = hash_name
     if hash_name parser.store.functions.get.is_none then
         List::new(List[Op]) = hash_ops
-        location TYPE_INT_T OpValue::TypeCast make_op hash_ops.push
+        location TYPE_INT_T OpValue::TypeCast Op::new hash_ops.push
         List::new(List[Parameter]) = hash_params
-        enum_name make_param hash_params.push
+        enum_name Parameter::new hash_params.push
         List::new(List[Type]) = hash_returns
         "int" parse_type_str hash_returns.push
-        hash_returns hash_params make_stack_effect = hash_stack_effect
-        hash_stack_effect location hash_ops hash_name make_function_with_stack_effect = hash_fn
+        hash_returns hash_params StackEffect::new = hash_stack_effect
+        hash_stack_effect location hash_ops hash_name Function::with_stack_effect = hash_fn
         hash_fn hash_name parser.store.functions.set drop
     fi
 
     f"{enum_name}::eq" = eq_name
     if eq_name parser.store.functions.get.is_none then
         List::new(List[Op]) = eq_ops
-        location OpValue::Eq make_op eq_ops.push
+        location OpValue::Eq Op::new eq_ops.push
         List::new(List[Parameter]) = eq_params
-        enum_name make_param eq_params.push
-        enum_name make_param eq_params.push
+        enum_name Parameter::new eq_params.push
+        enum_name Parameter::new eq_params.push
         List::new(List[Type]) = eq_returns
         "bool" parse_type_str eq_returns.push
-        eq_returns eq_params make_stack_effect = eq_stack_effect
-        eq_stack_effect location eq_ops eq_name make_function_with_stack_effect = eq_fn
+        eq_returns eq_params StackEffect::new = eq_stack_effect
+        eq_stack_effect location eq_ops eq_name Function::with_stack_effect = eq_fn
         eq_fn eq_name parser.store.functions.set drop
     fi
 }
@@ -1589,20 +1591,20 @@ fn create_member_accessor
     # Getter
     f"{struct_name}::{member_name}" = getter_name
     List::new(List[Op]) = getter_ops
-    location TYPE_PTR_T OpValue::TypeCast make_op getter_ops.push
-    location offset OpValue::PushInt make_op getter_ops.push
-    location OpValue::Add make_op getter_ops.push
-    location OpValue::Load64 make_op getter_ops.push
-    location member_type parse_type_str OpValue::TypeCast make_op getter_ops.push
+    location TYPE_PTR_T OpValue::TypeCast Op::new getter_ops.push
+    location offset OpValue::PushInt Op::new getter_ops.push
+    location OpValue::Add Op::new getter_ops.push
+    location OpValue::Load64 Op::new getter_ops.push
+    location member_type parse_type_str OpValue::TypeCast Op::new getter_ops.push
 
     List::new(List[Parameter]) = getter_params
-    param_type make_param getter_params.push
+    param_type Parameter::new getter_params.push
     List::new(List[Type]) = getter_returns
     member_type parse_type_str getter_returns.push
-    getter_returns getter_params make_stack_effect = getter_stack_effect
+    getter_returns getter_params StackEffect::new = getter_stack_effect
     effect_type_vars getter_stack_effect StackEffect::set_type_vars
     effect_type_vars getter_stack_effect canonicalize_stack_effect_type_vars
-    getter_stack_effect location getter_ops getter_name make_function_with_stack_effect = getter
+    getter_stack_effect location getter_ops getter_name Function::with_stack_effect = getter
 
     if getter_name parser.store.functions.get.is_some then
         location f"Function `{getter_name}` is already defined" ErrorKind::DuplicateName raise_error
@@ -1612,19 +1614,19 @@ fn create_member_accessor
     # Setter
     f"{struct_name}::set_{member_name}" = setter_name
     List::new(List[Op]) = setter_ops
-    location TYPE_PTR_T OpValue::TypeCast make_op setter_ops.push
-    location offset OpValue::PushInt make_op setter_ops.push
-    location OpValue::Add make_op setter_ops.push
-    location OpValue::Store64 make_op setter_ops.push
+    location TYPE_PTR_T OpValue::TypeCast Op::new setter_ops.push
+    location offset OpValue::PushInt Op::new setter_ops.push
+    location OpValue::Add Op::new setter_ops.push
+    location OpValue::Store64 Op::new setter_ops.push
 
     List::new(List[Parameter]) = setter_params
-    param_type make_param setter_params.push
-    member_type make_param setter_params.push
+    param_type Parameter::new setter_params.push
+    member_type Parameter::new setter_params.push
     List::new(List[Type]) = setter_returns
-    setter_returns setter_params make_stack_effect = setter_stack_effect
+    setter_returns setter_params StackEffect::new = setter_stack_effect
     effect_type_vars setter_stack_effect StackEffect::set_type_vars
     effect_type_vars setter_stack_effect canonicalize_stack_effect_type_vars
-    setter_stack_effect location setter_ops setter_name make_function_with_stack_effect = setter
+    setter_stack_effect location setter_ops setter_name Function::with_stack_effect = setter
 
     if setter_name parser.store.functions.get.is_some then
         location f"Function `{setter_name}` is already defined" ErrorKind::DuplicateName raise_error
@@ -1731,7 +1733,7 @@ fn parse_trait_method_stack_effect cursor:TokenCursor -> StackEffect {
         fi
     fi
 
-    returns params make_stack_effect
+    returns params StackEffect::new
 }
 # Parse a bracket-delimited identifier-only type-parameter list:
 # `[T1 T2 ...]`. `context` (e.g. "trait", "trait method") is interpolated
@@ -1888,9 +1890,9 @@ fn inject_impl_trait_params
     for hidden in hidden_methods.iter do
         hidden HiddenTraitMethod::var_name = hidden_name
         hidden HiddenTraitMethod::fn_type = hidden_type
-        hidden_name hidden_type make_named_param hidden_params.push
-        hidden_name make_variable function Function::variables.push
-        function Function::location hidden_name OpValue::AssignVar make_op = assign_op
+        hidden_name hidden_type Parameter::named hidden_params.push
+        hidden_name Variable::new function Function::variables.push
+        function Function::location hidden_name OpValue::AssignVar Op::new = assign_op
         hidden_type Option::Some assign_op Op::set_type_hint
         insert_pos assign_op function Function::ops.insert
         1 += insert_pos
@@ -2099,26 +2101,26 @@ fn parse_match_arm_pattern
 {
     if MATCH_WILDCARD arm_token Token::value == then
         function_name cursor parser parse_pattern_terminator = wildcard_guard_ops
-        Option::None MATCH_WILDCARD "" make_enum_variant = wildcard
-        wildcard_guard_ops wildcard PatternValue::EnumVariant make_match_arm = wildcard_arm
-        arm_token Token::location wildcard_arm OpValue::MatchArm make_op ops.push
+        Option::None MATCH_WILDCARD "" EnumVariant::new = wildcard
+        wildcard_guard_ops wildcard PatternValue::EnumVariant MatchArm::new = wildcard_arm
+        arm_token Token::location wildcard_arm OpValue::MatchArm Op::new ops.push
     elif TokenKind::Literal arm_token Token::kind == then
         function_name cursor parser parse_pattern_terminator = literal_guard_ops
         arm_token parse_literal_match_pattern = literal_pattern
-        literal_guard_ops literal_pattern PatternValue::Literal make_match_arm = literal_arm
-        arm_token Token::location literal_arm OpValue::MatchArm make_op ops.push
+        literal_guard_ops literal_pattern PatternValue::Literal MatchArm::new = literal_arm
+        arm_token Token::location literal_arm OpValue::MatchArm Op::new ops.push
     elif TokenKind::Identifier arm_token Token::kind != then
         arm_token Token::location "Expected match pattern or `_`" ErrorKind::UnexpectedToken raise_error
     elif { Token::value "{" == } cursor.peek.filter.is_some then
         cursor arm_token parser parse_struct_match_pattern = struct_pattern
         function_name cursor parser parse_pattern_terminator = struct_guard_ops
-        struct_guard_ops struct_pattern PatternValue::Struct make_match_arm = struct_arm
-        arm_token Token::location struct_arm OpValue::MatchArm make_op ops.push
+        struct_guard_ops struct_pattern PatternValue::Struct MatchArm::new = struct_arm
+        arm_token Token::location struct_arm OpValue::MatchArm Op::new ops.push
     elif arm_token Token::value "::" str::find 0 > then
         function_name cursor parser parse_pattern_terminator = bare_guard_ops
-        Option::None arm_token Token::value "" make_enum_variant = bare_variant
-        bare_guard_ops bare_variant PatternValue::EnumVariant make_match_arm = bare_arm
-        arm_token Token::location bare_arm OpValue::MatchArm make_op ops.push
+        Option::None arm_token Token::value "" EnumVariant::new = bare_variant
+        bare_guard_ops bare_variant PatternValue::EnumVariant MatchArm::new = bare_arm
+        arm_token Token::location bare_arm OpValue::MatchArm Op::new ops.push
     else
         arm_token Token::value "::" str::find = separator
         arm_token Token::value 0 separator str::substring = enum_name
@@ -2143,10 +2145,10 @@ fn parse_match_arm_pattern
         fi
 
         function_name cursor parser parse_pattern_terminator = enum_guard_ops
-        Option::None variant_name enum_name make_enum_variant = variant
+        Option::None variant_name enum_name EnumVariant::new = variant
         bindings variant EnumVariant::set_bindings
-        enum_guard_ops variant PatternValue::EnumVariant make_match_arm = variant_arm
-        arm_token Token::location variant_arm OpValue::MatchArm make_op ops.push
+        enum_guard_ops variant PatternValue::EnumVariant MatchArm::new = variant_arm
+        arm_token Token::location variant_arm OpValue::MatchArm Op::new ops.push
     fi
 }
 # Parse a match-arm body (either a `{...}` block or a single-line expression
@@ -2180,12 +2182,12 @@ fn parse_match_arm_body parser:Parser cursor:TokenCursor function_name:str ops:L
 
 fn parse_match_block parser:Parser token:Token cursor:TokenCursor function_name:str -> List[Op] {
     List::new(List[Op]) = ops
-    token Token::location OpValue::MatchStart make_op ops.push
+    token Token::location OpValue::MatchStart Op::new ops.push
 
     while true do
         cursor expect_token = arm_token
         if "end" arm_token Token::value == then
-            arm_token Token::location OpValue::MatchEnd make_op ops.push
+            arm_token Token::location OpValue::MatchEnd Op::new ops.push
             break
         fi
         ops function_name cursor arm_token parser parse_match_arm_pattern
@@ -2339,13 +2341,13 @@ fn handle_keyword_import parser:Parser cursor:TokenCursor -> Op {
         if { Token::value "{" == } next_opt.filter.is_some then
             path_location cursor parse_selective_import_symbols = symbols
             symbols resolved SelectiveImport = selective
-            path_location selective OpValue::ImportFileSelective make_op return
+            path_location selective OpValue::ImportFileSelective Op::new return
         fi
-        path_location resolved OpValue::ImportFile make_op return
+        path_location resolved OpValue::ImportFile Op::new return
     fi
     path_token Token::location "Expected string literal for import path" ErrorKind::UnexpectedToken raise_error
     # Unreachable - raise_error exits
-    path_token Token::location "" OpValue::ImportFile make_op
+    path_token Token::location "" OpValue::ImportFile Op::new
 }
 
 fn selective_import_type_dependencies
@@ -2534,7 +2536,7 @@ fn handle_selective_import parser:Parser selective:SelectiveImport location:Loca
         return
     fi
 
-    symbol_store_new make_parser = import_parser
+    symbol_store_new Parser::new = import_parser
     parser.search_paths import_parser->search_paths
     import_path import_parser.included_files.add drop
     import_path lex_file = import_tokens
@@ -2568,24 +2570,24 @@ fn handle_selective_import parser:Parser selective:SelectiveImport location:Loca
 fn handle_question_operator parser:Parser token:Token function_name:str ops:List[Op] {
     token Token::location = loc
 
-    loc OpValue::Dup make_op ops.push
-    loc OpValue::IfStart make_op ops.push
-    loc "is_ok" OpValue::MethodCall make_op ops.push
-    loc OpValue::Not make_op ops.push
-    loc OpValue::IfCondition make_op ops.push
+    loc OpValue::Dup Op::new ops.push
+    loc OpValue::IfStart Op::new ops.push
+    loc "is_ok" OpValue::MethodCall Op::new ops.push
+    loc OpValue::Not Op::new ops.push
+    loc OpValue::IfCondition Op::new ops.push
 
     function_name parser.store.functions.get = fn_opt
     if fn_opt.is_some then
         fn_opt.unwrap Function::stack_effect StackEffect::return_types = ret_types
         if 0 ret_types.length != then
             0 ret_types.get = ret_type
-            loc ret_type OpValue::TypeCast make_op ops.push
+            loc ret_type OpValue::TypeCast Op::new ops.push
         fi
     fi
 
-    loc OpValue::FnReturn make_op ops.push
-    loc OpValue::IfEnd make_op ops.push
-    loc "unwrap" OpValue::MethodCall make_op ops.push
+    loc OpValue::FnReturn Op::new ops.push
+    loc OpValue::IfEnd Op::new ops.push
+    loc "unwrap" OpValue::MethodCall Op::new ops.push
 }
 
 # ============================================================================
@@ -2656,17 +2658,17 @@ fn handle_keyword_for parser:Parser token:Token cursor:TokenCursor function_name
 
     # Loop preamble: store iterator into hidden local, then open the while
     # loop with the `next`/`is_some` condition.
-    for_loc hidden_iter_name OpValue::AssignVar make_op ops.push
-    for_loc OpValue::WhileStart make_op ops.push
-    for_loc hidden_iter_name OpValue::PushVar make_op ops.push
-    for_loc "next" OpValue::MethodCall make_op ops.push
-    for_loc hidden_opt_name OpValue::AssignVar make_op ops.push
-    for_loc hidden_opt_name OpValue::PushVar make_op ops.push
-    for_loc "is_some" OpValue::MethodCall make_op ops.push
-    for_loc OpValue::WhileCondition make_op ops.push
-    for_loc hidden_opt_name OpValue::PushVar make_op ops.push
-    for_loc "unwrap" OpValue::MethodCall make_op ops.push
-    for_loc loop_var_name OpValue::AssignVar make_op ops.push
+    for_loc hidden_iter_name OpValue::AssignVar Op::new ops.push
+    for_loc OpValue::WhileStart Op::new ops.push
+    for_loc hidden_iter_name OpValue::PushVar Op::new ops.push
+    for_loc "next" OpValue::MethodCall Op::new ops.push
+    for_loc hidden_opt_name OpValue::AssignVar Op::new ops.push
+    for_loc hidden_opt_name OpValue::PushVar Op::new ops.push
+    for_loc "is_some" OpValue::MethodCall Op::new ops.push
+    for_loc OpValue::WhileCondition Op::new ops.push
+    for_loc hidden_opt_name OpValue::PushVar Op::new ops.push
+    for_loc "unwrap" OpValue::MethodCall Op::new ops.push
+    for_loc loop_var_name OpValue::AssignVar Op::new ops.push
 
     # Body phase — emit ops until the matching `done`, then close the while.
     0 = body_nesting_depth
@@ -2679,7 +2681,7 @@ fn handle_keyword_for parser:Parser token:Token cursor:TokenCursor function_name
         body_peek_opt.unwrap = body_token
         if "done" body_token Token::value == 0 body_nesting_depth == && then
             cursor.pop drop
-            body_token Token::location OpValue::WhileEnd make_op ops.push
+            body_token Token::location OpValue::WhileEnd Op::new ops.push
             return
         fi
         if "while" body_token Token::value == then
@@ -2711,7 +2713,7 @@ fn get_op_keyword parser:Parser token:Token cursor:TokenCursor function_name:str
     # Simple keyword -> OpValue lookup
     keyword keyword_to_op_value = simple_opt
     if simple_opt.is_some then
-        token Token::location simple_opt.unwrap make_op ops.push
+        token Token::location simple_opt.unwrap Op::new ops.push
         return
     fi
 
@@ -2811,7 +2813,7 @@ fn get_op_keyword parser:Parser token:Token cursor:TokenCursor function_name:str
             fi
         done
         TokenKind::Identifier cursor expect_token_kind = name_token
-        token Token::location name_token Token::value OpValue::DeclareGlobal make_op ops.push
+        token Token::location name_token Token::value OpValue::DeclareGlobal Op::new ops.push
         return
     fi
 
@@ -2982,7 +2984,7 @@ fn parse_struct_literal
     done
 
     field_order name_token Token::value StructLiteral = literal
-    name_token Token::location literal OpValue::StructLiteral make_op all_ops.push
+    name_token Token::location literal OpValue::StructLiteral Op::new all_ops.push
     all_ops
 }
 
@@ -3051,7 +3053,7 @@ fn token_to_op parser:Parser token:Token cursor:TokenCursor function_name:str op
         fi
 
         # Plain identifier
-        token Token::location token Token::value OpValue::Identifier make_op ops.push
+        token Token::location token Token::value OpValue::Identifier Op::new ops.push
         return
     fi
 
@@ -3090,7 +3092,7 @@ fn parse_ops parser:Parser tokens:List[Token] -> List[Op] {
 }
 
 fn parse_and_resolve tokens:List[Token] search_paths:List[str] -> ParseResolveResult {
-    symbol_store_new make_parser = parser
+    symbol_store_new Parser::new = parser
     search_paths parser Parser::set_search_paths
     tokens parser parse_ops = ops
     ops parser resolve_identifiers_global = resolved_ops
@@ -3157,7 +3159,7 @@ fn resolve_array_identifiers
                 rai_name OpValue::FnPush rai_item Op::set_value
                 true rai_name store.functions.get.unwrap Function::set_is_used
             else
-                rai_item Op::location f"Identifier `{rai_name}` is not defined" ErrorKind::UndefinedName make_error errors.push
+                rai_item Op::location f"Identifier `{rai_name}` is not defined" ErrorKind::UndefinedName CasaError::new errors.push
             fi
         fi
     done
@@ -3174,12 +3176,12 @@ fn resolve_enum_variant
     if variant EnumVariant::enum_name.length 0 != variant EnumVariant::ordinal.is_none && then
         variant EnumVariant::enum_name store.enums.get = rev_enum_opt
         if rev_enum_opt.is_none then
-            op Op::location f"Enum `{variant EnumVariant::enum_name}` is not defined" ErrorKind::UndefinedName make_error errors.push
+            op Op::location f"Enum `{variant EnumVariant::enum_name}` is not defined" ErrorKind::UndefinedName CasaError::new errors.push
         else
             rev_enum_opt.unwrap = rev_enum
             variant EnumVariant::variant_name rev_enum CasaEnum::variants string_list_index = rev_ordinal
             if 0 rev_ordinal < then
-                op Op::location f"Variant `{variant EnumVariant::variant_name}` is not defined in enum `{variant EnumVariant::enum_name}`" ErrorKind::UndefinedName make_error errors.push
+                op Op::location f"Variant `{variant EnumVariant::variant_name}` is not defined in enum `{variant EnumVariant::enum_name}`" ErrorKind::UndefinedName CasaError::new errors.push
             else
                 rev_ordinal Option::Some variant EnumVariant::set_ordinal
             fi
@@ -3188,7 +3190,7 @@ fn resolve_enum_variant
     # Register bindings as variables
     if 0 variant EnumVariant::bindings.length != then
         for rev_var_name in variant EnumVariant::bindings.iter do
-            rev_var_name make_variable = rev_var
+            rev_var_name Variable::new = rev_var
             if GLOBAL_SCOPE_LABEL function Function::name == then
                 rev_var rev_var_name store.variables.set drop
             else
@@ -3241,7 +3243,7 @@ fn expand_imports parser:Parser ops:List[Op] -> List[Op] {
 
 fn resolve_identifiers_global parser:Parser ops:List[Op] -> List[Op] {
     ops parser expand_imports = expanded_ops
-    empty_location List::new(List[Op]) GLOBAL_SCOPE_LABEL make_function = dummy
+    empty_location List::new(List[Op]) GLOBAL_SCOPE_LABEL Function::new = dummy
     dummy expanded_ops parser.store resolve_identifiers
 }
 
@@ -3255,7 +3257,7 @@ fn resolve_identifiers store:SymbolStore ops:List[Op] function:Function -> List[
 
         if current_op.value OpValue::DeclareGlobal(global_name) is then
             if global_name store.variables.get.is_none then
-                current_op Op::location f"`{global_name}` is not a global variable" ErrorKind::UndefinedGlobal make_error resolve_errors.push
+                current_op Op::location f"`{global_name}` is not a global variable" ErrorKind::UndefinedGlobal CasaError::new resolve_errors.push
             fi
             global_name declared_globals.add = declared_globals
             continue
@@ -3263,24 +3265,24 @@ fn resolve_identifiers store:SymbolStore ops:List[Op] function:Function -> List[
 
         if current_op.value OpValue::AssignInc(inc_name) is then
             if inc_name store.constants.get.is_some then
-                current_op Op::location f"Cannot assign to constant `{inc_name}`" ErrorKind::Syntax make_error resolve_errors.push
+                current_op Op::location f"Cannot assign to constant `{inc_name}`" ErrorKind::Syntax CasaError::new resolve_errors.push
                 continue
             fi
         fi
 
         if current_op.value OpValue::AssignDec(dec_name) is then
             if dec_name store.constants.get.is_some then
-                current_op Op::location f"Cannot assign to constant `{dec_name}`" ErrorKind::Syntax make_error resolve_errors.push
+                current_op Op::location f"Cannot assign to constant `{dec_name}`" ErrorKind::Syntax CasaError::new resolve_errors.push
                 continue
             fi
         fi
 
         if current_op.value OpValue::AssignVar(var_name) is then
             if var_name store.constants.get.is_some then
-                current_op Op::location f"Cannot assign to constant `{var_name}`" ErrorKind::Syntax make_error resolve_errors.push
+                current_op Op::location f"Cannot assign to constant `{var_name}`" ErrorKind::Syntax CasaError::new resolve_errors.push
                 continue
             fi
-            var_name make_variable = variable
+            var_name Variable::new = variable
             if GLOBAL_SCOPE_LABEL function Function::name == then
                 variable var_name store.variables.set drop
                 continue
@@ -3355,7 +3357,7 @@ fn resolve_identifiers store:SymbolStore ops:List[Op] function:Function -> List[
 # wildcard arms need no resolution.
 
 fn register_struct_pattern_binding store:SymbolStore function:Function binding_name:str {
-    binding_name make_variable = match_struct_variant
+    binding_name Variable::new = match_struct_variant
     if GLOBAL_SCOPE_LABEL function Function::name == then
         match_struct_variant binding_name store.variables.set drop
     else
@@ -3400,7 +3402,7 @@ fn try_resolve_fn_ref
     if '&' 0 ident.at != then false return fi
     ident 1 ident.length 1 - str::substring = ref_name
     if 0 ref_name.length == then
-        op Op::location "Expected function name after `&`" ErrorKind::Syntax make_error resolve_errors.push
+        op Op::location "Expected function name after `&`" ErrorKind::Syntax CasaError::new resolve_errors.push
         true return
     fi
     if ref_name "::" str::find 0 <= then
@@ -3418,7 +3420,7 @@ fn try_resolve_fn_ref
         ref_name OpValue::FnPush op Op::set_value
         true ref_fn_opt.unwrap Function::set_is_used
     else
-        op Op::location f"Function `{ref_name}` is not defined" ErrorKind::UndefinedName make_error resolve_errors.push
+        op Op::location f"Function `{ref_name}` is not defined" ErrorKind::UndefinedName CasaError::new resolve_errors.push
     fi
     true
 }
@@ -3439,9 +3441,9 @@ fn try_resolve_enum_variant_ident
     ident separator 2 + ident.length separator - 2 - str::substring = binding_name
     binding_name enum_opt.unwrap CasaEnum::variants string_list_index = ordinal
     if 0 ordinal < then
-        op Op::location f"Variant `{binding_name}` is not defined in enum `{enum_name}`" ErrorKind::UndefinedName make_error resolve_errors.push
+        op Op::location f"Variant `{binding_name}` is not defined in enum `{enum_name}`" ErrorKind::UndefinedName CasaError::new resolve_errors.push
     else
-        ordinal Option::Some binding_name enum_name make_enum_variant = enum_variant
+        ordinal Option::Some binding_name enum_name EnumVariant::new = enum_variant
         enum_variant OpValue::PushEnumVariant op Op::set_value
     fi
     true
@@ -3456,7 +3458,7 @@ fn try_resolve_trait_method_call function:Function op:Op ident:str -> bool {
     ident ident "::" str::find 2 + ident.length ident "::" str::find - 2 - str::substring = trait_method
     f"__trait_{type_var}_{trait_method}" = hidden_var
     if hidden_var function Function::variables variable_list_contains ! then
-        hidden_var make_variable function Function::variables.push
+        hidden_var Variable::new function Function::variables.push
     fi
     hidden_var OpValue::TraitMethodCall op Op::set_value
     true
@@ -3526,5 +3528,5 @@ fn resolve_plain_identifier
         return
     fi
 
-    op Op::location f"Identifier `{ident}` is not defined" ErrorKind::UndefinedName make_error resolve_errors.push
+    op Op::location f"Identifier `{ident}` is not defined" ErrorKind::UndefinedName CasaError::new resolve_errors.push
 }

--- a/compiler/typechecker.casa
+++ b/compiler/typechecker.casa
@@ -347,14 +347,26 @@ fn unify_generic_params_t type_a:Type type_b:Type store:SymbolStore -> Option[Ty
     type_b.type_params = params_b_opt
     if params_a_opt.is_none then type_b Option::Some return fi
     if params_b_opt.is_none then type_a Option::Some return fi
-    params_a_opt.unwrap = params_a
-    params_b_opt.unwrap = params_b
+    if params_a_opt Option::Some(params_a) is then
+    else
+        empty_location "Expected option value while unwrapping params_a_opt" ErrorKind::Syntax raise_error
+        1 exit
+    fi
+    if params_b_opt Option::Some(params_b) is then
+    else
+        empty_location "Expected option value while unwrapping params_b_opt" ErrorKind::Syntax raise_error
+        1 exit
+    fi
     if params_a.length params_b.length != then Option::None(Option[Type]) return fi
     List::new(List[Type]) = unified
     for pair in params_b.iter params_a.iter.zip do
         store pair.second pair.first unify_type_t ? unified.push
     done
-    type_a.base.unwrap = base
+    if type_a.base Option::Some(base) is then
+    else
+        empty_location "Expected option value while unwrapping type_a.base" ErrorKind::Syntax raise_error
+        1 exit
+    fi
     unified base GenericType Type::Generic Option::Some
 }
 
@@ -366,19 +378,19 @@ fn unify_type_t type_a:Type type_b:Type store:SymbolStore -> Option[Type] {
     if type_b.has_unresolved_type_var then type_a Option::Some return fi
     type_a.base = base_a
     type_b.base = base_b
-    if base_a.is_some then
-        if base_b.is_some then
-            if base_a.unwrap base_b.unwrap == then
+    if base_a Option::Some(base_a_name) is then
+        if base_b Option::Some(base_b_name) is then
+            if base_a_name base_b_name == then
                 store type_b type_a unify_generic_params_t = generic_result
                 if generic_result.is_some then generic_result return fi
             fi
         fi
     fi
-    if base_a.is_some then
-        if base_a.unwrap type_b.format == then type_a Option::Some return fi
+    if base_a Option::Some(base_a_name2) is then
+        if base_a_name2 type_b.format == then type_a Option::Some return fi
     fi
-    if base_b.is_some then
-        if base_b.unwrap type_a.format == then type_b Option::Some return fi
+    if base_b Option::Some(base_b_name2) is then
+        if base_b_name2 type_a.format == then type_b Option::Some return fi
     fi
     Option::None(Option[Type])
 }
@@ -401,7 +413,12 @@ fn stacks_compatible stack_a:List[Type] stack_b:List[Type] store:SymbolStore -> 
             if unified.is_none then
                 List::new(List[Type]) return
             fi
-            unified.unwrap result.push
+            if unified Option::Some(unified_type) is then
+                unified_type result.push
+            else
+                empty_location "Expected unified stack type" ErrorKind::Syntax raise_error
+                1 exit
+            fi
         fi
         1 += index
     done
@@ -469,7 +486,11 @@ impl TypeChecker {
         if existing.is_none then
             actual type_var bindings.set return
         fi
-        existing.unwrap = bound
+        if existing Option::Some(bound) is then
+        else
+            empty_location "Expected option value while unwrapping existing" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         actual.is_unknown_placeholder = actual_unknown
         bound.is_unknown_placeholder = bound_unknown
         if
@@ -503,7 +524,11 @@ impl TypeChecker {
         if base_opt.is_none then false return fi
         expected Parameter::typ.type_params = expected_params_opt
         if expected_params_opt.is_none then false return fi
-        expected_params_opt.unwrap = expected_params
+        if expected_params_opt Option::Some(expected_params) is then
+        else
+            empty_location "Expected option value while unwrapping expected_params_opt" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         # Check if any param is a type variable
         false = has_type_var
         for expected_param in expected_params.iter do
@@ -515,7 +540,11 @@ impl TypeChecker {
         done
         if has_type_var ! then false return fi
 
-        base_opt.unwrap = base
+        if base_opt Option::Some(base) is then
+        else
+            empty_location "Expected option value while unwrapping base_opt" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         tc.stack_pop_type match
             Type::Generic(actual_g) => {
                 if 0 actual_g.params.length == then
@@ -792,7 +821,11 @@ impl TypeChecker {
         # Enums: tag comparison via bytecode; data-carrying variants need annotation.
         if is_enum1 is_enum2 || then
             if is_enum1 then
-                base1 tc.store.enums.get.unwrap = casa_enum
+                if base1 tc.store.enums.get Option::Some(casa_enum) is then
+                else
+                    empty_location "Expected option value while unwrapping base1 tc.store.enums.get" ErrorKind::Syntax raise_error
+                    1 exit
+                fi
                 if casa_enum has_inner_values then
                     base1 GenericType::new Type::Generic Option::Some op Op::set_type_hint
                 fi
@@ -924,9 +957,11 @@ fn bound_implies_word bound:TraitBound store:SymbolStore -> bool {
     if "Word" bound_name == then true return fi
     bound_name store.traits.get = bound_trait_opt
     if bound_trait_opt.is_none then false return fi
-    for super_bound in bound_trait_opt.unwrap CasaTrait::supertraits.iter do
-        if store super_bound bound_implies_word then true return fi
-    done
+    if bound_trait_opt Option::Some(bound_trait) is then
+        for super_bound in bound_trait CasaTrait::supertraits.iter do
+            if store super_bound bound_implies_word then true return fi
+        done
+    fi
     false
 }
 # Validate that `type_name` satisfies the `Word` marker trait at the given op
@@ -940,11 +975,17 @@ impl TypeChecker {
     fn assert_word_bound tc:TypeChecker op:Op type_name:str function_opt:Option[Function] {
         if type_name TYPE_UNKNOWN == then return fi
         if function_opt.is_none then return fi
-        function_opt.unwrap Function::stack_effect = word_stack_effect
+        if function_opt Option::Some(function) is then
+            function Function::stack_effect = word_stack_effect
+        else
+            return
+        fi
         if type_name word_stack_effect StackEffect::type_vars.has ! then return fi
         type_name word_stack_effect StackEffect::trait_bounds.get = word_bound_opt
         if word_bound_opt.is_none then return fi
-        if tc.store word_bound_opt.unwrap bound_implies_word then return fi
+        if word_bound_opt Option::Some(word_bound) is then
+            if tc.store word_bound bound_implies_word then return fi
+        fi
         op Op::location f"Type variable `{type_name}` does not satisfy `Word` bound; add `[{type_name}: Word]` (or a trait that extends `Word`) to the function's type parameters" ErrorKind::TypeMismatch raise_error
     }
 }
@@ -998,8 +1039,8 @@ fn unify_variable_assignment
     store effective_type variable Variable::typ unify_type_t = unified
     if unified.is_none then
         op Op::location f"Cannot override {scope} variable `{var_name}` of type `{variable Variable::typ.format}` with other type `{effective_type.format}`" ErrorKind::InvalidVariable add_error
-    else
-        unified.unwrap variable Variable::set_typ
+    elif unified Option::Some(unified_type) is then
+        unified_type variable Variable::set_typ
     fi
 }
 
@@ -1017,7 +1058,11 @@ impl TypeChecker {
         op Op::type_hint.is_some = has_annotation
         stack_type_t = effective_type_t
         if has_annotation then
-            op Op::type_hint.unwrap = effective_type_t
+            if op Op::type_hint Option::Some(effective_type_t) is then
+            else
+                empty_location "Expected option value while unwrapping op Op::type_hint" ErrorKind::Syntax raise_error
+                1 exit
+            fi
         fi
         if has_annotation ! stack_type_t.has_unresolved && then
             op Op::location f"Cannot infer element type of empty array literal assigned to `{var_name}`; add a type annotation (e.g. `= {var_name}:array[int]`) or an explicit cast (e.g. `[] (array[int])`)." ErrorKind::TypeMismatch raise_error
@@ -1025,7 +1070,11 @@ impl TypeChecker {
 
         # Try local variables first
         if function_opt.is_some then
-            function_opt.unwrap = function
+            if function_opt Option::Some(function) is then
+            else
+                empty_location "Expected option value while unwrapping function_opt" ErrorKind::Syntax raise_error
+                1 exit
+            fi
             var_name function Function::variables variable_list_index = local_index
             if 0 local_index >= then
                 local_index function Function::variables.get = local_var
@@ -1038,7 +1087,11 @@ impl TypeChecker {
         # Try global variables
         var_name tc.store.variables.get = global_opt
         if global_opt.is_some then
-            global_opt.unwrap = global_var
+            if global_opt Option::Some(global_var) is then
+            else
+                empty_location "Expected option value while unwrapping global_opt" ErrorKind::Syntax raise_error
+                1 exit
+            fi
             tc.store "global" effective_type_t global_var op unify_variable_assignment
             effective_type_t tc.expect_type_t
             return
@@ -1065,9 +1118,17 @@ impl TypeChecker {
         trait_suffix trait_sep 1 + trait_suffix.length trait_sep - 1 - str::substring = trait_method_name
         trait_type_var function Function::stack_effect StackEffect::trait_bounds.get = trait_bound_opt
         if trait_bound_opt.is_none then return fi
-        trait_bound_opt.unwrap TraitBound::name tc.store.traits.get = trait_def_opt
+        if trait_bound_opt Option::Some(trait_bound) is then
+            trait_bound TraitBound::name tc.store.traits.get = trait_def_opt
+        else
+            return
+        fi
         if trait_def_opt.is_none then return fi
-        trait_def_opt.unwrap = trait_def
+        if trait_def_opt Option::Some(trait_def) is then
+        else
+            empty_location "Expected option value while unwrapping trait_def_opt" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         for trait_method_entry in trait_def tc.store collect_trait_methods.iter do
             if trait_method_name trait_method_entry TraitMethod::name == then
                 tc.stack_pop_drop
@@ -1083,7 +1144,11 @@ impl TypeChecker {
     fn check_push_var tc:TypeChecker op:Op function_opt:Option[Function] {
         if op.value OpValue::PushCapture(capture_name) is then
             if function_opt.is_some then
-                function_opt.unwrap = function
+                if function_opt Option::Some(function) is then
+                else
+                    empty_location "Expected option value while unwrapping function_opt" ErrorKind::Syntax raise_error
+                    1 exit
+                fi
                 capture_name function Function::captures variable_list_index = capture_index
                 if 0 capture_index >= then
                     if capture_index function Function::captures.get Variable::typ.is_unknown ! then
@@ -1118,7 +1183,11 @@ impl TypeChecker {
 
         # Check local variables first
         if function_opt.is_some then
-            function_opt.unwrap = function
+            if function_opt Option::Some(function) is then
+            else
+                empty_location "Expected option value while unwrapping function_opt" ErrorKind::Syntax raise_error
+                1 exit
+            fi
             var_name function Function::variables variable_list_index = local_index
             if 0 local_index >= then
                 if local_index function Function::variables.get Variable::typ.is_unknown ! then
@@ -1132,9 +1201,9 @@ impl TypeChecker {
 
         # Check global variables
         var_name tc.store.variables.get = global_opt
-        if global_opt.is_some then
-            if global_opt.unwrap Variable::typ.is_unknown ! then
-                global_opt.unwrap Variable::typ tc.stack_push_type
+        if global_opt Option::Some(global_var) is then
+            if global_var Variable::typ.is_unknown ! then
+                global_var Variable::typ tc.stack_push_type
             else
                 TYPE_UNKNOWN_T tc.stack_push_type
             fi
@@ -1303,16 +1372,27 @@ fn type_satisfies_trait
     # Accept both bare ("Iterable") and concrete generic ("Iterable[int]") trait names.
     trait_name parse_type_str = trait_type
     trait_type.base = trait_base_opt
-    trait_name trait_base_opt.unwrap_or = trait_lookup_name
+    trait_name = trait_lookup_name
+    if trait_base_opt Option::Some(trait_base) is then
+        trait_base = trait_lookup_name
+    fi
     trait_lookup_name store.traits.get = trait_opt
     if trait_opt.is_none then false return fi
-    trait_opt.unwrap = trait_def
+    if trait_opt Option::Some(trait_def) is then
+    else
+        empty_location "Expected option value while unwrapping trait_opt" ErrorKind::Syntax raise_error
+        1 exit
+    fi
     # Build substitution map from trait's type_params to concrete args from trait_name.
     Map::new(Map[str Type]) = trait_subs
     if trait_base_opt.is_some then
         trait_type.type_params = trait_args_opt
         if trait_args_opt.is_some then
-            trait_args_opt.unwrap = trait_args
+            if trait_args_opt Option::Some(trait_args) is then
+            else
+                empty_location "Expected option value while unwrapping trait_args_opt" ErrorKind::Syntax raise_error
+                1 exit
+            fi
             trait_def CasaTrait::type_params = tparams
             if trait_args.length tparams.length == then
                 for sub_pair in trait_args.iter tparams.iter.zip do
@@ -1322,11 +1402,11 @@ fn type_satisfies_trait
         fi
     fi
     # Type variable with matching bound satisfies the trait
-    if function_opt.is_some then
-        function_opt.unwrap Function::stack_effect StackEffect::trait_bounds = bounds
+    if function_opt Option::Some(function) is then
+        function Function::stack_effect StackEffect::trait_bounds = bounds
         type_name_str bounds.get = bound_opt
-        if bound_opt.is_some then
-            if trait_name bound_opt.unwrap trait_bound_to_str == then true return fi
+        if bound_opt Option::Some(bound) is then
+            if trait_name bound trait_bound_to_str == then true return fi
         fi
     fi
     for method in trait_def store collect_trait_methods.iter do
@@ -1336,8 +1416,8 @@ fn type_satisfies_trait
         # Fall back to the generic base type (e.g. `Option::to_str` for `Option[int]`)
         if fn_opt.is_none then
             type_name.base = base_opt
-            if base_opt.is_some then
-                f"{base_opt.unwrap}::{method TraitMethod::name}" = fn_name
+            if base_opt Option::Some(base) is then
+                f"{base}::{method TraitMethod::name}" = fn_name
                 fn_name store.functions.get = fn_opt
                 true = via_generic_base
             fi
@@ -1349,7 +1429,11 @@ fn type_satisfies_trait
             fi
             false return
         fi
-        fn_opt.unwrap = function
+        if fn_opt Option::Some(function) is then
+        else
+            empty_location "Expected option value while unwrapping fn_opt" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         store function ensure_typechecked
         if "None -> None" function Function::stack_effect stack_effect_to_str == then false return fi
         # When satisfying via the generic base, skip strict stack-effect comparison:
@@ -1480,15 +1564,19 @@ fn method_diff_bind_for_bound
 -> Map[str Type] {
     bound TraitBound::name store.traits.get = trait_opt
     if trait_opt.is_none then bindings return fi
-    trait_opt.unwrap = trait_def
+    if trait_opt Option::Some(trait_def) is then
+    else
+        empty_location "Expected option value while unwrapping trait_opt" ErrorKind::Syntax raise_error
+        1 exit
+    fi
     trait_def CasaTrait::type_params = trait_params
     bound TraitBound::type_args = bound_args
     if bound_args.length trait_params.length != then bindings return fi
     for trait_method in trait_def CasaTrait::methods.iter do
         f"{concrete}::{trait_method TraitMethod::name}" store.functions.get = concrete_fn_opt
-        if concrete_fn_opt.is_some then
+        if concrete_fn_opt Option::Some(concrete_fn) is then
             concrete trait_method TraitMethod::stack_effect resolve_trait_stack_effect = trait_resolved
-            concrete_fn_opt.unwrap Function::stack_effect trait_resolved bound_args trait_params effect bindings diff_method_stack_effect = bindings
+            concrete_fn Function::stack_effect trait_resolved bound_args trait_params effect bindings diff_method_stack_effect = bindings
         fi
     done
     bindings
@@ -1502,10 +1590,14 @@ fn method_diff_bind_all
 -> Map[str Type] {
     effect StackEffect::trait_bounds.keys = bound_keys
     for bound_type_var in bound_keys.iter do
-        bound_type_var effect StackEffect::trait_bounds.get.unwrap = bound_constraint
+        if bound_type_var effect StackEffect::trait_bounds.get Option::Some(bound_constraint) is then
+        else
+            empty_location "Expected option value while unwrapping bound_type_var effect StackEffect::trait_bounds.get" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         bound_type_var bindings.get = concrete_opt
-        if concrete_opt.is_some then
-            store concrete_opt.unwrap.format bound_constraint effect bindings method_diff_bind_for_bound = bindings
+        if concrete_opt Option::Some(concrete) is then
+            store concrete.format bound_constraint effect bindings method_diff_bind_for_bound = bindings
         fi
     done
     bindings
@@ -1545,7 +1637,11 @@ impl TypeChecker {
                         if existing_binding_opt.is_none then
                             actual binding_type_var bindings.set = bindings
                         else
-                            existing_binding_opt.unwrap = existing_binding
+                            if existing_binding_opt Option::Some(existing_binding) is then
+                            else
+                                empty_location "Expected option value while unwrapping existing_binding_opt" ErrorKind::Syntax raise_error
+                                1 exit
+                            fi
                             if existing_binding actual.eq ! then
                                 location f"Type variable `{binding_type_var}` bound to `{existing_binding.format}` but got `{actual.format}`" ErrorKind::TypeMismatch raise_error
                             fi
@@ -1587,7 +1683,11 @@ impl TypeChecker {
         type_var_keys.length 1 - = type_index
         while 0 type_index >= do
             type_index type_var_keys.get = type_var
-            type_var effect StackEffect::trait_bounds.get.unwrap = trait_bound
+            if type_var effect StackEffect::trait_bounds.get Option::Some(trait_bound) is then
+            else
+                empty_location "Expected option value while unwrapping type_var effect StackEffect::trait_bounds.get" ErrorKind::Syntax raise_error
+                1 exit
+            fi
             # Resolve trait type args against current bindings so that
             # `Carrier[T]` becomes `Carrier[int]` once T has been bound.
             trait_bound trait_bound_to_type = trait_bound_type
@@ -1598,16 +1698,28 @@ impl TypeChecker {
                 type_index 1 - = type_index
                 continue
             fi
-            concrete_opt.unwrap = concrete_t
+            if concrete_opt Option::Some(concrete_t) is then
+            else
+                empty_location "Expected option value while unwrapping concrete_opt" ErrorKind::Syntax raise_error
+                1 exit
+            fi
             concrete_t.format = concrete
-            trait_bound TraitBound::name tc.store.traits.get.unwrap = trait_def
+            if trait_bound TraitBound::name tc.store.traits.get Option::Some(trait_def) is then
+            else
+                empty_location "Expected option value while unwrapping trait_bound TraitBound::name tc.store.traits.get" ErrorKind::Syntax raise_error
+                1 exit
+            fi
 
             # Check if forwarding (type var has same trait bound in calling function)
             false = is_forwarding
-            if function_opt.is_some then
-                concrete function_opt.unwrap Function::stack_effect StackEffect::trait_bounds.get = caller_bound_opt
+            if function_opt Option::Some(function) is then
+                concrete function Function::stack_effect StackEffect::trait_bounds.get = caller_bound_opt
                 if caller_bound_opt.is_some then
-                    caller_bound_opt.unwrap = caller_bound_val
+                    if caller_bound_opt Option::Some(caller_bound_val) is then
+                    else
+                        empty_location "Expected option value while unwrapping caller_bound_opt" ErrorKind::Syntax raise_error
+                        1 exit
+                    fi
                     if trait_bound caller_bound_val trait_bound_eq then
                         true = is_forwarding
                     fi
@@ -1645,7 +1757,11 @@ impl TypeChecker {
                         f"{concrete}::{method TraitMethod::name}" = fn_name
                         fn_name tc.store.functions.get = global_fn_opt
                         if global_fn_opt.is_some then
-                            global_fn_opt.unwrap = global_fn
+                            if global_fn_opt Option::Some(global_fn) is then
+                            else
+                                empty_location "Expected option value while unwrapping global_fn_opt" ErrorKind::Syntax raise_error
+                                1 exit
+                            fi
                             if global_fn Function::is_used ! then
                                 true global_fn Function::set_is_used
                                 global_fn global_fn Function::ops tc.store resolve_identifiers global_fn Function::set_ops
@@ -1685,7 +1801,11 @@ impl TypeChecker {
         if fn_value OpValue::FnCall(fn_name) is then
             fn_name tc.store.functions.get = fn_opt
             if fn_opt.is_some then
-                fn_opt.unwrap = function
+                if fn_opt Option::Some(function) is then
+                else
+                    empty_location "Expected option value while unwrapping fn_opt" ErrorKind::Syntax raise_error
+                    1 exit
+                fi
                 tc.store function ensure_typechecked
                 function Function::stack_effect = effect
                 if 0 effect StackEffect::trait_bounds.keys.length != then
@@ -1709,7 +1829,11 @@ impl TypeChecker {
         elif fn_value OpValue::FnPush(push_name) is then
             push_name tc.store.functions.get = push_fn_opt
             if push_fn_opt.is_some then
-                push_fn_opt.unwrap = push_fn
+                if push_fn_opt Option::Some(push_fn) is then
+                else
+                    empty_location "Expected option value while unwrapping push_fn_opt" ErrorKind::Syntax raise_error
+                    1 exit
+                fi
                 tc.store push_fn ensure_typechecked
                 push_fn Function::stack_effect stack_effect_to_function_type tc.stack_push_type
             else
@@ -1765,7 +1889,11 @@ impl TypeChecker {
                     if unified_opt.is_none then
                         op Op::location f"Heterogeneous array literal: cannot unify `{elem_type_t.format}` and `{item_type_t.format}`" ErrorKind::TypeMismatch raise_error
                     else
-                        unified_opt.unwrap = elem_type_t
+                        if unified_opt Option::Some(elem_type_t) is then
+                        else
+                            empty_location "Expected option value while unwrapping unified_opt" ErrorKind::Syntax raise_error
+                            1 exit
+                        fi
                     fi
                     1 += items_idx
                 done
@@ -1872,7 +2000,11 @@ impl TypeChecker {
             _ => Option::None(Option[int])
         end = arg_count_opt
         if arg_count_opt.is_none then return fi
-        arg_count_opt.unwrap = arg_count
+        if arg_count_opt Option::Some(arg_count) is then
+        else
+            empty_location "Expected option value while unwrapping arg_count_opt" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         TYPE_INT_T tc.expect_type_t
         0 = index
         while index arg_count > do
@@ -1897,21 +2029,29 @@ impl TypeChecker {
             enum_name GenericType::new Type::Generic tc.stack_push_type
             return
         fi
-        enum_opt.unwrap = casa_enum
+        if enum_opt Option::Some(casa_enum) is then
+        else
+            empty_location "Expected option value while unwrapping enum_opt" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         variant EnumVariant::variant_name casa_enum CasaEnum::variant_types.get = inner_opt
         if inner_opt.is_none then
             # No inner values - push the enum type
             if 0 casa_enum CasaEnum::type_vars.length != then
-                casa_enum CasaEnum::type_vars enum_name build_parameterized_type_t tc.stack_push_type
+                casa_enum CasaEnum::type_vars enum_name build_parameterized_type tc.stack_push_type
             else
                 enum_name GenericType::new Type::Generic tc.stack_push_type
             fi
             return
         fi
-        inner_opt.unwrap = inner_types
+        if inner_opt Option::Some(inner_types) is then
+        else
+            empty_location "Expected option value while unwrapping inner_opt" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         if 0 inner_types.length == then
             if 0 casa_enum CasaEnum::type_vars.length != then
-                casa_enum CasaEnum::type_vars enum_name build_parameterized_type_t tc.stack_push_type
+                casa_enum CasaEnum::type_vars enum_name build_parameterized_type tc.stack_push_type
             else
                 enum_name GenericType::new Type::Generic tc.stack_push_type
             fi
@@ -1936,7 +2076,7 @@ impl TypeChecker {
                 fi
             done
             # Build resolved type name
-            bindings casa_enum CasaEnum::type_vars enum_name build_resolved_type_t tc.stack_push_type
+            bindings casa_enum CasaEnum::type_vars enum_name build_resolved_type tc.stack_push_type
         else
             # Non-generic variant: pop inner values directly
             for inner_type in inner_types.iter do
@@ -1960,7 +2100,11 @@ impl TypeChecker {
             TYPE_BOOL_T tc.stack_push_type
             return
         fi
-        base tc.store.enums.get.unwrap = casa_enum
+        if base tc.store.enums.get Option::Some(casa_enum) is then
+        else
+            empty_location "Expected option value while unwrapping base tc.store.enums.get" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         if op.value OpValue::IsCheck(variant) is ! then
             TYPE_BOOL_T tc.stack_push_type
             return
@@ -1975,7 +2119,11 @@ impl TypeChecker {
         if 0 variant EnumVariant::bindings.length != then
             variant EnumVariant::variant_name casa_enum CasaEnum::variant_types.get = inner_opt
             if inner_opt.is_some then
-                inner_opt.unwrap = inner_types
+                if inner_opt Option::Some(inner_types) is then
+                else
+                    empty_location "Expected option value while unwrapping inner_opt" ErrorKind::Syntax raise_error
+                    1 exit
+                fi
                 if variant EnumVariant::bindings.length inner_types.length != then
                     f"Variant `{variant EnumVariant::enum_name}::{variant EnumVariant::variant_name}` has {inner_types.length} inner value(s), but {variant EnumVariant::bindings.length} binding(s) provided" tc.raise_type_mismatch
                 fi
@@ -1992,7 +2140,11 @@ impl TypeChecker {
 
 fn set_binding_type var_name:str field_type:Type function_opt:Option[Function] store:SymbolStore {
     if function_opt.is_some then
-        function_opt.unwrap = function
+        if function_opt Option::Some(function) is then
+        else
+            empty_location "Expected option value while unwrapping function_opt" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         for variable in function Function::variables.iter do
             if var_name variable Variable::name == then
                 field_type variable Variable::set_typ
@@ -2001,8 +2153,8 @@ fn set_binding_type var_name:str field_type:Type function_opt:Option[Function] s
         done
     fi
     var_name store.variables.get = global_opt
-    if global_opt.is_some then
-        field_type global_opt.unwrap Variable::set_typ
+    if global_opt Option::Some(global_var) is then
+        field_type global_var Variable::set_typ
     fi
 }
 
@@ -2012,8 +2164,8 @@ impl TypeChecker {
         if match_value OpValue::MatchStart is then
             if 0 tc.stack.types.length == then
                 tc.within_param_cap = inferring_stack_effect
-                if function_opt.is_some then
-                    if function_opt.unwrap Function::name "lambda__" str::starts_with ! then
+                if function_opt Option::Some(function) is then
+                    if function Function::name "lambda__" str::starts_with ! then
                         false = inferring_stack_effect
                     fi
                 else
@@ -2077,7 +2229,11 @@ impl TypeChecker {
 
                 # Check exhaustiveness
                 if end_base tc.store.enums.get.is_some has_wildcard ! && then
-                    end_base tc.store.enums.get.unwrap = end_enum
+                    if end_base tc.store.enums.get Option::Some(end_enum) is then
+                    else
+                        empty_location "Expected option value while unwrapping end_base tc.store.enums.get" ErrorKind::Syntax raise_error
+                        1 exit
+                    fi
                     List::new(List[str]) = missing
                     for variant_name in end_enum CasaEnum::variants.iter do
                         if variant_name covered_set.has ! then
@@ -2153,22 +2309,27 @@ impl TypeChecker {
         if op.value OpValue::StructNew(casa_struct) is ! then return fi
         casa_struct CasaStruct::name = name
         # Build type variable bindings from actual stack values
-        Map::new(Map[str str]) = bindings
+        Map::new(Map[str Type]) = bindings
         for member in casa_struct CasaStruct::members.iter do
-            tc.stack_pop = actual
-            member Member::typ.format = expected
+            tc.stack_pop_type = actual
+            member Member::typ = expected
             # If expected is a type variable, bind it to the actual type
-            for type_var in casa_struct CasaStruct::type_vars.iter do
-                if expected type_var == then
-                    actual expected bindings.set = bindings
-                fi
-            done
+            expected match
+                Type::TypeVar(expected_var) => {
+                    for type_var in casa_struct CasaStruct::type_vars.iter do
+                        if expected_var type_var == then
+                            actual expected_var bindings.set = bindings
+                        fi
+                    done
+                }
+                _ => { }
+            end
         done
         # Construct the result type
         if 0 casa_struct CasaStruct::type_vars.length == then
             name GenericType::new Type::Generic tc.stack_push_type
         else
-            bindings casa_struct CasaStruct::type_vars name build_resolved_type tc.stack_push
+            bindings casa_struct CasaStruct::type_vars name build_resolved_type tc.stack_push_type
         fi
     }
 }
@@ -2186,7 +2347,11 @@ impl TypeChecker {
             name GenericType::new Type::Generic tc.stack_push_type
             return
         fi
-        struct_opt.unwrap = casa_struct
+        if struct_opt Option::Some(casa_struct) is then
+        else
+            empty_location "Expected option value while unwrapping struct_opt" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         # Pop field values in reverse order
         literal StructLiteral::field_order.length 1 - = index
         while 0 index >= do
@@ -2211,7 +2376,11 @@ impl TypeChecker {
 fn find_default_trait_method method_name:str store:SymbolStore -> Option[TraitMethod] {
     store.traits.keys = find_trait_keys
     for find_trait_key in find_trait_keys.iter do
-        find_trait_key store.traits.get.unwrap = find_trait_def
+        if find_trait_key store.traits.get Option::Some(find_trait_def) is then
+        else
+            empty_location "Expected option value while unwrapping find_trait_key store.traits.get" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         for find_method in find_trait_def CasaTrait::methods.iter do
             if method_name find_method TraitMethod::name == 0 find_method TraitMethod::default_ops.length != && then
                 find_method Option::Some return
@@ -2224,7 +2393,11 @@ fn find_default_trait_method method_name:str store:SymbolStore -> Option[TraitMe
 fn find_trait_for_method method_name:str store:SymbolStore -> Option[CasaTrait] {
     store.traits.keys = ftm_trait_keys
     for ftm_trait_key in ftm_trait_keys.iter do
-        ftm_trait_key store.traits.get.unwrap = ftm_trait_def
+        if ftm_trait_key store.traits.get Option::Some(ftm_trait_def) is then
+        else
+            empty_location "Expected option value while unwrapping ftm_trait_key store.traits.get" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         for ftm_method in ftm_trait_def CasaTrait::methods.iter do
             if method_name ftm_method TraitMethod::name == 0 ftm_method TraitMethod::default_ops.length != && then
                 ftm_trait_def Option::Some return
@@ -2240,8 +2413,8 @@ fn check_abstract_methods_present receiver:str trait_def:CasaTrait store:SymbolS
             f"{receiver}::{cam_method TraitMethod::name}" store.functions.get = cam_fn_opt
             if cam_fn_opt.is_none then
                 receiver parse_type_str.base = cam_base_opt
-                if cam_base_opt.is_some then
-                    f"{cam_base_opt.unwrap}::{cam_method TraitMethod::name}" store.functions.get = cam_fn_opt
+                if cam_base_opt Option::Some(cam_base) is then
+                    f"{cam_base}::{cam_method TraitMethod::name}" store.functions.get = cam_fn_opt
                 fi
             fi
             if cam_fn_opt.is_none then
@@ -2266,10 +2439,10 @@ fn instantiate_default_trait_method
     fi
     # Also check generic base
     receiver parse_type_str.base = already_base_opt
-    if already_base_opt.is_some then
-        f"{already_base_opt.unwrap}::{method_name}" store.functions.get = already_base_fn_opt
+    if already_base_opt Option::Some(already_base) is then
+        f"{already_base}::{method_name}" store.functions.get = already_base_fn_opt
         if already_base_fn_opt.is_some then
-            f"{already_base_opt.unwrap}::{method_name}" Option::Some return
+            f"{already_base}::{method_name}" Option::Some return
         fi
     fi
     if DEFAULT_METHOD_INSTANTIATING then Option::None(Option[str]) return fi
@@ -2281,14 +2454,22 @@ fn instantiate_default_trait_method
         false = DEFAULT_METHOD_INSTANTIATING
         Option::None(Option[str]) return
     fi
-    default_method_opt.unwrap = default_method
+    if default_method_opt Option::Some(default_method) is then
+    else
+        empty_location "Expected option value while unwrapping default_method_opt" ErrorKind::Syntax raise_error
+        1 exit
+    fi
 
     store method_name find_trait_for_method = trait_opt
     if trait_opt.is_none then
         false = DEFAULT_METHOD_INSTANTIATING
         Option::None(Option[str]) return
     fi
-    trait_opt.unwrap = trait_def
+    if trait_opt Option::Some(trait_def) is then
+    else
+        empty_location "Expected option value while unwrapping trait_opt" ErrorKind::Syntax raise_error
+        1 exit
+    fi
 
     # Check that receiver implements all abstract methods
     if store trait_def receiver check_abstract_methods_present ! then
@@ -2300,7 +2481,10 @@ fn instantiate_default_trait_method
 
     # Determine function name and whether to use generic or concrete form
     receiver parse_type_str.base = fn_base_opt
-    receiver fn_base_opt.unwrap_or = fn_type_name
+    receiver = fn_type_name
+    if fn_base_opt Option::Some(fn_base) is then
+        fn_base = fn_type_name
+    fi
     f"{fn_type_name}::{method_name}" = synth_fn_name
 
     # For generic receivers, keep trait type params as function type vars.
@@ -2308,7 +2492,11 @@ fn instantiate_default_trait_method
     Map::new(Map[str Type]) = trait_subs
     receiver = default_self_type
     if fn_base_opt.is_some then
-        fn_base_opt.unwrap = base_name
+        if fn_base_opt Option::Some(base_name) is then
+        else
+            empty_location "Expected option value while unwrapping fn_base_opt" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         if 0 type_params.length != then
             " " type_params.join = tparams_str
             f"{base_name}[{tparams_str}]" = default_self_type
@@ -2326,7 +2514,11 @@ fn instantiate_default_trait_method
             if 0 infer_method TraitMethod::default_ops.length == then
                 f"{receiver}::{infer_method TraitMethod::name}" store.functions.get = infer_fn_opt
                 if infer_fn_opt.is_some then
-                    infer_fn_opt.unwrap = infer_fn
+                    if infer_fn_opt Option::Some(infer_fn) is then
+                    else
+                        empty_location "Expected option value while unwrapping infer_fn_opt" ErrorKind::Syntax raise_error
+                        1 exit
+                    fi
                     store infer_fn ensure_typechecked
                     receiver infer_method TraitMethod::stack_effect resolve_trait_stack_effect = infer_trait_resolved
                     0 = ret_index
@@ -2376,9 +2568,14 @@ fn instantiate_default_trait_method
         if lambda_name "lambda__" str::starts_with ! then continue fi
         lambda_name store.functions.get = lambda_opt
         if lambda_opt.is_none then continue fi
+        if lambda_opt Option::Some(lambda) is then
+        else
+            empty_location "Expected lambda function during default method instantiation" ErrorKind::Syntax raise_error
+            1 exit
+        fi
 
         f"{lambda_name}__{synth_fn_name}_{cloned_lambda_index}" = cloned_lambda_name
-        lambda_opt.unwrap Function::ops clone_ops = lambda_ops
+        lambda Function::ops clone_ops = lambda_ops
         if 0 trait_subs.length != then
             trait_subs lambda_ops substitute_ops_types
         fi
@@ -2389,7 +2586,7 @@ fn instantiate_default_trait_method
             lambda_type_var lambda_effect StackEffect::type_vars.add = lambda_tvs
             lambda_tvs lambda_effect StackEffect::set_type_vars
         done
-        lambda_effect lambda_opt.unwrap Function::location lambda_ops cloned_lambda_name Function::with_stack_effect = cloned_lambda
+        lambda_effect lambda Function::location lambda_ops cloned_lambda_name Function::with_stack_effect = cloned_lambda
         cloned_lambda cloned_lambda_name store.functions.set drop
         cloned_lambda_name OpValue::FnPush body_op Op::set_value
         1 += cloned_lambda_index
@@ -2425,15 +2622,23 @@ impl TypeChecker {
         tc.stack_peek = receiver
 
         # Check if receiver is a trait-bounded type variable
-        if function_opt.is_some then
-            function_opt.unwrap Function::stack_effect StackEffect::trait_bounds = bounds
+        if function_opt Option::Some(function) is then
+            function Function::stack_effect StackEffect::trait_bounds = bounds
             receiver bounds.get = trait_opt
             if trait_opt.is_some then
-                trait_opt.unwrap = bound
+                if trait_opt Option::Some(bound) is then
+                else
+                    empty_location "Expected option value while unwrapping trait_opt" ErrorKind::Syntax raise_error
+                    1 exit
+                fi
                 bound TraitBound::name = trait_name
                 trait_name tc.store.traits.get = trait_def_opt
                 if trait_def_opt.is_some then
-                    trait_def_opt.unwrap = trait_def
+                    if trait_def_opt Option::Some(trait_def) is then
+                    else
+                        empty_location "Expected option value while unwrapping trait_def_opt" ErrorKind::Syntax raise_error
+                        1 exit
+                    fi
                     # Build substitution map from trait's type_params to the
                     # bound's concrete type_args, so that a trait method like
                     # `next self:self -> Option[T]` with bound `I: Iterable[int]`
@@ -2471,8 +2676,8 @@ impl TypeChecker {
         # Try generic base type
         if fn_opt.is_none then
             receiver parse_type_str.base = base_opt
-            if base_opt.is_some then
-                f"{base_opt.unwrap}::{method_name}" = fn_name
+            if base_opt Option::Some(base) is then
+                f"{base}::{method_name}" = fn_name
                 fn_name tc.store.functions.get = fn_opt
             fi
         fi
@@ -2481,13 +2686,21 @@ impl TypeChecker {
         if fn_opt.is_none then
             tc.store receiver method_name function_opt instantiate_default_trait_method = default_inst_opt
             if default_inst_opt.is_some then
-                default_inst_opt.unwrap = fn_name
+                if default_inst_opt Option::Some(fn_name) is then
+                else
+                    empty_location "Expected option value while unwrapping default_inst_opt" ErrorKind::Syntax raise_error
+                    1 exit
+                fi
                 fn_name tc.store.functions.get = fn_opt
             fi
         fi
 
         if fn_opt.is_some then
-            fn_opt.unwrap = function
+            if fn_opt Option::Some(function) is then
+            else
+                empty_location "Expected option value while unwrapping fn_opt" ErrorKind::Syntax raise_error
+                1 exit
+            fi
             if function Function::is_typechecked ! then
                 function function Function::ops tc.store resolve_identifiers function Function::set_ops
                 true function Function::set_is_used
@@ -2845,7 +3058,11 @@ fn type_check_ops ops:List[Op] function_opt:Option[Function] store:SymbolStore -
     store TypeChecker::new = checker
     Option::None(Option[int]) = budget
     if function_opt.is_some then
-        function_opt.unwrap = the_function
+        if function_opt Option::Some(the_function) is then
+        else
+            empty_location "Expected option value while unwrapping function_opt" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         if the_function Function::name "lambda__" str::starts_with ! then
             the_function Function::stack_effect StackEffect::parameters.length Option::Some = budget
         fi
@@ -2864,7 +3081,11 @@ fn type_check_ops ops:List[Op] function_opt:Option[Function] store:SymbolStore -
     # Verify against declared stack effect if function has one
     ERRORS.length errors_before_ops < = had_type_errors
     if function_opt.is_some had_type_errors ! && then
-        function_opt.unwrap = declared_function
+        if function_opt Option::Some(declared_function) is then
+        else
+            empty_location "Expected option value while unwrapping function_opt" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         declared_function Function::stack_effect = declared
         if
         declared stack_effect_to_str "None -> None" !=

--- a/compiler/typechecker.casa
+++ b/compiler/typechecker.casa
@@ -128,14 +128,14 @@ struct TypeChecker {
     current_expect_ctx:         str
     in_branch_condition:        bool
     store:                      SymbolStore
-    param_cap:                  int
+    param_cap:                  Option[int]
     underflow_reported_this_op: bool
 }
 
 impl TypeChecker {
     fn new store:SymbolStore -> TypeChecker {
         false # underflow_reported_this_op
-        -1 # param_cap (-1 = unlimited until type_check_ops sets a real cap)
+        Option::None(Option[int]) # param_cap
         store # store
         false # in_branch_condition
         "" # current_expect_ctx
@@ -152,8 +152,10 @@ impl TypeChecker {
 
 impl TypeChecker {
     fn within_param_cap tc:TypeChecker -> bool {
-        if -1 tc.param_cap == then true return fi
-        tc.param_cap tc.parameters.length <
+        if tc.param_cap Option::Some(cap) is then
+            cap tc.parameters.length < return
+        fi
+        true
     }
 }
 # Raise a TypeMismatch error at the type checker's current location.
@@ -1374,12 +1376,12 @@ fn type_satisfies_trait
     true
 }
 
-fn find_tparam_index tparams:List[str] name:str -> int {
-    -1 = found_index
+fn find_tparam_index tparams:List[str] name:str -> Option[int] {
+    Option::None(Option[int]) = found_index
     0 = scan_index
     while scan_index tparams.length > do
         if scan_index tparams.get name == then
-            scan_index = found_index
+            scan_index Option::Some = found_index
         fi
         1 += scan_index
     done
@@ -1412,8 +1414,8 @@ fn bind_from_type_slot
 -> Map[str Type] {
     if expected.type_var_name Option::Some(direct_tv_name) is then
         direct_tv_name tparams find_tparam_index = direct_tp_idx
-        if 0 direct_tp_idx >= then
-            direct_tp_idx bargs.get = direct_caller_ref
+        if direct_tp_idx Option::Some(direct_index) is then
+            direct_index bargs.get = direct_caller_ref
             actual direct_caller_ref effect bindings try_bind_caller_tvar return
         fi
         bindings return
@@ -1428,8 +1430,8 @@ fn bind_from_type_slot
     do
         if slot_index expected_g.params.get.type_var_name Option::Some(nested_name) is then
             nested_name tparams find_tparam_index = nested_tp_idx
-            if 0 nested_tp_idx >= then
-                nested_tp_idx bargs.get = nested_caller_ref
+            if nested_tp_idx Option::Some(nested_index) is then
+                nested_index bargs.get = nested_caller_ref
                 slot_index actual_g.params.get nested_caller_ref effect bindings try_bind_caller_tvar = bindings
             fi
         fi
@@ -1860,15 +1862,17 @@ impl TypeChecker {
 impl TypeChecker {
     fn check_syscalls tc:TypeChecker op:Op function_opt:Option[Function] {
         op.value match
-            OpValue::Syscall0 => 0
-            OpValue::Syscall1 => 1
-            OpValue::Syscall2 => 2
-            OpValue::Syscall3 => 3
-            OpValue::Syscall4 => 4
-            OpValue::Syscall5 => 5
-            OpValue::Syscall6 => 6
-            _ => -1
-        end = arg_count
+            OpValue::Syscall0 => 0 Option::Some
+            OpValue::Syscall1 => 1 Option::Some
+            OpValue::Syscall2 => 2 Option::Some
+            OpValue::Syscall3 => 3 Option::Some
+            OpValue::Syscall4 => 4 Option::Some
+            OpValue::Syscall5 => 5 Option::Some
+            OpValue::Syscall6 => 6 Option::Some
+            _ => Option::None(Option[int])
+        end = arg_count_opt
+        if arg_count_opt.is_none then return fi
+        arg_count_opt.unwrap = arg_count
         TYPE_INT_T tc.expect_type_t
         0 = index
         while index arg_count > do
@@ -2839,11 +2843,11 @@ impl TypeChecker {
 
 fn type_check_ops ops:List[Op] function_opt:Option[Function] store:SymbolStore -> StackEffect {
     store TypeChecker::new = checker
-    -1 = budget
+    Option::None(Option[int]) = budget
     if function_opt.is_some then
         function_opt.unwrap = the_function
         if the_function Function::name "lambda__" str::starts_with ! then
-            the_function Function::stack_effect StackEffect::parameters.length = budget
+            the_function Function::stack_effect StackEffect::parameters.length Option::Some = budget
         fi
     fi
     budget checker->param_cap

--- a/compiler/typechecker.casa
+++ b/compiler/typechecker.casa
@@ -150,123 +150,147 @@ impl TypeChecker {
     }
 }
 
-fn within_param_cap tc:TypeChecker -> bool {
-    if -1 tc.param_cap == then true return fi
-    tc.param_cap tc.parameters.length <
+impl TypeChecker {
+    fn within_param_cap tc:TypeChecker -> bool {
+        if -1 tc.param_cap == then true return fi
+        tc.param_cap tc.parameters.length <
+    }
 }
 # Raise a TypeMismatch error at the type checker's current location.
 
-fn raise_type_mismatch tc:TypeChecker message:str {
-    tc.current_location message ErrorKind::TypeMismatch raise_error
+impl TypeChecker {
+    fn raise_type_mismatch tc:TypeChecker message:str {
+        tc.current_location message ErrorKind::TypeMismatch raise_error
+    }
 }
 
 # ============================================================================
 # Stack operations
 # ============================================================================
 
-fn stack_push_type tc:TypeChecker typ:Type {
-    typ tc.stack.types.push
-    tc.current_location tc.stack.origins.push
+impl TypeChecker {
+    fn stack_push_type tc:TypeChecker typ:Type {
+        typ tc.stack.types.push
+        tc.current_location tc.stack.origins.push
+    }
 }
 
-fn stack_push tc:TypeChecker typ:str {
-    typ parse_type_str tc stack_push_type
+impl TypeChecker {
+    fn stack_push tc:TypeChecker typ:str {
+        typ parse_type_str tc.stack_push_type
+    }
 }
 
-fn report_stack_underflow tc:TypeChecker message:str {
-    if tc.underflow_reported_this_op then return fi
-    tc.current_location message ErrorKind::StackUnderflow add_error
-    true tc->underflow_reported_this_op
+impl TypeChecker {
+    fn report_stack_underflow tc:TypeChecker message:str {
+        if tc.underflow_reported_this_op then return fi
+        tc.current_location message ErrorKind::StackUnderflow add_error
+        true tc->underflow_reported_this_op
+    }
 }
 
-fn stack_underflow_message tc:TypeChecker -> str {
-    tc.current_expect_ctx = expect_what
-    if "" expect_what == then
-        "Stack underflow: expected a value but stack is empty" return
-    fi
-    f"Stack underflow: expected {expect_what} but stack is empty"
-}
-
-fn stack_peek tc:TypeChecker -> str {
-    if 0 tc.stack.types.length == then
-        if tc within_param_cap then
-            TYPE_UNKNOWN return
+impl TypeChecker {
+    fn stack_underflow_message tc:TypeChecker -> str {
+        tc.current_expect_ctx = expect_what
+        if "" expect_what == then
+            "Stack underflow: expected a value but stack is empty" return
         fi
-        tc stack_underflow_message tc report_stack_underflow
-        TYPE_MISSING return
-    fi
-    tc.stack.types.length 1 - tc.stack.types.get.format
+        f"Stack underflow: expected {expect_what} but stack is empty"
+    }
 }
 
-fn stack_pop tc:TypeChecker -> str {
-    if 0 tc.stack.types.length == then
-        if tc within_param_cap then
-            TYPE_UNKNOWN Parameter::new tc.parameters.push
-            TYPE_UNKNOWN return
+impl TypeChecker {
+    fn stack_peek tc:TypeChecker -> str {
+        if 0 tc.stack.types.length == then
+            if tc.within_param_cap then
+                TYPE_UNKNOWN return
+            fi
+            tc.stack_underflow_message tc.report_stack_underflow
+            TYPE_MISSING return
         fi
-        tc stack_underflow_message tc report_stack_underflow
-        TYPE_MISSING return
-    fi
-    tc.stack.origins.pop drop
-    tc.stack.types.pop.format
+        tc.stack.types.length 1 - tc.stack.types.get.format
+    }
 }
 
-fn stack_peek_type tc:TypeChecker -> Type {
-    if 0 tc.stack.types.length == then
-        if tc within_param_cap then
-            TYPE_UNKNOWN_T return
+impl TypeChecker {
+    fn stack_pop tc:TypeChecker -> str {
+        if 0 tc.stack.types.length == then
+            if tc.within_param_cap then
+                TYPE_UNKNOWN Parameter::new tc.parameters.push
+                TYPE_UNKNOWN return
+            fi
+            tc.stack_underflow_message tc.report_stack_underflow
+            TYPE_MISSING return
         fi
-        tc stack_underflow_message tc report_stack_underflow
-        TYPE_MISSING_T return
-    fi
-    tc.stack.types.length 1 - tc.stack.types.get
+        tc.stack.origins.pop drop
+        tc.stack.types.pop.format
+    }
 }
 
-fn stack_pop_type tc:TypeChecker -> Type {
-    if 0 tc.stack.types.length == then
-        if tc within_param_cap then
-            TYPE_UNKNOWN Parameter::new tc.parameters.push
-            TYPE_UNKNOWN_T return
+impl TypeChecker {
+    fn stack_peek_type tc:TypeChecker -> Type {
+        if 0 tc.stack.types.length == then
+            if tc.within_param_cap then
+                TYPE_UNKNOWN_T return
+            fi
+            tc.stack_underflow_message tc.report_stack_underflow
+            TYPE_MISSING_T return
         fi
-        tc stack_underflow_message tc report_stack_underflow
-        TYPE_MISSING_T return
-    fi
-    tc.stack.origins.pop drop
-    tc.stack.types.pop
+        tc.stack.types.length 1 - tc.stack.types.get
+    }
 }
 
-fn stack_pop_drop tc:TypeChecker {
-    if 0 tc.stack.types.length == then
-        if tc within_param_cap then
-            TYPE_UNKNOWN Parameter::new tc.parameters.push
+impl TypeChecker {
+    fn stack_pop_type tc:TypeChecker -> Type {
+        if 0 tc.stack.types.length == then
+            if tc.within_param_cap then
+                TYPE_UNKNOWN Parameter::new tc.parameters.push
+                TYPE_UNKNOWN_T return
+            fi
+            tc.stack_underflow_message tc.report_stack_underflow
+            TYPE_MISSING_T return
+        fi
+        tc.stack.origins.pop drop
+        tc.stack.types.pop
+    }
+}
+
+impl TypeChecker {
+    fn stack_pop_drop tc:TypeChecker {
+        if 0 tc.stack.types.length == then
+            if tc.within_param_cap then
+                TYPE_UNKNOWN Parameter::new tc.parameters.push
+                return
+            fi
+            tc.stack_underflow_message tc.report_stack_underflow
             return
         fi
-        tc stack_underflow_message tc report_stack_underflow
-        return
-    fi
-    tc.stack.origins.pop drop
-    tc.stack.types.pop drop
+        tc.stack.origins.pop drop
+        tc.stack.types.pop drop
+    }
 }
 
-fn expect_type_t tc:TypeChecker expected:Type {
-    if 0 tc.stack.types.length == then
-        if tc within_param_cap then
-            expected.format Parameter::new tc.parameters.push
+impl TypeChecker {
+    fn expect_type_t tc:TypeChecker expected:Type {
+        if 0 tc.stack.types.length == then
+            if tc.within_param_cap then
+                expected.format Parameter::new tc.parameters.push
+                return
+            fi
+            f"Stack underflow: expected `{expected.format}` but stack is empty" tc.report_stack_underflow
             return
         fi
-        f"Stack underflow: expected `{expected.format}` but stack is empty" tc report_stack_underflow
-        return
-    fi
-    tc.stack.origins.pop drop
-    tc.stack.types.pop = et_actual_t
-    if tc.store et_actual_t expected unify_type_t.is_some then return fi
-    et_actual_t.format = et_actual
-    expected.format = et_expected
-    "Type mismatch" = et_message
-    if "" tc.current_op_context != then
-        f"Type mismatch in {tc.current_op_context}" = et_message
-    fi
-    et_actual et_expected tc.current_location et_message ErrorKind::TypeMismatch add_error_expected
+        tc.stack.origins.pop drop
+        tc.stack.types.pop = et_actual_t
+        if tc.store et_actual_t expected unify_type_t.is_some then return fi
+        et_actual_t.format = et_actual
+        expected.format = et_expected
+        "Type mismatch" = et_message
+        if "" tc.current_op_context != then
+            f"Type mismatch in {tc.current_op_context}" = et_message
+        fi
+        et_actual et_expected tc.current_location et_message ErrorKind::TypeMismatch add_error_expected
+    }
 }
 
 # ============================================================================
@@ -432,256 +456,273 @@ fn resolve_return_type_t bindings:Map[str Type] ret:Type -> Type {
     end
 }
 
-fn bind_type_var tc:TypeChecker bindings:Map[str Type] type_var:str actual:Type -> Map[str Type] {
-    type_var bindings.get = existing
-    if existing.is_none then
-        actual type_var bindings.set return
-    fi
-    existing.unwrap = bound
-    actual.is_unknown_placeholder = actual_unknown
-    bound.is_unknown_placeholder = bound_unknown
-    if
-    bound_unknown
-    bound.has_unresolved_type_var ||
-    actual_unknown ! &&
-    then
-        actual type_var bindings.set return
-    fi
-    if
-    bound actual.eq !
-    actual_unknown ! &&
-    bound_unknown ! &&
-    actual.has_unresolved_type_var ! &&
-    then
-        f"Type variable `{type_var}` bound to `{bound.format}` but got `{actual.format}`" tc raise_type_mismatch
-    fi
-    bindings
+impl TypeChecker {
+    fn bind_type_var
+        tc:TypeChecker
+        bindings:Map[str Type]
+        type_var:str
+        actual:Type
+    -> Map[str Type] {
+        type_var bindings.get = existing
+        if existing.is_none then
+            actual type_var bindings.set return
+        fi
+        existing.unwrap = bound
+        actual.is_unknown_placeholder = actual_unknown
+        bound.is_unknown_placeholder = bound_unknown
+        if
+        bound_unknown
+        bound.has_unresolved_type_var ||
+        actual_unknown ! &&
+        then
+            actual type_var bindings.set return
+        fi
+        if
+        bound actual.eq !
+        actual_unknown ! &&
+        bound_unknown ! &&
+        actual.has_unresolved_type_var ! &&
+        then
+            f"Type variable `{type_var}` bound to `{bound.format}` but got `{actual.format}`" tc.raise_type_mismatch
+        fi
+        bindings
+    }
 }
 
-fn bind_generic_param
-    tc:TypeChecker
-    bindings:Map[str Type]
-    expected:Parameter
-    effect:StackEffect
--> bool {
-    # Bind type vars from a parameterized param like Map[K V].
-    expected Parameter::typ.base = base_opt
-    if base_opt.is_none then false return fi
-    expected Parameter::typ.type_params = expected_params_opt
-    if expected_params_opt.is_none then false return fi
-    expected_params_opt.unwrap = expected_params
-    # Check if any param is a type variable
-    false = has_type_var
-    for expected_param in expected_params.iter do
-        if expected_param.type_var_name Option::Some(probe_name) is then
-            if probe_name effect StackEffect::type_vars.has then
-                true = has_type_var
-            fi
-        fi
-    done
-    if has_type_var ! then false return fi
-
-    base_opt.unwrap = base
-    tc stack_pop_type match
-        Type::Generic(actual_g) => {
-            if 0 actual_g.params.length == then
-                expected_params bindings effect tc bind_unknowns = bindings
-                true return
-            fi
-            if base actual_g.base != then
-                "Type mismatch" tc raise_type_mismatch
-                true return
-            fi
-            if actual_g.params.length expected_params.length != then
-                "Type mismatch" tc raise_type_mismatch
-                true return
-            fi
-            0 = bind_index
-            while bind_index expected_params.length > do
-                if bind_index expected_params.get.type_var_name Option::Some(bind_name) is then
-                    if bind_name effect StackEffect::type_vars.has then
-                        bind_index actual_g.params.get bind_name bindings tc bind_type_var = bindings
-                    fi
+impl TypeChecker {
+    fn bind_generic_param
+        tc:TypeChecker
+        bindings:Map[str Type]
+        expected:Parameter
+        effect:StackEffect
+    -> bool {
+        # Bind type vars from a parameterized param like Map[K V].
+        expected Parameter::typ.base = base_opt
+        if base_opt.is_none then false return fi
+        expected Parameter::typ.type_params = expected_params_opt
+        if expected_params_opt.is_none then false return fi
+        expected_params_opt.unwrap = expected_params
+        # Check if any param is a type variable
+        false = has_type_var
+        for expected_param in expected_params.iter do
+            if expected_param.type_var_name Option::Some(probe_name) is then
+                if probe_name effect StackEffect::type_vars.has then
+                    true = has_type_var
                 fi
-                1 += bind_index
-            done
-            true return
-        }
-        Type::Unknown => {
-            expected_params bindings effect tc bind_unknowns = bindings
-            true return
-        }
-        _ => {
-            "Type mismatch" tc raise_type_mismatch
-        }
-    end
-    true
-}
-
-fn bind_unknowns
-    tc:TypeChecker
-    effect:StackEffect
-    bindings:Map[str Type]
-    expected_params:List[Type]
--> Map[str Type] {
-    for expected_param in expected_params.iter do
-        if expected_param.type_var_name Option::Some(unk_name) is then
-            if unk_name effect StackEffect::type_vars.has then
-                TYPE_UNKNOWN_T unk_name bindings tc bind_type_var = bindings
-            fi
-        fi
-    done
-    bindings
-}
-
-fn bind_fn_param
-    tc:TypeChecker
-    bindings:Map[str Type]
-    expected:Parameter
-    effect:StackEffect
--> bool {
-    # Bind type vars from a function-type param like fn[T -> T].
-    if expected Parameter::typ.is_fn_type_t ! then false return fi
-    # Check if any type var appears in the function type.
-    false = has_type_var
-    effect StackEffect::type_vars.to_list = type_var_list
-    for type_var in type_var_list.iter do
-        if type_var expected Parameter::typ.type_contains_var then
-            true = has_type_var
-        fi
-    done
-    if has_type_var ! then false return fi
-
-    tc stack_pop_type = actual
-    if actual.is_unknown_placeholder then
-        for type_var2 in type_var_list.iter do
-            if type_var2 expected Parameter::typ.type_contains_var then
-                TYPE_UNKNOWN_T type_var2 bindings tc bind_type_var = bindings
             fi
         done
-        true return
-    fi
-    if actual.is_fn_type_t ! then
-        "Type mismatch" tc raise_type_mismatch
-        true return
-    fi
-    expected Parameter::typ match
-        Type::Function(expected_fn) => {
-            actual match
-                Type::Function(actual_fn) => {
-                    expected_fn.parameters = expected_fn_params
-                    actual_fn.parameters = actual_fn_params
-                    0 = param_index
-                    while
-                    param_index expected_fn_params.length >
-                    param_index actual_fn_params.length > &&
-                    do
-                        param_index expected_fn_params.get.format = expected_param_name
-                        if expected_param_name effect StackEffect::type_vars.has then
-                            param_index actual_fn_params.get expected_param_name bindings tc bind_type_var = bindings
+        if has_type_var ! then false return fi
+
+        base_opt.unwrap = base
+        tc.stack_pop_type match
+            Type::Generic(actual_g) => {
+                if 0 actual_g.params.length == then
+                    expected_params bindings effect tc.bind_unknowns = bindings
+                    true return
+                fi
+                if base actual_g.base != then
+                    "Type mismatch" tc.raise_type_mismatch
+                    true return
+                fi
+                if actual_g.params.length expected_params.length != then
+                    "Type mismatch" tc.raise_type_mismatch
+                    true return
+                fi
+                0 = bind_index
+                while bind_index expected_params.length > do
+                    if bind_index expected_params.get.type_var_name Option::Some(bind_name) is then
+                        if bind_name effect StackEffect::type_vars.has then
+                            bind_index actual_g.params.get bind_name bindings tc.bind_type_var = bindings
                         fi
-                        1 += param_index
-                    done
-                    expected_fn.return_types = expected_fn_returns
-                    actual_fn.return_types = actual_fn_returns
-                    0 = return_index
-                    while
-                    return_index expected_fn_returns.length >
-                    return_index actual_fn_returns.length > &&
-                    do
-                        return_index expected_fn_returns.get.format = expected_return_name
-                        if expected_return_name effect StackEffect::type_vars.has then
-                            return_index actual_fn_returns.get expected_return_name bindings tc bind_type_var = bindings
-                        fi
-                        1 += return_index
-                    done
-                }
-                _ => { }
-            end
-        }
-        _ => { }
-    end
-    true
+                    fi
+                    1 += bind_index
+                done
+                true return
+            }
+            Type::Unknown => {
+                expected_params bindings effect tc.bind_unknowns = bindings
+                true return
+            }
+            _ => {
+                "Type mismatch" tc.raise_type_mismatch
+            }
+        end
+        true
+    }
 }
 
-fn apply_stack_effect tc:TypeChecker effect:StackEffect name:str {
-    # Simple case: no type variables
-    if 0 effect StackEffect::type_vars.length == then
+impl TypeChecker {
+    fn bind_unknowns
+        tc:TypeChecker
+        effect:StackEffect
+        bindings:Map[str Type]
+        expected_params:List[Type]
+    -> Map[str Type] {
+        for expected_param in expected_params.iter do
+            if expected_param.type_var_name Option::Some(unk_name) is then
+                if unk_name effect StackEffect::type_vars.has then
+                    TYPE_UNKNOWN_T unk_name bindings tc.bind_type_var = bindings
+                fi
+            fi
+        done
+        bindings
+    }
+}
+
+impl TypeChecker {
+    fn bind_fn_param
+        tc:TypeChecker
+        bindings:Map[str Type]
+        expected:Parameter
+        effect:StackEffect
+    -> bool {
+        # Bind type vars from a function-type param like fn[T -> T].
+        if expected Parameter::typ.is_fn_type_t ! then false return fi
+        # Check if any type var appears in the function type.
+        false = has_type_var
+        effect StackEffect::type_vars.to_list = type_var_list
+        for type_var in type_var_list.iter do
+            if type_var expected Parameter::typ.type_contains_var then
+                true = has_type_var
+            fi
+        done
+        if has_type_var ! then false return fi
+
+        tc.stack_pop_type = actual
+        if actual.is_unknown_placeholder then
+            for type_var2 in type_var_list.iter do
+                if type_var2 expected Parameter::typ.type_contains_var then
+                    TYPE_UNKNOWN_T type_var2 bindings tc.bind_type_var = bindings
+                fi
+            done
+            true return
+        fi
+        if actual.is_fn_type_t ! then
+            "Type mismatch" tc.raise_type_mismatch
+            true return
+        fi
+        expected Parameter::typ match
+            Type::Function(expected_fn) => {
+                actual match
+                    Type::Function(actual_fn) => {
+                        expected_fn.parameters = expected_fn_params
+                        actual_fn.parameters = actual_fn_params
+                        0 = param_index
+                        while
+                        param_index expected_fn_params.length >
+                        param_index actual_fn_params.length > &&
+                        do
+                            param_index expected_fn_params.get.format = expected_param_name
+                            if expected_param_name effect StackEffect::type_vars.has then
+                                param_index actual_fn_params.get expected_param_name bindings tc.bind_type_var = bindings
+                            fi
+                            1 += param_index
+                        done
+                        expected_fn.return_types = expected_fn_returns
+                        actual_fn.return_types = actual_fn_returns
+                        0 = return_index
+                        while
+                        return_index expected_fn_returns.length >
+                        return_index actual_fn_returns.length > &&
+                        do
+                            return_index expected_fn_returns.get.format = expected_return_name
+                            if expected_return_name effect StackEffect::type_vars.has then
+                                return_index actual_fn_returns.get expected_return_name bindings tc.bind_type_var = bindings
+                            fi
+                            1 += return_index
+                        done
+                    }
+                    _ => { }
+                end
+            }
+            _ => { }
+        end
+        true
+    }
+}
+
+impl TypeChecker {
+    fn apply_stack_effect tc:TypeChecker effect:StackEffect name:str {
+        # Simple case: no type variables
+        if 0 effect StackEffect::type_vars.length == then
+            0 = index
+            while index effect StackEffect::parameters.length > do
+                if "" name != then
+                    f"parameter {index 1 +} of `{name}`" tc->current_expect_ctx
+                fi
+                index effect StackEffect::parameters.get Parameter::typ tc.expect_type_t
+                1 += index
+            done
+            "" tc->current_expect_ctx
+            for return_type in effect StackEffect::return_types.iter do
+                return_type tc.stack_push_type
+            done
+            return
+        fi
+
+        # Generic case: bind type variables
+        Map::new(Map[str Type]) = bindings
         0 = index
         while index effect StackEffect::parameters.length > do
+            index effect StackEffect::parameters.get = param
+
             if "" name != then
                 f"parameter {index 1 +} of `{name}`" tc->current_expect_ctx
             fi
-            index effect StackEffect::parameters.get Parameter::typ tc expect_type_t
-            1 += index
-        done
-        "" tc->current_expect_ctx
-        for return_type in effect StackEffect::return_types.iter do
-            return_type tc stack_push_type
-        done
-        return
-    fi
 
-    # Generic case: bind type variables
-    Map::new(Map[str Type]) = bindings
-    0 = index
-    while index effect StackEffect::parameters.length > do
-        index effect StackEffect::parameters.get = param
+            # Direct type variable (e.g. T)
+            if param Parameter::typ.type_var_name Option::Some(direct_tv) is then
+                if direct_tv effect StackEffect::type_vars.has then
+                    tc.stack_pop_type = actual_type_var_t
+                    actual_type_var_t direct_tv bindings tc.bind_type_var = bindings
+                    1 += index
+                    continue
+                fi
+            fi
 
-        if "" name != then
-            f"parameter {index 1 +} of `{name}`" tc->current_expect_ctx
-        fi
-
-        # Direct type variable (e.g. T)
-        if param Parameter::typ.type_var_name Option::Some(direct_tv) is then
-            if direct_tv effect StackEffect::type_vars.has then
-                tc stack_pop_type = actual_type_var_t
-                actual_type_var_t direct_tv bindings tc bind_type_var = bindings
+            # Parameterized type with type vars (e.g. Option[T], Map[K V])
+            if effect param bindings tc.bind_generic_param then
                 1 += index
                 continue
             fi
-        fi
 
-        # Parameterized type with type vars (e.g. Option[T], Map[K V])
-        if effect param bindings tc bind_generic_param then
+            # Function type with type vars (e.g. fn[T -> T])
+            if effect param bindings tc.bind_fn_param then
+                1 += index
+                continue
+            fi
+
+            param Parameter::typ tc.expect_type_t
             1 += index
-            continue
-        fi
+        done
+        "" tc->current_expect_ctx
 
-        # Function type with type vars (e.g. fn[T -> T])
-        if effect param bindings tc bind_fn_param then
-            1 += index
-            continue
-        fi
-
-        param Parameter::typ tc expect_type_t
-        1 += index
-    done
-    "" tc->current_expect_ctx
-
-    # Push resolved return types
-    for return_type in effect StackEffect::return_types.iter do
-        return_type bindings resolve_return_type_t tc stack_push_type
-    done
+        # Push resolved return types
+        for return_type in effect StackEffect::return_types.iter do
+            return_type bindings resolve_return_type_t tc.stack_push_type
+        done
+    }
 }
 
 # ============================================================================
 # Check arithmetic operations
 # ============================================================================
 
-fn check_arithmetic tc:TypeChecker op:Op {
-    op.value = op_value
-    if
-    op_value OpValue::Add is
-    op_value OpValue::Sub is ||
-    then
-        TYPE_INT_T tc expect_type_t
-        tc stack_pop_type tc stack_push_type
-    else
-        TYPE_INT_T tc expect_type_t
-        TYPE_INT_T tc expect_type_t
-        TYPE_INT_T tc stack_push_type
-    fi
+impl TypeChecker {
+    fn check_arithmetic tc:TypeChecker op:Op {
+        op.value = op_value
+        if
+        op_value OpValue::Add is
+        op_value OpValue::Sub is ||
+        then
+            TYPE_INT_T tc.expect_type_t
+            tc.stack_pop_type tc.stack_push_type
+        else
+            TYPE_INT_T tc.expect_type_t
+            TYPE_INT_T tc.expect_type_t
+            TYPE_INT_T tc.stack_push_type
+        fi
+    }
 }
 
 # ============================================================================
@@ -708,159 +749,167 @@ fn comparison_op_str cmp_value:OpValue -> str {
     ">="
 }
 
-fn check_comparison
-    tc:TypeChecker
-    op:Op
-    ops:List[Op]
-    op_index:int
-    function_opt:Option[Function]
--> int {
-    op.value = cmp_value
-    cmp_value OpValue::Eq is cmp_value OpValue::Ne is || = is_eq_op
-    if is_eq_op then "Eq" else "Ord" fi = trait_name
-    f"value with trait `{trait_name}`" tc->current_expect_ctx
-    tc stack_pop_type = type1_t
-    tc stack_pop_type = type2_t
-    type1_t.format = type1
-    type2_t.format = type2
-    # Stack-underflow placeholder on either side: defer to caller-level
-    # inference (lambda param synthesis, generic body deferral). Skip both
-    # the same-type rule and the trait-bound check.
-    if
-    TYPE_UNKNOWN type1 ==
-    TYPE_UNKNOWN type2 == ||
-    TYPE_MISSING type1 == ||
-    TYPE_MISSING type2 == ||
-    then
-        TYPE_BOOL_T tc stack_push_type
-        op_index return
-    fi
-    type1_t.match_base = base1
-    type2_t.match_base = base2
-    base1 tc.store.enums.get.is_some = is_enum1
-    base2 tc.store.enums.get.is_some = is_enum2
-    # Same-type rule applies before any specialization.
-    if type1_t type2_t.eq ! then
-        f"Cannot compare `{type2}` with `{type1}`" tc raise_type_mismatch
-        TYPE_BOOL_T tc stack_push_type
-        op_index return
-    fi
-    # Enums: tag comparison via bytecode; data-carrying variants need annotation.
-    if is_enum1 is_enum2 || then
-        if is_enum1 then
-            base1 tc.store.enums.get.unwrap = casa_enum
-            if casa_enum has_inner_values then
-                base1 GenericType::new Type::Generic Option::Some op Op::set_type_hint
+impl TypeChecker {
+    fn check_comparison
+        tc:TypeChecker
+        op:Op
+        ops:List[Op]
+        op_index:int
+        function_opt:Option[Function]
+    -> int {
+        op.value = cmp_value
+        cmp_value OpValue::Eq is cmp_value OpValue::Ne is || = is_eq_op
+        if is_eq_op then "Eq" else "Ord" fi = trait_name
+        f"value with trait `{trait_name}`" tc->current_expect_ctx
+        tc.stack_pop_type = type1_t
+        tc.stack_pop_type = type2_t
+        type1_t.format = type1
+        type2_t.format = type2
+        # Stack-underflow placeholder on either side: defer to caller-level
+        # inference (lambda param synthesis, generic body deferral). Skip both
+        # the same-type rule and the trait-bound check.
+        if
+        TYPE_UNKNOWN type1 ==
+        TYPE_UNKNOWN type2 == ||
+        TYPE_MISSING type1 == ||
+        TYPE_MISSING type2 == ||
+        then
+            TYPE_BOOL_T tc.stack_push_type
+            op_index return
+        fi
+        type1_t.match_base = base1
+        type2_t.match_base = base2
+        base1 tc.store.enums.get.is_some = is_enum1
+        base2 tc.store.enums.get.is_some = is_enum2
+        # Same-type rule applies before any specialization.
+        if type1_t type2_t.eq ! then
+            f"Cannot compare `{type2}` with `{type1}`" tc.raise_type_mismatch
+            TYPE_BOOL_T tc.stack_push_type
+            op_index return
+        fi
+        # Enums: tag comparison via bytecode; data-carrying variants need annotation.
+        if is_enum1 is_enum2 || then
+            if is_enum1 then
+                base1 tc.store.enums.get.unwrap = casa_enum
+                if casa_enum has_inner_values then
+                    base1 GenericType::new Type::Generic Option::Some op Op::set_type_hint
+                fi
             fi
+            TYPE_BOOL_T tc.stack_push_type
+            op_index return
         fi
-        TYPE_BOOL_T tc stack_push_type
-        op_index return
-    fi
-    # str: only ==/!=, annotated for the bytecode emitter.
-    if "str" type1 == then
-        if is_eq_op ! then
-            "Type `str` only supports `==` and `!=` comparison" tc raise_type_mismatch
+        # str: only ==/!=, annotated for the bytecode emitter.
+        if "str" type1 == then
+            if is_eq_op ! then
+                "Type `str` only supports `==` and `!=` comparison" tc.raise_type_mismatch
+            fi
+            TYPE_STR_T Option::Some op Op::set_type_hint
+            TYPE_BOOL_T tc.stack_push_type
+            op_index return
         fi
-        TYPE_STR_T Option::Some op Op::set_type_hint
-        TYPE_BOOL_T tc stack_push_type
-        op_index return
-    fi
-    # Other primitives: bytecode handles the comparison directly.
-    if type1_t.is_primitive_compare_type_t then
-        TYPE_BOOL_T tc stack_push_type
-        op_index return
-    fi
-    # User-defined types must satisfy Eq (or Ord) explicitly.
-    if tc.store function_opt trait_name type1_t type_satisfies_trait ! then
-        cmp_value comparison_op_str = cmp_str
-        op Op::location f"Type `{type1}` cannot be compared with `{cmp_str}`: does not satisfy trait `{trait_name}`" ErrorKind::MissingTraitMethod add_error
-        TYPE_BOOL_T tc stack_push_type
-        op_index return
-    fi
-    # Lower the operator to the corresponding trait method call.
-    cmp_value comparison_method_name = method_name
-    type2_t tc stack_push_type
-    type1_t tc stack_push_type
-    method_name OpValue::MethodCall op Op::set_value
-    function_opt op_index ops op tc check_method_call
+        # Other primitives: bytecode handles the comparison directly.
+        if type1_t.is_primitive_compare_type_t then
+            TYPE_BOOL_T tc.stack_push_type
+            op_index return
+        fi
+        # User-defined types must satisfy Eq (or Ord) explicitly.
+        if tc.store function_opt trait_name type1_t type_satisfies_trait ! then
+            cmp_value comparison_op_str = cmp_str
+            op Op::location f"Type `{type1}` cannot be compared with `{cmp_str}`: does not satisfy trait `{trait_name}`" ErrorKind::MissingTraitMethod add_error
+            TYPE_BOOL_T tc.stack_push_type
+            op_index return
+        fi
+        # Lower the operator to the corresponding trait method call.
+        cmp_value comparison_method_name = method_name
+        type2_t tc.stack_push_type
+        type1_t tc.stack_push_type
+        method_name OpValue::MethodCall op Op::set_value
+        function_opt op_index ops op tc.check_method_call
+    }
 }
 
 # ============================================================================
 # Check boolean operations
 # ============================================================================
 
-fn check_boolean tc:TypeChecker op:Op {
-    if op.value OpValue::Not is then
-        tc stack_pop_drop
-    else
-        tc stack_pop_drop
-        tc stack_pop_drop
-    fi
-    TYPE_BOOL_T tc stack_push_type
+impl TypeChecker {
+    fn check_boolean tc:TypeChecker op:Op {
+        if op.value OpValue::Not is then
+            tc.stack_pop_drop
+        else
+            tc.stack_pop_drop
+            tc.stack_pop_drop
+        fi
+        TYPE_BOOL_T tc.stack_push_type
+    }
 }
 
 # ============================================================================
 # Check bitwise operations
 # ============================================================================
 
-fn check_bitwise tc:TypeChecker op:Op {
-    op.value = bitwise_value
-    if bitwise_value OpValue::BitNot is then
-        TYPE_INT_T tc expect_type_t
-        TYPE_INT_T tc stack_push_type
-    elif
-    bitwise_value OpValue::Shl is
-    bitwise_value OpValue::Shr is ||
-    then
-        TYPE_INT_T tc expect_type_t
-        tc stack_pop_type tc stack_push_type
-    else
-        TYPE_INT_T tc expect_type_t
-        TYPE_INT_T tc expect_type_t
-        TYPE_INT_T tc stack_push_type
-    fi
+impl TypeChecker {
+    fn check_bitwise tc:TypeChecker op:Op {
+        op.value = bitwise_value
+        if bitwise_value OpValue::BitNot is then
+            TYPE_INT_T tc.expect_type_t
+            TYPE_INT_T tc.stack_push_type
+        elif
+        bitwise_value OpValue::Shl is
+        bitwise_value OpValue::Shr is ||
+        then
+            TYPE_INT_T tc.expect_type_t
+            tc.stack_pop_type tc.stack_push_type
+        else
+            TYPE_INT_T tc.expect_type_t
+            TYPE_INT_T tc.expect_type_t
+            TYPE_INT_T tc.stack_push_type
+        fi
+    }
 }
 
 # ============================================================================
 # Check stack manipulation operations
 # ============================================================================
 
-fn check_stack_ops tc:TypeChecker op:Op {
-    op.value = stack_value
-    if stack_value OpValue::Drop is then
-        "value for `drop`" tc->current_expect_ctx
-        tc stack_pop_drop
-    elif stack_value OpValue::Dup is then
-        "value for `dup`" tc->current_expect_ctx
-        tc stack_pop = typ
-        typ tc stack_push
-        typ tc stack_push
-    elif stack_value OpValue::Swap is then
-        "argument 1 of `swap`" tc->current_expect_ctx
-        tc stack_pop_type = type1_t
-        "argument 2 of `swap`" tc->current_expect_ctx
-        tc stack_pop_type = type2_t
-        type1_t tc stack_push_type
-        type2_t tc stack_push_type
-    elif stack_value OpValue::Over is then
-        "argument 1 of `over`" tc->current_expect_ctx
-        tc stack_pop = type1
-        "argument 2 of `over`" tc->current_expect_ctx
-        tc stack_pop = type2
-        type2 tc stack_push
-        type1 tc stack_push
-        type2 tc stack_push
-    elif stack_value OpValue::Rot is then
-        "argument 1 of `rot`" tc->current_expect_ctx
-        tc stack_pop_type = type1_t
-        "argument 2 of `rot`" tc->current_expect_ctx
-        tc stack_pop_type = type2_t
-        "argument 3 of `rot`" tc->current_expect_ctx
-        tc stack_pop_type = type3_t
-        type2_t tc stack_push_type
-        type1_t tc stack_push_type
-        type3_t tc stack_push_type
-    fi
+impl TypeChecker {
+    fn check_stack_ops tc:TypeChecker op:Op {
+        op.value = stack_value
+        if stack_value OpValue::Drop is then
+            "value for `drop`" tc->current_expect_ctx
+            tc.stack_pop_drop
+        elif stack_value OpValue::Dup is then
+            "value for `dup`" tc->current_expect_ctx
+            tc.stack_pop = typ
+            typ tc.stack_push
+            typ tc.stack_push
+        elif stack_value OpValue::Swap is then
+            "argument 1 of `swap`" tc->current_expect_ctx
+            tc.stack_pop_type = type1_t
+            "argument 2 of `swap`" tc->current_expect_ctx
+            tc.stack_pop_type = type2_t
+            type1_t tc.stack_push_type
+            type2_t tc.stack_push_type
+        elif stack_value OpValue::Over is then
+            "argument 1 of `over`" tc->current_expect_ctx
+            tc.stack_pop = type1
+            "argument 2 of `over`" tc->current_expect_ctx
+            tc.stack_pop = type2
+            type2 tc.stack_push
+            type1 tc.stack_push
+            type2 tc.stack_push
+        elif stack_value OpValue::Rot is then
+            "argument 1 of `rot`" tc->current_expect_ctx
+            tc.stack_pop_type = type1_t
+            "argument 2 of `rot`" tc->current_expect_ctx
+            tc.stack_pop_type = type2_t
+            "argument 3 of `rot`" tc->current_expect_ctx
+            tc.stack_pop_type = type3_t
+            type2_t tc.stack_push_type
+            type1_t tc.stack_push_type
+            type3_t tc.stack_push_type
+        fi
+    }
 }
 
 # ============================================================================
@@ -885,40 +934,44 @@ fn bound_implies_word bound:TraitBound store:SymbolStore -> bool {
 # type variable is allowed; the concrete type bound at the call site will
 # satisfy `Word` automatically.
 
-fn assert_word_bound tc:TypeChecker op:Op type_name:str function_opt:Option[Function] {
-    if type_name TYPE_UNKNOWN == then return fi
-    if function_opt.is_none then return fi
-    function_opt.unwrap Function::stack_effect = word_stack_effect
-    if type_name word_stack_effect StackEffect::type_vars.has ! then return fi
-    type_name word_stack_effect StackEffect::trait_bounds.get = word_bound_opt
-    if word_bound_opt.is_none then return fi
-    if tc.store word_bound_opt.unwrap bound_implies_word then return fi
-    op Op::location f"Type variable `{type_name}` does not satisfy `Word` bound; add `[{type_name}: Word]` (or a trait that extends `Word`) to the function's type parameters" ErrorKind::TypeMismatch raise_error
+impl TypeChecker {
+    fn assert_word_bound tc:TypeChecker op:Op type_name:str function_opt:Option[Function] {
+        if type_name TYPE_UNKNOWN == then return fi
+        if function_opt.is_none then return fi
+        function_opt.unwrap Function::stack_effect = word_stack_effect
+        if type_name word_stack_effect StackEffect::type_vars.has ! then return fi
+        type_name word_stack_effect StackEffect::trait_bounds.get = word_bound_opt
+        if word_bound_opt.is_none then return fi
+        if tc.store word_bound_opt.unwrap bound_implies_word then return fi
+        op Op::location f"Type variable `{type_name}` does not satisfy `Word` bound; add `[{type_name}: Word]` (or a trait that extends `Word`) to the function's type parameters" ErrorKind::TypeMismatch raise_error
+    }
 }
 
-fn check_memory tc:TypeChecker op:Op function_opt:Option[Function] {
-    op.value = mem_value
-    if
-    mem_value OpValue::Load8 is
-    mem_value OpValue::Load16 is ||
-    mem_value OpValue::Load32 is ||
-    mem_value OpValue::Load64 is ||
-    then
-        TYPE_PTR_T tc expect_type_t
-        TYPE_INT_T tc stack_push_type
-    elif
-    mem_value OpValue::Store8 is
-    mem_value OpValue::Store16 is ||
-    mem_value OpValue::Store32 is ||
-    mem_value OpValue::Store64 is ||
-    then
-        TYPE_PTR_T tc expect_type_t
-        tc stack_pop = stored_type
-        function_opt stored_type op tc assert_word_bound
-    elif mem_value OpValue::HeapAlloc is then
-        TYPE_INT_T tc expect_type_t
-        TYPE_PTR_T tc stack_push_type
-    fi
+impl TypeChecker {
+    fn check_memory tc:TypeChecker op:Op function_opt:Option[Function] {
+        op.value = mem_value
+        if
+        mem_value OpValue::Load8 is
+        mem_value OpValue::Load16 is ||
+        mem_value OpValue::Load32 is ||
+        mem_value OpValue::Load64 is ||
+        then
+            TYPE_PTR_T tc.expect_type_t
+            TYPE_INT_T tc.stack_push_type
+        elif
+        mem_value OpValue::Store8 is
+        mem_value OpValue::Store16 is ||
+        mem_value OpValue::Store32 is ||
+        mem_value OpValue::Store64 is ||
+        then
+            TYPE_PTR_T tc.expect_type_t
+            tc.stack_pop = stored_type
+            function_opt stored_type op tc.assert_word_bound
+        elif mem_value OpValue::HeapAlloc is then
+            TYPE_INT_T tc.expect_type_t
+            TYPE_PTR_T tc.stack_push_type
+        fi
+    }
 }
 
 # ============================================================================
@@ -948,46 +1001,48 @@ fn unify_variable_assignment
     fi
 }
 
-fn check_assignment tc:TypeChecker op:Op function_opt:Option[Function] {
-    if
-    op.value OpValue::AssignDec is
-    op.value OpValue::AssignInc is ||
-    then
-        TYPE_INT_T tc expect_type_t
-        return
-    fi
-    if op.value OpValue::AssignVar(var_name) is ! then return fi
-    tc stack_peek_type = stack_type_t
-    op Op::type_hint.is_some = has_annotation
-    stack_type_t = effective_type_t
-    if has_annotation then
-        op Op::type_hint.unwrap = effective_type_t
-    fi
-    if has_annotation ! stack_type_t.has_unresolved && then
-        op Op::location f"Cannot infer element type of empty array literal assigned to `{var_name}`; add a type annotation (e.g. `= {var_name}:array[int]`) or an explicit cast (e.g. `[] (array[int])`)." ErrorKind::TypeMismatch raise_error
-    fi
-
-    # Try local variables first
-    if function_opt.is_some then
-        function_opt.unwrap = function
-        var_name function Function::variables variable_list_index = local_index
-        if 0 local_index >= then
-            local_index function Function::variables.get = local_var
-            tc.store "local" effective_type_t local_var op unify_variable_assignment
-            effective_type_t tc expect_type_t
+impl TypeChecker {
+    fn check_assignment tc:TypeChecker op:Op function_opt:Option[Function] {
+        if
+        op.value OpValue::AssignDec is
+        op.value OpValue::AssignInc is ||
+        then
+            TYPE_INT_T tc.expect_type_t
             return
         fi
-    fi
+        if op.value OpValue::AssignVar(var_name) is ! then return fi
+        tc.stack_peek_type = stack_type_t
+        op Op::type_hint.is_some = has_annotation
+        stack_type_t = effective_type_t
+        if has_annotation then
+            op Op::type_hint.unwrap = effective_type_t
+        fi
+        if has_annotation ! stack_type_t.has_unresolved && then
+            op Op::location f"Cannot infer element type of empty array literal assigned to `{var_name}`; add a type annotation (e.g. `= {var_name}:array[int]`) or an explicit cast (e.g. `[] (array[int])`)." ErrorKind::TypeMismatch raise_error
+        fi
 
-    # Try global variables
-    var_name tc.store.variables.get = global_opt
-    if global_opt.is_some then
-        global_opt.unwrap = global_var
-        tc.store "global" effective_type_t global_var op unify_variable_assignment
-        effective_type_t tc expect_type_t
-        return
-    fi
-    effective_type_t tc expect_type_t
+        # Try local variables first
+        if function_opt.is_some then
+            function_opt.unwrap = function
+            var_name function Function::variables variable_list_index = local_index
+            if 0 local_index >= then
+                local_index function Function::variables.get = local_var
+                tc.store "local" effective_type_t local_var op unify_variable_assignment
+                effective_type_t tc.expect_type_t
+                return
+            fi
+        fi
+
+        # Try global variables
+        var_name tc.store.variables.get = global_opt
+        if global_opt.is_some then
+            global_opt.unwrap = global_var
+            tc.store "global" effective_type_t global_var op unify_variable_assignment
+            effective_type_t tc.expect_type_t
+            return
+        fi
+        effective_type_t tc.expect_type_t
+    }
 }
 
 # ============================================================================
@@ -999,202 +1054,210 @@ fn check_assignment tc:TypeChecker op:Op function_opt:Option[Function] {
 # fn-pointer type we just pushed and apply the resolved trait method stack effect
 # so the correct return type lands on the stack.
 
-fn simulate_trait_method_call tc:TypeChecker function:Function var_name:str {
-    var_name 8 var_name.length 8 - str::substring = trait_suffix
-    trait_suffix "_" str::find = trait_sep
-    if trait_sep 0 >= then return fi
-    trait_suffix 0 trait_sep str::substring = trait_type_var
-    trait_suffix trait_sep 1 + trait_suffix.length trait_sep - 1 - str::substring = trait_method_name
-    trait_type_var function Function::stack_effect StackEffect::trait_bounds.get = trait_bound_opt
-    if trait_bound_opt.is_none then return fi
-    trait_bound_opt.unwrap TraitBound::name tc.store.traits.get = trait_def_opt
-    if trait_def_opt.is_none then return fi
-    trait_def_opt.unwrap = trait_def
-    for trait_method_entry in trait_def tc.store collect_trait_methods.iter do
-        if trait_method_name trait_method_entry TraitMethod::name == then
-            tc stack_pop_drop
-            trait_type_var trait_method_entry TraitMethod::stack_effect resolve_trait_stack_effect = resolved_exec_effect
-            f"{trait_type_var}::{trait_method_name}" resolved_exec_effect tc apply_stack_effect
-            return
-        fi
-    done
+impl TypeChecker {
+    fn simulate_trait_method_call tc:TypeChecker function:Function var_name:str {
+        var_name 8 var_name.length 8 - str::substring = trait_suffix
+        trait_suffix "_" str::find = trait_sep
+        if trait_sep 0 >= then return fi
+        trait_suffix 0 trait_sep str::substring = trait_type_var
+        trait_suffix trait_sep 1 + trait_suffix.length trait_sep - 1 - str::substring = trait_method_name
+        trait_type_var function Function::stack_effect StackEffect::trait_bounds.get = trait_bound_opt
+        if trait_bound_opt.is_none then return fi
+        trait_bound_opt.unwrap TraitBound::name tc.store.traits.get = trait_def_opt
+        if trait_def_opt.is_none then return fi
+        trait_def_opt.unwrap = trait_def
+        for trait_method_entry in trait_def tc.store collect_trait_methods.iter do
+            if trait_method_name trait_method_entry TraitMethod::name == then
+                tc.stack_pop_drop
+                trait_type_var trait_method_entry TraitMethod::stack_effect resolve_trait_stack_effect = resolved_exec_effect
+                f"{trait_type_var}::{trait_method_name}" resolved_exec_effect tc.apply_stack_effect
+                return
+            fi
+        done
+    }
 }
 
-fn check_push_var tc:TypeChecker op:Op function_opt:Option[Function] {
-    if op.value OpValue::PushCapture(capture_name) is then
-        if function_opt.is_some then
-            function_opt.unwrap = function
-            capture_name function Function::captures variable_list_index = capture_index
-            if 0 capture_index >= then
-                if capture_index function Function::captures.get Variable::typ.is_unknown ! then
-                    capture_index function Function::captures.get Variable::typ tc stack_push_type
-                    return
+impl TypeChecker {
+    fn check_push_var tc:TypeChecker op:Op function_opt:Option[Function] {
+        if op.value OpValue::PushCapture(capture_name) is then
+            if function_opt.is_some then
+                function_opt.unwrap = function
+                capture_name function Function::captures variable_list_index = capture_index
+                if 0 capture_index >= then
+                    if capture_index function Function::captures.get Variable::typ.is_unknown ! then
+                        capture_index function Function::captures.get Variable::typ tc.stack_push_type
+                        return
+                    fi
                 fi
             fi
+            TYPE_UNKNOWN_T tc.stack_push_type
+            return
         fi
-        TYPE_UNKNOWN_T tc stack_push_type
-        return
-    fi
 
-    if op.value OpValue::TraitMethodCall(trait_var_name) is then
-        if function_opt Option::Some(function) is then
-            trait_var_name function Function::variables variable_list_index = trait_index
-            if 0 trait_index >= then
-                if trait_index function Function::variables.get Variable::typ.is_unknown ! then
-                    trait_index function Function::variables.get Variable::typ tc stack_push_type
+        if op.value OpValue::TraitMethodCall(trait_var_name) is then
+            if function_opt Option::Some(function) is then
+                trait_var_name function Function::variables variable_list_index = trait_index
+                if 0 trait_index >= then
+                    if trait_index function Function::variables.get Variable::typ.is_unknown ! then
+                        trait_index function Function::variables.get Variable::typ tc.stack_push_type
+                    else
+                        TYPE_UNKNOWN_T tc.stack_push_type
+                    fi
                 else
-                    TYPE_UNKNOWN_T tc stack_push_type
+                    TYPE_UNKNOWN_T tc.stack_push_type
                 fi
-            else
-                TYPE_UNKNOWN_T tc stack_push_type
-            fi
-            trait_var_name function tc simulate_trait_method_call
-        fi
-        return
-    fi
-
-    # PUSH_VARIABLE
-    if op.value OpValue::PushVar(var_name) is ! then return fi
-
-    # Check local variables first
-    if function_opt.is_some then
-        function_opt.unwrap = function
-        var_name function Function::variables variable_list_index = local_index
-        if 0 local_index >= then
-            if local_index function Function::variables.get Variable::typ.is_unknown ! then
-                local_index function Function::variables.get Variable::typ tc stack_push_type
-            else
-                TYPE_UNKNOWN_T tc stack_push_type
+                trait_var_name function tc.simulate_trait_method_call
             fi
             return
         fi
-    fi
 
-    # Check global variables
-    var_name tc.store.variables.get = global_opt
-    if global_opt.is_some then
-        if global_opt.unwrap Variable::typ.is_unknown ! then
-            global_opt.unwrap Variable::typ tc stack_push_type
-        else
-            TYPE_UNKNOWN_T tc stack_push_type
+        # PUSH_VARIABLE
+        if op.value OpValue::PushVar(var_name) is ! then return fi
+
+        # Check local variables first
+        if function_opt.is_some then
+            function_opt.unwrap = function
+            var_name function Function::variables variable_list_index = local_index
+            if 0 local_index >= then
+                if local_index function Function::variables.get Variable::typ.is_unknown ! then
+                    local_index function Function::variables.get Variable::typ tc.stack_push_type
+                else
+                    TYPE_UNKNOWN_T tc.stack_push_type
+                fi
+                return
+            fi
         fi
-        return
-    fi
 
-    op Op::location f"Variable `{var_name}` is not defined" ErrorKind::UndefinedName raise_error
+        # Check global variables
+        var_name tc.store.variables.get = global_opt
+        if global_opt.is_some then
+            if global_opt.unwrap Variable::typ.is_unknown ! then
+                global_opt.unwrap Variable::typ tc.stack_push_type
+            else
+                TYPE_UNKNOWN_T tc.stack_push_type
+            fi
+            return
+        fi
+
+        op Op::location f"Variable `{var_name}` is not defined" ErrorKind::UndefinedName raise_error
+    }
 }
 
 # ============================================================================
 # Check if/elif/else/fi blocks
 # ============================================================================
 
-fn check_if_block tc:TypeChecker op:Op {
-    op.value = if_value
-    if if_value OpValue::IfStart is then
-        IfContext::new = if_ctx
-        op Op::location if_ctx IfContext::set_current_branch_location
-        if_ctx BranchFrame::BranchIf = if_frame
-        if_frame tc.branched_stacks.push
-        true tc->in_branch_condition
-    elif if_value OpValue::IfCondition is then
-        false tc->in_branch_condition
-        TYPE_BOOL_T tc expect_type_t
-        if 0 tc.branched_stacks.length == then return fi
-        tc.branched_stacks.length 1 - tc.branched_stacks.get = top_frame
-        if top_frame BranchFrame::BranchIf(if_ctx) is then
-            if if_ctx IfContext::condition_present ! then
-                true if_ctx IfContext::set_condition_present
-                tc.stack if_ctx IfContext::before.restore
-                tc.stack if_ctx IfContext::after.restore
-                "if" if_ctx IfContext::set_current_branch_label
+impl TypeChecker {
+    fn check_if_block tc:TypeChecker op:Op {
+        op.value = if_value
+        if if_value OpValue::IfStart is then
+            IfContext::new = if_ctx
+            op Op::location if_ctx IfContext::set_current_branch_location
+            if_ctx BranchFrame::BranchIf = if_frame
+            if_frame tc.branched_stacks.push
+            true tc->in_branch_condition
+        elif if_value OpValue::IfCondition is then
+            false tc->in_branch_condition
+            TYPE_BOOL_T tc.expect_type_t
+            if 0 tc.branched_stacks.length == then return fi
+            tc.branched_stacks.length 1 - tc.branched_stacks.get = top_frame
+            if top_frame BranchFrame::BranchIf(if_ctx) is then
+                if if_ctx IfContext::condition_present ! then
+                    true if_ctx IfContext::set_condition_present
+                    tc.stack if_ctx IfContext::before.restore
+                    tc.stack if_ctx IfContext::after.restore
+                    "if" if_ctx IfContext::set_current_branch_label
+                fi
+            fi
+        elif
+        if_value OpValue::IfElif is
+        if_value OpValue::IfElse is ||
+        then
+            if 0 tc.branched_stacks.length == then return fi
+            tc.branched_stacks.length 1 - tc.branched_stacks.get = top_frame
+            if top_frame BranchFrame::BranchIf(if_ctx) is then
+                if if_value OpValue::IfElse is then
+                    true if_ctx IfContext::set_default_present
+                    false tc->in_branch_condition
+                else
+                    true tc->in_branch_condition
+                fi
+                if_ctx IfContext::before = if_before
+                if_ctx IfContext::after = if_after
+                if if_before tc.stack.equals if_after if_before.equals && then
+                    op Op::location if_ctx IfContext::set_current_branch_location
+                    return
+                fi
+                tc.store if_after tc.stack.unify_types = unified
+                if 0 unified.length != if_after if_before.equals ! && then
+                    unified if_after->types
+                    if_before tc.stack.restore
+                    op Op::location if_ctx IfContext::set_current_branch_location
+                    return
+                fi
+                if if_after if_before.equals then
+                    tc.stack if_after.restore
+                    if_before tc.stack.restore
+                    op Op::location if_ctx IfContext::set_current_branch_location
+                    return
+                fi
+                op Op::location "Branches have incompatible stack effects" ErrorKind::StackMismatch add_error
+            fi
+        elif if_value OpValue::IfEnd is then
+            tc.branched_stacks.pop = top_frame
+            if top_frame BranchFrame::BranchIf(if_ctx) is then
+                if_ctx IfContext::before = if_before
+                if_ctx IfContext::after = if_after
+                if if_before tc.stack.equals if_after if_before.equals && then
+                    return
+                fi
+                tc.store if_after tc.stack.unify_types = unified
+                if 0 unified.length != if_ctx IfContext::default_present && then
+                    if_after tc.stack.restore
+                    unified tc.stack->types
+                    return
+                fi
+                tc.store if_before tc.stack.unify_types = unified_before
+                if 0 unified_before.length != if_ctx IfContext::default_present ! && then
+                    if_before tc.stack.restore
+                    unified_before tc.stack->types
+                    return
+                fi
+                op Op::location "Branches have incompatible stack effects" ErrorKind::StackMismatch add_error
             fi
         fi
-    elif
-    if_value OpValue::IfElif is
-    if_value OpValue::IfElse is ||
-    then
-        if 0 tc.branched_stacks.length == then return fi
-        tc.branched_stacks.length 1 - tc.branched_stacks.get = top_frame
-        if top_frame BranchFrame::BranchIf(if_ctx) is then
-            if if_value OpValue::IfElse is then
-                true if_ctx IfContext::set_default_present
-                false tc->in_branch_condition
-            else
-                true tc->in_branch_condition
-            fi
-            if_ctx IfContext::before = if_before
-            if_ctx IfContext::after = if_after
-            if if_before tc.stack.equals if_after if_before.equals && then
-                op Op::location if_ctx IfContext::set_current_branch_location
-                return
-            fi
-            tc.store if_after tc.stack.unify_types = unified
-            if 0 unified.length != if_after if_before.equals ! && then
-                unified if_after->types
-                if_before tc.stack.restore
-                op Op::location if_ctx IfContext::set_current_branch_location
-                return
-            fi
-            if if_after if_before.equals then
-                tc.stack if_after.restore
-                if_before tc.stack.restore
-                op Op::location if_ctx IfContext::set_current_branch_location
-                return
-            fi
-            op Op::location "Branches have incompatible stack effects" ErrorKind::StackMismatch add_error
-        fi
-    elif if_value OpValue::IfEnd is then
-        tc.branched_stacks.pop = top_frame
-        if top_frame BranchFrame::BranchIf(if_ctx) is then
-            if_ctx IfContext::before = if_before
-            if_ctx IfContext::after = if_after
-            if if_before tc.stack.equals if_after if_before.equals && then
-                return
-            fi
-            tc.store if_after tc.stack.unify_types = unified
-            if 0 unified.length != if_ctx IfContext::default_present && then
-                if_after tc.stack.restore
-                unified tc.stack->types
-                return
-            fi
-            tc.store if_before tc.stack.unify_types = unified_before
-            if 0 unified_before.length != if_ctx IfContext::default_present ! && then
-                if_before tc.stack.restore
-                unified_before tc.stack->types
-                return
-            fi
-            op Op::location "Branches have incompatible stack effects" ErrorKind::StackMismatch add_error
-        fi
-    fi
+    }
 }
 
 # ============================================================================
 # Check while/do/break/continue/done blocks
 # ============================================================================
 
-fn check_while_block tc:TypeChecker op:Op {
-    op.value = while_value
-    if while_value OpValue::WhileStart is then
-        WhileContext::new = while_ctx
-        tc.stack while_ctx WhileContext::before.restore
-        op Op::location while_ctx WhileContext::set_current_branch_location
-        while_ctx BranchFrame::BranchWhile = while_frame
-        while_frame tc.branched_stacks.push
-    elif while_value OpValue::WhileCondition is then
-        TYPE_BOOL_T tc expect_type_t
-        if 0 tc.branched_stacks.length == then return fi
-        tc.branched_stacks.length 1 - tc.branched_stacks.get = top_frame
-        if top_frame BranchFrame::BranchWhile(while_ctx) is then
-            true while_ctx WhileContext::set_condition_present
+impl TypeChecker {
+    fn check_while_block tc:TypeChecker op:Op {
+        op.value = while_value
+        if while_value OpValue::WhileStart is then
+            WhileContext::new = while_ctx
+            tc.stack while_ctx WhileContext::before.restore
+            op Op::location while_ctx WhileContext::set_current_branch_location
+            while_ctx BranchFrame::BranchWhile = while_frame
+            while_frame tc.branched_stacks.push
+        elif while_value OpValue::WhileCondition is then
+            TYPE_BOOL_T tc.expect_type_t
+            if 0 tc.branched_stacks.length == then return fi
+            tc.branched_stacks.length 1 - tc.branched_stacks.get = top_frame
+            if top_frame BranchFrame::BranchWhile(while_ctx) is then
+                true while_ctx WhileContext::set_condition_present
+            fi
+        elif
+        while_value OpValue::WhileBreak is
+        while_value OpValue::WhileContinue is ||
+        then
+            if 0 tc.branched_stacks.length == then return fi
+        elif while_value OpValue::WhileEnd is then
+            tc.branched_stacks.pop drop
         fi
-    elif
-    while_value OpValue::WhileBreak is
-    while_value OpValue::WhileContinue is ||
-    then
-        if 0 tc.branched_stacks.length == then return fi
-    elif while_value OpValue::WhileEnd is then
-        tc.branched_stacks.pop drop
-    fi
+    }
 }
 
 # ============================================================================
@@ -1446,455 +1509,477 @@ fn method_diff_bind_all
     bindings
 }
 
-fn inject_trait_fn_ptrs
-    tc:TypeChecker
-    effect:StackEffect
-    ops:List[Op]
-    op_index:int
-    location:Location
-    function_opt:Option[Function]
--> int {
-    # Bind type variables from the stack (peek at positions)
-    Map::new(Map[str Type]) = bindings
+impl TypeChecker {
+    fn inject_trait_fn_ptrs
+        tc:TypeChecker
+        effect:StackEffect
+        ops:List[Op]
+        op_index:int
+        location:Location
+        function_opt:Option[Function]
+    -> int {
+        # Bind type variables from the stack (peek at positions)
+        Map::new(Map[str Type]) = bindings
 
-    # Collect non-hidden parameters
-    List::new(List[Parameter]) = non_hidden
-    for param in effect StackEffect::parameters.iter do
-        if param Parameter::name "__trait_" str::starts_with ! then
-            param non_hidden.push
-        fi
-    done
+        # Collect non-hidden parameters
+        List::new(List[Parameter]) = non_hidden
+        for param in effect StackEffect::parameters.iter do
+            if param Parameter::name "__trait_" str::starts_with ! then
+                param non_hidden.push
+            fi
+        done
 
-    # Peek at stack to bind type variables
-    tc.stack.types.length = depth
-    0 = index
-    while index non_hidden.length > do
-        depth 1 - index - = stack_index
-        if 0 stack_index >= then
-            index non_hidden.get = stack_param
-            stack_index tc.stack.types.get = actual
-            if stack_param Parameter::typ.type_var_name Option::Some(binding_type_var) is then
-                if binding_type_var effect StackEffect::type_vars.has then
-                    binding_type_var bindings.get = existing_binding_opt
-                    if existing_binding_opt.is_none then
-                        actual binding_type_var bindings.set = bindings
-                    else
-                        existing_binding_opt.unwrap = existing_binding
-                        if existing_binding actual.eq ! then
-                            location f"Type variable `{binding_type_var}` bound to `{existing_binding.format}` but got `{actual.format}`" ErrorKind::TypeMismatch raise_error
+        # Peek at stack to bind type variables
+        tc.stack.types.length = depth
+        0 = index
+        while index non_hidden.length > do
+            depth 1 - index - = stack_index
+            if 0 stack_index >= then
+                index non_hidden.get = stack_param
+                stack_index tc.stack.types.get = actual
+                if stack_param Parameter::typ.type_var_name Option::Some(binding_type_var) is then
+                    if binding_type_var effect StackEffect::type_vars.has then
+                        binding_type_var bindings.get = existing_binding_opt
+                        if existing_binding_opt.is_none then
+                            actual binding_type_var bindings.set = bindings
+                        else
+                            existing_binding_opt.unwrap = existing_binding
+                            if existing_binding actual.eq ! then
+                                location f"Type variable `{binding_type_var}` bound to `{existing_binding.format}` but got `{actual.format}`" ErrorKind::TypeMismatch raise_error
+                            fi
                         fi
+                    else
+                        effect StackEffect::type_vars actual stack_param Parameter::typ bindings bind_generic_params_standalone = bindings
                     fi
                 else
                     effect StackEffect::type_vars actual stack_param Parameter::typ bindings bind_generic_params_standalone = bindings
                 fi
-            else
-                effect StackEffect::type_vars actual stack_param Parameter::typ bindings bind_generic_params_standalone = bindings
+            fi
+            1 += index
+        done
+
+        # Method stack-effect diff binding for bounds with type-var args.
+        # For a bound like `I: Iterable[T]` where T is still unbound but I is
+        # bound from the stack, inspect the concrete type's implementation of
+        # each trait method and diff its stack effect against the trait's declared
+        # stack effect to bind T. Single pass in declaration order.
+        tc.store bindings function_opt effect method_diff_bind_all = bindings
+
+        # Check TYPE_CAST lookahead for return type binding
+        if op_index ops.length > then
+            op_index ops.get = next_op
+            if next_op.value OpValue::TypeCast(cast_type) is then
+                for return_type in effect StackEffect::return_types.iter do
+                    effect StackEffect::type_vars cast_type return_type bindings bind_generic_params_standalone = bindings
+                done
             fi
         fi
-        1 += index
-    done
 
-    # Method stack-effect diff binding for bounds with type-var args.
-    # For a bound like `I: Iterable[T]` where T is still unbound but I is
-    # bound from the stack, inspect the concrete type's implementation of
-    # each trait method and diff its stack effect against the trait's declared
-    # stack effect to bind T. Single pass in declaration order.
-    tc.store bindings function_opt effect method_diff_bind_all = bindings
+        # Inject FN_PUSH ops for each trait bound.
+        # Iterate type vars in reverse so the first param in the stack effect (which
+        # the parser prepends in forward key order) ends up on the top of the stack,
+        # matching the order apply_stack_effect pops parameters in.
+        0 = inserted
+        op_index 1 - = insert_pos
+        effect StackEffect::trait_bounds.keys = type_var_keys
+        type_var_keys.length 1 - = type_index
+        while 0 type_index >= do
+            type_index type_var_keys.get = type_var
+            type_var effect StackEffect::trait_bounds.get.unwrap = trait_bound
+            # Resolve trait type args against current bindings so that
+            # `Carrier[T]` becomes `Carrier[int]` once T has been bound.
+            trait_bound trait_bound_to_type = trait_bound_type
+            bindings trait_bound_type.substitute_t.format = trait_name
+            type_var bindings.get = concrete_opt
+            if concrete_opt.is_none then
+                location f"Cannot determine concrete type for type variable `{type_var}`" ErrorKind::TypeMismatch raise_error
+                type_index 1 - = type_index
+                continue
+            fi
+            concrete_opt.unwrap = concrete_t
+            concrete_t.format = concrete
+            trait_bound TraitBound::name tc.store.traits.get.unwrap = trait_def
 
-    # Check TYPE_CAST lookahead for return type binding
-    if op_index ops.length > then
-        op_index ops.get = next_op
-        if next_op.value OpValue::TypeCast(cast_type) is then
-            for return_type in effect StackEffect::return_types.iter do
-                effect StackEffect::type_vars cast_type return_type bindings bind_generic_params_standalone = bindings
-            done
-        fi
-    fi
-
-    # Inject FN_PUSH ops for each trait bound.
-    # Iterate type vars in reverse so the first param in the stack effect (which
-    # the parser prepends in forward key order) ends up on the top of the stack,
-    # matching the order apply_stack_effect pops parameters in.
-    0 = inserted
-    op_index 1 - = insert_pos
-    effect StackEffect::trait_bounds.keys = type_var_keys
-    type_var_keys.length 1 - = type_index
-    while 0 type_index >= do
-        type_index type_var_keys.get = type_var
-        type_var effect StackEffect::trait_bounds.get.unwrap = trait_bound
-        # Resolve trait type args against current bindings so that
-        # `Carrier[T]` becomes `Carrier[int]` once T has been bound.
-        trait_bound trait_bound_to_type = trait_bound_type
-        bindings trait_bound_type.substitute_t.format = trait_name
-        type_var bindings.get = concrete_opt
-        if concrete_opt.is_none then
-            location f"Cannot determine concrete type for type variable `{type_var}`" ErrorKind::TypeMismatch raise_error
-            type_index 1 - = type_index
-            continue
-        fi
-        concrete_opt.unwrap = concrete_t
-        concrete_t.format = concrete
-        trait_bound TraitBound::name tc.store.traits.get.unwrap = trait_def
-
-        # Check if forwarding (type var has same trait bound in calling function)
-        false = is_forwarding
-        if function_opt.is_some then
-            concrete function_opt.unwrap Function::stack_effect StackEffect::trait_bounds.get = caller_bound_opt
-            if caller_bound_opt.is_some then
-                caller_bound_opt.unwrap = caller_bound_val
-                if trait_bound caller_bound_val trait_bound_eq then
-                    true = is_forwarding
+            # Check if forwarding (type var has same trait bound in calling function)
+            false = is_forwarding
+            if function_opt.is_some then
+                concrete function_opt.unwrap Function::stack_effect StackEffect::trait_bounds.get = caller_bound_opt
+                if caller_bound_opt.is_some then
+                    caller_bound_opt.unwrap = caller_bound_val
+                    if trait_bound caller_bound_val trait_bound_eq then
+                        true = is_forwarding
+                    fi
                 fi
             fi
-        fi
 
-        trait_def tc.store collect_trait_methods = expanded_methods
-        if is_forwarding then
-            # Forward hidden fn ptrs from calling function (abstract methods only)
-            expanded_methods.length 1 - = method_index
-            while 0 method_index >= do
-                method_index expanded_methods.get = method
-                if 0 method TraitMethod::default_ops.length == then
-                    f"__trait_{concrete}_{method TraitMethod::name}" = hidden_var
-                    location hidden_var OpValue::PushVar Op::new = push_op
-                    insert_pos push_op ops.insert
-                    1 += insert_pos
-                    1 += inserted
-                    concrete method TraitMethod::stack_effect resolve_trait_stack_effect = forward_stack_effect
-                    forward_stack_effect stack_effect_to_function_type tc stack_push_type
-                fi
-                method_index 1 - = method_index
-            done
-        else
-            # Verify structural satisfaction
-            if tc.store function_opt trait_name concrete_t type_satisfies_trait ! then
-                location f"Type `{concrete}` does not satisfy trait `{trait_name}`" ErrorKind::TypeMismatch raise_error
-            fi
-            # Inject FN_PUSH for each abstract method (reversed)
-            # Skip default methods — they are instantiated on demand
-            expanded_methods.length 1 - = method_index
-            while 0 method_index >= do
-                method_index expanded_methods.get = method
-                if 0 method TraitMethod::default_ops.length == then
-                    f"{concrete}::{method TraitMethod::name}" = fn_name
-                    fn_name tc.store.functions.get = global_fn_opt
-                    if global_fn_opt.is_some then
-                        global_fn_opt.unwrap = global_fn
-                        if global_fn Function::is_used ! then
-                            true global_fn Function::set_is_used
-                            global_fn global_fn Function::ops tc.store resolve_identifiers global_fn Function::set_ops
-                        fi
-                        tc.store global_fn ensure_typechecked
-                        location fn_name OpValue::FnPush Op::new = push_op
+            trait_def tc.store collect_trait_methods = expanded_methods
+            if is_forwarding then
+                # Forward hidden fn ptrs from calling function (abstract methods only)
+                expanded_methods.length 1 - = method_index
+                while 0 method_index >= do
+                    method_index expanded_methods.get = method
+                    if 0 method TraitMethod::default_ops.length == then
+                        f"__trait_{concrete}_{method TraitMethod::name}" = hidden_var
+                        location hidden_var OpValue::PushVar Op::new = push_op
                         insert_pos push_op ops.insert
                         1 += insert_pos
                         1 += inserted
-                        global_fn Function::stack_effect stack_effect_to_function_type tc stack_push_type
-                    else
-                        location f"Function `{fn_name}` required by trait `{trait_name}` not found" ErrorKind::TypeMismatch raise_error
+                        concrete method TraitMethod::stack_effect resolve_trait_stack_effect = forward_stack_effect
+                        forward_stack_effect stack_effect_to_function_type tc.stack_push_type
                     fi
+                    method_index 1 - = method_index
+                done
+            else
+                # Verify structural satisfaction
+                if tc.store function_opt trait_name concrete_t type_satisfies_trait ! then
+                    location f"Type `{concrete}` does not satisfy trait `{trait_name}`" ErrorKind::TypeMismatch raise_error
                 fi
-                method_index 1 - = method_index
-            done
-        fi
-        type_index 1 - = type_index
-    done
-    inserted
+                # Inject FN_PUSH for each abstract method (reversed)
+                # Skip default methods — they are instantiated on demand
+                expanded_methods.length 1 - = method_index
+                while 0 method_index >= do
+                    method_index expanded_methods.get = method
+                    if 0 method TraitMethod::default_ops.length == then
+                        f"{concrete}::{method TraitMethod::name}" = fn_name
+                        fn_name tc.store.functions.get = global_fn_opt
+                        if global_fn_opt.is_some then
+                            global_fn_opt.unwrap = global_fn
+                            if global_fn Function::is_used ! then
+                                true global_fn Function::set_is_used
+                                global_fn global_fn Function::ops tc.store resolve_identifiers global_fn Function::set_ops
+                            fi
+                            tc.store global_fn ensure_typechecked
+                            location fn_name OpValue::FnPush Op::new = push_op
+                            insert_pos push_op ops.insert
+                            1 += insert_pos
+                            1 += inserted
+                            global_fn Function::stack_effect stack_effect_to_function_type tc.stack_push_type
+                        else
+                            location f"Function `{fn_name}` required by trait `{trait_name}` not found" ErrorKind::TypeMismatch raise_error
+                        fi
+                    fi
+                    method_index 1 - = method_index
+                done
+            fi
+            type_index 1 - = type_index
+        done
+        inserted
+    }
 }
 
 # ============================================================================
 # Check function-related operations
 # ============================================================================
 
-fn check_function_ops
-    tc:TypeChecker
-    op:Op
-    ops:List[Op]
-    op_index:int
-    function_opt:Option[Function]
--> int {
-    op.value = fn_value
-    if fn_value OpValue::FnCall(fn_name) is then
-        fn_name tc.store.functions.get = fn_opt
-        if fn_opt.is_some then
-            fn_opt.unwrap = function
-            tc.store function ensure_typechecked
-            function Function::stack_effect = effect
-            if 0 effect StackEffect::trait_bounds.keys.length != then
-                function_opt op Op::location op_index ops effect tc inject_trait_fn_ptrs = injected
-                injected += op_index
+impl TypeChecker {
+    fn check_function_ops
+        tc:TypeChecker
+        op:Op
+        ops:List[Op]
+        op_index:int
+        function_opt:Option[Function]
+    -> int {
+        op.value = fn_value
+        if fn_value OpValue::FnCall(fn_name) is then
+            fn_name tc.store.functions.get = fn_opt
+            if fn_opt.is_some then
+                fn_opt.unwrap = function
+                tc.store function ensure_typechecked
+                function Function::stack_effect = effect
+                if 0 effect StackEffect::trait_bounds.keys.length != then
+                    function_opt op Op::location op_index ops effect tc.inject_trait_fn_ptrs = injected
+                    injected += op_index
+                fi
+                fn_name effect tc.apply_stack_effect
             fi
-            fn_name effect tc apply_stack_effect
-        fi
-    elif fn_value OpValue::FnExec is then
-        tc stack_peek_type = fn_ptr_type
-        if fn_ptr_type.is_unknown_placeholder then
-            TYPE_UNKNOWN_T tc expect_type_t
-        else
-            fn_ptr_type tc expect_type_t
-            if fn_ptr_type Type::Function(fn_type) is then
-                if 0 fn_type FunctionType::parameters.length != 0 fn_type FunctionType::return_types.length != || then
-                    "exec" fn_type function_type_to_stack_effect tc apply_stack_effect
+        elif fn_value OpValue::FnExec is then
+            tc.stack_peek_type = fn_ptr_type
+            if fn_ptr_type.is_unknown_placeholder then
+                TYPE_UNKNOWN_T tc.expect_type_t
+            else
+                fn_ptr_type tc.expect_type_t
+                if fn_ptr_type Type::Function(fn_type) is then
+                    if 0 fn_type FunctionType::parameters.length != 0 fn_type FunctionType::return_types.length != || then
+                        "exec" fn_type function_type_to_stack_effect tc.apply_stack_effect
+                    fi
+                fi
+            fi
+        elif fn_value OpValue::FnPush(push_name) is then
+            push_name tc.store.functions.get = push_fn_opt
+            if push_fn_opt.is_some then
+                push_fn_opt.unwrap = push_fn
+                tc.store push_fn ensure_typechecked
+                push_fn Function::stack_effect stack_effect_to_function_type tc.stack_push_type
+            else
+                "fn" tc.stack_push
+            fi
+        elif fn_value OpValue::FnReturn is then
+            if tc.has_return_types ! then
+                true tc->has_return_types
+                tc.stack tc.return_types.restore
+            fi
+            if 0 tc.branched_stacks.length != then
+                tc.branched_stacks.length 1 - tc.branched_stacks.get = top_frame
+                if top_frame BranchFrame::BranchIf(if_ctx) is then
+                    if_ctx IfContext::before tc.stack.restore
+                elif top_frame BranchFrame::BranchWhile(while_ctx) is then
+                    while_ctx WhileContext::before tc.stack.restore
+                elif top_frame BranchFrame::BranchMatch(match_ctx) is then
+                    match_ctx MatchContext::before tc.stack.restore
                 fi
             fi
         fi
-    elif fn_value OpValue::FnPush(push_name) is then
-        push_name tc.store.functions.get = push_fn_opt
-        if push_fn_opt.is_some then
-            push_fn_opt.unwrap = push_fn
-            tc.store push_fn ensure_typechecked
-            push_fn Function::stack_effect stack_effect_to_function_type tc stack_push_type
-        else
-            "fn" tc stack_push
-        fi
-    elif fn_value OpValue::FnReturn is then
-        if tc.has_return_types ! then
-            true tc->has_return_types
-            tc.stack tc.return_types.restore
-        fi
-        if 0 tc.branched_stacks.length != then
-            tc.branched_stacks.length 1 - tc.branched_stacks.get = top_frame
-            if top_frame BranchFrame::BranchIf(if_ctx) is then
-                if_ctx IfContext::before tc.stack.restore
-            elif top_frame BranchFrame::BranchWhile(while_ctx) is then
-                while_ctx WhileContext::before tc.stack.restore
-            elif top_frame BranchFrame::BranchMatch(match_ctx) is then
-                match_ctx MatchContext::before tc.stack.restore
-            fi
-        fi
-    fi
-    op_index
+        op_index
+    }
 }
 
 # ============================================================================
 # Check literal push operations
 # ============================================================================
 
-fn check_literals tc:TypeChecker op:Op function_opt:Option[Function] {
-    op.value = literal_value
-    if literal_value OpValue::PushInt is then
-        TYPE_INT_T tc stack_push_type
-    elif literal_value OpValue::PushStr is then
-        TYPE_STR_T tc stack_push_type
-    elif literal_value OpValue::PushBool is then
-        TYPE_BOOL_T tc stack_push_type
-    elif literal_value OpValue::PushChar is then
-        TYPE_CHAR_T tc stack_push_type
-    elif literal_value OpValue::PushArray(items) is then
-        if 0 items.length == then
-            List::new(List[Type]) = empty_params
-            TYPE_UNKNOWN_T empty_params.push
-            empty_params "array" GenericType Type::Generic tc stack_push_type
-        else
-            function_opt items tc run_type_check_ops
-            TYPE_UNKNOWN_T = elem_type_t
-            0 = items_idx
-            while items_idx items.length > do
-                tc stack_pop_type = item_type_t
-                tc.store item_type_t elem_type_t unify_type_t = unified_opt
-                if unified_opt.is_none then
-                    op Op::location f"Heterogeneous array literal: cannot unify `{elem_type_t.format}` and `{item_type_t.format}`" ErrorKind::TypeMismatch raise_error
-                else
-                    unified_opt.unwrap = elem_type_t
-                fi
-                1 += items_idx
+impl TypeChecker {
+    fn check_literals tc:TypeChecker op:Op function_opt:Option[Function] {
+        op.value = literal_value
+        if literal_value OpValue::PushInt is then
+            TYPE_INT_T tc.stack_push_type
+        elif literal_value OpValue::PushStr is then
+            TYPE_STR_T tc.stack_push_type
+        elif literal_value OpValue::PushBool is then
+            TYPE_BOOL_T tc.stack_push_type
+        elif literal_value OpValue::PushChar is then
+            TYPE_CHAR_T tc.stack_push_type
+        elif literal_value OpValue::PushArray(items) is then
+            if 0 items.length == then
+                List::new(List[Type]) = empty_params
+                TYPE_UNKNOWN_T empty_params.push
+                empty_params "array" GenericType Type::Generic tc.stack_push_type
+            else
+                function_opt items tc.run_type_check_ops
+                TYPE_UNKNOWN_T = elem_type_t
+                0 = items_idx
+                while items_idx items.length > do
+                    tc.stack_pop_type = item_type_t
+                    tc.store item_type_t elem_type_t unify_type_t = unified_opt
+                    if unified_opt.is_none then
+                        op Op::location f"Heterogeneous array literal: cannot unify `{elem_type_t.format}` and `{item_type_t.format}`" ErrorKind::TypeMismatch raise_error
+                    else
+                        unified_opt.unwrap = elem_type_t
+                    fi
+                    1 += items_idx
+                done
+                List::new(List[Type]) = item_params
+                elem_type_t item_params.push
+                item_params "array" GenericType Type::Generic tc.stack_push_type
+            fi
+        elif literal_value OpValue::ExprGroup(group_ops) is then
+            function_opt group_ops tc.run_type_check_ops
+        elif literal_value OpValue::FstringConcat(count) is then
+            0 = index
+            while index count > do
+                TYPE_STR_T tc.expect_type_t
+                1 += index
             done
-            List::new(List[Type]) = item_params
-            elem_type_t item_params.push
-            item_params "array" GenericType Type::Generic tc stack_push_type
+            TYPE_STR_T tc.stack_push_type
         fi
-    elif literal_value OpValue::ExprGroup(group_ops) is then
-        function_opt group_ops tc run_type_check_ops
-    elif literal_value OpValue::FstringConcat(count) is then
-        0 = index
-        while index count > do
-            TYPE_STR_T tc expect_type_t
-            1 += index
-        done
-        TYPE_STR_T tc stack_push_type
-    fi
+    }
 }
 
 # ============================================================================
 # Check print dispatch
 # ============================================================================
 
-fn check_io tc:TypeChecker op:Op ops:List[Op] op_index:int function_opt:Option[Function] -> int {
-    "value with trait `Display`" tc->current_expect_ctx
-    tc stack_peek_type = peek_t
-    peek_t.format = typ
-    if "str" typ == then
-        tc stack_pop_drop
-        OpValue::PrintStr op Op::set_value
-        op_index return
-    fi
-    if "bool" typ == then
-        tc stack_pop_drop
-        OpValue::PrintBool op Op::set_value
-        op_index return
-    fi
-    if "char" typ == then
-        tc stack_pop_drop
-        OpValue::PrintChar op Op::set_value
-        op_index return
-    fi
-    if "cstr" typ == then
-        tc stack_pop_drop
-        OpValue::PrintCstr op Op::set_value
-        op_index return
-    fi
-    if "int" typ == then
-        tc stack_pop_drop
-        OpValue::PrintInt op Op::set_value
-        op_index return
-    fi
-    if TYPE_MISSING typ == then
-        tc stack_pop_drop
-        op_index return
-    fi
-    if tc.store function_opt "Display" peek_t type_satisfies_trait ! then
-        op Op::location f"Type `{typ}` cannot be printed: does not satisfy trait `Display`" ErrorKind::MissingTraitMethod add_error
-        tc stack_pop_drop
-        op_index return
-    fi
-    "to_str" OpValue::MethodCall op Op::set_value
-    function_opt op_index ops op tc check_method_call = new_index
-    op Op::location OpValue::Print Op::new = print_op
-    new_index print_op ops.insert
-    new_index
+impl TypeChecker {
+    fn check_io
+        tc:TypeChecker
+        op:Op
+        ops:List[Op]
+        op_index:int
+        function_opt:Option[Function]
+    -> int {
+        "value with trait `Display`" tc->current_expect_ctx
+        tc.stack_peek_type = peek_t
+        peek_t.format = typ
+        if "str" typ == then
+            tc.stack_pop_drop
+            OpValue::PrintStr op Op::set_value
+            op_index return
+        fi
+        if "bool" typ == then
+            tc.stack_pop_drop
+            OpValue::PrintBool op Op::set_value
+            op_index return
+        fi
+        if "char" typ == then
+            tc.stack_pop_drop
+            OpValue::PrintChar op Op::set_value
+            op_index return
+        fi
+        if "cstr" typ == then
+            tc.stack_pop_drop
+            OpValue::PrintCstr op Op::set_value
+            op_index return
+        fi
+        if "int" typ == then
+            tc.stack_pop_drop
+            OpValue::PrintInt op Op::set_value
+            op_index return
+        fi
+        if TYPE_MISSING typ == then
+            tc.stack_pop_drop
+            op_index return
+        fi
+        if tc.store function_opt "Display" peek_t type_satisfies_trait ! then
+            op Op::location f"Type `{typ}` cannot be printed: does not satisfy trait `Display`" ErrorKind::MissingTraitMethod add_error
+            tc.stack_pop_drop
+            op_index return
+        fi
+        "to_str" OpValue::MethodCall op Op::set_value
+        function_opt op_index ops op tc.check_method_call = new_index
+        op Op::location OpValue::Print Op::new = print_op
+        new_index print_op ops.insert
+        new_index
+    }
 }
 
 # ============================================================================
 # Check typeof
 # ============================================================================
 
-fn check_typeof tc:TypeChecker op:Op {
-    tc stack_pop = typ
-    typ parse_type_str Option::Some op Op::set_type_hint
-    TYPE_STR_T tc stack_push_type
+impl TypeChecker {
+    fn check_typeof tc:TypeChecker op:Op {
+        tc.stack_pop = typ
+        typ parse_type_str Option::Some op Op::set_type_hint
+        TYPE_STR_T tc.stack_push_type
+    }
 }
 
 # ============================================================================
 # Check syscalls
 # ============================================================================
 
-fn check_syscalls tc:TypeChecker op:Op function_opt:Option[Function] {
-    op.value match
-        OpValue::Syscall0 => 0
-        OpValue::Syscall1 => 1
-        OpValue::Syscall2 => 2
-        OpValue::Syscall3 => 3
-        OpValue::Syscall4 => 4
-        OpValue::Syscall5 => 5
-        OpValue::Syscall6 => 6
-        _ => -1
-    end = arg_count
-    TYPE_INT_T tc expect_type_t
-    0 = index
-    while index arg_count > do
-        tc stack_pop = arg_type
-        function_opt arg_type op tc assert_word_bound
-        1 += index
-    done
-    TYPE_INT_T tc stack_push_type
+impl TypeChecker {
+    fn check_syscalls tc:TypeChecker op:Op function_opt:Option[Function] {
+        op.value match
+            OpValue::Syscall0 => 0
+            OpValue::Syscall1 => 1
+            OpValue::Syscall2 => 2
+            OpValue::Syscall3 => 3
+            OpValue::Syscall4 => 4
+            OpValue::Syscall5 => 5
+            OpValue::Syscall6 => 6
+            _ => -1
+        end = arg_count
+        TYPE_INT_T tc.expect_type_t
+        0 = index
+        while index arg_count > do
+            tc.stack_pop = arg_type
+            function_opt arg_type op tc.assert_word_bound
+            1 += index
+        done
+        TYPE_INT_T tc.stack_push_type
+    }
 }
 
 # ============================================================================
 # Check enum variant push
 # ============================================================================
 
-fn check_enum_variant tc:TypeChecker op:Op {
-    if op.value OpValue::PushEnumVariant(variant) is ! then return fi
-    variant EnumVariant::enum_name = enum_name
-    enum_name tc.store.enums.get = enum_opt
-    if enum_opt.is_none then
-        enum_name GenericType::new Type::Generic tc stack_push_type
-        return
-    fi
-    enum_opt.unwrap = casa_enum
-    variant EnumVariant::variant_name casa_enum CasaEnum::variant_types.get = inner_opt
-    if inner_opt.is_none then
-        # No inner values - push the enum type
-        if 0 casa_enum CasaEnum::type_vars.length != then
-            casa_enum CasaEnum::type_vars enum_name build_parameterized_type_t tc stack_push_type
-        else
-            enum_name GenericType::new Type::Generic tc stack_push_type
+impl TypeChecker {
+    fn check_enum_variant tc:TypeChecker op:Op {
+        if op.value OpValue::PushEnumVariant(variant) is ! then return fi
+        variant EnumVariant::enum_name = enum_name
+        enum_name tc.store.enums.get = enum_opt
+        if enum_opt.is_none then
+            enum_name GenericType::new Type::Generic tc.stack_push_type
+            return
         fi
-        return
-    fi
-    inner_opt.unwrap = inner_types
-    if 0 inner_types.length == then
-        if 0 casa_enum CasaEnum::type_vars.length != then
-            casa_enum CasaEnum::type_vars enum_name build_parameterized_type_t tc stack_push_type
-        else
-            enum_name GenericType::new Type::Generic tc stack_push_type
-        fi
-        return
-    fi
-
-    # Data-carrying variant: pop inner values, resolve generics
-    if 0 casa_enum CasaEnum::type_vars.length != then
-        # Generic enum variant (e.g. Option::Some with T)
-        # Bind type vars from inner values
-        Map::new(Map[str Type]) = bindings
-        Set::new(Set[str]) = type_vars
-        for type_var in casa_enum CasaEnum::type_vars.iter do
-            type_var type_vars.add = type_vars
-        done
-        for expected in inner_types.iter do
-            if expected.type_var_name Option::Some(tv_name) is tv_name type_vars.has && then
-                tc stack_pop_type = actual_t
-                actual_t tv_name bindings tc bind_type_var = bindings
+        enum_opt.unwrap = casa_enum
+        variant EnumVariant::variant_name casa_enum CasaEnum::variant_types.get = inner_opt
+        if inner_opt.is_none then
+            # No inner values - push the enum type
+            if 0 casa_enum CasaEnum::type_vars.length != then
+                casa_enum CasaEnum::type_vars enum_name build_parameterized_type_t tc.stack_push_type
             else
-                expected tc expect_type_t
+                enum_name GenericType::new Type::Generic tc.stack_push_type
             fi
-        done
-        # Build resolved type name
-        bindings casa_enum CasaEnum::type_vars enum_name build_resolved_type_t tc stack_push_type
-    else
-        # Non-generic variant: pop inner values directly
-        for inner_type in inner_types.iter do
-            inner_type tc expect_type_t
-        done
-        enum_name GenericType::new Type::Generic tc stack_push_type
-    fi
+            return
+        fi
+        inner_opt.unwrap = inner_types
+        if 0 inner_types.length == then
+            if 0 casa_enum CasaEnum::type_vars.length != then
+                casa_enum CasaEnum::type_vars enum_name build_parameterized_type_t tc.stack_push_type
+            else
+                enum_name GenericType::new Type::Generic tc.stack_push_type
+            fi
+            return
+        fi
+
+        # Data-carrying variant: pop inner values, resolve generics
+        if 0 casa_enum CasaEnum::type_vars.length != then
+            # Generic enum variant (e.g. Option::Some with T)
+            # Bind type vars from inner values
+            Map::new(Map[str Type]) = bindings
+            Set::new(Set[str]) = type_vars
+            for type_var in casa_enum CasaEnum::type_vars.iter do
+                type_var type_vars.add = type_vars
+            done
+            for expected in inner_types.iter do
+                if expected.type_var_name Option::Some(tv_name) is tv_name type_vars.has && then
+                    tc.stack_pop_type = actual_t
+                    actual_t tv_name bindings tc.bind_type_var = bindings
+                else
+                    expected tc.expect_type_t
+                fi
+            done
+            # Build resolved type name
+            bindings casa_enum CasaEnum::type_vars enum_name build_resolved_type_t tc.stack_push_type
+        else
+            # Non-generic variant: pop inner values directly
+            for inner_type in inner_types.iter do
+                inner_type tc.expect_type_t
+            done
+            enum_name GenericType::new Type::Generic tc.stack_push_type
+        fi
+    }
 }
 
 # ============================================================================
 # Check is keyword
 # ============================================================================
 
-fn check_is tc:TypeChecker op:Op function_opt:Option[Function] {
-    tc stack_pop_type = typ
-    typ.match_base = base
-    if base tc.store.enums.get.is_none then
-        f"`is` requires an enum type, got `{typ.format}`" tc raise_type_mismatch
-        TYPE_BOOL_T tc stack_push_type
-        return
-    fi
-    base tc.store.enums.get.unwrap = casa_enum
-    if op.value OpValue::IsCheck(variant) is ! then
-        TYPE_BOOL_T tc stack_push_type
-        return
-    fi
-    # Validate the variant belongs to the correct enum
-    if "" variant EnumVariant::enum_name != then
-        if variant EnumVariant::enum_name casa_enum CasaEnum::name != then
-            f"Cannot check `{variant EnumVariant::enum_name}::{variant EnumVariant::variant_name}` on value of type `{typ.format}`" tc raise_type_mismatch
+impl TypeChecker {
+    fn check_is tc:TypeChecker op:Op function_opt:Option[Function] {
+        tc.stack_pop_type = typ
+        typ.match_base = base
+        if base tc.store.enums.get.is_none then
+            f"`is` requires an enum type, got `{typ.format}`" tc.raise_type_mismatch
+            TYPE_BOOL_T tc.stack_push_type
+            return
         fi
-    fi
-    # Validate binding count for data-carrying variants
-    if 0 variant EnumVariant::bindings.length != then
-        variant EnumVariant::variant_name casa_enum CasaEnum::variant_types.get = inner_opt
-        if inner_opt.is_some then
-            inner_opt.unwrap = inner_types
-            if variant EnumVariant::bindings.length inner_types.length != then
-                f"Variant `{variant EnumVariant::enum_name}::{variant EnumVariant::variant_name}` has {inner_types.length} inner value(s), but {variant EnumVariant::bindings.length} binding(s) provided" tc raise_type_mismatch
+        base tc.store.enums.get.unwrap = casa_enum
+        if op.value OpValue::IsCheck(variant) is ! then
+            TYPE_BOOL_T tc.stack_push_type
+            return
+        fi
+        # Validate the variant belongs to the correct enum
+        if "" variant EnumVariant::enum_name != then
+            if variant EnumVariant::enum_name casa_enum CasaEnum::name != then
+                f"Cannot check `{variant EnumVariant::enum_name}::{variant EnumVariant::variant_name}` on value of type `{typ.format}`" tc.raise_type_mismatch
             fi
         fi
-    fi
-    typ.format variant function_opt tc register_enum_pattern_bindings
-    TYPE_BOOL_T tc stack_push_type
+        # Validate binding count for data-carrying variants
+        if 0 variant EnumVariant::bindings.length != then
+            variant EnumVariant::variant_name casa_enum CasaEnum::variant_types.get = inner_opt
+            if inner_opt.is_some then
+                inner_opt.unwrap = inner_types
+                if variant EnumVariant::bindings.length inner_types.length != then
+                    f"Variant `{variant EnumVariant::enum_name}::{variant EnumVariant::variant_name}` has {inner_types.length} inner value(s), but {variant EnumVariant::bindings.length} binding(s) provided" tc.raise_type_mismatch
+                fi
+            fi
+        fi
+        typ.format variant function_opt tc register_enum_pattern_bindings
+        TYPE_BOOL_T tc.stack_push_type
+    }
 }
 
 # ============================================================================
@@ -1917,196 +2002,202 @@ fn set_binding_type var_name:str field_type:Type function_opt:Option[Function] s
     fi
 }
 
-fn check_match tc:TypeChecker op:Op function_opt:Option[Function] {
-    op.value = match_value
-    if match_value OpValue::MatchStart is then
-        if 0 tc.stack.types.length == then
-            tc within_param_cap = inferring_stack_effect
-            if function_opt.is_some then
-                if function_opt.unwrap Function::name "lambda__" str::starts_with ! then
+impl TypeChecker {
+    fn check_match tc:TypeChecker op:Op function_opt:Option[Function] {
+        op.value = match_value
+        if match_value OpValue::MatchStart is then
+            if 0 tc.stack.types.length == then
+                tc.within_param_cap = inferring_stack_effect
+                if function_opt.is_some then
+                    if function_opt.unwrap Function::name "lambda__" str::starts_with ! then
+                        false = inferring_stack_effect
+                    fi
+                else
                     false = inferring_stack_effect
                 fi
-            else
-                false = inferring_stack_effect
+                if inferring_stack_effect ! then
+                    op Op::location "`match` requires a subject value on the stack" ErrorKind::StackUnderflow add_error
+                    true tc->underflow_reported_this_op
+                fi
             fi
-            if inferring_stack_effect ! then
-                op Op::location "`match` requires a subject value on the stack" ErrorKind::StackUnderflow add_error
-                true tc->underflow_reported_this_op
-            fi
-        fi
-        tc stack_pop = match_type
-        match_type MatchContext::new = match_ctx
-        # Snapshot the entry stack state eagerly so that an OpFnReturn visiting
-        # this frame before any OpMatchArm still finds a correct `before` to
-        # restore from. Matches the pre-refactor make_branched_stack behavior.
-        tc.stack match_ctx MatchContext::before.restore
-        tc.stack match_ctx MatchContext::after.restore
-        op Op::location match_ctx MatchContext::set_current_branch_location
-        match_ctx BranchFrame::BranchMatch = match_frame
-        match_frame tc.branched_stacks.push
-    elif match_value OpValue::MatchArm is then
-        op function_opt tc typecheck_match_op
-    elif match_value OpValue::MatchEnd is then
-        tc.branched_stacks.pop = top_frame
-        if top_frame BranchFrame::BranchMatch(match_ctx) is then
-            # Record last arm label
-            if "" match_ctx MatchContext::current_branch_label != then
-                match_ctx MatchContext::current_branch_label match_ctx MatchContext::branch_records.push
-            fi
-            # Record last arm stack effect (same logic as next-arm recording)
-            if match_ctx MatchContext::condition_present then
-                match_ctx MatchContext::before = match_before
-                match_ctx MatchContext::after = match_after
-                if
-                match_before tc.stack.equals
-                match_after match_before.equals && !
-                then
-                    tc.store match_after tc.stack.unify_types = last_unified
-                    if 0 last_unified.length != match_after match_before.equals ! && then
-                        last_unified match_after->types
-                    elif match_after match_before.equals then
-                        tc.stack match_after.restore
-                    else
-                        op Op::location "Match arms have incompatible stack effects" ErrorKind::StackMismatch add_error
+            tc.stack_pop = match_type
+            match_type MatchContext::new = match_ctx
+            # Snapshot the entry stack state eagerly so that an OpFnReturn visiting
+            # this frame before any OpMatchArm still finds a correct `before` to
+            # restore from. Matches the pre-refactor make_branched_stack behavior.
+            tc.stack match_ctx MatchContext::before.restore
+            tc.stack match_ctx MatchContext::after.restore
+            op Op::location match_ctx MatchContext::set_current_branch_location
+            match_ctx BranchFrame::BranchMatch = match_frame
+            match_frame tc.branched_stacks.push
+        elif match_value OpValue::MatchArm is then
+            op function_opt tc typecheck_match_op
+        elif match_value OpValue::MatchEnd is then
+            tc.branched_stacks.pop = top_frame
+            if top_frame BranchFrame::BranchMatch(match_ctx) is then
+                # Record last arm label
+                if "" match_ctx MatchContext::current_branch_label != then
+                    match_ctx MatchContext::current_branch_label match_ctx MatchContext::branch_records.push
+                fi
+                # Record last arm stack effect (same logic as next-arm recording)
+                if match_ctx MatchContext::condition_present then
+                    match_ctx MatchContext::before = match_before
+                    match_ctx MatchContext::after = match_after
+                    if
+                    match_before tc.stack.equals
+                    match_after match_before.equals && !
+                    then
+                        tc.store match_after tc.stack.unify_types = last_unified
+                        if 0 last_unified.length != match_after match_before.equals ! && then
+                            last_unified match_after->types
+                        elif match_after match_before.equals then
+                            tc.stack match_after.restore
+                        else
+                            op Op::location "Match arms have incompatible stack effects" ErrorKind::StackMismatch add_error
+                        fi
                     fi
+                    match_before tc.stack.restore
                 fi
-                match_before tc.stack.restore
-            fi
 
-            match_ctx MatchContext::match_type = end_match_type
-            end_match_type parse_type_str.match_base = end_base
+                match_ctx MatchContext::match_type = end_match_type
+                end_match_type parse_type_str.match_base = end_base
 
-            # Build covered set
-            Set::new(Set[str]) = covered_set
-            for record in match_ctx MatchContext::branch_records.iter do
-                if record "__covered:" str::starts_with then
-                    record 10 record.length 10 - str::substring covered_set.add = covered_set
-                fi
-            done
-            MATCH_WILDCARD covered_set.has = has_wildcard
-
-            # Check exhaustiveness
-            if end_base tc.store.enums.get.is_some has_wildcard ! && then
-                end_base tc.store.enums.get.unwrap = end_enum
-                List::new(List[str]) = missing
-                for variant_name in end_enum CasaEnum::variants.iter do
-                    if variant_name covered_set.has ! then
-                        variant_name missing.push
+                # Build covered set
+                Set::new(Set[str]) = covered_set
+                for record in match_ctx MatchContext::branch_records.iter do
+                    if record "__covered:" str::starts_with then
+                        record 10 record.length 10 - str::substring covered_set.add = covered_set
                     fi
                 done
-                if 0 missing.length != then
-                    List::new(List[str]) = formatted_missing
-                    for variant_name in missing.iter do
-                        f"`{end_base}::{variant_name}`" formatted_missing.push
-                    done
-                    ", " formatted_missing.join = missing_str
-                    op Op::location f"Non-exhaustive match, missing arms: {missing_str}" ErrorKind::TypeMismatch raise_error
-                fi
-            fi
-            if end_base tc.store.structs.get.is_some has_wildcard ! && then
-                if end_base covered_set.has ! then
-                    op Op::location f"Non-exhaustive match on struct `{end_match_type}`" ErrorKind::TypeMismatch raise_error
-                fi
-            fi
-            # Literal exhaustiveness
-            if
-            "bool" end_base ==
-            "int" end_base == ||
-            "char" end_base == ||
-            "str" end_base == ||
-            then
-                if has_wildcard ! then
-                    if "bool" end_base == then
-                        List::new(List[str]) = bool_missing
-                        if "true" covered_set.has ! then "true" bool_missing.push fi
-                        if "false" covered_set.has ! then "false" bool_missing.push fi
-                        if 0 bool_missing.length != then
-                            op Op::location "Non-exhaustive match on `bool`" ErrorKind::TypeMismatch raise_error
+                MATCH_WILDCARD covered_set.has = has_wildcard
+
+                # Check exhaustiveness
+                if end_base tc.store.enums.get.is_some has_wildcard ! && then
+                    end_base tc.store.enums.get.unwrap = end_enum
+                    List::new(List[str]) = missing
+                    for variant_name in end_enum CasaEnum::variants.iter do
+                        if variant_name covered_set.has ! then
+                            variant_name missing.push
                         fi
-                    else
-                        op Op::location f"Non-exhaustive match on type `{end_base}`. A wildcard `_` arm is required" ErrorKind::TypeMismatch raise_error
+                    done
+                    if 0 missing.length != then
+                        List::new(List[str]) = formatted_missing
+                        for variant_name in missing.iter do
+                            f"`{end_base}::{variant_name}`" formatted_missing.push
+                        done
+                        ", " formatted_missing.join = missing_str
+                        op Op::location f"Non-exhaustive match, missing arms: {missing_str}" ErrorKind::TypeMismatch raise_error
                     fi
                 fi
-            fi
+                if end_base tc.store.structs.get.is_some has_wildcard ! && then
+                    if end_base covered_set.has ! then
+                        op Op::location f"Non-exhaustive match on struct `{end_match_type}`" ErrorKind::TypeMismatch raise_error
+                    fi
+                fi
+                # Literal exhaustiveness
+                if
+                "bool" end_base ==
+                "int" end_base == ||
+                "char" end_base == ||
+                "str" end_base == ||
+                then
+                    if has_wildcard ! then
+                        if "bool" end_base == then
+                            List::new(List[str]) = bool_missing
+                            if "true" covered_set.has ! then "true" bool_missing.push fi
+                            if "false" covered_set.has ! then "false" bool_missing.push fi
+                            if 0 bool_missing.length != then
+                                op Op::location "Non-exhaustive match on `bool`" ErrorKind::TypeMismatch raise_error
+                            fi
+                        else
+                            op Op::location f"Non-exhaustive match on type `{end_base}`. A wildcard `_` arm is required" ErrorKind::TypeMismatch raise_error
+                        fi
+                    fi
+                fi
 
-            # Apply final stack state
-            match_ctx MatchContext::before = final_before
-            match_ctx MatchContext::after = final_after
-            # When stack == before and before == after, nothing changed
-            if final_before tc.stack.equals final_after final_before.equals && then
-                return
+                # Apply final stack state
+                match_ctx MatchContext::before = final_before
+                match_ctx MatchContext::after = final_after
+                # When stack == before and before == after, nothing changed
+                if final_before tc.stack.equals final_after final_before.equals && then
+                    return
+                fi
+                # When stack == before but after differs (e.g. wildcard-only match),
+                # accept the after state directly
+                if final_before tc.stack.equals final_after final_before.equals ! && then
+                    final_after tc.stack.restore
+                    return
+                fi
+                tc.store final_after tc.stack.unify_types = unified
+                if 0 unified.length != then
+                    final_after tc.stack.restore
+                    unified tc.stack->types
+                    return
+                fi
+                op Op::location "Match arms have incompatible stack effects" ErrorKind::StackMismatch add_error
             fi
-            # When stack == before but after differs (e.g. wildcard-only match),
-            # accept the after state directly
-            if final_before tc.stack.equals final_after final_before.equals ! && then
-                final_after tc.stack.restore
-                return
-            fi
-            tc.store final_after tc.stack.unify_types = unified
-            if 0 unified.length != then
-                final_after tc.stack.restore
-                unified tc.stack->types
-                return
-            fi
-            op Op::location "Match arms have incompatible stack effects" ErrorKind::StackMismatch add_error
         fi
-    fi
+    }
 }
 
 # ============================================================================
 # Check struct new
 # ============================================================================
 
-fn check_struct_new tc:TypeChecker op:Op {
-    if op.value OpValue::StructNew(casa_struct) is ! then return fi
-    casa_struct CasaStruct::name = name
-    # Build type variable bindings from actual stack values
-    Map::new(Map[str str]) = bindings
-    for member in casa_struct CasaStruct::members.iter do
-        tc stack_pop = actual
-        member Member::typ.format = expected
-        # If expected is a type variable, bind it to the actual type
-        for type_var in casa_struct CasaStruct::type_vars.iter do
-            if expected type_var == then
-                actual expected bindings.set = bindings
-            fi
+impl TypeChecker {
+    fn check_struct_new tc:TypeChecker op:Op {
+        if op.value OpValue::StructNew(casa_struct) is ! then return fi
+        casa_struct CasaStruct::name = name
+        # Build type variable bindings from actual stack values
+        Map::new(Map[str str]) = bindings
+        for member in casa_struct CasaStruct::members.iter do
+            tc.stack_pop = actual
+            member Member::typ.format = expected
+            # If expected is a type variable, bind it to the actual type
+            for type_var in casa_struct CasaStruct::type_vars.iter do
+                if expected type_var == then
+                    actual expected bindings.set = bindings
+                fi
+            done
         done
-    done
-    # Construct the result type
-    if 0 casa_struct CasaStruct::type_vars.length == then
-        name GenericType::new Type::Generic tc stack_push_type
-    else
-        bindings casa_struct CasaStruct::type_vars name build_resolved_type tc stack_push
-    fi
+        # Construct the result type
+        if 0 casa_struct CasaStruct::type_vars.length == then
+            name GenericType::new Type::Generic tc.stack_push_type
+        else
+            bindings casa_struct CasaStruct::type_vars name build_resolved_type tc.stack_push
+        fi
+    }
 }
 
 # ============================================================================
 # Check struct literal
 # ============================================================================
 
-fn check_struct_literal tc:TypeChecker op:Op {
-    if op.value OpValue::StructLiteral(literal) is ! then return fi
-    literal StructLiteral::struct_name = name
-    name tc.store.structs.get = struct_opt
-    if struct_opt.is_none then
-        name GenericType::new Type::Generic tc stack_push_type
-        return
-    fi
-    struct_opt.unwrap = casa_struct
-    # Pop field values in reverse order
-    literal StructLiteral::field_order.length 1 - = index
-    while 0 index >= do
-        index literal StructLiteral::field_order.get = field_name
-        # Find member type
-        for member in casa_struct CasaStruct::members.iter do
-            if field_name member Member::name == then
-                member Member::typ tc expect_type_t
-                break
-            fi
+impl TypeChecker {
+    fn check_struct_literal tc:TypeChecker op:Op {
+        if op.value OpValue::StructLiteral(literal) is ! then return fi
+        literal StructLiteral::struct_name = name
+        name tc.store.structs.get = struct_opt
+        if struct_opt.is_none then
+            name GenericType::new Type::Generic tc.stack_push_type
+            return
+        fi
+        struct_opt.unwrap = casa_struct
+        # Pop field values in reverse order
+        literal StructLiteral::field_order.length 1 - = index
+        while 0 index >= do
+            index literal StructLiteral::field_order.get = field_name
+            # Find member type
+            for member in casa_struct CasaStruct::members.iter do
+                if field_name member Member::name == then
+                    member Member::typ tc.expect_type_t
+                    break
+                fi
+            done
+            index 1 - = index
         done
-        index 1 - = index
-    done
-    name GenericType::new Type::Generic tc stack_push_type
+        name GenericType::new Type::Generic tc.stack_push_type
+    }
 }
 
 # ============================================================================
@@ -2318,127 +2409,131 @@ fn instantiate_default_trait_method
 # Check method call
 # ============================================================================
 
-fn check_method_call
-    tc:TypeChecker
-    op:Op
-    ops:List[Op]
-    op_index:int
-    function_opt:Option[Function]
--> int {
-    if op.value OpValue::MethodCall(method_name) is ! then op_index return fi
-    tc stack_peek = receiver
+impl TypeChecker {
+    fn check_method_call
+        tc:TypeChecker
+        op:Op
+        ops:List[Op]
+        op_index:int
+        function_opt:Option[Function]
+    -> int {
+        if op.value OpValue::MethodCall(method_name) is ! then op_index return fi
+        tc.stack_peek = receiver
 
-    # Check if receiver is a trait-bounded type variable
-    if function_opt.is_some then
-        function_opt.unwrap Function::stack_effect StackEffect::trait_bounds = bounds
-        receiver bounds.get = trait_opt
-        if trait_opt.is_some then
-            trait_opt.unwrap = bound
-            bound TraitBound::name = trait_name
-            trait_name tc.store.traits.get = trait_def_opt
-            if trait_def_opt.is_some then
-                trait_def_opt.unwrap = trait_def
-                # Build substitution map from trait's type_params to the
-                # bound's concrete type_args, so that a trait method like
-                # `next self:self -> Option[T]` with bound `I: Iterable[int]`
-                # resolves to `next self:I -> Option[int]` at the call site.
-                Map::new(Map[str Type]) = constraint_subs
-                trait_def CasaTrait::type_params = constraint_params
-                bound TraitBound::type_args = constraint_args
-                if constraint_params.length constraint_args.length == then
-                    for pair in constraint_args.iter constraint_params.iter.zip do
-                        pair.second parse_type_str pair.first constraint_subs.set = constraint_subs
+        # Check if receiver is a trait-bounded type variable
+        if function_opt.is_some then
+            function_opt.unwrap Function::stack_effect StackEffect::trait_bounds = bounds
+            receiver bounds.get = trait_opt
+            if trait_opt.is_some then
+                trait_opt.unwrap = bound
+                bound TraitBound::name = trait_name
+                trait_name tc.store.traits.get = trait_def_opt
+                if trait_def_opt.is_some then
+                    trait_def_opt.unwrap = trait_def
+                    # Build substitution map from trait's type_params to the
+                    # bound's concrete type_args, so that a trait method like
+                    # `next self:self -> Option[T]` with bound `I: Iterable[int]`
+                    # resolves to `next self:I -> Option[int]` at the call site.
+                    Map::new(Map[str Type]) = constraint_subs
+                    trait_def CasaTrait::type_params = constraint_params
+                    bound TraitBound::type_args = constraint_args
+                    if constraint_params.length constraint_args.length == then
+                        for pair in constraint_args.iter constraint_params.iter.zip do
+                            pair.second parse_type_str pair.first constraint_subs.set = constraint_subs
+                        done
+                    fi
+                    for trait_method in trait_def tc.store collect_trait_methods.iter do
+                        if method_name trait_method TraitMethod::name == then
+                            f"__trait_{receiver}_{method_name}" = hidden_var
+                            tc.stack_pop_drop
+                            constraint_subs receiver trait_method TraitMethod::stack_effect resolve_trait_stack_effect apply_type_subs_to_stack_effect = resolved_stack_effect
+                            receiver tc.stack_push
+                            f"{receiver}::{method_name}" resolved_stack_effect tc.apply_stack_effect
+                            hidden_var OpValue::PushVar op Op::set_value
+                            # Insert FN_EXEC op after the PUSH_VARIABLE
+                            op Op::location OpValue::FnExec Op::new = exec_op
+                            op_index exec_op ops.insert
+                            op_index 1 + return
+                        fi
                     done
                 fi
-                for trait_method in trait_def tc.store collect_trait_methods.iter do
-                    if method_name trait_method TraitMethod::name == then
-                        f"__trait_{receiver}_{method_name}" = hidden_var
-                        tc stack_pop_drop
-                        constraint_subs receiver trait_method TraitMethod::stack_effect resolve_trait_stack_effect apply_type_subs_to_stack_effect = resolved_stack_effect
-                        receiver tc stack_push
-                        f"{receiver}::{method_name}" resolved_stack_effect tc apply_stack_effect
-                        hidden_var OpValue::PushVar op Op::set_value
-                        # Insert FN_EXEC op after the PUSH_VARIABLE
-                        op Op::location OpValue::FnExec Op::new = exec_op
-                        op_index exec_op ops.insert
-                        op_index 1 + return
-                    fi
-                done
             fi
         fi
-    fi
 
-    # Look up Type::method
-    f"{receiver}::{method_name}" = fn_name
-    fn_name tc.store.functions.get = fn_opt
+        # Look up Type::method
+        f"{receiver}::{method_name}" = fn_name
+        fn_name tc.store.functions.get = fn_opt
 
-    # Try generic base type
-    if fn_opt.is_none then
-        receiver parse_type_str.base = base_opt
-        if base_opt.is_some then
-            f"{base_opt.unwrap}::{method_name}" = fn_name
-            fn_name tc.store.functions.get = fn_opt
+        # Try generic base type
+        if fn_opt.is_none then
+            receiver parse_type_str.base = base_opt
+            if base_opt.is_some then
+                f"{base_opt.unwrap}::{method_name}" = fn_name
+                fn_name tc.store.functions.get = fn_opt
+            fi
         fi
-    fi
 
-    # Try instantiating a default trait method
-    if fn_opt.is_none then
-        tc.store receiver method_name function_opt instantiate_default_trait_method = default_inst_opt
-        if default_inst_opt.is_some then
-            default_inst_opt.unwrap = fn_name
-            fn_name tc.store.functions.get = fn_opt
+        # Try instantiating a default trait method
+        if fn_opt.is_none then
+            tc.store receiver method_name function_opt instantiate_default_trait_method = default_inst_opt
+            if default_inst_opt.is_some then
+                default_inst_opt.unwrap = fn_name
+                fn_name tc.store.functions.get = fn_opt
+            fi
         fi
-    fi
 
-    if fn_opt.is_some then
-        fn_opt.unwrap = function
-        if function Function::is_typechecked ! then
-            function function Function::ops tc.store resolve_identifiers function Function::set_ops
-            true function Function::set_is_used
+        if fn_opt.is_some then
+            fn_opt.unwrap = function
+            if function Function::is_typechecked ! then
+                function function Function::ops tc.store resolve_identifiers function Function::set_ops
+                true function Function::set_is_used
+            fi
+            tc.store function ensure_typechecked
+            function Function::stack_effect = effect
+            if 0 effect StackEffect::trait_bounds.keys.length != then
+                function_opt op Op::location op_index ops effect tc.inject_trait_fn_ptrs += op_index
+            fi
+            fn_name effect tc.apply_stack_effect
+            fn_name OpValue::FnCall op Op::set_value
+        else
+            op Op::location f"Method `{fn_name}` does not exist" ErrorKind::UndefinedName raise_error
         fi
-        tc.store function ensure_typechecked
-        function Function::stack_effect = effect
-        if 0 effect StackEffect::trait_bounds.keys.length != then
-            function_opt op Op::location op_index ops effect tc inject_trait_fn_ptrs += op_index
-        fi
-        fn_name effect tc apply_stack_effect
-        fn_name OpValue::FnCall op Op::set_value
-    else
-        op Op::location f"Method `{fn_name}` does not exist" ErrorKind::UndefinedName raise_error
-    fi
-    op_index
+        op_index
+    }
 }
 
 # ============================================================================
 # Check f-string expression conversion (Display trait dispatch)
 # ============================================================================
 
-fn check_fstring_to_str
-    tc:TypeChecker
-    op:Op
-    ops:List[Op]
-    op_index:int
-    function_opt:Option[Function]
--> int {
-    "value with trait `Display`" tc->current_expect_ctx
-    if TYPE_STR_T tc stack_peek_type.eq then
-        op_index return
-    fi
-    tc stack_peek_type = fstring_type_t
-    fstring_type_t.format = fstring_type
-    if TYPE_MISSING fstring_type == then
-        tc stack_pop_drop
-        TYPE_STR_T tc stack_push_type
-        op_index return
-    fi
-    if tc.store function_opt "Display" fstring_type_t type_satisfies_trait ! then
-        op Op::location f"Type `{fstring_type}` cannot be used in f-string: does not satisfy trait `Display`" ErrorKind::MissingTraitMethod add_error
-        tc stack_pop_drop
-        TYPE_STR_T tc stack_push_type
-        op_index return
-    fi
-    "to_str" OpValue::MethodCall op Op::set_value
-    function_opt op_index ops op tc check_method_call
+impl TypeChecker {
+    fn check_fstring_to_str
+        tc:TypeChecker
+        op:Op
+        ops:List[Op]
+        op_index:int
+        function_opt:Option[Function]
+    -> int {
+        "value with trait `Display`" tc->current_expect_ctx
+        if TYPE_STR_T tc.stack_peek_type.eq then
+            op_index return
+        fi
+        tc.stack_peek_type = fstring_type_t
+        fstring_type_t.format = fstring_type
+        if TYPE_MISSING fstring_type == then
+            tc.stack_pop_drop
+            TYPE_STR_T tc.stack_push_type
+            op_index return
+        fi
+        if tc.store function_opt "Display" fstring_type_t type_satisfies_trait ! then
+            op Op::location f"Type `{fstring_type}` cannot be used in f-string: does not satisfy trait `Display`" ErrorKind::MissingTraitMethod add_error
+            tc.stack_pop_drop
+            TYPE_STR_T tc.stack_push_type
+            op_index return
+        fi
+        "to_str" OpValue::MethodCall op Op::set_value
+        function_opt op_index ops op tc.check_method_call
+    }
 }
 
 # ============================================================================
@@ -2460,284 +2555,286 @@ fn ensure_typechecked function:Function store:SymbolStore {
 # Main type check dispatch
 # ============================================================================
 
-fn run_type_check_ops checker:TypeChecker ops:List[Op] function_opt:Option[Function] {
-    0 = op_index
-    while op_index ops.length > do
-        op_index ops.get = current_op
-        1 += op_index
-        current_op Op::location checker->current_location
-        "" checker->current_expect_ctx
-        false checker->underflow_reported_this_op
-        current_op.value = op_value
-        # Arithmetic
-        if
-        op_value OpValue::Add is
-        op_value OpValue::Sub is ||
-        op_value OpValue::Mul is ||
-        op_value OpValue::Div is ||
-        op_value OpValue::Mod is ||
-        then
-            current_op checker check_arithmetic
-            continue
-        fi
+impl TypeChecker {
+    fn run_type_check_ops checker:TypeChecker ops:List[Op] function_opt:Option[Function] {
+        0 = op_index
+        while op_index ops.length > do
+            op_index ops.get = current_op
+            1 += op_index
+            current_op Op::location checker->current_location
+            "" checker->current_expect_ctx
+            false checker->underflow_reported_this_op
+            current_op.value = op_value
+            # Arithmetic
+            if
+            op_value OpValue::Add is
+            op_value OpValue::Sub is ||
+            op_value OpValue::Mul is ||
+            op_value OpValue::Div is ||
+            op_value OpValue::Mod is ||
+            then
+                current_op checker.check_arithmetic
+                continue
+            fi
 
-        # Comparison
-        if
-        op_value OpValue::Eq is
-        op_value OpValue::Ne is ||
-        op_value OpValue::Lt is ||
-        op_value OpValue::Le is ||
-        op_value OpValue::Gt is ||
-        op_value OpValue::Ge is ||
-        then
-            function_opt op_index ops current_op checker check_comparison = op_index
-            continue
-        fi
+            # Comparison
+            if
+            op_value OpValue::Eq is
+            op_value OpValue::Ne is ||
+            op_value OpValue::Lt is ||
+            op_value OpValue::Le is ||
+            op_value OpValue::Gt is ||
+            op_value OpValue::Ge is ||
+            then
+                function_opt op_index ops current_op checker.check_comparison = op_index
+                continue
+            fi
 
-        # Boolean
-        if
-        op_value OpValue::And is
-        op_value OpValue::Or is ||
-        op_value OpValue::Not is ||
-        then
-            current_op checker check_boolean
-            continue
-        fi
+            # Boolean
+            if
+            op_value OpValue::And is
+            op_value OpValue::Or is ||
+            op_value OpValue::Not is ||
+            then
+                current_op checker.check_boolean
+                continue
+            fi
 
-        # Bitwise
-        if
-        op_value OpValue::BitAnd is
-        op_value OpValue::BitOr is ||
-        op_value OpValue::BitXor is ||
-        op_value OpValue::BitNot is ||
-        op_value OpValue::Shl is ||
-        op_value OpValue::Shr is ||
-        then
-            current_op checker check_bitwise
-            continue
-        fi
+            # Bitwise
+            if
+            op_value OpValue::BitAnd is
+            op_value OpValue::BitOr is ||
+            op_value OpValue::BitXor is ||
+            op_value OpValue::BitNot is ||
+            op_value OpValue::Shl is ||
+            op_value OpValue::Shr is ||
+            then
+                current_op checker.check_bitwise
+                continue
+            fi
 
-        # Stack ops
-        if
-        op_value OpValue::Drop is
-        op_value OpValue::Dup is ||
-        op_value OpValue::Swap is ||
-        op_value OpValue::Over is ||
-        op_value OpValue::Rot is ||
-        then
-            current_op checker check_stack_ops
-            continue
-        fi
+            # Stack ops
+            if
+            op_value OpValue::Drop is
+            op_value OpValue::Dup is ||
+            op_value OpValue::Swap is ||
+            op_value OpValue::Over is ||
+            op_value OpValue::Rot is ||
+            then
+                current_op checker.check_stack_ops
+                continue
+            fi
 
-        # Memory
-        if
-        op_value OpValue::Load8 is
-        op_value OpValue::Load16 is ||
-        op_value OpValue::Load32 is ||
-        op_value OpValue::Load64 is ||
-        op_value OpValue::Store8 is ||
-        op_value OpValue::Store16 is ||
-        op_value OpValue::Store32 is ||
-        op_value OpValue::Store64 is ||
-        op_value OpValue::HeapAlloc is ||
-        then
-            function_opt current_op checker check_memory
-            continue
-        fi
+            # Memory
+            if
+            op_value OpValue::Load8 is
+            op_value OpValue::Load16 is ||
+            op_value OpValue::Load32 is ||
+            op_value OpValue::Load64 is ||
+            op_value OpValue::Store8 is ||
+            op_value OpValue::Store16 is ||
+            op_value OpValue::Store32 is ||
+            op_value OpValue::Store64 is ||
+            op_value OpValue::HeapAlloc is ||
+            then
+                function_opt current_op checker.check_memory
+                continue
+            fi
 
-        # Assignment
-        if
-        op_value OpValue::AssignVar is
-        op_value OpValue::AssignDec is ||
-        op_value OpValue::AssignInc is ||
-        then
-            function_opt current_op checker check_assignment
-            continue
-        fi
+            # Assignment
+            if
+            op_value OpValue::AssignVar is
+            op_value OpValue::AssignDec is ||
+            op_value OpValue::AssignInc is ||
+            then
+                function_opt current_op checker.check_assignment
+                continue
+            fi
 
-        # Push variable / capture
-        if
-        op_value OpValue::PushVar is
-        op_value OpValue::PushCapture is ||
-        then
-            function_opt current_op checker check_push_var
-            continue
-        fi
+            # Push variable / capture
+            if
+            op_value OpValue::PushVar is
+            op_value OpValue::PushCapture is ||
+            then
+                function_opt current_op checker.check_push_var
+                continue
+            fi
 
-        # If block
-        if
-        op_value OpValue::IfStart is
-        op_value OpValue::IfCondition is ||
-        op_value OpValue::IfElif is ||
-        op_value OpValue::IfElse is ||
-        op_value OpValue::IfEnd is ||
-        then
-            current_op checker check_if_block
-            continue
-        fi
+            # If block
+            if
+            op_value OpValue::IfStart is
+            op_value OpValue::IfCondition is ||
+            op_value OpValue::IfElif is ||
+            op_value OpValue::IfElse is ||
+            op_value OpValue::IfEnd is ||
+            then
+                current_op checker.check_if_block
+                continue
+            fi
 
-        # While block
-        if
-        op_value OpValue::WhileStart is
-        op_value OpValue::WhileCondition is ||
-        op_value OpValue::WhileBreak is ||
-        op_value OpValue::WhileContinue is ||
-        op_value OpValue::WhileEnd is ||
-        then
-            current_op checker check_while_block
-            continue
-        fi
+            # While block
+            if
+            op_value OpValue::WhileStart is
+            op_value OpValue::WhileCondition is ||
+            op_value OpValue::WhileBreak is ||
+            op_value OpValue::WhileContinue is ||
+            op_value OpValue::WhileEnd is ||
+            then
+                current_op checker.check_while_block
+                continue
+            fi
 
-        # Function ops
-        if
-        op_value OpValue::FnCall is
-        op_value OpValue::FnExec is ||
-        op_value OpValue::FnPush is ||
-        op_value OpValue::FnReturn is ||
-        then
-            function_opt op_index ops current_op checker check_function_ops = op_index
-            continue
-        fi
+            # Function ops
+            if
+            op_value OpValue::FnCall is
+            op_value OpValue::FnExec is ||
+            op_value OpValue::FnPush is ||
+            op_value OpValue::FnReturn is ||
+            then
+                function_opt op_index ops current_op checker.check_function_ops = op_index
+                continue
+            fi
 
-        # Literals
-        if
-        op_value OpValue::PushInt is
-        op_value OpValue::PushStr is ||
-        op_value OpValue::PushBool is ||
-        op_value OpValue::PushChar is ||
-        op_value OpValue::PushArray is ||
-        op_value OpValue::ExprGroup is ||
-        op_value OpValue::FstringConcat is ||
-        then
-            function_opt current_op checker check_literals
-            continue
-        fi
+            # Literals
+            if
+            op_value OpValue::PushInt is
+            op_value OpValue::PushStr is ||
+            op_value OpValue::PushBool is ||
+            op_value OpValue::PushChar is ||
+            op_value OpValue::PushArray is ||
+            op_value OpValue::ExprGroup is ||
+            op_value OpValue::FstringConcat is ||
+            then
+                function_opt current_op checker.check_literals
+                continue
+            fi
 
-        # IO
-        if op_value OpValue::Print is then
-            function_opt op_index ops current_op checker check_io = op_index
-            continue
-        fi
+            # IO
+            if op_value OpValue::Print is then
+                function_opt op_index ops current_op checker.check_io = op_index
+                continue
+            fi
 
-        # Typeof
-        if op_value OpValue::Typeof is then
-            current_op checker check_typeof
-            continue
-        fi
+            # Typeof
+            if op_value OpValue::Typeof is then
+                current_op checker.check_typeof
+                continue
+            fi
 
-        # Syscalls
-        if
-        op_value OpValue::Syscall0 is
-        op_value OpValue::Syscall1 is ||
-        op_value OpValue::Syscall2 is ||
-        op_value OpValue::Syscall3 is ||
-        op_value OpValue::Syscall4 is ||
-        op_value OpValue::Syscall5 is ||
-        op_value OpValue::Syscall6 is ||
-        then
-            function_opt current_op checker check_syscalls
-            continue
-        fi
+            # Syscalls
+            if
+            op_value OpValue::Syscall0 is
+            op_value OpValue::Syscall1 is ||
+            op_value OpValue::Syscall2 is ||
+            op_value OpValue::Syscall3 is ||
+            op_value OpValue::Syscall4 is ||
+            op_value OpValue::Syscall5 is ||
+            op_value OpValue::Syscall6 is ||
+            then
+                function_opt current_op checker.check_syscalls
+                continue
+            fi
 
-        # Argc / Argv
-        if op_value OpValue::Argc is then
-            TYPE_INT_T checker stack_push_type
-            continue
-        fi
-        if op_value OpValue::Argv is then
-            TYPE_PTR_T checker stack_push_type
-            continue
-        fi
-        if op_value OpValue::Envp is then
-            TYPE_PTR_T checker stack_push_type
-            continue
-        fi
+            # Argc / Argv
+            if op_value OpValue::Argc is then
+                TYPE_INT_T checker.stack_push_type
+                continue
+            fi
+            if op_value OpValue::Argv is then
+                TYPE_PTR_T checker.stack_push_type
+                continue
+            fi
+            if op_value OpValue::Envp is then
+                TYPE_PTR_T checker.stack_push_type
+                continue
+            fi
 
-        # Enum variant
-        if op_value OpValue::PushEnumVariant is then
-            current_op checker check_enum_variant
-            continue
-        fi
+            # Enum variant
+            if op_value OpValue::PushEnumVariant is then
+                current_op checker.check_enum_variant
+                continue
+            fi
 
-        # Is check
-        if op_value OpValue::IsCheck is then
-            function_opt current_op checker check_is
-            continue
-        fi
+            # Is check
+            if op_value OpValue::IsCheck is then
+                function_opt current_op checker.check_is
+                continue
+            fi
 
-        # Match block
-        if
-        op_value OpValue::MatchStart is
-        op_value OpValue::MatchArm is ||
-        op_value OpValue::MatchEnd is ||
-        then
-            function_opt current_op checker check_match
-            continue
-        fi
+            # Match block
+            if
+            op_value OpValue::MatchStart is
+            op_value OpValue::MatchArm is ||
+            op_value OpValue::MatchEnd is ||
+            then
+                function_opt current_op checker.check_match
+                continue
+            fi
 
-        # Struct new
-        if op_value OpValue::StructNew is then
-            current_op checker check_struct_new
-            continue
-        fi
+            # Struct new
+            if op_value OpValue::StructNew is then
+                current_op checker.check_struct_new
+                continue
+            fi
 
-        # Struct literal
-        if op_value OpValue::StructLiteral is then
-            current_op checker check_struct_literal
-            continue
-        fi
+            # Struct literal
+            if op_value OpValue::StructLiteral is then
+                current_op checker.check_struct_literal
+                continue
+            fi
 
-        # Method call
-        if op_value OpValue::MethodCall is then
-            function_opt op_index ops current_op checker check_method_call = op_index
-            continue
-        fi
+            # Method call
+            if op_value OpValue::MethodCall is then
+                function_opt op_index ops current_op checker.check_method_call = op_index
+                continue
+            fi
 
-        # Trait-bound method call
-        if op_value OpValue::TraitMethodCall is then
-            function_opt current_op checker check_push_var
-            continue
-        fi
+            # Trait-bound method call
+            if op_value OpValue::TraitMethodCall is then
+                function_opt current_op checker.check_push_var
+                continue
+            fi
 
-        # F-string expression -> str conversion (Display trait)
-        if op_value OpValue::FstringToStr is then
-            function_opt op_index ops current_op checker check_fstring_to_str = op_index
-            continue
-        fi
+            # F-string expression -> str conversion (Display trait)
+            if op_value OpValue::FstringToStr is then
+                function_opt op_index ops current_op checker.check_fstring_to_str = op_index
+                continue
+            fi
 
-        # Type cast
-        if op_value OpValue::TypeCast(cast_type) is then
-            checker.store current_op Op::location function_opt cast_type validate_type_exists
-            checker stack_pop drop
-            cast_type checker stack_push_type
-            continue
-        fi
+            # Type cast
+            if op_value OpValue::TypeCast(cast_type) is then
+                checker.store current_op Op::location function_opt cast_type validate_type_exists
+                checker.stack_pop drop
+                cast_type checker.stack_push_type
+                continue
+            fi
 
-        # Import file and DeclareGlobal (compile-time only, no type effect)
-        if
-        op_value OpValue::ImportFile is
-        op_value OpValue::ImportFileSelective is ||
-        op_value OpValue::DeclareGlobal is ||
-        then
-            continue
-        fi
+            # Import file and DeclareGlobal (compile-time only, no type effect)
+            if
+            op_value OpValue::ImportFile is
+            op_value OpValue::ImportFileSelective is ||
+            op_value OpValue::DeclareGlobal is ||
+            then
+                continue
+            fi
 
-        # Print variants (already resolved, should not appear)
-        if
-        op_value OpValue::PrintBool is
-        op_value OpValue::PrintChar is ||
-        op_value OpValue::PrintCstr is ||
-        op_value OpValue::PrintInt is ||
-        op_value OpValue::PrintStr is ||
-        then
-            continue
-        fi
+            # Print variants (already resolved, should not appear)
+            if
+            op_value OpValue::PrintBool is
+            op_value OpValue::PrintChar is ||
+            op_value OpValue::PrintCstr is ||
+            op_value OpValue::PrintInt is ||
+            op_value OpValue::PrintStr is ||
+            then
+                continue
+            fi
 
-        # Identifier (should be resolved by parser)
-        if op_value OpValue::Identifier is then
-            continue
-        fi
-    done
+            # Identifier (should be resolved by parser)
+            if op_value OpValue::Identifier is then
+                continue
+            fi
+        done
+    }
 }
 
 fn type_check_ops ops:List[Op] function_opt:Option[Function] store:SymbolStore -> StackEffect {
@@ -2751,7 +2848,7 @@ fn type_check_ops ops:List[Op] function_opt:Option[Function] store:SymbolStore -
     fi
     budget checker->param_cap
     ERRORS.length = errors_before_ops
-    function_opt ops checker run_type_check_ops
+    function_opt ops checker.run_type_check_ops
 
     # Build inferred stack effect
     List::new(List[Type]) = inferred_returns

--- a/compiler/typechecker.casa
+++ b/compiler/typechecker.casa
@@ -25,22 +25,22 @@ impl TypedStack {
     }
 
     fn snapshot self:TypedStack -> TypedStack {
-        self TypedStack::origins.clone self TypedStack::types.clone TypedStack
+        self.origins.clone self.types.clone TypedStack
     }
 
     fn restore self:TypedStack source:TypedStack {
-        source TypedStack::types.clone self TypedStack::set_types
-        source TypedStack::origins.clone self TypedStack::set_origins
+        source.types.clone self->types
+        source.origins.clone self->origins
     }
 
     # Pure stack comparison on the types slice (origins are not compared).
     fn equals self:TypedStack other:TypedStack -> bool {
-        self TypedStack::types other TypedStack::types stacks_equal
+        self.types other.types stacks_equal
     }
 
     # Produce the unified types list between two TypedStacks, or empty on incompatibility.
     fn unify_types self:TypedStack candidate:TypedStack store:SymbolStore -> List[Type] {
-        store self TypedStack::types candidate TypedStack::types stacks_compatible
+        store self.types candidate.types stacks_compatible
     }
 }
 
@@ -112,7 +112,7 @@ fn make_match_context match_type:str -> MatchContext {
 # ============================================================================
 
 struct TypeChecker {
-    live:                       TypedStack
+    stack:                      TypedStack
     parameters:                 List[Parameter]
     return_types:               TypedStack
     has_return_types:           bool
@@ -138,18 +138,18 @@ fn make_typechecker store:SymbolStore -> TypeChecker {
     false # has_return_types
     TypedStack::new # return_types
     List::new(List[Parameter]) # parameters
-    TypedStack::new # live
+    TypedStack::new # stack
     TypeChecker
 }
 
 fn within_param_cap tc:TypeChecker -> bool {
-    if -1 tc TypeChecker::param_cap == then true return fi
-    tc TypeChecker::param_cap tc TypeChecker::parameters.length <
+    if -1 tc.param_cap == then true return fi
+    tc.param_cap tc.parameters.length <
 }
 # Raise a TypeMismatch error at the type checker's current location.
 
 fn raise_type_mismatch tc:TypeChecker message:str {
-    tc TypeChecker::current_location message ErrorKind::TypeMismatch raise_error
+    tc.current_location message ErrorKind::TypeMismatch raise_error
 }
 
 # ============================================================================
@@ -157,8 +157,8 @@ fn raise_type_mismatch tc:TypeChecker message:str {
 # ============================================================================
 
 fn stack_push_type tc:TypeChecker typ:Type {
-    typ tc TypeChecker::live TypedStack::types.push
-    tc TypeChecker::current_location tc TypeChecker::live TypedStack::origins.push
+    typ tc.stack.types.push
+    tc.current_location tc.stack.origins.push
 }
 
 fn stack_push tc:TypeChecker typ:str {
@@ -166,13 +166,13 @@ fn stack_push tc:TypeChecker typ:str {
 }
 
 fn report_stack_underflow tc:TypeChecker message:str {
-    if tc TypeChecker::underflow_reported_this_op then return fi
-    tc TypeChecker::current_location message ErrorKind::StackUnderflow add_error
-    true tc TypeChecker::set_underflow_reported_this_op
+    if tc.underflow_reported_this_op then return fi
+    tc.current_location message ErrorKind::StackUnderflow add_error
+    true tc->underflow_reported_this_op
 }
 
 fn stack_underflow_message tc:TypeChecker -> str {
-    tc TypeChecker::current_expect_ctx = expect_what
+    tc.current_expect_ctx = expect_what
     if "" expect_what == then
         "Stack underflow: expected a value but stack is empty" return
     fi
@@ -180,85 +180,85 @@ fn stack_underflow_message tc:TypeChecker -> str {
 }
 
 fn stack_peek tc:TypeChecker -> str {
-    if 0 tc TypeChecker::live TypedStack::types.length == then
+    if 0 tc.stack.types.length == then
         if tc within_param_cap then
             TYPE_UNKNOWN return
         fi
         tc stack_underflow_message tc report_stack_underflow
         TYPE_MISSING return
     fi
-    tc TypeChecker::live TypedStack::types.length 1 - tc TypeChecker::live TypedStack::types.get.format
+    tc.stack.types.length 1 - tc.stack.types.get.format
 }
 
 fn stack_pop tc:TypeChecker -> str {
-    if 0 tc TypeChecker::live TypedStack::types.length == then
+    if 0 tc.stack.types.length == then
         if tc within_param_cap then
-            TYPE_UNKNOWN make_param tc TypeChecker::parameters.push
+            TYPE_UNKNOWN make_param tc.parameters.push
             TYPE_UNKNOWN return
         fi
         tc stack_underflow_message tc report_stack_underflow
         TYPE_MISSING return
     fi
-    tc TypeChecker::live TypedStack::origins.pop drop
-    tc TypeChecker::live TypedStack::types.pop.format
+    tc.stack.origins.pop drop
+    tc.stack.types.pop.format
 }
 
 fn stack_peek_type tc:TypeChecker -> Type {
-    if 0 tc TypeChecker::live TypedStack::types.length == then
+    if 0 tc.stack.types.length == then
         if tc within_param_cap then
             TYPE_UNKNOWN_T return
         fi
         tc stack_underflow_message tc report_stack_underflow
         TYPE_MISSING_T return
     fi
-    tc TypeChecker::live TypedStack::types.length 1 - tc TypeChecker::live TypedStack::types.get
+    tc.stack.types.length 1 - tc.stack.types.get
 }
 
 fn stack_pop_type tc:TypeChecker -> Type {
-    if 0 tc TypeChecker::live TypedStack::types.length == then
+    if 0 tc.stack.types.length == then
         if tc within_param_cap then
-            TYPE_UNKNOWN make_param tc TypeChecker::parameters.push
+            TYPE_UNKNOWN make_param tc.parameters.push
             TYPE_UNKNOWN_T return
         fi
         tc stack_underflow_message tc report_stack_underflow
         TYPE_MISSING_T return
     fi
-    tc TypeChecker::live TypedStack::origins.pop drop
-    tc TypeChecker::live TypedStack::types.pop
+    tc.stack.origins.pop drop
+    tc.stack.types.pop
 }
 
 fn stack_pop_drop tc:TypeChecker {
-    if 0 tc TypeChecker::live TypedStack::types.length == then
+    if 0 tc.stack.types.length == then
         if tc within_param_cap then
-            TYPE_UNKNOWN make_param tc TypeChecker::parameters.push
+            TYPE_UNKNOWN make_param tc.parameters.push
             return
         fi
         tc stack_underflow_message tc report_stack_underflow
         return
     fi
-    tc TypeChecker::live TypedStack::origins.pop drop
-    tc TypeChecker::live TypedStack::types.pop drop
+    tc.stack.origins.pop drop
+    tc.stack.types.pop drop
 }
 
 fn expect_type_t tc:TypeChecker expected:Type {
-    if 0 tc TypeChecker::live TypedStack::types.length == then
+    if 0 tc.stack.types.length == then
         if tc within_param_cap then
-            expected.format make_param tc TypeChecker::parameters.push
+            expected.format make_param tc.parameters.push
             return
         fi
         f"Stack underflow: expected `{expected.format}` but stack is empty" tc report_stack_underflow
         return
     fi
-    tc TypeChecker::live TypedStack::origins.pop drop
-    tc TypeChecker::live TypedStack::types.pop = et_actual_t
+    tc.stack.origins.pop drop
+    tc.stack.types.pop = et_actual_t
     if tc.store et_actual_t expected unify_type_t.is_some then return fi
     et_actual_t.format = et_actual
     expected.format = et_expected
     "Type mismatch" = et_message
-    if "" tc TypeChecker::current_op_context != then
-        f"Type mismatch in {tc TypeChecker::current_op_context}" = et_message
+    if "" tc.current_op_context != then
+        f"Type mismatch in {tc.current_op_context}" = et_message
     fi
-    et_actual et_expected tc TypeChecker::current_location et_message ErrorKind::TypeMismatch add_error_expected
+    et_actual et_expected tc.current_location et_message ErrorKind::TypeMismatch add_error_expected
 }
 
 # ============================================================================
@@ -602,12 +602,12 @@ fn apply_stack_effect tc:TypeChecker effect:StackEffect name:str {
         0 = index
         while index effect StackEffect::parameters.length > do
             if "" name != then
-                f"parameter {index 1 +} of `{name}`" tc TypeChecker::set_current_expect_ctx
+                f"parameter {index 1 +} of `{name}`" tc->current_expect_ctx
             fi
             index effect StackEffect::parameters.get Parameter::typ tc expect_type_t
             1 += index
         done
-        "" tc TypeChecker::set_current_expect_ctx
+        "" tc->current_expect_ctx
         for return_type in effect StackEffect::return_types.iter do
             return_type tc stack_push_type
         done
@@ -621,7 +621,7 @@ fn apply_stack_effect tc:TypeChecker effect:StackEffect name:str {
         index effect StackEffect::parameters.get = param
 
         if "" name != then
-            f"parameter {index 1 +} of `{name}`" tc TypeChecker::set_current_expect_ctx
+            f"parameter {index 1 +} of `{name}`" tc->current_expect_ctx
         fi
 
         # Direct type variable (e.g. T)
@@ -649,7 +649,7 @@ fn apply_stack_effect tc:TypeChecker effect:StackEffect name:str {
         param Parameter::typ tc expect_type_t
         1 += index
     done
-    "" tc TypeChecker::set_current_expect_ctx
+    "" tc->current_expect_ctx
 
     # Push resolved return types
     for return_type in effect StackEffect::return_types.iter do
@@ -710,7 +710,7 @@ fn check_comparison
     op.value = cmp_value
     cmp_value OpValue::Eq is cmp_value OpValue::Ne is || = is_eq_op
     if is_eq_op then "Eq" else "Ord" fi = trait_name
-    f"value with trait `{trait_name}`" tc TypeChecker::set_current_expect_ctx
+    f"value with trait `{trait_name}`" tc->current_expect_ctx
     tc stack_pop_type = type1_t
     tc stack_pop_type = type2_t
     type1_t.format = type1
@@ -820,34 +820,34 @@ fn check_bitwise tc:TypeChecker op:Op {
 fn check_stack_ops tc:TypeChecker op:Op {
     op.value = stack_value
     if stack_value OpValue::Drop is then
-        "value for `drop`" tc TypeChecker::set_current_expect_ctx
+        "value for `drop`" tc->current_expect_ctx
         tc stack_pop_drop
     elif stack_value OpValue::Dup is then
-        "value for `dup`" tc TypeChecker::set_current_expect_ctx
+        "value for `dup`" tc->current_expect_ctx
         tc stack_pop = typ
         typ tc stack_push
         typ tc stack_push
     elif stack_value OpValue::Swap is then
-        "argument 1 of `swap`" tc TypeChecker::set_current_expect_ctx
+        "argument 1 of `swap`" tc->current_expect_ctx
         tc stack_pop_type = type1_t
-        "argument 2 of `swap`" tc TypeChecker::set_current_expect_ctx
+        "argument 2 of `swap`" tc->current_expect_ctx
         tc stack_pop_type = type2_t
         type1_t tc stack_push_type
         type2_t tc stack_push_type
     elif stack_value OpValue::Over is then
-        "argument 1 of `over`" tc TypeChecker::set_current_expect_ctx
+        "argument 1 of `over`" tc->current_expect_ctx
         tc stack_pop = type1
-        "argument 2 of `over`" tc TypeChecker::set_current_expect_ctx
+        "argument 2 of `over`" tc->current_expect_ctx
         tc stack_pop = type2
         type2 tc stack_push
         type1 tc stack_push
         type2 tc stack_push
     elif stack_value OpValue::Rot is then
-        "argument 1 of `rot`" tc TypeChecker::set_current_expect_ctx
+        "argument 1 of `rot`" tc->current_expect_ctx
         tc stack_pop_type = type1_t
-        "argument 2 of `rot`" tc TypeChecker::set_current_expect_ctx
+        "argument 2 of `rot`" tc->current_expect_ctx
         tc stack_pop_type = type2_t
-        "argument 3 of `rot`" tc TypeChecker::set_current_expect_ctx
+        "argument 3 of `rot`" tc->current_expect_ctx
         tc stack_pop_type = type3_t
         type2_t tc stack_push_type
         type1_t tc stack_push_type
@@ -1086,18 +1086,18 @@ fn check_if_block tc:TypeChecker op:Op {
         make_if_context = if_ctx
         op Op::location if_ctx IfContext::set_current_branch_location
         if_ctx BranchFrame::BranchIf = if_frame
-        if_frame tc TypeChecker::branched_stacks.push
-        true tc TypeChecker::set_in_branch_condition
+        if_frame tc.branched_stacks.push
+        true tc->in_branch_condition
     elif if_value OpValue::IfCondition is then
-        false tc TypeChecker::set_in_branch_condition
+        false tc->in_branch_condition
         TYPE_BOOL_T tc expect_type_t
-        if 0 tc TypeChecker::branched_stacks.length == then return fi
-        tc TypeChecker::branched_stacks.length 1 - tc TypeChecker::branched_stacks.get = top_frame
+        if 0 tc.branched_stacks.length == then return fi
+        tc.branched_stacks.length 1 - tc.branched_stacks.get = top_frame
         if top_frame BranchFrame::BranchIf(if_ctx) is then
             if if_ctx IfContext::condition_present ! then
                 true if_ctx IfContext::set_condition_present
-                tc TypeChecker::live if_ctx IfContext::before.restore
-                tc TypeChecker::live if_ctx IfContext::after.restore
+                tc.stack if_ctx IfContext::before.restore
+                tc.stack if_ctx IfContext::after.restore
                 "if" if_ctx IfContext::set_current_branch_label
             fi
         fi
@@ -1105,54 +1105,54 @@ fn check_if_block tc:TypeChecker op:Op {
     if_value OpValue::IfElif is
     if_value OpValue::IfElse is ||
     then
-        if 0 tc TypeChecker::branched_stacks.length == then return fi
-        tc TypeChecker::branched_stacks.length 1 - tc TypeChecker::branched_stacks.get = top_frame
+        if 0 tc.branched_stacks.length == then return fi
+        tc.branched_stacks.length 1 - tc.branched_stacks.get = top_frame
         if top_frame BranchFrame::BranchIf(if_ctx) is then
             if if_value OpValue::IfElse is then
                 true if_ctx IfContext::set_default_present
-                false tc TypeChecker::set_in_branch_condition
+                false tc->in_branch_condition
             else
-                true tc TypeChecker::set_in_branch_condition
+                true tc->in_branch_condition
             fi
             if_ctx IfContext::before = if_before
             if_ctx IfContext::after = if_after
-            if if_before tc TypeChecker::live.equals if_after if_before.equals && then
+            if if_before tc.stack.equals if_after if_before.equals && then
                 op Op::location if_ctx IfContext::set_current_branch_location
                 return
             fi
-            tc.store if_after tc TypeChecker::live.unify_types = unified
+            tc.store if_after tc.stack.unify_types = unified
             if 0 unified.length != if_after if_before.equals ! && then
-                unified if_after TypedStack::set_types
-                if_before tc TypeChecker::live.restore
+                unified if_after->types
+                if_before tc.stack.restore
                 op Op::location if_ctx IfContext::set_current_branch_location
                 return
             fi
             if if_after if_before.equals then
-                tc TypeChecker::live if_after.restore
-                if_before tc TypeChecker::live.restore
+                tc.stack if_after.restore
+                if_before tc.stack.restore
                 op Op::location if_ctx IfContext::set_current_branch_location
                 return
             fi
             op Op::location "Branches have incompatible stack effects" ErrorKind::StackMismatch add_error
         fi
     elif if_value OpValue::IfEnd is then
-        tc TypeChecker::branched_stacks.pop = top_frame
+        tc.branched_stacks.pop = top_frame
         if top_frame BranchFrame::BranchIf(if_ctx) is then
             if_ctx IfContext::before = if_before
             if_ctx IfContext::after = if_after
-            if if_before tc TypeChecker::live.equals if_after if_before.equals && then
+            if if_before tc.stack.equals if_after if_before.equals && then
                 return
             fi
-            tc.store if_after tc TypeChecker::live.unify_types = unified
+            tc.store if_after tc.stack.unify_types = unified
             if 0 unified.length != if_ctx IfContext::default_present && then
-                if_after tc TypeChecker::live.restore
-                unified tc TypeChecker::live TypedStack::set_types
+                if_after tc.stack.restore
+                unified tc.stack->types
                 return
             fi
-            tc.store if_before tc TypeChecker::live.unify_types = unified_before
+            tc.store if_before tc.stack.unify_types = unified_before
             if 0 unified_before.length != if_ctx IfContext::default_present ! && then
-                if_before tc TypeChecker::live.restore
-                unified_before tc TypeChecker::live TypedStack::set_types
+                if_before tc.stack.restore
+                unified_before tc.stack->types
                 return
             fi
             op Op::location "Branches have incompatible stack effects" ErrorKind::StackMismatch add_error
@@ -1168,14 +1168,14 @@ fn check_while_block tc:TypeChecker op:Op {
     op.value = while_value
     if while_value OpValue::WhileStart is then
         make_while_context = while_ctx
-        tc TypeChecker::live while_ctx WhileContext::before.restore
+        tc.stack while_ctx WhileContext::before.restore
         op Op::location while_ctx WhileContext::set_current_branch_location
         while_ctx BranchFrame::BranchWhile = while_frame
-        while_frame tc TypeChecker::branched_stacks.push
+        while_frame tc.branched_stacks.push
     elif while_value OpValue::WhileCondition is then
         TYPE_BOOL_T tc expect_type_t
-        if 0 tc TypeChecker::branched_stacks.length == then return fi
-        tc TypeChecker::branched_stacks.length 1 - tc TypeChecker::branched_stacks.get = top_frame
+        if 0 tc.branched_stacks.length == then return fi
+        tc.branched_stacks.length 1 - tc.branched_stacks.get = top_frame
         if top_frame BranchFrame::BranchWhile(while_ctx) is then
             true while_ctx WhileContext::set_condition_present
         fi
@@ -1183,9 +1183,9 @@ fn check_while_block tc:TypeChecker op:Op {
     while_value OpValue::WhileBreak is
     while_value OpValue::WhileContinue is ||
     then
-        if 0 tc TypeChecker::branched_stacks.length == then return fi
+        if 0 tc.branched_stacks.length == then return fi
     elif while_value OpValue::WhileEnd is then
-        tc TypeChecker::branched_stacks.pop drop
+        tc.branched_stacks.pop drop
     fi
 }
 
@@ -1458,13 +1458,13 @@ fn inject_trait_fn_ptrs
     done
 
     # Peek at stack to bind type variables
-    tc TypeChecker::live TypedStack::types.length = depth
+    tc.stack.types.length = depth
     0 = index
     while index non_hidden.length > do
         depth 1 - index - = stack_index
         if 0 stack_index >= then
             index non_hidden.get = stack_param
-            stack_index tc TypeChecker::live TypedStack::types.get = actual
+            stack_index tc.stack.types.get = actual
             if stack_param Parameter::typ.type_var_name Option::Some(binding_type_var) is then
                 if binding_type_var effect StackEffect::type_vars.has then
                     binding_type_var bindings.get = existing_binding_opt
@@ -1640,18 +1640,18 @@ fn check_function_ops
             "fn" tc stack_push
         fi
     elif fn_value OpValue::FnReturn is then
-        if tc TypeChecker::has_return_types ! then
-            true tc TypeChecker::set_has_return_types
-            tc TypeChecker::live tc TypeChecker::return_types.restore
+        if tc.has_return_types ! then
+            true tc->has_return_types
+            tc.stack tc.return_types.restore
         fi
-        if 0 tc TypeChecker::branched_stacks.length != then
-            tc TypeChecker::branched_stacks.length 1 - tc TypeChecker::branched_stacks.get = top_frame
+        if 0 tc.branched_stacks.length != then
+            tc.branched_stacks.length 1 - tc.branched_stacks.get = top_frame
             if top_frame BranchFrame::BranchIf(if_ctx) is then
-                if_ctx IfContext::before tc TypeChecker::live.restore
+                if_ctx IfContext::before tc.stack.restore
             elif top_frame BranchFrame::BranchWhile(while_ctx) is then
-                while_ctx WhileContext::before tc TypeChecker::live.restore
+                while_ctx WhileContext::before tc.stack.restore
             elif top_frame BranchFrame::BranchMatch(match_ctx) is then
-                match_ctx MatchContext::before tc TypeChecker::live.restore
+                match_ctx MatchContext::before tc.stack.restore
             fi
         fi
     fi
@@ -1712,7 +1712,7 @@ fn check_literals tc:TypeChecker op:Op function_opt:Option[Function] {
 # ============================================================================
 
 fn check_io tc:TypeChecker op:Op ops:List[Op] op_index:int function_opt:Option[Function] -> int {
-    "value with trait `Display`" tc TypeChecker::set_current_expect_ctx
+    "value with trait `Display`" tc->current_expect_ctx
     tc stack_peek_type = peek_t
     peek_t.format = typ
     if "str" typ == then
@@ -1912,7 +1912,7 @@ fn set_binding_type var_name:str field_type:Type function_opt:Option[Function] s
 fn check_match tc:TypeChecker op:Op function_opt:Option[Function] {
     op.value = match_value
     if match_value OpValue::MatchStart is then
-        if 0 tc TypeChecker::live TypedStack::types.length == then
+        if 0 tc.stack.types.length == then
             tc within_param_cap = inferring_stack_effect
             if function_opt.is_some then
                 if function_opt.unwrap Function::name "lambda__" str::starts_with ! then
@@ -1923,7 +1923,7 @@ fn check_match tc:TypeChecker op:Op function_opt:Option[Function] {
             fi
             if inferring_stack_effect ! then
                 op Op::location "`match` requires a subject value on the stack" ErrorKind::StackUnderflow add_error
-                true tc TypeChecker::set_underflow_reported_this_op
+                true tc->underflow_reported_this_op
             fi
         fi
         tc stack_pop = match_type
@@ -1931,15 +1931,15 @@ fn check_match tc:TypeChecker op:Op function_opt:Option[Function] {
         # Snapshot the entry stack state eagerly so that an OpFnReturn visiting
         # this frame before any OpMatchArm still finds a correct `before` to
         # restore from. Matches the pre-refactor make_branched_stack behavior.
-        tc TypeChecker::live match_ctx MatchContext::before.restore
-        tc TypeChecker::live match_ctx MatchContext::after.restore
+        tc.stack match_ctx MatchContext::before.restore
+        tc.stack match_ctx MatchContext::after.restore
         op Op::location match_ctx MatchContext::set_current_branch_location
         match_ctx BranchFrame::BranchMatch = match_frame
-        match_frame tc TypeChecker::branched_stacks.push
+        match_frame tc.branched_stacks.push
     elif match_value OpValue::MatchArm is then
         op function_opt tc typecheck_match_op
     elif match_value OpValue::MatchEnd is then
-        tc TypeChecker::branched_stacks.pop = top_frame
+        tc.branched_stacks.pop = top_frame
         if top_frame BranchFrame::BranchMatch(match_ctx) is then
             # Record last arm label
             if "" match_ctx MatchContext::current_branch_label != then
@@ -1950,19 +1950,19 @@ fn check_match tc:TypeChecker op:Op function_opt:Option[Function] {
                 match_ctx MatchContext::before = match_before
                 match_ctx MatchContext::after = match_after
                 if
-                match_before tc TypeChecker::live.equals
+                match_before tc.stack.equals
                 match_after match_before.equals && !
                 then
-                    tc.store match_after tc TypeChecker::live.unify_types = last_unified
+                    tc.store match_after tc.stack.unify_types = last_unified
                     if 0 last_unified.length != match_after match_before.equals ! && then
-                        last_unified match_after TypedStack::set_types
+                        last_unified match_after->types
                     elif match_after match_before.equals then
-                        tc TypeChecker::live match_after.restore
+                        tc.stack match_after.restore
                     else
                         op Op::location "Match arms have incompatible stack effects" ErrorKind::StackMismatch add_error
                     fi
                 fi
-                match_before tc TypeChecker::live.restore
+                match_before tc.stack.restore
             fi
 
             match_ctx MatchContext::match_type = end_match_type
@@ -2025,19 +2025,19 @@ fn check_match tc:TypeChecker op:Op function_opt:Option[Function] {
             match_ctx MatchContext::before = final_before
             match_ctx MatchContext::after = final_after
             # When stack == before and before == after, nothing changed
-            if final_before tc TypeChecker::live.equals final_after final_before.equals && then
+            if final_before tc.stack.equals final_after final_before.equals && then
                 return
             fi
             # When stack == before but after differs (e.g. wildcard-only match),
             # accept the after state directly
-            if final_before tc TypeChecker::live.equals final_after final_before.equals ! && then
-                final_after tc TypeChecker::live.restore
+            if final_before tc.stack.equals final_after final_before.equals ! && then
+                final_after tc.stack.restore
                 return
             fi
-            tc.store final_after tc TypeChecker::live.unify_types = unified
+            tc.store final_after tc.stack.unify_types = unified
             if 0 unified.length != then
-                final_after tc TypeChecker::live.restore
-                unified tc TypeChecker::live TypedStack::set_types
+                final_after tc.stack.restore
+                unified tc.stack->types
                 return
             fi
             op Op::location "Match arms have incompatible stack effects" ErrorKind::StackMismatch add_error
@@ -2412,7 +2412,7 @@ fn check_fstring_to_str
     op_index:int
     function_opt:Option[Function]
 -> int {
-    "value with trait `Display`" tc TypeChecker::set_current_expect_ctx
+    "value with trait `Display`" tc->current_expect_ctx
     if TYPE_STR_T tc stack_peek_type.eq then
         op_index return
     fi
@@ -2457,9 +2457,9 @@ fn run_type_check_ops checker:TypeChecker ops:List[Op] function_opt:Option[Funct
     while op_index ops.length > do
         op_index ops.get = current_op
         1 += op_index
-        current_op Op::location checker TypeChecker::set_current_location
-        "" checker TypeChecker::set_current_expect_ctx
-        false checker TypeChecker::set_underflow_reported_this_op
+        current_op Op::location checker->current_location
+        "" checker->current_expect_ctx
+        false checker->underflow_reported_this_op
         current_op.value = op_value
         # Arithmetic
         if
@@ -2741,16 +2741,16 @@ fn type_check_ops ops:List[Op] function_opt:Option[Function] store:SymbolStore -
             the_function Function::stack_effect StackEffect::parameters.length = budget
         fi
     fi
-    budget checker TypeChecker::set_param_cap
+    budget checker->param_cap
     ERRORS.length = errors_before_ops
     function_opt ops checker run_type_check_ops
 
     # Build inferred stack effect
     List::new(List[Type]) = inferred_returns
-    for inferred_type in checker TypeChecker::live TypedStack::types.iter do
+    for inferred_type in checker.stack.types.iter do
         inferred_type inferred_returns.push
     done
-    inferred_returns checker TypeChecker::parameters make_stack_effect = inferred
+    inferred_returns checker.parameters make_stack_effect = inferred
 
     # Verify against declared stack effect if function has one
     ERRORS.length errors_before_ops < = had_type_errors

--- a/compiler/typechecker.casa
+++ b/compiler/typechecker.casa
@@ -79,32 +79,38 @@ enum BranchFrame {
     BranchMatch (MatchContext)
 }
 
-fn make_if_context -> IfContext {
-    empty_location
-    ""
-    false
-    false
-    TypedStack::new
-    TypedStack::new
-    IfContext
+impl IfContext {
+    fn new -> IfContext {
+        empty_location
+        ""
+        false
+        false
+        TypedStack::new
+        TypedStack::new
+        IfContext
+    }
 }
 
-fn make_while_context -> WhileContext {
-    empty_location
-    false
-    TypedStack::new
-    WhileContext
+impl WhileContext {
+    fn new -> WhileContext {
+        empty_location
+        false
+        TypedStack::new
+        WhileContext
+    }
 }
 
-fn make_match_context match_type:str -> MatchContext {
-    empty_location
-    ""
-    match_type
-    List::new(List[str])
-    false
-    TypedStack::new
-    TypedStack::new
-    MatchContext
+impl MatchContext {
+    fn new match_type:str -> MatchContext {
+        empty_location
+        ""
+        match_type
+        List::new(List[str])
+        false
+        TypedStack::new
+        TypedStack::new
+        MatchContext
+    }
 }
 
 # ============================================================================
@@ -126,20 +132,22 @@ struct TypeChecker {
     underflow_reported_this_op: bool
 }
 
-fn make_typechecker store:SymbolStore -> TypeChecker {
-    false # underflow_reported_this_op
-    -1 # param_cap (-1 = unlimited until type_check_ops sets a real cap)
-    store # store
-    false # in_branch_condition
-    "" # current_expect_ctx
-    "" # current_op_context
-    empty_location # current_location
-    List::new(List[BranchFrame]) # branched_stacks
-    false # has_return_types
-    TypedStack::new # return_types
-    List::new(List[Parameter]) # parameters
-    TypedStack::new # stack
-    TypeChecker
+impl TypeChecker {
+    fn new store:SymbolStore -> TypeChecker {
+        false # underflow_reported_this_op
+        -1 # param_cap (-1 = unlimited until type_check_ops sets a real cap)
+        store # store
+        false # in_branch_condition
+        "" # current_expect_ctx
+        "" # current_op_context
+        empty_location # current_location
+        List::new(List[BranchFrame]) # branched_stacks
+        false # has_return_types
+        TypedStack::new # return_types
+        List::new(List[Parameter]) # parameters
+        TypedStack::new # stack
+        TypeChecker
+    }
 }
 
 fn within_param_cap tc:TypeChecker -> bool {
@@ -193,7 +201,7 @@ fn stack_peek tc:TypeChecker -> str {
 fn stack_pop tc:TypeChecker -> str {
     if 0 tc.stack.types.length == then
         if tc within_param_cap then
-            TYPE_UNKNOWN make_param tc.parameters.push
+            TYPE_UNKNOWN Parameter::new tc.parameters.push
             TYPE_UNKNOWN return
         fi
         tc stack_underflow_message tc report_stack_underflow
@@ -217,7 +225,7 @@ fn stack_peek_type tc:TypeChecker -> Type {
 fn stack_pop_type tc:TypeChecker -> Type {
     if 0 tc.stack.types.length == then
         if tc within_param_cap then
-            TYPE_UNKNOWN make_param tc.parameters.push
+            TYPE_UNKNOWN Parameter::new tc.parameters.push
             TYPE_UNKNOWN_T return
         fi
         tc stack_underflow_message tc report_stack_underflow
@@ -230,7 +238,7 @@ fn stack_pop_type tc:TypeChecker -> Type {
 fn stack_pop_drop tc:TypeChecker {
     if 0 tc.stack.types.length == then
         if tc within_param_cap then
-            TYPE_UNKNOWN make_param tc.parameters.push
+            TYPE_UNKNOWN Parameter::new tc.parameters.push
             return
         fi
         tc stack_underflow_message tc report_stack_underflow
@@ -243,7 +251,7 @@ fn stack_pop_drop tc:TypeChecker {
 fn expect_type_t tc:TypeChecker expected:Type {
     if 0 tc.stack.types.length == then
         if tc within_param_cap then
-            expected.format make_param tc.parameters.push
+            expected.format Parameter::new tc.parameters.push
             return
         fi
         f"Stack underflow: expected `{expected.format}` but stack is empty" tc report_stack_underflow
@@ -742,7 +750,7 @@ fn check_comparison
         if is_enum1 then
             base1 tc.store.enums.get.unwrap = casa_enum
             if casa_enum has_inner_values then
-                base1 make_named_type Option::Some op Op::set_type_hint
+                base1 GenericType::new Type::Generic Option::Some op Op::set_type_hint
             fi
         fi
         TYPE_BOOL_T tc stack_push_type
@@ -1083,7 +1091,7 @@ fn check_push_var tc:TypeChecker op:Op function_opt:Option[Function] {
 fn check_if_block tc:TypeChecker op:Op {
     op.value = if_value
     if if_value OpValue::IfStart is then
-        make_if_context = if_ctx
+        IfContext::new = if_ctx
         op Op::location if_ctx IfContext::set_current_branch_location
         if_ctx BranchFrame::BranchIf = if_frame
         if_frame tc.branched_stacks.push
@@ -1167,7 +1175,7 @@ fn check_if_block tc:TypeChecker op:Op {
 fn check_while_block tc:TypeChecker op:Op {
     op.value = while_value
     if while_value OpValue::WhileStart is then
-        make_while_context = while_ctx
+        WhileContext::new = while_ctx
         tc.stack while_ctx WhileContext::before.restore
         op Op::location while_ctx WhileContext::set_current_branch_location
         while_ctx BranchFrame::BranchWhile = while_frame
@@ -1548,7 +1556,7 @@ fn inject_trait_fn_ptrs
                 method_index expanded_methods.get = method
                 if 0 method TraitMethod::default_ops.length == then
                     f"__trait_{concrete}_{method TraitMethod::name}" = hidden_var
-                    location hidden_var OpValue::PushVar make_op = push_op
+                    location hidden_var OpValue::PushVar Op::new = push_op
                     insert_pos push_op ops.insert
                     1 += insert_pos
                     1 += inserted
@@ -1577,7 +1585,7 @@ fn inject_trait_fn_ptrs
                             global_fn global_fn Function::ops tc.store resolve_identifiers global_fn Function::set_ops
                         fi
                         tc.store global_fn ensure_typechecked
-                        location fn_name OpValue::FnPush make_op = push_op
+                        location fn_name OpValue::FnPush Op::new = push_op
                         insert_pos push_op ops.insert
                         1 += insert_pos
                         1 += inserted
@@ -1751,7 +1759,7 @@ fn check_io tc:TypeChecker op:Op ops:List[Op] op_index:int function_opt:Option[F
     fi
     "to_str" OpValue::MethodCall op Op::set_value
     function_opt op_index ops op tc check_method_call = new_index
-    op Op::location OpValue::Print make_op = print_op
+    op Op::location OpValue::Print Op::new = print_op
     new_index print_op ops.insert
     new_index
 }
@@ -1800,7 +1808,7 @@ fn check_enum_variant tc:TypeChecker op:Op {
     variant EnumVariant::enum_name = enum_name
     enum_name tc.store.enums.get = enum_opt
     if enum_opt.is_none then
-        enum_name make_named_type tc stack_push_type
+        enum_name GenericType::new Type::Generic tc stack_push_type
         return
     fi
     enum_opt.unwrap = casa_enum
@@ -1810,7 +1818,7 @@ fn check_enum_variant tc:TypeChecker op:Op {
         if 0 casa_enum CasaEnum::type_vars.length != then
             casa_enum CasaEnum::type_vars enum_name build_parameterized_type_t tc stack_push_type
         else
-            enum_name make_named_type tc stack_push_type
+            enum_name GenericType::new Type::Generic tc stack_push_type
         fi
         return
     fi
@@ -1819,7 +1827,7 @@ fn check_enum_variant tc:TypeChecker op:Op {
         if 0 casa_enum CasaEnum::type_vars.length != then
             casa_enum CasaEnum::type_vars enum_name build_parameterized_type_t tc stack_push_type
         else
-            enum_name make_named_type tc stack_push_type
+            enum_name GenericType::new Type::Generic tc stack_push_type
         fi
         return
     fi
@@ -1848,7 +1856,7 @@ fn check_enum_variant tc:TypeChecker op:Op {
         for inner_type in inner_types.iter do
             inner_type tc expect_type_t
         done
-        enum_name make_named_type tc stack_push_type
+        enum_name GenericType::new Type::Generic tc stack_push_type
     fi
 }
 
@@ -1927,7 +1935,7 @@ fn check_match tc:TypeChecker op:Op function_opt:Option[Function] {
             fi
         fi
         tc stack_pop = match_type
-        match_type make_match_context = match_ctx
+        match_type MatchContext::new = match_ctx
         # Snapshot the entry stack state eagerly so that an OpFnReturn visiting
         # this frame before any OpMatchArm still finds a correct `before` to
         # restore from. Matches the pre-refactor make_branched_stack behavior.
@@ -2066,7 +2074,7 @@ fn check_struct_new tc:TypeChecker op:Op {
     done
     # Construct the result type
     if 0 casa_struct CasaStruct::type_vars.length == then
-        name make_named_type tc stack_push_type
+        name GenericType::new Type::Generic tc stack_push_type
     else
         bindings casa_struct CasaStruct::type_vars name build_resolved_type tc stack_push
     fi
@@ -2081,7 +2089,7 @@ fn check_struct_literal tc:TypeChecker op:Op {
     literal StructLiteral::struct_name = name
     name tc.store.structs.get = struct_opt
     if struct_opt.is_none then
-        name make_named_type tc stack_push_type
+        name GenericType::new Type::Generic tc stack_push_type
         return
     fi
     struct_opt.unwrap = casa_struct
@@ -2098,7 +2106,7 @@ fn check_struct_literal tc:TypeChecker op:Op {
         done
         index 1 - = index
     done
-    name make_named_type tc stack_push_type
+    name GenericType::new Type::Generic tc stack_push_type
 }
 
 # ============================================================================
@@ -2259,7 +2267,7 @@ fn instantiate_default_trait_method
     for synth_param in resolved_stack_effect StackEffect::parameters.iter do
         if "" synth_param Parameter::name != then
             synth_param Parameter::typ synth_param Parameter::name Variable synth_vars.push
-            empty_location synth_param Parameter::name OpValue::AssignVar make_op synth_ops.push
+            empty_location synth_param Parameter::name OpValue::AssignVar Op::new synth_ops.push
         fi
     done
 
@@ -2281,12 +2289,12 @@ fn instantiate_default_trait_method
         fi
         List::new(List[Parameter]) = lambda_params
         List::new(List[Type]) = lambda_returns
-        lambda_returns lambda_params make_stack_effect = lambda_effect
+        lambda_returns lambda_params StackEffect::new = lambda_effect
         for lambda_type_var in resolved_stack_effect StackEffect::type_vars.to_list.iter do
             lambda_type_var lambda_effect StackEffect::type_vars.add = lambda_tvs
             lambda_tvs lambda_effect StackEffect::set_type_vars
         done
-        lambda_effect lambda_opt.unwrap Function::location lambda_ops cloned_lambda_name make_function_with_stack_effect = cloned_lambda
+        lambda_effect lambda_opt.unwrap Function::location lambda_ops cloned_lambda_name Function::with_stack_effect = cloned_lambda
         cloned_lambda cloned_lambda_name store.functions.set drop
         cloned_lambda_name OpValue::FnPush body_op Op::set_value
         1 += cloned_lambda_index
@@ -2296,7 +2304,7 @@ fn instantiate_default_trait_method
     done
 
     # Create, register, and typecheck the function
-    resolved_stack_effect empty_location synth_ops synth_fn_name make_function_with_stack_effect = synth_fn
+    resolved_stack_effect empty_location synth_ops synth_fn_name Function::with_stack_effect = synth_fn
     synth_vars synth_fn Function::set_variables
     true synth_fn Function::set_is_used
     synth_fn synth_fn_name store.functions.set drop
@@ -2351,7 +2359,7 @@ fn check_method_call
                         f"{receiver}::{method_name}" resolved_stack_effect tc apply_stack_effect
                         hidden_var OpValue::PushVar op Op::set_value
                         # Insert FN_EXEC op after the PUSH_VARIABLE
-                        op Op::location OpValue::FnExec make_op = exec_op
+                        op Op::location OpValue::FnExec Op::new = exec_op
                         op_index exec_op ops.insert
                         op_index 1 + return
                     fi
@@ -2733,7 +2741,7 @@ fn run_type_check_ops checker:TypeChecker ops:List[Op] function_opt:Option[Funct
 }
 
 fn type_check_ops ops:List[Op] function_opt:Option[Function] store:SymbolStore -> StackEffect {
-    store make_typechecker = checker
+    store TypeChecker::new = checker
     -1 = budget
     if function_opt.is_some then
         function_opt.unwrap = the_function
@@ -2750,7 +2758,7 @@ fn type_check_ops ops:List[Op] function_opt:Option[Function] store:SymbolStore -
     for inferred_type in checker.stack.types.iter do
         inferred_type inferred_returns.push
     done
-    inferred_returns checker.parameters make_stack_effect = inferred
+    inferred_returns checker.parameters StackEffect::new = inferred
 
     # Verify against declared stack effect if function has one
     ERRORS.length errors_before_ops < = had_type_errors

--- a/formatter/format.casa
+++ b/formatter/format.casa
@@ -58,6 +58,25 @@ fn make_indent depth:int -> str {
 }
 
 # ============================================================================
+# Formatter state
+# ============================================================================
+
+struct Formatter {
+    source: str
+    output: StringBuilder
+    depth:  int
+}
+
+impl Formatter {
+    fn new source:str -> Formatter {
+        0
+        StringBuilder::new
+        source
+        Formatter
+    }
+}
+
+# ============================================================================
 # Token classification helpers
 # ============================================================================
 
@@ -226,609 +245,610 @@ fn is_field_line line:List[Token] -> bool {
 # Emit a line of tokens with proper spacing
 # ============================================================================
 
-fn emit_line_tokens line:List[Token] depth:int source:str output:StringBuilder {
-    depth make_indent output.append
-    0 line.get Token::value = first_val
-    "fn" first_val == = is_fn_decl
-    false = seen_open_brace
-    0 = ti
-    while ti line.length > do
-        ti line.get = lt
-        lt Token::value = lv
-        source lt token_text output.append
-        if "{" lv == then true = seen_open_brace fi
-        ti 1 + = next_ti
-        if next_ti line.length > then
-            next_ti line.get = next_tok
-            next_tok Token::value = next_val
-            true = need_space
-            if lv should_skip_space_after then false = need_space fi
-            if next_tok Token::kind next_val lt Token::kind should_skip_space_before_tokens then
-                false = need_space
-            fi
-            # Colon in fn params: no space around it
-            if ":" lv == then
-                if ti line is_fn_param_colon then false = need_space fi
-            fi
-            if ":" next_val == then
-                if next_ti line is_fn_param_colon then false = need_space fi
-            fi
-            # Force space inside block braces and between } and a list literal.
-            # F-string expression delimiters share the brace glyphs but have
-            # distinct kinds, so they keep their no-space rule.
-            if "{" lv == lt Token::kind is_fstring_interior ! && then
+impl Formatter {
+    fn emit_line_tokens self:Formatter line:List[Token] {
+        self.depth make_indent self.output.append
+        0 line.get Token::value = first_val
+        "fn" first_val == = is_fn_decl
+        false = seen_open_brace
+        0 = ti
+        while ti line.length > do
+            ti line.get = lt
+            lt Token::value = lv
+            self.source lt token_text self.output.append
+            if "{" lv == then true = seen_open_brace fi
+            ti 1 + = next_ti
+            if next_ti line.length > then
+                next_ti line.get = next_tok
+                next_tok Token::value = next_val
                 true = need_space
-            fi
-            if "}" next_val == next_tok Token::kind is_fstring_interior ! && then
-                true = need_space
-            fi
-            if "}" lv == "[" next_val == && lt Token::kind is_fstring_interior ! && then
-                true = need_space
-            fi
-            # Setter shorthand `self->field`: no space around -> in body.
-            # In fn signatures the `->` before `{` is the return arrow and
-            # keeps default spacing.
-            if is_fn_decl ! seen_open_brace || then
-                if "->" lv == then false = need_space fi
-                if "->" next_val == then false = need_space fi
-            fi
-            # No space before `,` (list literal commas).
-            if "," next_val == then false = need_space fi
-            # No space before `(` after enum-variant-style prev `Foo::Bar`.
-            if "(" next_val == lv "::" str::contains && then
-                false = need_space
-            fi
-            if "[" next_val == lv lt Token::kind is_generic_bracket_prev && then
-                false = need_space
-            fi
-            if need_space then " " output.append fi
-        fi
-        1 += ti
-    done
-    "\n" output.append
-}
-
-# ============================================================================
-# Measure line length as it would be emitted
-# ============================================================================
-
-fn measure_line_length line:List[Token] depth:int source:str -> int {
-    depth 4 * = len
-    0 line.get Token::value = first_val
-    "fn" first_val == = is_fn_decl
-    false = seen_open_brace
-    0 = mi
-    while mi line.length > do
-        mi line.get = m_tok
-        source m_tok token_text.length len + = len
-        m_tok Token::value = m_val
-        if "{" m_val == then true = seen_open_brace fi
-        mi 1 + = m_next
-        if m_next line.length > then
-            m_next line.get = m_next_tok
-            m_next_tok Token::value = m_next_val
-            true = m_space
-            if m_val should_skip_space_after then false = m_space fi
-            if m_next_tok Token::kind m_next_val m_tok Token::kind should_skip_space_before_tokens then
-                false = m_space
-            fi
-            if ":" m_val == then
-                if mi line is_fn_param_colon then false = m_space fi
-            fi
-            if ":" m_next_val == then
-                if m_next line is_fn_param_colon then false = m_space fi
-            fi
-            if "{" m_val == m_tok Token::kind is_fstring_interior ! && then
-                true = m_space
-            fi
-            if "}" m_next_val == m_next_tok Token::kind is_fstring_interior ! && then
-                true = m_space
-            fi
-            if "}" m_val == "[" m_next_val == && m_tok Token::kind is_fstring_interior ! && then
-                true = m_space
-            fi
-            if is_fn_decl ! seen_open_brace || then
-                if "->" m_val == then false = m_space fi
-                if "->" m_next_val == then false = m_space fi
-            fi
-            if "," m_next_val == then false = m_space fi
-            if "(" m_next_val == m_val "::" str::contains && then
-                false = m_space
-            fi
-            if "[" m_next_val == m_val mi line.get Token::kind is_generic_bracket_prev && then
-                false = m_space
-            fi
-            if m_space then 1 len + = len fi
-        fi
-        1 += mi
-    done
-    len
-}
-
-# ============================================================================
-# Emit a wrapped function declaration
-# ============================================================================
-
-fn emit_wrapped_fn_decl line:List[Token] depth:int source:str output:StringBuilder {
-    # Line 1: fn name (and optional generics)
-    depth make_indent output.append
-    "fn " output.append
-    source 1 line.get token_text output.append
-
-    2 = wi
-    # Handle generics [T] or [T: Trait, V]
-    if wi line.length > then
-        if "[" wi line.get Token::value == then
-            false = gen_done
-            while wi line.length > gen_done ! && do
-                source wi line.get token_text output.append
-                if "]" wi line.get Token::value == then
-                    1 += wi
-                    "\n" output.append
-                    true = gen_done
-                else
-                    1 += wi
+                if lv should_skip_space_after then false = need_space fi
+                if next_tok Token::kind next_val lt Token::kind should_skip_space_before_tokens then
+                    false = need_space
                 fi
-            done
+                # Colon in fn params: no space around it
+                if ":" lv == then
+                    if ti line is_fn_param_colon then false = need_space fi
+                fi
+                if ":" next_val == then
+                    if next_ti line is_fn_param_colon then false = need_space fi
+                fi
+                # Force space inside block braces and between } and a list literal.
+                # F-string expression delimiters share the brace glyphs but have
+                # distinct kinds, so they keep their no-space rule.
+                if "{" lv == lt Token::kind is_fstring_interior ! && then
+                    true = need_space
+                fi
+                if "}" next_val == next_tok Token::kind is_fstring_interior ! && then
+                    true = need_space
+                fi
+                if "}" lv == "[" next_val == && lt Token::kind is_fstring_interior ! && then
+                    true = need_space
+                fi
+                # Setter shorthand `self->field`: no space around -> in body.
+                # In fn signatures the `->` before `{` is the return arrow and
+                # keeps default spacing.
+                if is_fn_decl ! seen_open_brace || then
+                    if "->" lv == then false = need_space fi
+                    if "->" next_val == then false = need_space fi
+                fi
+                # No space before `,` (list literal commas).
+                if "," next_val == then false = need_space fi
+                # No space before `(` after enum-variant-style prev `Foo::Bar`.
+                if "(" next_val == lv "::" str::contains && then
+                    false = need_space
+                fi
+                if "[" next_val == lv lt Token::kind is_generic_bracket_prev && then
+                    false = need_space
+                fi
+                if need_space then " " self.output.append fi
+            fi
+            1 += ti
+        done
+        "\n" self.output.append
+    }
+
+    # ============================================================================
+    # Measure line length as it would be emitted
+    # ============================================================================
+
+    fn measure_line_length self:Formatter line:List[Token] -> int {
+        self.depth 4 * = len
+        0 line.get Token::value = first_val
+        "fn" first_val == = is_fn_decl
+        false = seen_open_brace
+        0 = mi
+        while mi line.length > do
+            mi line.get = m_tok
+            self.source m_tok token_text.length len + = len
+            m_tok Token::value = m_val
+            if "{" m_val == then true = seen_open_brace fi
+            mi 1 + = m_next
+            if m_next line.length > then
+                m_next line.get = m_next_tok
+                m_next_tok Token::value = m_next_val
+                true = m_space
+                if m_val should_skip_space_after then false = m_space fi
+                if m_next_tok Token::kind m_next_val m_tok Token::kind should_skip_space_before_tokens then
+                    false = m_space
+                fi
+                if ":" m_val == then
+                    if mi line is_fn_param_colon then false = m_space fi
+                fi
+                if ":" m_next_val == then
+                    if m_next line is_fn_param_colon then false = m_space fi
+                fi
+                if "{" m_val == m_tok Token::kind is_fstring_interior ! && then
+                    true = m_space
+                fi
+                if "}" m_next_val == m_next_tok Token::kind is_fstring_interior ! && then
+                    true = m_space
+                fi
+                if "}" m_val == "[" m_next_val == && m_tok Token::kind is_fstring_interior ! && then
+                    true = m_space
+                fi
+                if is_fn_decl ! seen_open_brace || then
+                    if "->" m_val == then false = m_space fi
+                    if "->" m_next_val == then false = m_space fi
+                fi
+                if "," m_next_val == then false = m_space fi
+                if "(" m_next_val == m_val "::" str::contains && then
+                    false = m_space
+                fi
+                if "[" m_next_val == m_val mi line.get Token::kind is_generic_bracket_prev && then
+                    false = m_space
+                fi
+                if m_space then 1 len + = len fi
+            fi
+            1 += mi
+        done
+        len
+    }
+
+    # ============================================================================
+    # Emit a wrapped function declaration
+    # ============================================================================
+
+    fn emit_wrapped_fn_decl self:Formatter line:List[Token] {
+        # Line 1: fn name (and optional generics)
+        self.depth make_indent self.output.append
+        "fn " self.output.append
+        self.source 1 line.get token_text self.output.append
+
+        2 = wi
+        # Handle generics [T] or [T: Trait, V]
+        if wi line.length > then
+            if "[" wi line.get Token::value == then
+                false = gen_done
+                while wi line.length > gen_done ! && do
+                    self.source wi line.get token_text self.output.append
+                    if "]" wi line.get Token::value == then
+                        1 += wi
+                        "\n" self.output.append
+                        true = gen_done
+                    else
+                        1 += wi
+                    fi
+                done
+            else
+                "\n" self.output.append
+            fi
         else
-            "\n" output.append
+            "\n" self.output.append
         fi
-    else
-        "\n" output.append
-    fi
 
-    # Emit parameters, one per line
-    while wi line.length > do
-        wi line.get Token::value = wv
+        # Emit parameters, one per line
+        while wi line.length > do
+            wi line.get Token::value = wv
 
-        # -> starts the return type line
-        if "->" wv == then
-            depth make_indent output.append
-            while wi line.length > do
-                source wi line.get token_text output.append
-                wi 1 + = w_next
-                if w_next line.length > then
-                    w_next line.get Token::value = ret_next_val
-                    true = ret_space
-                    if wi line.get Token::value should_skip_space_after then
-                        false = ret_space
+            # -> starts the return type line
+            if "->" wv == then
+                self.depth make_indent self.output.append
+                while wi line.length > do
+                    self.source wi line.get token_text self.output.append
+                    wi 1 + = w_next
+                    if w_next line.length > then
+                        w_next line.get Token::value = ret_next_val
+                        true = ret_space
+                        if wi line.get Token::value should_skip_space_after then
+                            false = ret_space
+                        fi
+                        if ret_next_val "[" == ret_next_val "]" == || then
+                            false = ret_space
+                        fi
+                        if ret_space then " " self.output.append fi
                     fi
-                    if ret_next_val "[" == ret_next_val "]" == || then
-                        false = ret_space
-                    fi
-                    if ret_space then " " output.append fi
-                fi
+                    1 += wi
+                done
+                "\n" self.output.append
+            elif "{" wv == then
+                # No return type, emit just {
+                self.depth make_indent self.output.append
+                "{\n" self.output.append
+                line.length = wi
+            else
+                # Parameter: name:Type
+                self.depth 1 + make_indent self.output.append
+                self.source wi line.get token_text self.output.append
                 1 += wi
-            done
-            "\n" output.append
-        elif "{" wv == then
-            # No return type, emit just {
-            depth make_indent output.append
-            "{\n" output.append
-            line.length = wi
-        else
-            # Parameter: name:Type
-            depth 1 + make_indent output.append
-            source wi line.get token_text output.append
-            1 += wi
-            # Colon
-            if wi line.length > then
-                if ":" wi line.get Token::value == then
-                    ":" output.append
-                    1 += wi
-                    # Type tokens until next param or -> or {
-                    false = param_done
-                    while wi line.length > param_done ! && do
-                        wi line.get Token::value = pv
-                        if "->" pv == then
-                            true = param_done
-                        elif "{" pv == then
-                            true = param_done
-                        else
-                            # Check if this is a new param (Identifier followed by :)
-                            false = is_new_param
-                            if TokenKind::Identifier wi line.get Token::kind == then
-                                wi 1 + = check_col
-                                if check_col line.length > then
-                                    if ":" check_col line.get Token::value == then
-                                        true = is_new_param
-                                    fi
-                                fi
-                            fi
-                            if is_new_param then
+                # Colon
+                if wi line.length > then
+                    if ":" wi line.get Token::value == then
+                        ":" self.output.append
+                        1 += wi
+                        # Type tokens until next param or -> or {
+                        false = param_done
+                        while wi line.length > param_done ! && do
+                            wi line.get Token::value = pv
+                            if "->" pv == then
+                                true = param_done
+                            elif "{" pv == then
                                 true = param_done
                             else
-                                wi line.get Token::value = type_val
-                                # Space before type token, respecting bracket and colon rules
-                                if "[" type_val != "]" type_val != && then
-                                    wi 1 - line.get Token::value = prev_tok_val
-                                    if "[" prev_tok_val != ":" prev_tok_val != && then
-                                        " " output.append
+                                # Check if this is a new param (Identifier followed by :)
+                                false = is_new_param
+                                if TokenKind::Identifier wi line.get Token::kind == then
+                                    wi 1 + = check_col
+                                    if check_col line.length > then
+                                        if ":" check_col line.get Token::value == then
+                                            true = is_new_param
+                                        fi
                                     fi
                                 fi
-                                source wi line.get token_text output.append
-                                1 += wi
+                                if is_new_param then
+                                    true = param_done
+                                else
+                                    wi line.get Token::value = type_val
+                                    # Space before type token, respecting bracket and colon rules
+                                    if "[" type_val != "]" type_val != && then
+                                        wi 1 - line.get Token::value = prev_tok_val
+                                        if "[" prev_tok_val != ":" prev_tok_val != && then
+                                            " " self.output.append
+                                        fi
+                                    fi
+                                    self.source wi line.get token_text self.output.append
+                                    1 += wi
+                                fi
                             fi
-                        fi
-                    done
-                    "\n" output.append
+                        done
+                        "\n" self.output.append
+                    else
+                        "\n" self.output.append
+                    fi
                 else
-                    "\n" output.append
+                    "\n" self.output.append
                 fi
-            else
-                "\n" output.append
             fi
-        fi
-    done
-}
+        done
+    }
 
-# ============================================================================
-# Format struct/enum body with field alignment
-# ============================================================================
+    # ============================================================================
+    # Format struct/enum body with field alignment
+    # ============================================================================
 
-fn format_struct_body tokens:List[Token] pos:int depth:int source:str output:StringBuilder -> int {
-    # Pass 1: scan for max field name length
-    pos = scan_pos
-    0 = max_name_len
-    false = scan_done
-    while scan_pos tokens.length > scan_done ! && do
-        scan_pos tokens.get = scan_tok
-        if scan_tok is_eof_token then
-            true = scan_done
-        elif TokenKind::Newline scan_tok Token::kind == then
-            1 += scan_pos
-        elif "}" scan_tok Token::value == then
-            true = scan_done
-        elif TokenKind::Identifier scan_tok Token::kind == then
-            scan_pos 1 + = colon_check
-            if colon_check tokens.length > then
-                if ":" colon_check tokens.get Token::value == then
-                    scan_tok Token::value.length = name_len
-                    if max_name_len name_len > then
-                        name_len = max_name_len
+    fn format_struct_body self:Formatter tokens:List[Token] pos:int -> int {
+        # Pass 1: scan for max field name length
+        pos = scan_pos
+        0 = max_name_len
+        false = scan_done
+        while scan_pos tokens.length > scan_done ! && do
+            scan_pos tokens.get = scan_tok
+            if scan_tok is_eof_token then
+                true = scan_done
+            elif TokenKind::Newline scan_tok Token::kind == then
+                1 += scan_pos
+            elif "}" scan_tok Token::value == then
+                true = scan_done
+            elif TokenKind::Identifier scan_tok Token::kind == then
+                scan_pos 1 + = colon_check
+                if colon_check tokens.length > then
+                    if ":" colon_check tokens.get Token::value == then
+                        scan_tok Token::value.length = name_len
+                        if max_name_len name_len > then
+                            name_len = max_name_len
+                        fi
                     fi
                 fi
+                1 += scan_pos
+            else
+                1 += scan_pos
             fi
-            1 += scan_pos
-        else
-            1 += scan_pos
-        fi
-    done
+        done
 
-    # Pass 2: emit fields with alignment
-    false = emit_done
-    while pos tokens.length > emit_done ! && do
-        pos tokens.get = em_tok
-        if em_tok is_eof_token then
-            true = emit_done
-        elif TokenKind::Newline em_tok Token::kind == then
-            1 += pos
-        elif "}" em_tok Token::value == then
-            true = emit_done
-        else
-            # Collect one line
-            List::new(List[Token]) = em_line
-            false = em_line_done
-            while pos tokens.length > em_line_done ! && do
-                pos tokens.get = em_lt
-                if em_lt is_eof_token then
-                    true = em_line_done
-                elif TokenKind::Newline em_lt Token::kind == then
-                    true = em_line_done
+        # Pass 2: emit fields with alignment
+        false = emit_done
+        while pos tokens.length > emit_done ! && do
+            pos tokens.get = em_tok
+            if em_tok is_eof_token then
+                true = emit_done
+            elif TokenKind::Newline em_tok Token::kind == then
+                1 += pos
+            elif "}" em_tok Token::value == then
+                true = emit_done
+            else
+                # Collect one line
+                List::new(List[Token]) = em_line
+                false = em_line_done
+                while pos tokens.length > em_line_done ! && do
+                    pos tokens.get = em_lt
+                    if em_lt is_eof_token then
+                        true = em_line_done
+                    elif TokenKind::Newline em_lt Token::kind == then
+                        true = em_line_done
+                    else
+                        em_lt em_line.push
+                        1 += pos
+                    fi
+                done
+
+                if em_line is_field_line then
+                    # Aligned field: name:  Type
+                    self.depth make_indent self.output.append
+                    0 em_line.get Token::value self.output.append
+                    ":" self.output.append
+                    0 em_line.get Token::value.length = cur_name_len
+                    max_name_len cur_name_len - 1 + = padding
+                    0 = pad_i
+                    while pad_i padding > do
+                        " " self.output.append
+                        1 += pad_i
+                    done
+                    2 = type_i
+                    while type_i em_line.length > do
+                        self.source type_i em_line.get token_text self.output.append
+                        type_i 1 + = next_type_i
+                        if next_type_i em_line.length > then
+                            next_type_i em_line.get Token::value = field_next_val
+                            true = field_space
+                            if type_i em_line.get Token::value should_skip_space_after then
+                                false = field_space
+                            fi
+                            if field_next_val "[" == field_next_val "]" == || then
+                                false = field_space
+                            fi
+                            if field_space then " " self.output.append fi
+                        fi
+                        1 += type_i
+                    done
+                    "\n" self.output.append
                 else
-                    em_lt em_line.push
+                    em_line self.emit_line_tokens
+                fi
+            fi
+        done
+
+        # Emit closing brace
+        self.depth 1 - make_indent self.output.append
+        "}\n" self.output.append
+
+        # Skip past closing brace and newline
+        if pos tokens.length > then
+            if "}" pos tokens.get Token::value == then
+                1 += pos
+            fi
+        fi
+        if pos tokens.length > then
+            if TokenKind::Newline pos tokens.get Token::kind == then
+                1 += pos
+            fi
+        fi
+
+        pos
+    }
+
+    # ============================================================================
+    # Format tokens into a string
+    # ============================================================================
+
+    fn format_tokens self:Formatter tokens:List[Token] -> str {
+        0 = pos
+        0 self->depth
+        0 = consecutive_newlines
+        false = prev_was_open
+        false = prev_was_comment
+        false = prev_was_section_comment
+        false = prev_was_definition
+        false = prev_was_import
+
+        while pos tokens.length > do
+            pos tokens.get = token
+
+            # End of file
+            if token is_eof_token then
+                self.output.build return
+            fi
+
+            # Handle newline token
+            if TokenKind::Newline token Token::kind == then
+                1 += consecutive_newlines
+                1 += pos
+                continue
+            fi
+
+            # We have a non-newline, non-Eof token. Collect the full line.
+            List::new(List[Token]) = line_tokens
+            false = collect_done
+            while pos tokens.length > collect_done ! && do
+                pos tokens.get = cur
+                if cur is_eof_token then
+                    true = collect_done
+                elif TokenKind::Newline cur Token::kind == then
+                    true = collect_done
+                else
+                    cur line_tokens.push
                     1 += pos
                 fi
             done
 
-            if em_line is_field_line then
-                # Aligned field: name:  Type
-                depth make_indent output.append
-                0 em_line.get Token::value output.append
-                ":" output.append
-                0 em_line.get Token::value.length = cur_name_len
-                max_name_len cur_name_len - 1 + = padding
-                0 = pad_i
-                while pad_i padding > do
-                    " " output.append
-                    1 += pad_i
-                done
-                2 = type_i
-                while type_i em_line.length > do
-                    source type_i em_line.get token_text output.append
-                    type_i 1 + = next_type_i
-                    if next_type_i em_line.length > then
-                        next_type_i em_line.get Token::value = field_next_val
-                        true = field_space
-                        if type_i em_line.get Token::value should_skip_space_after then
-                            false = field_space
-                        fi
-                        if field_next_val "[" == field_next_val "]" == || then
-                            false = field_space
-                        fi
-                        if field_space then " " output.append fi
-                    fi
-                    1 += type_i
-                done
-                "\n" output.append
-            else
-                output source depth em_line emit_line_tokens
+            if line_tokens.length 0 == then continue fi
+
+            # Get first token value for indent adjustments
+            0 line_tokens.get Token::value = first_value
+
+            # Decrease self.depth for closing/dedent keywords
+            if first_value is_block_close_value then
+                if 0 self.depth != then self.depth 1 - self->depth fi
             fi
-        fi
-    done
-
-    # Emit closing brace
-    depth 1 - make_indent output.append
-    "}\n" output.append
-
-    # Skip past closing brace and newline
-    if pos tokens.length > then
-        if "}" pos tokens.get Token::value == then
-            1 += pos
-        fi
-    fi
-    if pos tokens.length > then
-        if TokenKind::Newline pos tokens.get Token::kind == then
-            1 += pos
-        fi
-    fi
-
-    pos
-}
-
-# ============================================================================
-# Format tokens into a string
-# ============================================================================
-
-fn format_tokens tokens:List[Token] source:str -> str {
-    StringBuilder::new = output
-    0 = pos
-    0 = depth
-    0 = consecutive_newlines
-    false = prev_was_open
-    false = prev_was_comment
-    false = prev_was_section_comment
-    false = prev_was_definition
-    false = prev_was_import
-
-    while pos tokens.length > do
-        pos tokens.get = token
-
-        # End of file
-        if token is_eof_token then
-            output.build return
-        fi
-
-        # Handle newline token
-        if TokenKind::Newline token Token::kind == then
-            1 += consecutive_newlines
-            1 += pos
-            continue
-        fi
-
-        # We have a non-newline, non-Eof token. Collect the full line.
-        List::new(List[Token]) = line_tokens
-        false = collect_done
-        while pos tokens.length > collect_done ! && do
-            pos tokens.get = cur
-            if cur is_eof_token then
-                true = collect_done
-            elif TokenKind::Newline cur Token::kind == then
-                true = collect_done
-            else
-                cur line_tokens.push
-                1 += pos
+            if first_value is_dedent_keyword then
+                if 0 self.depth != then self.depth 1 - self->depth fi
             fi
-        done
 
-        if line_tokens.length 0 == then continue fi
+            # Blank line normalization
+            if 0 self.output.length != then
+                consecutive_newlines 1 - = blank_lines
+                0 = allowed_blanks
 
-        # Get first token value for indent adjustments
-        0 line_tokens.get Token::value = first_value
-
-        # Decrease depth for closing/dedent keywords
-        if first_value is_block_close_value then
-            if 0 depth != then 1 -= depth fi
-        fi
-        if first_value is_dedent_keyword then
-            if 0 depth != then 1 -= depth fi
-        fi
-
-        # Blank line normalization
-        if 0 output.length != then
-            consecutive_newlines 1 - = blank_lines
-            0 = allowed_blanks
-
-            if 0 blank_lines != then
-                if 0 line_tokens.get is_section_separator_comment then
-                    if prev_was_section_comment then
-                        0 = allowed_blanks
+                if 0 blank_lines != then
+                    if 0 line_tokens.get is_section_separator_comment then
+                        if prev_was_section_comment then
+                            0 = allowed_blanks
+                        else
+                            1 = allowed_blanks
+                        fi
+                    elif 0 self.depth == then
+                        if first_value is_toplevel_definition prev_was_definition || then
+                            if "import" first_value == prev_was_import && ! then
+                                1 = allowed_blanks
+                            fi
+                        fi
                     else
                         1 = allowed_blanks
                     fi
-                elif 0 depth == then
-                    if first_value is_toplevel_definition prev_was_definition || then
-                        if "import" first_value == prev_was_import && ! then
-                            1 = allowed_blanks
-                        fi
-                    fi
                 else
-                    1 = allowed_blanks
-                fi
-            else
-                if 0 depth == then
-                    if 0 line_tokens.get is_section_separator_comment then
-                        if prev_was_section_comment ! then
-                            1 = allowed_blanks
-                        fi
-                    elif first_value is_toplevel_definition prev_was_definition || then
-                        if "import" first_value == prev_was_import && ! then
-                            1 = allowed_blanks
-                        fi
-                    fi
-                fi
-            fi
-
-            if prev_was_open then
-                0 = allowed_blanks
-            fi
-            if first_value is_block_close_value then
-                0 = allowed_blanks
-            fi
-            if first_value is_dedent_keyword then
-                0 = allowed_blanks
-            fi
-
-            0 = nl_i
-            while nl_i allowed_blanks > do
-                "\n" output.append
-                1 += nl_i
-            done
-        fi
-        0 = consecutive_newlines
-
-        # Check if this is a struct/enum header — handle field alignment
-        false = handled_struct
-        if "struct" first_value == "enum" first_value == || then
-            line_tokens.length 1 - line_tokens.get = last_tok
-            if last_tok is_block_open_token then
-                output source depth line_tokens emit_line_tokens
-                1 += depth
-                output source depth pos tokens format_struct_body = pos
-                1 -= depth
-                1 = consecutive_newlines
-                false = prev_was_open
-                false = prev_was_comment
-                false = prev_was_section_comment
-                true = prev_was_definition
-                true = handled_struct
-            fi
-        fi
-
-        if handled_struct ! then
-            # Check if this is a fn declaration (possibly wrapped across lines)
-            false = wrapped_fn
-            if "fn" first_value == then
-                # Check if this line contains { (complete declaration)
-                false = has_open_brace
-                for brace_token in line_tokens.iter do
-                    if "{" brace_token Token::value == then
-                        true = has_open_brace
-                    fi
-                done
-                if has_open_brace ! then
-                    # Incomplete fn declaration: collect continuation lines
-                    # until we find { or end of declaration
-                    false = decl_complete
-                    while pos tokens.length > decl_complete ! && do
-                        pos tokens.get = decl_tok
-                        if decl_tok is_eof_token then
-                            true = decl_complete
-                        elif TokenKind::Newline decl_tok Token::kind == then
-                            1 += pos
-                        elif "}" decl_tok Token::value == then
-                            # Closing brace of enclosing block: stop, don't consume
-                            true = decl_complete
-                        elif TokenKind::Keyword decl_tok Token::kind == then
-                            # New keyword (fn, struct, etc): this fn has no body
-                            decl_tok Token::value = decl_kw
-                            if "fn" decl_kw == "struct" decl_kw == ||
-                            "enum" decl_kw == || "impl" decl_kw == ||
-                            "trait" decl_kw == ||
-                            then
-                                true = decl_complete
-                            else
-                                decl_tok line_tokens.push
-                                1 += pos
+                    if 0 self.depth == then
+                        if 0 line_tokens.get is_section_separator_comment then
+                            if prev_was_section_comment ! then
+                                1 = allowed_blanks
                             fi
-                        else
-                            # Collect this continuation line
-                            false = decl_line_done
-                            while pos tokens.length > decl_line_done ! && do
-                                pos tokens.get = sl_tok
-                                if sl_tok is_eof_token then
-                                    true = decl_line_done
-                                elif TokenKind::Newline sl_tok Token::kind == then
-                                    true = decl_line_done
-                                else
-                                    sl_tok line_tokens.push
-                                    1 += pos
-                                    if "{" sl_tok Token::value == then
-                                        true = decl_complete
-                                        true = decl_line_done
-                                    fi
-                                fi
-                            done
+                        elif first_value is_toplevel_definition prev_was_definition || then
+                            if "import" first_value == prev_was_import && ! then
+                                1 = allowed_blanks
+                            fi
+                        fi
+                    fi
+                fi
+
+                if prev_was_open then
+                    0 = allowed_blanks
+                fi
+                if first_value is_block_close_value then
+                    0 = allowed_blanks
+                fi
+                if first_value is_dedent_keyword then
+                    0 = allowed_blanks
+                fi
+
+                0 = nl_i
+                while nl_i allowed_blanks > do
+                    "\n" self.output.append
+                    1 += nl_i
+                done
+            fi
+            0 = consecutive_newlines
+
+            # Check if this is a struct/enum header — handle field alignment
+            false = handled_struct
+            if "struct" first_value == "enum" first_value == || then
+                line_tokens.length 1 - line_tokens.get = last_tok
+                if last_tok is_block_open_token then
+                    line_tokens self.emit_line_tokens
+                    self.depth 1 + self->depth
+                    pos tokens self.format_struct_body = pos
+                    self.depth 1 - self->depth
+                    1 = consecutive_newlines
+                    false = prev_was_open
+                    false = prev_was_comment
+                    false = prev_was_section_comment
+                    true = prev_was_definition
+                    true = handled_struct
+                fi
+            fi
+
+            if handled_struct ! then
+                # Check if this is a fn declaration (possibly wrapped across lines)
+                false = wrapped_fn
+                if "fn" first_value == then
+                    # Check if this line contains { (complete declaration)
+                    false = has_open_brace
+                    for brace_token in line_tokens.iter do
+                        if "{" brace_token Token::value == then
+                            true = has_open_brace
                         fi
                     done
-                fi
+                    if has_open_brace ! then
+                        # Incomplete fn declaration: collect continuation lines
+                        # until we find { or end of declaration
+                        false = decl_complete
+                        while pos tokens.length > decl_complete ! && do
+                            pos tokens.get = decl_tok
+                            if decl_tok is_eof_token then
+                                true = decl_complete
+                            elif TokenKind::Newline decl_tok Token::kind == then
+                                1 += pos
+                            elif "}" decl_tok Token::value == then
+                                # Closing brace of enclosing block: stop, don't consume
+                                true = decl_complete
+                            elif TokenKind::Keyword decl_tok Token::kind == then
+                                # New keyword (fn, struct, etc): this fn has no body
+                                decl_tok Token::value = decl_kw
+                                if "fn" decl_kw == "struct" decl_kw == ||
+                                "enum" decl_kw == || "impl" decl_kw == ||
+                                "trait" decl_kw == ||
+                                then
+                                    true = decl_complete
+                                else
+                                    decl_tok line_tokens.push
+                                    1 += pos
+                                fi
+                            else
+                                # Collect this continuation line
+                                false = decl_line_done
+                                while pos tokens.length > decl_line_done ! && do
+                                    pos tokens.get = sl_tok
+                                    if sl_tok is_eof_token then
+                                        true = decl_line_done
+                                    elif TokenKind::Newline sl_tok Token::kind == then
+                                        true = decl_line_done
+                                    else
+                                        sl_tok line_tokens.push
+                                        1 += pos
+                                        if "{" sl_tok Token::value == then
+                                            true = decl_complete
+                                            true = decl_line_done
+                                        fi
+                                    fi
+                                done
+                            fi
+                        done
+                    fi
 
-                # Now line_tokens has the full declaration. Check length.
-                source depth line_tokens measure_line_length = decl_len
-                if decl_len 100 < then
-                    output source depth line_tokens emit_wrapped_fn_decl
-                    true = wrapped_fn
-                fi
-            fi
-
-            if wrapped_fn ! then
-                output source depth line_tokens emit_line_tokens
-            fi
-
-            # Increase depth for block-opening tokens
-            false = prev_was_open
-            line_tokens.length 1 - line_tokens.get = last_token
-            if last_token is_block_open_token then
-                1 += depth
-                true = prev_was_open
-            fi
-
-            # Check if line contains match keyword
-            for mt in line_tokens.iter do
-                if TokenKind::Keyword mt Token::kind == then
-                    if "match" mt Token::value == then
-                        1 += depth
-                        true = prev_was_open
+                    # Now line_tokens has the full declaration. Check length.
+                    line_tokens self.measure_line_length = decl_len
+                    if decl_len 100 < then
+                        line_tokens self.emit_wrapped_fn_decl
+                        true = wrapped_fn
                     fi
                 fi
-            done
 
-            # Track if this line was a comment
-            if TokenKind::Comment 0 line_tokens.get Token::kind == then
-                true = prev_was_comment
-                # Track section comment context (separator or comment between separators)
-                if 0 line_tokens.get is_section_separator_comment then
-                    true = prev_was_section_comment
-                elif prev_was_section_comment then
-                    # Comment between separators, keep the flag
+                if wrapped_fn ! then
+                    line_tokens self.emit_line_tokens
                 fi
-            else
-                false = prev_was_comment
-                false = prev_was_section_comment
-            fi
 
-            # Track if this was a top-level definition or import
-            if 0 depth == then
-                if first_value is_toplevel_definition "import" first_value == || then
-                    true = prev_was_definition
+                # Increase self.depth for block-opening tokens
+                false = prev_was_open
+                line_tokens.length 1 - line_tokens.get = last_token
+                if last_token is_block_open_token then
+                    self.depth 1 + self->depth
+                    true = prev_was_open
+                fi
+
+                # Check if line contains match keyword
+                for mt in line_tokens.iter do
+                    if TokenKind::Keyword mt Token::kind == then
+                        if "match" mt Token::value == then
+                            self.depth 1 + self->depth
+                            true = prev_was_open
+                        fi
+                    fi
+                done
+
+                # Track if this line was a comment
+                if TokenKind::Comment 0 line_tokens.get Token::kind == then
+                    true = prev_was_comment
+                    # Track section comment context (separator or comment between separators)
+                    if 0 line_tokens.get is_section_separator_comment then
+                        true = prev_was_section_comment
+                    elif prev_was_section_comment then
+                        # Comment between separators, keep the flag
+                    fi
+                else
+                    false = prev_was_comment
+                    false = prev_was_section_comment
+                fi
+
+                # Track if this was a top-level definition or import
+                if 0 self.depth == then
+                    if first_value is_toplevel_definition "import" first_value == || then
+                        true = prev_was_definition
+                    else
+                        false = prev_was_definition
+                    fi
+                    "import" first_value == = prev_was_import
                 else
                     false = prev_was_definition
+                    false = prev_was_import
                 fi
-                "import" first_value == = prev_was_import
-            else
-                false = prev_was_definition
-                false = prev_was_import
-            fi
 
-            # else keyword: restore depth for body
-            if "else" first_value == then
-                1 += depth
-                true = prev_was_open
+                # else keyword: restore self.depth for body
+                if "else" first_value == then
+                    self.depth 1 + self->depth
+                    true = prev_was_open
+                fi
             fi
-        fi
-    done
+        done
 
-    output.build
+        self.output.build
+    }
 }
 
 # ============================================================================
@@ -840,7 +860,8 @@ fn main {
 
     source fmt_lex = tokens_opt
     if tokens_opt Option::Some(tokens) is then
-        source tokens format_tokens = formatted
+        source Formatter::new = formatter
+        tokens formatter.format_tokens = formatted
         formatted print
     else
         source print

--- a/lsp.casa
+++ b/lsp.casa
@@ -181,52 +181,65 @@ fn path_to_uri path:str -> str {
 # JSON builders for LSP types
 # ============================================================================
 
-fn lsp_range_to_json range:LspRange -> JsonValue {
-    json_object
-    "line" range LspRange::start_line JsonValue::JsonInt json_set
-    "character" range LspRange::start_col JsonValue::JsonInt json_set
-    JsonValue::JsonObject = start_json
-    json_object
-    "line" range LspRange::end_line JsonValue::JsonInt json_set
-    "character" range LspRange::end_col JsonValue::JsonInt json_set
-    JsonValue::JsonObject = end_json
-    json_object
-    "start" start_json json_set
-    "end" end_json json_set
-    JsonValue::JsonObject
+impl LspRange {
+    fn to_json range:LspRange -> JsonValue {
+        json_object
+        "line" range LspRange::start_line JsonValue::JsonInt json_set
+        "character" range LspRange::start_col JsonValue::JsonInt json_set
+        JsonValue::JsonObject = start_json
+        json_object
+        "line" range LspRange::end_line JsonValue::JsonInt json_set
+        "character" range LspRange::end_col JsonValue::JsonInt json_set
+        JsonValue::JsonObject = end_json
+        json_object
+        "start" start_json json_set
+        "end" end_json json_set
+        JsonValue::JsonObject
+    }
 }
 
-fn lsp_location_to_json loc:LspLocation -> JsonValue {
-    json_object
-    "uri" loc LspLocation::uri JsonValue::JsonString json_set
-    "range" loc LspLocation::range lsp_range_to_json json_set
-    JsonValue::JsonObject
+impl LspLocation {
+    fn to_json loc:LspLocation -> JsonValue {
+        loc LspLocation::range = loc_range
+        json_object
+        "uri" loc LspLocation::uri JsonValue::JsonString json_set
+        "range" loc_range.to_json json_set
+        JsonValue::JsonObject
+    }
 }
 
-fn lsp_diagnostic_to_json diag:LspDiagnostic -> JsonValue {
-    json_object
-    "range" diag LspDiagnostic::range lsp_range_to_json json_set
-    "message" diag LspDiagnostic::message JsonValue::JsonString json_set
-    "severity" diag LspDiagnostic::severity JsonValue::JsonInt json_set
-    "source" "casa" JsonValue::JsonString json_set
-    JsonValue::JsonObject
+impl LspDiagnostic {
+    fn to_json diag:LspDiagnostic -> JsonValue {
+        diag LspDiagnostic::range = diag_range
+        json_object
+        "range" diag_range.to_json json_set
+        "message" diag LspDiagnostic::message JsonValue::JsonString json_set
+        "severity" diag LspDiagnostic::severity JsonValue::JsonInt json_set
+        "source" "casa" JsonValue::JsonString json_set
+        JsonValue::JsonObject
+    }
 }
 
-fn completion_item_to_json item:CompletionItem -> JsonValue {
-    json_object = result_obj
-    result_obj "label" item CompletionItem::label JsonValue::JsonString json_set = result_obj
-    result_obj "kind" item CompletionItem::kind JsonValue::JsonInt json_set = result_obj
-    if "" item CompletionItem::detail != then
-        result_obj "detail" item CompletionItem::detail JsonValue::JsonString json_set = result_obj
-    fi
-    result_obj JsonValue::JsonObject
+impl CompletionItem {
+    fn to_json item:CompletionItem -> JsonValue {
+        json_object = result_obj
+        result_obj "label" item CompletionItem::label JsonValue::JsonString json_set = result_obj
+        result_obj "kind" item CompletionItem::kind JsonValue::JsonInt json_set = result_obj
+        if "" item CompletionItem::detail != then
+            result_obj "detail" item CompletionItem::detail JsonValue::JsonString json_set = result_obj
+        fi
+        result_obj JsonValue::JsonObject
+    }
 }
 
-fn text_edit_to_json range:LspRange new_text:str -> JsonValue {
-    json_object
-    "range" range lsp_range_to_json json_set
-    "newText" new_text JsonValue::JsonString json_set
-    JsonValue::JsonObject
+impl TextEdit {
+    fn to_json edit:TextEdit -> JsonValue {
+        edit TextEdit::range = edit_range
+        json_object
+        "range" edit_range.to_json json_set
+        "newText" edit TextEdit::new_text JsonValue::JsonString json_set
+        JsonValue::JsonObject
+    }
 }
 
 # ============================================================================
@@ -470,7 +483,7 @@ fn diagnostics_from result:CompileResult path:str -> List[LspDiagnostic] {
 fn publish_diagnostics uri:str diagnostics:List[LspDiagnostic] {
     List::new(List[JsonValue]) = json_array
     for diagnostic in diagnostics.iter do
-        diagnostic lsp_diagnostic_to_json json_array.push
+        diagnostic.to_json json_array.push
     done
     json_object
     "uri" uri JsonValue::JsonString json_set
@@ -850,7 +863,7 @@ fn handle_definition message:JsonValue {
     message extract_position = position
     position LspRange::start_col position LspRange::start_line state compute_definition = loc_opt
     if loc_opt.is_some then
-        loc_opt.unwrap lsp_location_to_json request_id send_response
+        loc_opt.unwrap.to_json request_id send_response
     else
         JsonValue::JsonNull request_id send_response
     fi
@@ -1179,7 +1192,7 @@ fn handle_hover message:JsonValue {
     "kind" "markdown" JsonValue::JsonString json_set
     "value" hover HoverContent::content JsonValue::JsonString json_set
     JsonValue::JsonObject json_set
-    "range" hover HoverContent::range lsp_range_to_json json_set
+    "range" hover HoverContent::range.to_json json_set
     JsonValue::JsonObject request_id send_response
 }
 
@@ -1469,7 +1482,7 @@ fn handle_completion message:JsonValue {
     # Build response
     List::new(List[JsonValue]) = json_items
     for completion_item in items.iter do
-        completion_item completion_item_to_json json_items.push
+        completion_item.to_json json_items.push
     done
     json_object
     "isIncomplete" false JsonValue::JsonBool json_set
@@ -1700,7 +1713,7 @@ fn handle_references message:JsonValue {
     refs_opt.unwrap = refs
     List::new(List[JsonValue]) = json_refs
     for ref_loc in refs.iter do
-        ref_loc lsp_location_to_json json_refs.push
+        ref_loc.to_json json_refs.push
     done
     json_refs JsonValue::JsonArray request_id send_response
 }
@@ -1798,7 +1811,7 @@ fn handle_rename message:JsonValue {
         change_uri edits_map.get.unwrap = edit_list
         List::new(List[JsonValue]) = edit_json_list
         for edit_item in edit_list.iter do
-            edit_item TextEdit::new_text edit_item TextEdit::range text_edit_to_json edit_json_list.push
+            edit_item.to_json edit_json_list.push
         done
         changes change_uri edit_json_list JsonValue::JsonArray json_set = changes
     done

--- a/lsp.casa
+++ b/lsp.casa
@@ -423,9 +423,9 @@ fn diagnostics_from result:CompileResult path:str -> List[LspDiagnostic] {
         # Build message
         StringBuilder::new = msg_builder
         error CasaError::message msg_builder.append
-        if error CasaError::expected.is_some then
+        if error.expected.is_some then
             "\nExpected: " msg_builder.append
-            error CasaError::expected.unwrap msg_builder.append
+            error.expected.unwrap msg_builder.append
         fi
         if error CasaError::got.is_some then
             "\n" msg_builder.append
@@ -1649,7 +1649,7 @@ fn compute_references
     # Check function definition name first (parameter ops share the name token location)
     col line state find_function_at_position = fn_at_pos
     if fn_at_pos Option::Some(matched_function) is then
-        matched_function Function::location matched_function Function::name OpValue::FnCall make_op = op
+        matched_function Function::location matched_function Function::name OpValue::FnCall Op::new = op
         Option::None(Option[Function]) = func
     else
         col line state find_op_at_position = result
@@ -1718,7 +1718,7 @@ fn compute_rename
     # Check function definition name first (parameter ops share the name token location)
     col line state find_function_at_position = fn_at_pos
     if fn_at_pos Option::Some(matched_function) is then
-        matched_function Function::location matched_function Function::name OpValue::FnCall make_op = op
+        matched_function Function::location matched_function Function::name OpValue::FnCall Op::new = op
         Option::None(Option[Function]) = func
         matched_function Function::name function_short_name = old_name
     else

--- a/lsp.casa
+++ b/lsp.casa
@@ -265,13 +265,19 @@ fn read_message reader:StdinReader -> Option[JsonValue] {
         Option::None(Option[JsonValue])
         return
     fi
-    content_length.unwrap reader stdin_read_exact = body
+    if content_length Option::Some(length) is then
+    else
+        Option::None(Option[JsonValue]) return
+    fi
+    length reader stdin_read_exact = body
     body Cursor::new = cursor
     cursor json_parse = parse_result
     if parse_result.is_error then
         Option::None(Option[JsonValue])
+    elif parse_result Result::Ok(parsed) is then
+        parsed Option::Some
     else
-        parse_result.unwrap Option::Some
+        Option::None(Option[JsonValue])
     fi
 }
 
@@ -314,7 +320,11 @@ fn compile_document file_path:str source:str open_docs:Map[str DocumentState] ->
     # Seed SOURCE_CACHE from peer open documents
     open_docs.keys = uris
     for uri in uris.iter do
-        uri open_docs.get.unwrap = cached_state
+        if uri open_docs.get Option::Some(cached_state) is then
+        else
+            empty_location "Expected option value while unwrapping uri open_docs.get" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         if cached_state DocumentState::file_path file_path != then
             cached_state DocumentState::source cached_state DocumentState::file_path SOURCE_CACHE.set = SOURCE_CACHE
         fi
@@ -337,8 +347,8 @@ fn compile_document file_path:str source:str open_docs:Map[str DocumentState] ->
 
     # Snapshot file source (post-include)
     file_path SOURCE_CACHE.get = source_opt
-    if source_opt.is_some then
-        source_opt.unwrap
+    if source_opt Option::Some(snapshot_source) is then
+        snapshot_source
     else
         source
     fi
@@ -350,7 +360,11 @@ fn compile_document file_path:str source:str open_docs:Map[str DocumentState] ->
     Map::new(Map[str Variable]) = vars_copy
     store.variables.keys = var_keys
     for var_name in var_keys.iter do
-        var_name store.variables.get.unwrap = var_value
+        if var_name store.variables.get Option::Some(var_value) is then
+        else
+            empty_location "Expected option value while unwrapping var_name store.variables.get" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         var_value var_name vars_copy.set = vars_copy
     done
     vars_copy
@@ -358,7 +372,11 @@ fn compile_document file_path:str source:str open_docs:Map[str DocumentState] ->
     Map::new(Map[str CasaEnum]) = enums_copy
     store.enums.keys = enum_keys
     for enum_name in enum_keys.iter do
-        enum_name store.enums.get.unwrap = enum_value
+        if enum_name store.enums.get Option::Some(enum_value) is then
+        else
+            empty_location "Expected option value while unwrapping enum_name store.enums.get" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         enum_value enum_name enums_copy.set = enums_copy
     done
     enums_copy
@@ -366,7 +384,11 @@ fn compile_document file_path:str source:str open_docs:Map[str DocumentState] ->
     Map::new(Map[str CasaStruct]) = structs_copy
     store.structs.keys = struct_keys
     for struct_name in struct_keys.iter do
-        struct_name store.structs.get.unwrap = struct_value
+        if struct_name store.structs.get Option::Some(struct_value) is then
+        else
+            empty_location "Expected option value while unwrapping struct_name store.structs.get" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         struct_value struct_name structs_copy.set = structs_copy
     done
     structs_copy
@@ -374,7 +396,11 @@ fn compile_document file_path:str source:str open_docs:Map[str DocumentState] ->
     Map::new(Map[str Function]) = fns_copy
     store.functions.keys = fn_keys
     for fn_name in fn_keys.iter do
-        fn_name store.functions.get.unwrap = fn_value
+        if fn_name store.functions.get Option::Some(fn_value) is then
+        else
+            empty_location "Expected option value while unwrapping fn_name store.functions.get" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         fn_value fn_name fns_copy.set = fns_copy
     done
     fns_copy
@@ -427,7 +453,11 @@ fn diagnostics_from result:CompileResult path:str -> List[LspDiagnostic] {
         fi
         error CasaError::location Location::file source_cache.get = source_opt
         if source_opt.is_some then
-            source_opt.unwrap = error_source
+            if source_opt Option::Some(error_source) is then
+            else
+                empty_location "Expected option value while unwrapping source_opt" ErrorKind::Syntax raise_error
+                1 exit
+            fi
         else
             fallback_source = error_source
         fi
@@ -435,15 +465,15 @@ fn diagnostics_from result:CompileResult path:str -> List[LspDiagnostic] {
         # Build message
         StringBuilder::new = msg_builder
         error CasaError::message msg_builder.append
-        if error.expected.is_some then
+        if error.expected Option::Some(expected) is then
             "\nExpected: " msg_builder.append
-            error.expected.unwrap msg_builder.append
+            expected msg_builder.append
         fi
-        if error CasaError::got.is_some then
+        if error CasaError::got Option::Some(got) is then
             "\n" msg_builder.append
             error CasaError::got_label msg_builder.append
             ": " msg_builder.append
-            error CasaError::got.unwrap msg_builder.append
+            got msg_builder.append
         fi
 
         DIAGNOSTIC_ERROR
@@ -464,7 +494,11 @@ fn diagnostics_from result:CompileResult path:str -> List[LspDiagnostic] {
         fi
         warning CasaWarning::location Location::file source_cache.get = warn_source_opt
         if warn_source_opt.is_some then
-            warn_source_opt.unwrap = warn_source
+            if warn_source_opt Option::Some(warn_source) is then
+            else
+                empty_location "Expected option value while unwrapping warn_source_opt" ErrorKind::Syntax raise_error
+                1 exit
+            fi
         else
             fallback_source = warn_source
         fi
@@ -530,7 +564,11 @@ fn find_op_at_position state:DocumentState line:int col:int -> Option[FindResult
     # Search function ops
     state DocumentState::functions.keys = func_keys
     for func_name in func_keys.iter do
-        func_name state DocumentState::functions.get.unwrap = func
+        if func_name state DocumentState::functions.get Option::Some(func) is then
+        else
+            empty_location "Expected option value while unwrapping func_name state DocumentState::functions.get" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         if
         "" func Function::location Location::file ==
         func Function::location Location::file state DocumentState::file_path != ||
@@ -547,7 +585,11 @@ fn find_function_at_position state:DocumentState line:int col:int -> Option[Func
     col line state DocumentState::source position_to_offset = target_offset
     state DocumentState::functions.keys = func_keys
     for func_name in func_keys.iter do
-        func_name state DocumentState::functions.get.unwrap = func
+        if func_name state DocumentState::functions.get Option::Some(func) is then
+        else
+            empty_location "Expected option value while unwrapping func_name state DocumentState::functions.get" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         if
         "" func Function::location Location::file ==
         func Function::location Location::file state DocumentState::file_path != ||
@@ -584,7 +626,11 @@ fn function_short_name name:str -> str {
 fn find_containing_function state:DocumentState offset:int -> Option[Function] {
     state DocumentState::functions.keys = func_keys
     for func_name in func_keys.iter do
-        func_name state DocumentState::functions.get.unwrap = func
+        if func_name state DocumentState::functions.get Option::Some(func) is then
+        else
+            empty_location "Expected option value while unwrapping func_name state DocumentState::functions.get" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         if "" func Function::location Location::file == then
             continue
         fi
@@ -608,7 +654,11 @@ fn find_containing_function state:DocumentState offset:int -> Option[Function] {
 fn casa_location_to_lsp location:Location -> LspLocation {
     location Location::file SOURCE_CACHE.get = source_opt
     if source_opt.is_some then
-        source_opt.unwrap = location_source
+        if source_opt Option::Some(location_source) is then
+        else
+            empty_location "Expected option value while unwrapping source_opt" ErrorKind::Syntax raise_error
+            1 exit
+        fi
     else
         "" = location_source
     fi
@@ -669,35 +719,100 @@ fn split_qualified name:str -> List[str] {
 # ============================================================================
 
 fn extract_uri message:JsonValue -> str {
-    "params" message json_get_object.unwrap = params
-    "textDocument" params json_get_object.unwrap = text_document
-    "uri" text_document json_get_str.unwrap
+    if "params" message json_get_object Option::Some(params) is then
+    else
+        empty_location "Expected option value while unwrapping params message json_get_object" ErrorKind::Syntax raise_error
+        1 exit
+    fi
+    if "textDocument" params json_get_object Option::Some(text_document) is then
+    else
+        empty_location "Expected option value while unwrapping textDocument params json_get_object" ErrorKind::Syntax raise_error
+        1 exit
+    fi
+    if "uri" text_document json_get_str Option::Some(uri) is then
+        uri return
+    fi
+    empty_location "Expected option value while unwrapping uri text_document json_get_str" ErrorKind::Syntax raise_error
+    1 exit
+    ""
 }
 
 fn extract_position message:JsonValue -> LspRange {
-    "params" message json_get_object.unwrap = params
-    "position" params json_get_object.unwrap = position
-    "line" position json_get_int.unwrap = line
-    "character" position json_get_int.unwrap = character
+    if "params" message json_get_object Option::Some(params) is then
+    else
+        empty_location "Expected option value while unwrapping params message json_get_object" ErrorKind::Syntax raise_error
+        1 exit
+    fi
+    if "position" params json_get_object Option::Some(position) is then
+    else
+        empty_location "Expected option value while unwrapping position params json_get_object" ErrorKind::Syntax raise_error
+        1 exit
+    fi
+    if "line" position json_get_int Option::Some(line) is then
+    else
+        empty_location "Expected option value while unwrapping line position json_get_int" ErrorKind::Syntax raise_error
+        1 exit
+    fi
+    if "character" position json_get_int Option::Some(character) is then
+    else
+        empty_location "Expected option value while unwrapping character position json_get_int" ErrorKind::Syntax raise_error
+        1 exit
+    fi
     0 0 character line LspRange
 }
 
 fn handle_did_open message:JsonValue {
-    "params" message json_get_object.unwrap = params
-    "textDocument" params json_get_object.unwrap = text_document
-    "uri" text_document json_get_str.unwrap = uri
-    "text" text_document json_get_str.unwrap = text
+    if "params" message json_get_object Option::Some(params) is then
+    else
+        empty_location "Expected option value while unwrapping params message json_get_object" ErrorKind::Syntax raise_error
+        1 exit
+    fi
+    if "textDocument" params json_get_object Option::Some(text_document) is then
+    else
+        empty_location "Expected option value while unwrapping textDocument params json_get_object" ErrorKind::Syntax raise_error
+        1 exit
+    fi
+    if "uri" text_document json_get_str Option::Some(uri) is then
+    else
+        empty_location "Expected option value while unwrapping uri text_document json_get_str" ErrorKind::Syntax raise_error
+        1 exit
+    fi
+    if "text" text_document json_get_str Option::Some(text) is then
+    else
+        empty_location "Expected option value while unwrapping text text_document json_get_str" ErrorKind::Syntax raise_error
+        1 exit
+    fi
     text uri ingest_document = diagnostics
     diagnostics uri publish_diagnostics
 }
 
 fn handle_did_change message:JsonValue {
-    "params" message json_get_object.unwrap = params
-    "textDocument" params json_get_object.unwrap = text_document
-    "uri" text_document json_get_str.unwrap = uri
-    "contentChanges" params json_get_array.unwrap = changes
+    if "params" message json_get_object Option::Some(params) is then
+    else
+        empty_location "Expected option value while unwrapping params message json_get_object" ErrorKind::Syntax raise_error
+        1 exit
+    fi
+    if "textDocument" params json_get_object Option::Some(text_document) is then
+    else
+        empty_location "Expected option value while unwrapping textDocument params json_get_object" ErrorKind::Syntax raise_error
+        1 exit
+    fi
+    if "uri" text_document json_get_str Option::Some(uri) is then
+    else
+        empty_location "Expected option value while unwrapping uri text_document json_get_str" ErrorKind::Syntax raise_error
+        1 exit
+    fi
+    if "contentChanges" params json_get_array Option::Some(changes) is then
+    else
+        empty_location "Expected option value while unwrapping contentChanges params json_get_array" ErrorKind::Syntax raise_error
+        1 exit
+    fi
     0 changes.get = change
-    "text" change json_get_str.unwrap = text
+    if "text" change json_get_str Option::Some(text) is then
+    else
+        empty_location "Expected option value while unwrapping text change json_get_str" ErrorKind::Syntax raise_error
+        1 exit
+    fi
     text uri ingest_document = diagnostics
     diagnostics uri publish_diagnostics
 }
@@ -709,7 +824,11 @@ fn handle_did_save message:JsonValue {
         f"error: handle_did_save read failed for {uri}: {read_err.to_str}" eprintln
         return
     fi
-    read_result.unwrap = saved_source
+    if read_result Result::Ok(saved_source) is then
+    else
+        empty_location "Expected option value while unwrapping read_result" ErrorKind::Syntax raise_error
+        1 exit
+    fi
     saved_source uri ingest_document = diagnostics
     diagnostics uri publish_diagnostics
 }
@@ -741,15 +860,15 @@ fn find_variable_definition
 -> Option[LspLocation] {
     Option::None(Option[Op]) = best_op
 
-    if function.is_some then
-        best_op usage_offset function.unwrap Function::ops name find_best_assignment = best_op
+    if function Option::Some(fn_def) is then
+        best_op usage_offset fn_def Function::ops name find_best_assignment = best_op
     fi
     if best_op.is_none then
         best_op usage_offset state DocumentState::ops name find_best_assignment = best_op
     fi
 
-    if best_op.is_some then
-        best_op.unwrap Op::location casa_location_to_lsp Option::Some
+    if best_op Option::Some(best) is then
+        best Op::location casa_location_to_lsp Option::Some
     else
         Option::None(Option[LspLocation])
     fi
@@ -761,7 +880,11 @@ fn compute_definition state:DocumentState line:int col:int -> Option[LspLocation
         Option::None(Option[LspLocation])
         return
     fi
-    result.unwrap = find
+    if result Option::Some(find) is then
+    else
+        empty_location "Expected option value while unwrapping result" ErrorKind::Syntax raise_error
+        1 exit
+    fi
     find FindResult::op = op
     find FindResult::function = func
     col line state DocumentState::source position_to_offset = cursor_offset
@@ -786,12 +909,12 @@ fn compute_definition state:DocumentState line:int col:int -> Option[LspLocation
         if qpart_is_type then
             op op_str_value "::" str::split = parts
             0 parts.get = type_name
-            if type_name state DocumentState::structs.has then
-                type_name state DocumentState::structs.get.unwrap CasaStruct::location casa_location_to_lsp Option::Some
+            if type_name state DocumentState::structs.get Option::Some(casa_struct) is then
+                casa_struct CasaStruct::location casa_location_to_lsp Option::Some
                 return
             fi
-            if type_name state DocumentState::enums.has then
-                type_name state DocumentState::enums.get.unwrap CasaEnum::location casa_location_to_lsp Option::Some
+            if type_name state DocumentState::enums.get Option::Some(casa_enum) is then
+                casa_enum CasaEnum::location casa_location_to_lsp Option::Some
                 return
             fi
             Option::None(Option[LspLocation])
@@ -799,7 +922,11 @@ fn compute_definition state:DocumentState line:int col:int -> Option[LspLocation
         fi
         op op_str_value state DocumentState::functions.get = fn_opt
         if fn_opt.is_some then
-            fn_opt.unwrap = fn_def
+            if fn_opt Option::Some(fn_def) is then
+            else
+                empty_location "Expected option value while unwrapping fn_opt" ErrorKind::Syntax raise_error
+                1 exit
+            fi
             if "" fn_def Function::location Location::file != then
                 fn_def Function::location casa_location_to_lsp Option::Some
                 return
@@ -828,11 +955,17 @@ fn compute_definition state:DocumentState line:int col:int -> Option[LspLocation
             Option::None(Option[LspLocation])
             return
         fi
-        enum_name state DocumentState::enums.get.unwrap = casa_enum
+        if enum_name state DocumentState::enums.get Option::Some(casa_enum) is then
+        else
+            empty_location "Expected option value while unwrapping enum_name state DocumentState::enums.get" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         enum_variant EnumVariant::variant_name casa_enum CasaEnum::variant_locations.get = variant_loc_opt
-        if qpart_is_member variant_loc_opt.is_some && then
-            variant_loc_opt.unwrap casa_location_to_lsp Option::Some
-            return
+        if qpart_is_member then
+            if variant_loc_opt Option::Some(variant_loc) is then
+                variant_loc casa_location_to_lsp Option::Some
+                return
+            fi
         fi
         casa_enum CasaEnum::location casa_location_to_lsp Option::Some
         return
@@ -841,12 +974,12 @@ fn compute_definition state:DocumentState line:int col:int -> Option[LspLocation
     # TYPE_CAST
     if op_value OpValue::TypeCast(cast_type) is then
         cast_type.format = cast_name
-        if cast_name state DocumentState::structs.has then
-            cast_name state DocumentState::structs.get.unwrap CasaStruct::location casa_location_to_lsp Option::Some
+        if cast_name state DocumentState::structs.get Option::Some(casa_struct) is then
+            casa_struct CasaStruct::location casa_location_to_lsp Option::Some
             return
         fi
-        if cast_name state DocumentState::enums.has then
-            cast_name state DocumentState::enums.get.unwrap CasaEnum::location casa_location_to_lsp Option::Some
+        if cast_name state DocumentState::enums.get Option::Some(casa_enum) is then
+            casa_enum CasaEnum::location casa_location_to_lsp Option::Some
             return
         fi
     fi
@@ -856,19 +989,27 @@ fn compute_definition state:DocumentState line:int col:int -> Option[LspLocation
 
 fn handle_definition message:JsonValue {
     message extract_uri = uri
-    "id" message json_get_value.unwrap = request_id
+    if "id" message json_get_value Option::Some(request_id) is then
+    else
+        empty_location "Expected option value while unwrapping id message json_get_value" ErrorKind::Syntax raise_error
+        1 exit
+    fi
 
     uri DOCUMENT_STATES.get = state_opt
     if state_opt.is_none then
         JsonValue::JsonNull request_id send_response
         return
     fi
-    state_opt.unwrap = state
+    if state_opt Option::Some(state) is then
+    else
+        empty_location "Expected option value while unwrapping state_opt" ErrorKind::Syntax raise_error
+        1 exit
+    fi
 
     message extract_position = position
     position LspRange::start_col position LspRange::start_line state compute_definition = loc_opt
-    if loc_opt.is_some then
-        loc_opt.unwrap.to_json request_id send_response
+    if loc_opt Option::Some(loc) is then
+        loc.to_json request_id send_response
     else
         JsonValue::JsonNull request_id send_response
     fi
@@ -880,7 +1021,11 @@ fn handle_definition message:JsonValue {
 
 fn resolve_variable_type name:str func:Option[Function] state:DocumentState -> Option[str] {
     if func.is_some then
-        func.unwrap = resolved_func
+        if func Option::Some(resolved_func) is then
+        else
+            empty_location "Expected option value while unwrapping func" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         for variable in resolved_func Function::variables.iter do
             if variable Variable::name name == then
                 if "" variable Variable::typ.format != then
@@ -899,8 +1044,8 @@ fn resolve_variable_type name:str func:Option[Function] state:DocumentState -> O
         done
     fi
     name state DocumentState::variables.get = global_var_opt
-    if global_var_opt.is_some then
-        global_var_opt.unwrap Variable::typ.format = global_type
+    if global_var_opt Option::Some(global_var) is then
+        global_var Variable::typ.format = global_type
         if "" global_type != then
             global_type Option::Some
             return
@@ -916,7 +1061,11 @@ fn format_hover op:Op state:DocumentState func:Option[Function] -> Option[str] {
     if op_value OpValue::FnCall is op_value OpValue::FnPush is || then
         op op_str_value state DocumentState::functions.get = fn_opt
         if fn_opt.is_some then
-            fn_opt.unwrap = hover_func
+            if fn_opt Option::Some(hover_func) is then
+            else
+                empty_location "Expected option value while unwrapping fn_opt" ErrorKind::Syntax raise_error
+                1 exit
+            fi
             StringBuilder::new = builder
             "fn " builder.append
             hover_func Function::name builder.append
@@ -957,8 +1106,8 @@ fn format_hover op:Op state:DocumentState func:Option[Function] -> Option[str] {
     if op_value OpValue::PushVar is op_value OpValue::PushCapture is || then
         op op_str_value = var_name
         state func var_name resolve_variable_type = var_type
-        if var_type.is_some then
-            f"{var_name}: {var_type.unwrap}" Option::Some
+        if var_type Option::Some(resolved_var_type) is then
+            f"{var_name}: {resolved_var_type}" Option::Some
         else
             var_name Option::Some
         fi
@@ -1021,8 +1170,8 @@ fn format_hover op:Op state:DocumentState func:Option[Function] -> Option[str] {
     # Assignment
     if op_value OpValue::AssignVar(assign_name) is then
         state func assign_name resolve_variable_type = assign_type
-        if assign_type.is_some then
-            f"= {assign_name}: {assign_type.unwrap}" Option::Some
+        if assign_type Option::Some(resolved_assign_type) is then
+            f"= {assign_name}: {resolved_assign_type}" Option::Some
         else
             f"= {assign_name}" Option::Some
         fi
@@ -1031,8 +1180,8 @@ fn format_hover op:Op state:DocumentState func:Option[Function] -> Option[str] {
 
     # Stack effects
     op_value op_value_stack_effect = effect_opt
-    if effect_opt.is_some then
-        effect_opt.unwrap Option::Some
+    if effect_opt Option::Some(effect) is then
+        effect Option::Some
         return
     fi
 
@@ -1087,7 +1236,11 @@ fn format_qualified_member_hover
         Option::None(Option[HoverContent])
         return
     fi
-    range f"```casa\n{member_content.unwrap}\n```" HoverContent Option::Some
+    if member_content Option::Some(content) is then
+        range f"```casa\n{content}\n```" HoverContent Option::Some
+        return
+    fi
+    Option::None(Option[HoverContent])
 }
 
 fn compute_hover state:DocumentState line:int col:int -> Option[HoverContent] {
@@ -1096,7 +1249,11 @@ fn compute_hover state:DocumentState line:int col:int -> Option[HoverContent] {
         Option::None(Option[HoverContent])
         return
     fi
-    result.unwrap = find
+    if result Option::Some(find) is then
+    else
+        empty_location "Expected option value while unwrapping result" ErrorKind::Syntax raise_error
+        1 exit
+    fi
     find FindResult::op = op
     find FindResult::function = func
     col line state DocumentState::source position_to_offset = cursor_offset
@@ -1119,13 +1276,13 @@ fn compute_hover state:DocumentState line:int col:int -> Option[HoverContent] {
                 op state DocumentState::source qualified_type_range = qualified_range
                 # Look up type
                 Option::None(Option[str]) = qualified_content
-                if qualified_type_name state DocumentState::structs.has then
-                    qualified_type_name state DocumentState::structs.get.unwrap format_struct_hover Option::Some = qualified_content
-                elif qualified_type_name state DocumentState::enums.has then
-                    qualified_type_name state DocumentState::enums.get.unwrap format_enum_hover Option::Some = qualified_content
+                if qualified_type_name state DocumentState::structs.get Option::Some(hover_struct) is then
+                    hover_struct format_struct_hover Option::Some = qualified_content
+                elif qualified_type_name state DocumentState::enums.get Option::Some(hover_enum) is then
+                    hover_enum format_enum_hover Option::Some = qualified_content
                 fi
-                if qualified_content.is_some then
-                    qualified_range f"```casa\n{qualified_content.unwrap}\n```" HoverContent Option::Some
+                if qualified_content Option::Some(content) is then
+                    qualified_range f"```casa\n{content}\n```" HoverContent Option::Some
                     return
                 fi
             else
@@ -1146,8 +1303,8 @@ fn compute_hover state:DocumentState line:int col:int -> Option[HoverContent] {
             op enum_variant_of = enum_variant
             if QPART_TYPE qpart == then
                 op state DocumentState::source qualified_type_range = enum_range
-                if enum_variant EnumVariant::enum_name state DocumentState::enums.has then
-                    enum_variant EnumVariant::enum_name state DocumentState::enums.get.unwrap format_enum_hover = enum_text
+                if enum_variant EnumVariant::enum_name state DocumentState::enums.get Option::Some(hover_enum) is then
+                    hover_enum format_enum_hover = enum_text
                     enum_range f"```casa\n{enum_text}\n```" HoverContent Option::Some
                     return
                 fi
@@ -1169,19 +1326,31 @@ fn compute_hover state:DocumentState line:int col:int -> Option[HoverContent] {
         return
     fi
     op Op::location Location::span Span::length op Op::location Location::span Span::offset state DocumentState::source offset_to_lsp_range = hover_range
-    hover_range f"```casa\n{hover_content.unwrap}\n```" HoverContent Option::Some
+    if hover_content Option::Some(content) is then
+        hover_range f"```casa\n{content}\n```" HoverContent Option::Some
+        return
+    fi
+    Option::None(Option[HoverContent])
 }
 
 fn handle_hover message:JsonValue {
     message extract_uri = uri
-    "id" message json_get_value.unwrap = request_id
+    if "id" message json_get_value Option::Some(request_id) is then
+    else
+        empty_location "Expected option value while unwrapping id message json_get_value" ErrorKind::Syntax raise_error
+        1 exit
+    fi
 
     uri DOCUMENT_STATES.get = state_opt
     if state_opt.is_none then
         JsonValue::JsonNull request_id send_response
         return
     fi
-    state_opt.unwrap = state
+    if state_opt Option::Some(state) is then
+    else
+        empty_location "Expected option value while unwrapping state_opt" ErrorKind::Syntax raise_error
+        1 exit
+    fi
 
     message extract_position = position
     position LspRange::start_col position LspRange::start_line state compute_hover = hover_opt
@@ -1189,7 +1358,11 @@ fn handle_hover message:JsonValue {
         JsonValue::JsonNull request_id send_response
         return
     fi
-    hover_opt.unwrap = hover
+    if hover_opt Option::Some(hover) is then
+    else
+        empty_location "Expected option value while unwrapping hover_opt" ErrorKind::Syntax raise_error
+        1 exit
+    fi
     json_object
     "contents" json_object
     "kind" "markdown" JsonValue::JsonString json_set
@@ -1205,8 +1378,8 @@ fn handle_hover message:JsonValue {
 
 fn methods_for_type receiver_type:str state:DocumentState -> List[CompletionItem] {
     receiver_type parse_type_str.base = base_opt
-    if base_opt.is_some then
-        base_opt.unwrap
+    if base_opt Option::Some(base) is then
+        base
     else
         receiver_type
     fi
@@ -1228,7 +1401,11 @@ fn members_for_qualified type_name:str state:DocumentState -> List[CompletionIte
     # Enum variants
     type_name state DocumentState::enums.get = enum_opt
     if enum_opt.is_some then
-        enum_opt.unwrap = casa_enum
+        if enum_opt Option::Some(casa_enum) is then
+        else
+            empty_location "Expected option value while unwrapping enum_opt" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         for variant_name in casa_enum CasaEnum::variants.iter do
             "" COMPLETION_ENUM_MEMBER variant_name CompletionItem items.push
         done
@@ -1318,18 +1495,26 @@ fn resolve_chain_type parts:List[str] state:DocumentState offset:int -> Option[s
         Option::None(Option[str])
         return
     fi
-    current_type.unwrap = resolved_type
+    if current_type Option::Some(resolved_type) is then
+    else
+        empty_location "Expected option value while unwrapping current_type" ErrorKind::Syntax raise_error
+        1 exit
+    fi
     1 = part_index
     while part_index parts.length > do
         resolved_type parse_type_str.base = base_opt
-        if base_opt.is_some then base_opt.unwrap else resolved_type fi = base_type
+        if base_opt Option::Some(base) is then base else resolved_type fi = base_type
         part_index parts.get = method_name
         f"{base_type}::{method_name}" state DocumentState::functions.get = fn_opt
         if fn_opt.is_none then
             Option::None(Option[str])
             return
         fi
-        fn_opt.unwrap = func
+        if fn_opt Option::Some(func) is then
+        else
+            empty_location "Expected option value while unwrapping fn_opt" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         if 0 func Function::stack_effect StackEffect::return_types.length == then
             Option::None(Option[str])
             return
@@ -1363,8 +1548,8 @@ fn handle_triggered_completion state:DocumentState offset:int -> List[Completion
     if '.' pos source.at == then
         pos source extract_chain_before = chain
         offset state chain resolve_chain_type = receiver_type
-        if receiver_type.is_some then
-            state receiver_type.unwrap methods_for_type
+        if receiver_type Option::Some(resolved_receiver_type) is then
+            state resolved_receiver_type methods_for_type
             return
         fi
     fi
@@ -1398,7 +1583,11 @@ fn compute_completion state:DocumentState line:int col:int trigger:str -> List[C
     # Structs
     state DocumentState::structs.keys = struct_keys
     for struct_name in struct_keys.iter do
-        struct_name state DocumentState::structs.get.unwrap = struct_val
+        if struct_name state DocumentState::structs.get Option::Some(struct_val) is then
+        else
+            empty_location "Expected option value while unwrapping struct_name state DocumentState::structs.get" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         StringBuilder::new = member_builder
         0 = member_index
         while member_index struct_val CasaStruct::members.length > do
@@ -1421,7 +1610,11 @@ fn compute_completion state:DocumentState line:int col:int trigger:str -> List[C
     # Local variables
     cursor_offset state find_containing_function = containing_func_opt
     if containing_func_opt.is_some then
-        containing_func_opt.unwrap = containing_func
+        if containing_func_opt Option::Some(containing_func) is then
+        else
+            empty_location "Expected option value while unwrapping containing_func_opt" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         for local_var in containing_func Function::variables.iter do
             local_var Variable::typ.format COMPLETION_VARIABLE local_var Variable::name CompletionItem items.push
         done
@@ -1430,7 +1623,9 @@ fn compute_completion state:DocumentState line:int col:int trigger:str -> List[C
     # Global variables
     state DocumentState::variables.keys = global_var_keys
     for global_var_name in global_var_keys.iter do
-        global_var_name state DocumentState::variables.get.unwrap Variable::typ.format COMPLETION_VARIABLE global_var_name CompletionItem items.push
+        if global_var_name state DocumentState::variables.get Option::Some(global_var) is then
+            global_var Variable::typ.format COMPLETION_VARIABLE global_var_name CompletionItem items.push
+        fi
     done
 
     # Keywords
@@ -1456,7 +1651,11 @@ fn compute_completion state:DocumentState line:int col:int trigger:str -> List[C
 
 fn handle_completion message:JsonValue {
     message extract_uri = uri
-    "id" message json_get_value.unwrap = request_id
+    if "id" message json_get_value Option::Some(request_id) is then
+    else
+        empty_location "Expected option value while unwrapping id message json_get_value" ErrorKind::Syntax raise_error
+        1 exit
+    fi
 
     uri DOCUMENT_STATES.get = state_opt
     if state_opt.is_none then
@@ -1466,16 +1665,28 @@ fn handle_completion message:JsonValue {
         JsonValue::JsonObject request_id send_response
         return
     fi
-    state_opt.unwrap = state
+    if state_opt Option::Some(state) is then
+    else
+        empty_location "Expected option value while unwrapping state_opt" ErrorKind::Syntax raise_error
+        1 exit
+    fi
 
     # Check trigger character
-    "params" message json_get_object.unwrap = params
+    if "params" message json_get_object Option::Some(params) is then
+    else
+        empty_location "Expected option value while unwrapping params message json_get_object" ErrorKind::Syntax raise_error
+        1 exit
+    fi
     "context" params json_get_object = context_opt
     "" = trigger
-    if context_opt.is_some then
-        "triggerCharacter" context_opt.unwrap json_get_str = trigger_opt
+    if context_opt Option::Some(context) is then
+        "triggerCharacter" context json_get_str = trigger_opt
         if trigger_opt.is_some then
-            trigger_opt.unwrap = trigger
+            if trigger_opt Option::Some(trigger) is then
+            else
+                empty_location "Expected option value while unwrapping trigger_opt" ErrorKind::Syntax raise_error
+                1 exit
+            fi
         fi
     fi
 
@@ -1562,7 +1773,11 @@ fn collect_refs_in_all_functions
 {
     state DocumentState::functions.keys = fn_keys
     for fn_name in fn_keys.iter do
-        fn_name state DocumentState::functions.get.unwrap = func
+        if fn_name state DocumentState::functions.get Option::Some(func) is then
+        else
+            empty_location "Expected option value while unwrapping fn_name state DocumentState::functions.get" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         if COLLECTOR_FN collector_kind == then
             results name func Function::ops collect_fn_refs
         elif COLLECTOR_VAR collector_kind == then
@@ -1577,7 +1792,11 @@ fn collect_refs_in_all_functions
 
 fn is_local_variable name:str func:Option[Function] -> bool {
     if func.is_none then false return fi
-    func.unwrap = resolved_func
+    if func Option::Some(resolved_func) is then
+    else
+        empty_location "Expected option value while unwrapping func" ErrorKind::Syntax raise_error
+        1 exit
+    fi
     for variable in resolved_func Function::variables.iter do
         if variable Variable::name name == then
             true return
@@ -1604,9 +1823,9 @@ fn find_all_references
         op op_str_value = fn_name
         if include_declaration then
             fn_name state DocumentState::functions.get = fn_opt
-            if fn_opt.is_some then
-                if "" fn_opt.unwrap Function::location Location::file != then
-                    fn_opt.unwrap Function::location casa_location_to_lsp results.push
+            if fn_opt Option::Some(fn_def) is then
+                if "" fn_def Function::location Location::file != then
+                    fn_def Function::location casa_location_to_lsp results.push
                 fi
             fi
         fi
@@ -1620,7 +1839,9 @@ fn find_all_references
     if op is_var_op then
         op op_str_value = var_name
         if func var_name is_local_variable then
-            results var_name func.unwrap Function::ops collect_var_refs
+            if func Option::Some(local_func) is then
+                results var_name local_func Function::ops collect_var_refs
+            fi
         else
             results var_name state DocumentState::ops collect_var_refs
             results var_name COLLECTOR_VAR state collect_refs_in_all_functions
@@ -1644,8 +1865,10 @@ fn find_all_references
     # Enum variant
     if op_value OpValue::PushEnumVariant(variant) is then
         variant EnumVariant::enum_name = enum_name
-        if include_declaration enum_name state DocumentState::enums.has && then
-            enum_name state DocumentState::enums.get.unwrap CasaEnum::location casa_location_to_lsp results.push
+        if include_declaration then
+            if enum_name state DocumentState::enums.get Option::Some(casa_enum) is then
+                casa_enum CasaEnum::location casa_location_to_lsp results.push
+            fi
         fi
         results enum_name state DocumentState::ops collect_enum_refs
         results enum_name COLLECTOR_ENUM state collect_refs_in_all_functions
@@ -1673,7 +1896,11 @@ fn compute_references
             Option::None(Option[List[LspLocation]])
             return
         fi
-        result.unwrap = find
+        if result Option::Some(find) is then
+        else
+            empty_location "Expected option value while unwrapping result" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         find FindResult::op = op
         find FindResult::function = func
     fi
@@ -1688,22 +1915,37 @@ fn compute_references
 
 fn handle_references message:JsonValue {
     message extract_uri = uri
-    "id" message json_get_value.unwrap = request_id
+    if "id" message json_get_value Option::Some(request_id) is then
+    else
+        empty_location "Expected option value while unwrapping id message json_get_value" ErrorKind::Syntax raise_error
+        1 exit
+    fi
 
     uri DOCUMENT_STATES.get = state_opt
     if state_opt.is_none then
         JsonValue::JsonNull request_id send_response
         return
     fi
-    state_opt.unwrap = state
+    if state_opt Option::Some(state) is then
+    else
+        empty_location "Expected option value while unwrapping state_opt" ErrorKind::Syntax raise_error
+        1 exit
+    fi
 
     # includeDeclaration
-    "context" "params" message json_get_object.unwrap json_get_object = context_opt
+    Option::None(Option[JsonValue]) = context_opt
+    if "params" message json_get_object Option::Some(params) is then
+        "context" params json_get_object = context_opt
+    fi
     true = include_decl
-    if context_opt.is_some then
-        "includeDeclaration" context_opt.unwrap json_get_bool = include_decl_opt
+    if context_opt Option::Some(context) is then
+        "includeDeclaration" context json_get_bool = include_decl_opt
         if include_decl_opt.is_some then
-            include_decl_opt.unwrap = include_decl
+            if include_decl_opt Option::Some(include_decl) is then
+            else
+                empty_location "Expected option value while unwrapping include_decl_opt" ErrorKind::Syntax raise_error
+                1 exit
+            fi
         fi
     fi
 
@@ -1713,7 +1955,11 @@ fn handle_references message:JsonValue {
         JsonValue::JsonNull request_id send_response
         return
     fi
-    refs_opt.unwrap = refs
+    if refs_opt Option::Some(refs) is then
+    else
+        empty_location "Expected option value while unwrapping refs_opt" ErrorKind::Syntax raise_error
+        1 exit
+    fi
     List::new(List[JsonValue]) = json_refs
     for ref_loc in refs.iter do
         ref_loc.to_json json_refs.push
@@ -1743,7 +1989,11 @@ fn compute_rename
             Option::None(Option[Map[str List[TextEdit]]])
             return
         fi
-        result.unwrap = find
+        if result Option::Some(find) is then
+        else
+            empty_location "Expected option value while unwrapping result" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         find FindResult::op = op
         find FindResult::function = func
         op op_str_value = old_name
@@ -1774,8 +2024,8 @@ fn compute_rename
 
         new_name edit_range TextEdit = edit_item
         ref_uri edits_map.get = existing_opt
-        if existing_opt.is_some then
-            edit_item existing_opt.unwrap.push
+        if existing_opt Option::Some(existing) is then
+            edit_item existing.push
         else
             List::new(List[TextEdit]) = new_list
             edit_item new_list.push
@@ -1788,16 +2038,33 @@ fn compute_rename
 
 fn handle_rename message:JsonValue {
     message extract_uri = uri
-    "id" message json_get_value.unwrap = request_id
+    if "id" message json_get_value Option::Some(request_id) is then
+    else
+        empty_location "Expected option value while unwrapping id message json_get_value" ErrorKind::Syntax raise_error
+        1 exit
+    fi
 
     uri DOCUMENT_STATES.get = state_opt
     if state_opt.is_none then
         JsonValue::JsonNull request_id send_response
         return
     fi
-    state_opt.unwrap = state
+    if state_opt Option::Some(state) is then
+    else
+        empty_location "Expected option value while unwrapping state_opt" ErrorKind::Syntax raise_error
+        1 exit
+    fi
 
-    "newName" "params" message json_get_object.unwrap json_get_str.unwrap = new_name
+    if "params" message json_get_object Option::Some(params) is then
+    else
+        empty_location "Expected option value while unwrapping params message json_get_object" ErrorKind::Syntax raise_error
+        1 exit
+    fi
+    if "newName" params json_get_str Option::Some(new_name) is then
+    else
+        empty_location "Expected option value while unwrapping newName params json_get_str" ErrorKind::Syntax raise_error
+        1 exit
+    fi
 
     message extract_position = position
     new_name position LspRange::start_col position LspRange::start_line state compute_rename = edits_opt
@@ -1805,13 +2072,21 @@ fn handle_rename message:JsonValue {
         JsonValue::JsonNull request_id send_response
         return
     fi
-    edits_opt.unwrap = edits_map
+    if edits_opt Option::Some(edits_map) is then
+    else
+        empty_location "Expected option value while unwrapping edits_opt" ErrorKind::Syntax raise_error
+        1 exit
+    fi
 
     # Convert to JSON changes object
     json_object = changes
     edits_map.keys = change_uris
     for change_uri in change_uris.iter do
-        change_uri edits_map.get.unwrap = edit_list
+        if change_uri edits_map.get Option::Some(edit_list) is then
+        else
+            empty_location "Expected option value while unwrapping change_uri edits_map.get" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         List::new(List[JsonValue]) = edit_json_list
         for edit_item in edit_list.iter do
             edit_item.to_json edit_json_list.push
@@ -1934,7 +2209,11 @@ fn collect_semantic_tokens ops:List[Op] state:DocumentState tokens:List[Semantic
         if token_type_opt.is_none then
             continue
         fi
-        token_type_opt.unwrap = token_type
+        if token_type_opt Option::Some(token_type) is then
+        else
+            empty_location "Expected option value while unwrapping token_type_opt" ErrorKind::Syntax raise_error
+            1 exit
+        fi
 
         # Check for qualified names
         if
@@ -1999,13 +2278,21 @@ fn compute_semantic_tokens state:DocumentState -> List[SemanticToken] {
     # Collect from function ops
     state DocumentState::functions.keys = fn_keys
     for fn_name in fn_keys.iter do
-        fn_name state DocumentState::functions.get.unwrap = func
+        if fn_name state DocumentState::functions.get Option::Some(func) is then
+        else
+            empty_location "Expected option value while unwrapping fn_name state DocumentState::functions.get" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         tokens state func Function::ops collect_semantic_tokens
     done
 
     # Add function definition names + fn keyword
     for fn_def_name in fn_keys.iter do
-        fn_def_name state DocumentState::functions.get.unwrap = fn_def
+        if fn_def_name state DocumentState::functions.get Option::Some(fn_def) is then
+        else
+            empty_location "Expected option value while unwrapping fn_def_name state DocumentState::functions.get" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         if "" fn_def Function::location Location::file == then
             continue
         fi
@@ -2028,7 +2315,11 @@ fn compute_semantic_tokens state:DocumentState -> List[SemanticToken] {
     # Add enum definition names + enum keyword
     state DocumentState::enums.keys = enum_keys
     for enum_def_name in enum_keys.iter do
-        enum_def_name state DocumentState::enums.get.unwrap = enum_def
+        if enum_def_name state DocumentState::enums.get Option::Some(enum_def) is then
+        else
+            empty_location "Expected option value while unwrapping enum_def_name state DocumentState::enums.get" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         if enum_def CasaEnum::location Location::file state DocumentState::file_path != then
             continue
         fi
@@ -2045,7 +2336,11 @@ fn compute_semantic_tokens state:DocumentState -> List[SemanticToken] {
     # Add struct definition names + struct keyword
     state DocumentState::structs.keys = struct_keys
     for struct_def_name in struct_keys.iter do
-        struct_def_name state DocumentState::structs.get.unwrap = struct_def
+        if struct_def_name state DocumentState::structs.get Option::Some(struct_def) is then
+        else
+            empty_location "Expected option value while unwrapping struct_def_name state DocumentState::structs.get" ErrorKind::Syntax raise_error
+            1 exit
+        fi
         if struct_def CasaStruct::location Location::file state DocumentState::file_path != then
             continue
         fi
@@ -2085,7 +2380,11 @@ fn compute_semantic_tokens state:DocumentState -> List[SemanticToken] {
 
 fn handle_semantic_tokens message:JsonValue {
     message extract_uri = uri
-    "id" message json_get_value.unwrap = request_id
+    if "id" message json_get_value Option::Some(request_id) is then
+    else
+        empty_location "Expected option value while unwrapping id message json_get_value" ErrorKind::Syntax raise_error
+        1 exit
+    fi
 
     uri DOCUMENT_STATES.get = state_opt
     if state_opt.is_none then
@@ -2094,7 +2393,11 @@ fn handle_semantic_tokens message:JsonValue {
         JsonValue::JsonObject request_id send_response
         return
     fi
-    state_opt.unwrap = state
+    if state_opt Option::Some(state) is then
+    else
+        empty_location "Expected option value while unwrapping state_opt" ErrorKind::Syntax raise_error
+        1 exit
+    fi
 
     state compute_semantic_tokens = tokens
 
@@ -2255,11 +2558,23 @@ fn extract_library_paths message:JsonValue -> List[str] {
     List::new(List[str]) = paths
     "params" message json_get_object = params_option
     if params_option.is_none then paths return fi
-    "initializationOptions" params_option.unwrap json_get_object = init_options_option
+    if params_option Option::Some(params) is then
+    else
+        paths return
+    fi
+    "initializationOptions" params json_get_object = init_options_option
     if init_options_option.is_none then paths return fi
-    "libraryPaths" init_options_option.unwrap json_get_array = library_paths_option
+    if init_options_option Option::Some(init_options) is then
+    else
+        paths return
+    fi
+    "libraryPaths" init_options json_get_array = library_paths_option
     if library_paths_option.is_none then paths return fi
-    library_paths_option.unwrap = library_paths_array
+    if library_paths_option Option::Some(library_paths_array) is then
+    else
+        empty_location "Expected option value while unwrapping library_paths_option" ErrorKind::Syntax raise_error
+        1 exit
+    fi
     for path_value in library_paths_array.iter do
         if path_value JsonValue::JsonString(path_string) is then
             path_string paths.push
@@ -2270,7 +2585,11 @@ fn extract_library_paths message:JsonValue -> List[str] {
 
 fn handle_initialize message:JsonValue {
     global LSP_LIBRARY_PATHS
-    "id" message json_get_value.unwrap = request_id
+    if "id" message json_get_value Option::Some(request_id) is then
+    else
+        empty_location "Expected option value while unwrapping id message json_get_value" ErrorKind::Syntax raise_error
+        1 exit
+    fi
 
     message extract_library_paths = LSP_LIBRARY_PATHS
 
@@ -2318,7 +2637,11 @@ fn handle_initialize message:JsonValue {
 }
 
 fn handle_shutdown message:JsonValue {
-    "id" message json_get_value.unwrap = request_id
+    if "id" message json_get_value Option::Some(request_id) is then
+    else
+        empty_location "Expected option value while unwrapping id message json_get_value" ErrorKind::Syntax raise_error
+        1 exit
+    fi
     JsonValue::JsonNull request_id send_response
 }
 
@@ -2329,7 +2652,11 @@ fn handle_exit message:JsonValue {
 fn dispatch_message message:JsonValue {
     "method" message json_get_str = method_opt
     if method_opt.is_none then return fi
-    method_opt.unwrap = method
+    if method_opt Option::Some(method) is then
+    else
+        empty_location "Expected option value while unwrapping method_opt" ErrorKind::Syntax raise_error
+        1 exit
+    fi
 
     if "initialize" method == then
         message handle_initialize
@@ -2367,7 +2694,9 @@ fn main {
         if msg_opt.is_none then
             break
         fi
-        msg_opt.unwrap dispatch_message
+        if msg_opt Option::Some(message) is then
+            message dispatch_message
+        fi
     done
 }
 main

--- a/lsp.casa
+++ b/lsp.casa
@@ -119,7 +119,6 @@ const COLLECTOR_ENUM 3
 const QPART_TYPE 0
 const QPART_SEPARATOR 1
 const QPART_MEMBER 2
-const QPART_NONE -1
 List::new(List[str]) = LSP_LIBRARY_PATHS
 
 # ============================================================================
@@ -251,7 +250,7 @@ fn lsp_log message:str {
 }
 
 fn read_message reader:StdinReader -> Option[JsonValue] {
-    0 1 - = content_length
+    Option::None(Option[int]) = content_length
     # Read headers until empty line
     while true do
         reader stdin_read_line = header_line
@@ -259,14 +258,14 @@ fn read_message reader:StdinReader -> Option[JsonValue] {
             break
         fi
         if header_line "Content-Length: " str::starts_with then
-            header_line 16 header_line.length 16 - str::substring str_to_int = content_length
+            header_line 16 header_line.length 16 - str::substring str_to_int Option::Some = content_length
         fi
     done
-    if content_length 0 >= then
+    if content_length.is_none then
         Option::None(Option[JsonValue])
         return
     fi
-    content_length reader stdin_read_exact = body
+    content_length.unwrap reader stdin_read_exact = body
     body Cursor::new = cursor
     cursor json_parse = parse_result
     if parse_result.is_error then
@@ -624,22 +623,22 @@ fn casa_location_to_lsp location:Location -> LspLocation {
 # Qualified name utilities
 # ============================================================================
 
-fn qualified_name_part source:str op:Op cursor_offset:int -> int {
+fn qualified_name_part source:str op:Op cursor_offset:int -> Option[int] {
     op Op::location Location::span Span::offset = start
     op Op::location Location::span Span::length = length
     source start length str::substring = text
     text "::" str::find = separator
     if 0 separator < then
-        QPART_NONE
+        Option::None(Option[int])
         return
     fi
     cursor_offset start - = relative_offset
     if relative_offset separator > then
-        QPART_TYPE
+        QPART_TYPE Option::Some
     elif relative_offset separator 2 + > then
-        QPART_SEPARATOR
+        QPART_SEPARATOR Option::Some
     else
-        QPART_MEMBER
+        QPART_MEMBER Option::Some
     fi
 }
 
@@ -768,17 +767,23 @@ fn compute_definition state:DocumentState line:int col:int -> Option[LspLocation
     col line state DocumentState::source position_to_offset = cursor_offset
 
     # Check qualified name
-    cursor_offset op state DocumentState::source qualified_name_part = qpart
-    if QPART_SEPARATOR qpart == then
-        Option::None(Option[LspLocation])
-        return
+    false = qpart_is_type
+    false = qpart_is_member
+    cursor_offset op state DocumentState::source qualified_name_part = qpart_opt
+    if qpart_opt Option::Some(qpart) is then
+        if QPART_SEPARATOR qpart == then
+            Option::None(Option[LspLocation])
+            return
+        fi
+        QPART_TYPE qpart == = qpart_is_type
+        QPART_MEMBER qpart == = qpart_is_member
     fi
 
     op.value = op_value
 
     # FN_CALL / FN_PUSH
     if op_value OpValue::FnCall is op_value OpValue::FnPush is || then
-        if QPART_TYPE qpart == then
+        if qpart_is_type then
             op op_str_value "::" str::split = parts
             0 parts.get = type_name
             if type_name state DocumentState::structs.has then
@@ -825,7 +830,7 @@ fn compute_definition state:DocumentState line:int col:int -> Option[LspLocation
         fi
         enum_name state DocumentState::enums.get.unwrap = casa_enum
         enum_variant EnumVariant::variant_name casa_enum CasaEnum::variant_locations.get = variant_loc_opt
-        if QPART_MEMBER qpart == variant_loc_opt.is_some && then
+        if qpart_is_member variant_loc_opt.is_some && then
             variant_loc_opt.unwrap casa_location_to_lsp Option::Some
             return
         fi
@@ -1097,66 +1102,64 @@ fn compute_hover state:DocumentState line:int col:int -> Option[HoverContent] {
     col line state DocumentState::source position_to_offset = cursor_offset
 
     # Dead zone for :: separator
-    cursor_offset op state DocumentState::source qualified_name_part = qpart
-    if QPART_SEPARATOR qpart == then
-        Option::None(Option[HoverContent])
-        return
-    fi
-
-    # Qualified function call
-    if
-    QPART_NONE qpart !=
-    op.value OpValue::FnCall is op.value OpValue::FnPush is || &&
-    then
-        op op_str_value "::" str::split = qualified_parts
-        0 qualified_parts.get = qualified_type_name
-        if QPART_TYPE qpart == then
-            op state DocumentState::source qualified_type_range = qualified_range
-            # Look up type
-            Option::None(Option[str]) = qualified_content
-            if qualified_type_name state DocumentState::structs.has then
-                qualified_type_name state DocumentState::structs.get.unwrap format_struct_hover Option::Some = qualified_content
-            elif qualified_type_name state DocumentState::enums.has then
-                qualified_type_name state DocumentState::enums.get.unwrap format_enum_hover Option::Some = qualified_content
-            fi
-            if qualified_content.is_some then
-                qualified_range f"```casa\n{qualified_content.unwrap}\n```" HoverContent Option::Some
-                return
-            fi
-        else
-            # Member part: show function stack effect
-            op state DocumentState::source qualified_member_range = member_range
-            member_range state func op format_qualified_member_hover = member_hover
-            if member_hover.is_some then
-                member_hover
-                return
-            fi
-        fi
-        Option::None(Option[HoverContent])
-        return
-    fi
-
-    # Qualified enum variant
-    if
-    QPART_NONE qpart !=
-    op.value OpValue::PushEnumVariant is &&
-    then
-        op enum_variant_of = enum_variant
-        if QPART_TYPE qpart == then
-            op state DocumentState::source qualified_type_range = enum_range
-            if enum_variant EnumVariant::enum_name state DocumentState::enums.has then
-                enum_variant EnumVariant::enum_name state DocumentState::enums.get.unwrap format_enum_hover = enum_text
-                enum_range f"```casa\n{enum_text}\n```" HoverContent Option::Some
-                return
-            fi
-        else
-            op state DocumentState::source qualified_member_range = variant_range
-            f"{enum_variant EnumVariant::enum_name}::{enum_variant EnumVariant::variant_name}" = variant_content
-            variant_range f"```casa\n{variant_content}\n```" HoverContent Option::Some
+    cursor_offset op state DocumentState::source qualified_name_part = qpart_opt
+    if qpart_opt Option::Some(qpart) is then
+        if QPART_SEPARATOR qpart == then
+            Option::None(Option[HoverContent])
             return
         fi
-        Option::None(Option[HoverContent])
-        return
+
+        # Qualified function call
+        if
+        op.value OpValue::FnCall is op.value OpValue::FnPush is ||
+        then
+            op op_str_value "::" str::split = qualified_parts
+            0 qualified_parts.get = qualified_type_name
+            if QPART_TYPE qpart == then
+                op state DocumentState::source qualified_type_range = qualified_range
+                # Look up type
+                Option::None(Option[str]) = qualified_content
+                if qualified_type_name state DocumentState::structs.has then
+                    qualified_type_name state DocumentState::structs.get.unwrap format_struct_hover Option::Some = qualified_content
+                elif qualified_type_name state DocumentState::enums.has then
+                    qualified_type_name state DocumentState::enums.get.unwrap format_enum_hover Option::Some = qualified_content
+                fi
+                if qualified_content.is_some then
+                    qualified_range f"```casa\n{qualified_content.unwrap}\n```" HoverContent Option::Some
+                    return
+                fi
+            else
+                # Member part: show function stack effect
+                op state DocumentState::source qualified_member_range = member_range
+                member_range state func op format_qualified_member_hover = member_hover
+                if member_hover.is_some then
+                    member_hover
+                    return
+                fi
+            fi
+            Option::None(Option[HoverContent])
+            return
+        fi
+
+        # Qualified enum variant
+        if op.value OpValue::PushEnumVariant is then
+            op enum_variant_of = enum_variant
+            if QPART_TYPE qpart == then
+                op state DocumentState::source qualified_type_range = enum_range
+                if enum_variant EnumVariant::enum_name state DocumentState::enums.has then
+                    enum_variant EnumVariant::enum_name state DocumentState::enums.get.unwrap format_enum_hover = enum_text
+                    enum_range f"```casa\n{enum_text}\n```" HoverContent Option::Some
+                    return
+                fi
+            else
+                op state DocumentState::source qualified_member_range = variant_range
+                f"{enum_variant EnumVariant::enum_name}::{enum_variant EnumVariant::variant_name}" = variant_content
+                variant_range f"```casa\n{variant_content}\n```" HoverContent Option::Some
+                return
+            fi
+            Option::None(Option[HoverContent])
+            return
+        fi
     fi
 
     # General hover

--- a/tests/compiler/test_bytecode.casa
+++ b/tests/compiler/test_bytecode.casa
@@ -24,7 +24,9 @@ fn test_make_op value:OpValue -> Op {
 }
 
 fn test_make_op_with_type_hint value:OpValue type_hint:Type -> Op {
-    type_hint make_test_location value make_op_with_type_hint
+    make_test_location value make_op = op
+    type_hint Option::Some op->type_hint
+    op
 }
 
 # ============================================================================
@@ -55,13 +57,13 @@ fn test_intern_string {
     "table has two entries" 2 compiler BytecodeCompiler::string_table.length assert_eq
 }
 
-fn test_intern_constant {
-    "intern_constant" test_start
+fn test_intern_constant_table {
+    "intern_constant_table" test_start
     List::new(List[Op]) = ops
     ops TEST_STORE make_compiler = compiler
-    "first constant index" 0 "MY_CONST" compiler intern_constant assert_eq
-    "same constant same index" 0 "MY_CONST" compiler intern_constant assert_eq
-    "second constant index" 1 "OTHER" compiler intern_constant assert_eq
+    "first constant index" 0 "MY_CONST" compiler.constants_table intern_table assert_eq
+    "same constant same index" 0 "MY_CONST" compiler.constants_table intern_table assert_eq
+    "second constant index" 1 "OTHER" compiler.constants_table intern_table assert_eq
 }
 
 fn test_compile_push_int {
@@ -675,7 +677,7 @@ fn test_compile_fn_push {
 # ============================================================================
 test_new_label
 test_intern_string
-test_intern_constant
+test_intern_constant_table
 test_compile_push_int
 test_compile_push_bool
 test_compile_push_str

--- a/tests/compiler/test_bytecode.casa
+++ b/tests/compiler/test_bytecode.casa
@@ -37,11 +37,11 @@ fn test_new_label {
     "new_label" test_start
     List::new(List[Op]) = ops
     ops TEST_STORE BytecodeCompiler::new = compiler
-    compiler new_label = first_label
+    compiler.new_label = first_label
     "first label is 0" 0 first_label assert_eq
-    compiler new_label = second_label
+    compiler.new_label = second_label
     "second label is 1" 1 second_label assert_eq
-    compiler new_label = third_label
+    compiler.new_label = third_label
     "third label is 2" 2 third_label assert_eq
 }
 
@@ -49,11 +49,10 @@ fn test_intern_string {
     "intern_string" test_start
     List::new(List[Op]) = ops
     ops TEST_STORE BytecodeCompiler::new = compiler
-    # intern_string compiler:BytecodeCompiler value:str
-    # param1=compiler, param2=value -> value compiler intern_string
-    "first string index" 0 "hello" compiler intern_string assert_eq
-    "same string same index" 0 "hello" compiler intern_string assert_eq
-    "second string index" 1 "world" compiler intern_string assert_eq
+    # intern_string method keeps string table indices stable.
+    "first string index" 0 "hello" compiler.intern_string assert_eq
+    "same string same index" 0 "hello" compiler.intern_string assert_eq
+    "second string index" 1 "world" compiler.intern_string assert_eq
     "table has two entries" 2 compiler BytecodeCompiler::string_table.length assert_eq
 }
 
@@ -74,9 +73,8 @@ fn test_compile_push_int {
 
     ops TEST_STORE BytecodeCompiler::new = compiler
     List::new(List[InstValue]) = bytecode
-    # compile_ops compiler:BytecodeCompiler bytecode:List[InstValue]
-    # param1=compiler, param2=bytecode -> bytecode compiler compile_ops
-    bytecode compiler compile_ops
+    # compile_ops appends emitted instructions to bytecode.
+    bytecode compiler.compile_ops
 
     # Should have: LABEL, PUSH(42)
     "push_int bytecode length" 2 bytecode.length assert_eq
@@ -96,7 +94,7 @@ fn test_compile_push_bool {
 
     ops TEST_STORE BytecodeCompiler::new = compiler
     List::new(List[InstValue]) = bytecode
-    bytecode compiler compile_ops
+    bytecode compiler.compile_ops
 
     if 1 bytecode.get InstValue::Push(value) is then
         "push_bool true value" 1 value assert_eq
@@ -113,7 +111,7 @@ fn test_compile_push_str {
 
     ops TEST_STORE BytecodeCompiler::new = compiler
     List::new(List[InstValue]) = bytecode
-    bytecode compiler compile_ops
+    bytecode compiler.compile_ops
 
     if 1 bytecode.get InstValue::PushStr(string_index) is then
         "push_str string index" 0 string_index assert_eq
@@ -131,7 +129,7 @@ fn test_compile_push_char {
 
     ops TEST_STORE BytecodeCompiler::new = compiler
     List::new(List[InstValue]) = bytecode
-    bytecode compiler compile_ops
+    bytecode compiler.compile_ops
 
     if 1 bytecode.get InstValue::PushChar(char_value) is then
         "push_char value" 65 char_value assert_eq
@@ -151,7 +149,7 @@ fn test_compile_direct_ops {
 
     ops TEST_STORE BytecodeCompiler::new = compiler
     List::new(List[InstValue]) = bytecode
-    bytecode compiler compile_ops
+    bytecode compiler.compile_ops
 
     # Index 0 is label
     "add inst" 1 bytecode.get InstValue::Add is assert_true
@@ -172,7 +170,7 @@ fn test_compile_variable_assign_and_push {
 
     ops TEST_STORE BytecodeCompiler::new = compiler
     List::new(List[InstValue]) = bytecode
-    bytecode compiler compile_ops
+    bytecode compiler.compile_ops
 
     # Index 0 is label, 1 is GLOBAL_SET, 2 is GLOBAL_GET
     "assign var kind" 1 bytecode.get InstValue::GlobalSet is assert_true
@@ -198,7 +196,7 @@ fn test_compile_local_variable {
     List::new(List[InstValue]) = bytecode
     fn_ops TEST_STORE BytecodeCompiler::new = root_compiler
     fn_ops func root_compiler.child = compiler
-    bytecode compiler compile_ops
+    bytecode compiler.compile_ops
 
     # Index 0 is label, 1 is LOCAL_SET, 2 is LOCAL_GET
     if 1 bytecode.get InstValue::LocalSet(set_index) is then
@@ -221,7 +219,7 @@ fn test_compile_fstring_concat {
 
     ops TEST_STORE BytecodeCompiler::new = compiler
     List::new(List[InstValue]) = bytecode
-    bytecode compiler compile_ops
+    bytecode compiler.compile_ops
 
     if 1 bytecode.get InstValue::FstringConcat(fstring_count) is then
         "fstring concat count" 3 fstring_count assert_eq
@@ -238,7 +236,7 @@ fn test_compile_type_cast_no_output {
 
     ops TEST_STORE BytecodeCompiler::new = compiler
     List::new(List[InstValue]) = bytecode
-    bytecode compiler compile_ops
+    bytecode compiler.compile_ops
 
     # Only the label should be emitted, no instruction for type cast
     "type cast produces no inst" 1 bytecode.length assert_eq
@@ -252,7 +250,7 @@ fn test_compile_import_no_output {
 
     ops TEST_STORE BytecodeCompiler::new = compiler
     List::new(List[InstValue]) = bytecode
-    bytecode compiler compile_ops
+    bytecode compiler.compile_ops
 
     "import produces no inst" 1 bytecode.length assert_eq
 }
@@ -263,9 +261,9 @@ fn test_op_to_label_identity {
     ops TEST_STORE BytecodeCompiler::new = compiler
     OpValue::Add test_make_op = op_a
     OpValue::Add test_make_op = op_b
-    op_a compiler op_to_label = label_a_first
-    op_a compiler op_to_label = label_a_second
-    op_b compiler op_to_label = label_b
+    op_a compiler.op_to_label = label_a_first
+    op_a compiler.op_to_label = label_a_second
+    op_b compiler.op_to_label = label_b
     "same op same label" label_a_first label_a_second assert_eq
     "different op different label" label_a_first label_b != assert_true
 }
@@ -284,7 +282,7 @@ fn test_compile_if_block {
 
     ops TEST_STORE BytecodeCompiler::new = compiler
     List::new(List[InstValue]) = bytecode
-    bytecode compiler compile_ops
+    bytecode compiler.compile_ops
 
     # Expected: LABEL, JUMP_NE(end_label), LABEL(end_label)
     "if block bytecode length" 3 bytecode.length assert_eq
@@ -303,7 +301,7 @@ fn test_compile_while_block {
 
     ops TEST_STORE BytecodeCompiler::new = compiler
     List::new(List[InstValue]) = bytecode
-    bytecode compiler compile_ops
+    bytecode compiler.compile_ops
 
     # Expected: LABEL(fn), LABEL(start), JUMP_NE(end), JUMP(start), LABEL(end)
     "while block bytecode length" 5 bytecode.length assert_eq
@@ -322,7 +320,7 @@ fn test_compile_string_eq {
 
     ops TEST_STORE BytecodeCompiler::new = compiler
     List::new(List[InstValue]) = bytecode
-    bytecode compiler compile_ops
+    bytecode compiler.compile_ops
 
     "str_eq inst" 1 bytecode.get InstValue::StrEq is assert_true
 }
@@ -335,7 +333,7 @@ fn test_compile_string_ne {
 
     ops TEST_STORE BytecodeCompiler::new = compiler
     List::new(List[InstValue]) = bytecode
-    bytecode compiler compile_ops
+    bytecode compiler.compile_ops
 
     # Should emit STR_EQ + NOT
     "str_ne has str_eq" 1 bytecode.get InstValue::StrEq is assert_true
@@ -352,7 +350,7 @@ fn test_compile_assign_increment {
 
     ops TEST_STORE BytecodeCompiler::new = compiler
     List::new(List[InstValue]) = bytecode
-    bytecode compiler compile_ops
+    bytecode compiler.compile_ops
 
     # Expected: LABEL, GLOBAL_GET, ADD, GLOBAL_SET
     "inc bytecode length" 4 bytecode.length assert_eq
@@ -373,7 +371,7 @@ fn test_compile_assign_decrement {
 
     ops TEST_STORE BytecodeCompiler::new = compiler
     List::new(List[InstValue]) = bytecode
-    bytecode compiler compile_ops
+    bytecode compiler.compile_ops
 
     # Expected: LABEL, GLOBAL_GET, SWAP, SUB, GLOBAL_SET
     "dec bytecode length" 5 bytecode.length assert_eq
@@ -393,7 +391,7 @@ fn test_compile_push_bool_false {
 
     ops TEST_STORE BytecodeCompiler::new = compiler
     List::new(List[InstValue]) = bytecode
-    bytecode compiler compile_ops
+    bytecode compiler.compile_ops
 
     if 1 bytecode.get InstValue::Push(value) is then
         "push_bool_false value" 0 value assert_eq
@@ -426,7 +424,7 @@ fn test_compile_more_direct_ops {
 
     ops TEST_STORE BytecodeCompiler::new = compiler
     List::new(List[InstValue]) = bytecode
-    bytecode compiler compile_ops
+    bytecode compiler.compile_ops
 
     # Index 0 is label
     "mul inst" 1 bytecode.get InstValue::Mul is assert_true
@@ -459,7 +457,7 @@ fn test_compile_direct_ops_bitwise {
 
     ops TEST_STORE BytecodeCompiler::new = compiler
     List::new(List[InstValue]) = bytecode
-    bytecode compiler compile_ops
+    bytecode compiler.compile_ops
 
     "bit_and inst" 1 bytecode.get InstValue::BitAnd is assert_true
     "bit_or inst" 2 bytecode.get InstValue::BitOr is assert_true
@@ -483,7 +481,7 @@ fn test_compile_direct_ops_memory {
 
     ops TEST_STORE BytecodeCompiler::new = compiler
     List::new(List[InstValue]) = bytecode
-    bytecode compiler compile_ops
+    bytecode compiler.compile_ops
 
     "heap_alloc inst" 1 bytecode.get InstValue::HeapAlloc is assert_true
     "load8 inst" 2 bytecode.get InstValue::Load8 is assert_true
@@ -510,7 +508,7 @@ fn test_compile_direct_ops_syscall {
 
     ops TEST_STORE BytecodeCompiler::new = compiler
     List::new(List[InstValue]) = bytecode
-    bytecode compiler compile_ops
+    bytecode compiler.compile_ops
 
     "syscall0 inst" 1 bytecode.get InstValue::Syscall0 is assert_true
     "syscall1 inst" 2 bytecode.get InstValue::Syscall1 is assert_true
@@ -533,7 +531,7 @@ fn test_compile_direct_ops_print {
 
     ops TEST_STORE BytecodeCompiler::new = compiler
     List::new(List[InstValue]) = bytecode
-    bytecode compiler compile_ops
+    bytecode compiler.compile_ops
 
     "print_int inst" 1 bytecode.get InstValue::PrintInt is assert_true
     "print_str inst" 2 bytecode.get InstValue::PrintStr is assert_true
@@ -551,7 +549,7 @@ fn test_compile_direct_ops_fn {
 
     ops TEST_STORE BytecodeCompiler::new = compiler
     List::new(List[InstValue]) = bytecode
-    bytecode compiler compile_ops
+    bytecode compiler.compile_ops
 
     "fn_exec inst" 1 bytecode.get InstValue::FnExec is assert_true
     "fn_return inst" 2 bytecode.get InstValue::FnReturn is assert_true
@@ -572,7 +570,7 @@ fn test_compile_push_array {
 
     ops TEST_STORE BytecodeCompiler::new = compiler
     List::new(List[InstValue]) = bytecode
-    bytecode compiler compile_ops
+    bytecode compiler.compile_ops
 
     0 = has_static_array
     0 = has_alloc
@@ -604,7 +602,7 @@ fn test_compile_if_elif_else {
 
     ops TEST_STORE BytecodeCompiler::new = compiler
     List::new(List[InstValue]) = bytecode
-    bytecode compiler compile_ops
+    bytecode compiler.compile_ops
 
     # Expected bytecode layout:
     # 0: LABEL (fn)
@@ -639,7 +637,7 @@ fn test_compile_fn_call {
 
     ops TEST_STORE BytecodeCompiler::new = compiler
     List::new(List[InstValue]) = bytecode
-    bytecode compiler compile_ops
+    bytecode compiler.compile_ops
 
     # Should have: LABEL, FN_CALL
     "fn_call bytecode length" 2 bytecode.length assert_eq
@@ -663,7 +661,7 @@ fn test_compile_fn_push {
 
     ops TEST_STORE BytecodeCompiler::new = compiler
     List::new(List[InstValue]) = bytecode
-    bytecode compiler compile_ops
+    bytecode compiler.compile_ops
 
     # FnPush should emit FN_PUSH instruction with function name
     # Find FN_PUSH instruction in bytecode

--- a/tests/compiler/test_bytecode.casa
+++ b/tests/compiler/test_bytecode.casa
@@ -13,18 +13,18 @@ import "../../compiler/bytecode.casa"
 # ============================================================================
 
 fn make_test_location -> Location {
-    # make_location file:str offset:int length:int
-    # param1=file, param2=offset, param3=length -> length offset file make_location
-    1 0 "test.casa" make_location
+    # Location::new file:str offset:int length:int
+    # param1=file, param2=offset, param3=length -> length offset file Location::new
+    1 0 "test.casa" Location::new
 }
 # Helper to create an op with the unified OpValue payload.
 
 fn test_make_op value:OpValue -> Op {
-    make_test_location value make_op
+    make_test_location value Op::new
 }
 
 fn test_make_op_with_type_hint value:OpValue type_hint:Type -> Op {
-    make_test_location value make_op = op
+    make_test_location value Op::new = op
     type_hint Option::Some op->type_hint
     op
 }
@@ -36,7 +36,7 @@ fn test_make_op_with_type_hint value:OpValue type_hint:Type -> Op {
 fn test_new_label {
     "new_label" test_start
     List::new(List[Op]) = ops
-    ops TEST_STORE make_compiler = compiler
+    ops TEST_STORE BytecodeCompiler::new = compiler
     compiler new_label = first_label
     "first label is 0" 0 first_label assert_eq
     compiler new_label = second_label
@@ -48,7 +48,7 @@ fn test_new_label {
 fn test_intern_string {
     "intern_string" test_start
     List::new(List[Op]) = ops
-    ops TEST_STORE make_compiler = compiler
+    ops TEST_STORE BytecodeCompiler::new = compiler
     # intern_string compiler:BytecodeCompiler value:str
     # param1=compiler, param2=value -> value compiler intern_string
     "first string index" 0 "hello" compiler intern_string assert_eq
@@ -60,7 +60,7 @@ fn test_intern_string {
 fn test_intern_constant_table {
     "intern_constant_table" test_start
     List::new(List[Op]) = ops
-    ops TEST_STORE make_compiler = compiler
+    ops TEST_STORE BytecodeCompiler::new = compiler
     "first constant index" 0 "MY_CONST" compiler.constants_table intern_table assert_eq
     "same constant same index" 0 "MY_CONST" compiler.constants_table intern_table assert_eq
     "second constant index" 1 "OTHER" compiler.constants_table intern_table assert_eq
@@ -72,7 +72,7 @@ fn test_compile_push_int {
     List::new(List[Op]) = ops
     42 OpValue::PushInt test_make_op ops.push
 
-    ops TEST_STORE make_compiler = compiler
+    ops TEST_STORE BytecodeCompiler::new = compiler
     List::new(List[InstValue]) = bytecode
     # compile_ops compiler:BytecodeCompiler bytecode:List[InstValue]
     # param1=compiler, param2=bytecode -> bytecode compiler compile_ops
@@ -94,7 +94,7 @@ fn test_compile_push_bool {
     List::new(List[Op]) = ops
     1 OpValue::PushBool test_make_op ops.push
 
-    ops TEST_STORE make_compiler = compiler
+    ops TEST_STORE BytecodeCompiler::new = compiler
     List::new(List[InstValue]) = bytecode
     bytecode compiler compile_ops
 
@@ -111,7 +111,7 @@ fn test_compile_push_str {
     List::new(List[Op]) = ops
     "hello" OpValue::PushStr test_make_op ops.push
 
-    ops TEST_STORE make_compiler = compiler
+    ops TEST_STORE BytecodeCompiler::new = compiler
     List::new(List[InstValue]) = bytecode
     bytecode compiler compile_ops
 
@@ -129,7 +129,7 @@ fn test_compile_push_char {
     List::new(List[Op]) = ops
     'A' (int) OpValue::PushChar test_make_op ops.push
 
-    ops TEST_STORE make_compiler = compiler
+    ops TEST_STORE BytecodeCompiler::new = compiler
     List::new(List[InstValue]) = bytecode
     bytecode compiler compile_ops
 
@@ -149,7 +149,7 @@ fn test_compile_direct_ops {
     OpValue::Dup test_make_op ops.push
     OpValue::Drop test_make_op ops.push
 
-    ops TEST_STORE make_compiler = compiler
+    ops TEST_STORE BytecodeCompiler::new = compiler
     List::new(List[InstValue]) = bytecode
     bytecode compiler compile_ops
 
@@ -164,13 +164,13 @@ fn test_compile_variable_assign_and_push {
     "compile_variable_assign_and_push" test_start
 
     # Set up a global variable
-    "" make_variable "x" TEST_STORE.variables.set drop
+    "" Variable::new "x" TEST_STORE.variables.set drop
 
     List::new(List[Op]) = ops
     "x" OpValue::AssignVar test_make_op ops.push
     "x" OpValue::PushVar test_make_op ops.push
 
-    ops TEST_STORE make_compiler = compiler
+    ops TEST_STORE BytecodeCompiler::new = compiler
     List::new(List[InstValue]) = bytecode
     bytecode compiler compile_ops
 
@@ -190,13 +190,14 @@ fn test_compile_local_variable {
     "y" OpValue::AssignVar test_make_op fn_ops.push
     "y" OpValue::PushVar test_make_op fn_ops.push
 
-    # make_function name:str ops:List[Op] location:Location
+    # Function::new name:str ops:List[Op] location:Location
     # param1=name, param2=ops, param3=location
-    make_test_location fn_ops "test_fn" make_function = func
-    "y" make_variable func Function::variables.push
+    make_test_location fn_ops "test_fn" Function::new = func
+    "y" Variable::new func Function::variables.push
 
     List::new(List[InstValue]) = bytecode
-    Set::new(Set[str]) Map::new(Map[Op int]) 0 List::new(List[StaticStruct]) List::new(List[StaticArray]) List::new(List[str]) List::new(List[str]) func Option::Some fn_ops TEST_STORE make_compiler_with_tables = compiler
+    fn_ops TEST_STORE BytecodeCompiler::new = root_compiler
+    fn_ops func root_compiler.child = compiler
     bytecode compiler compile_ops
 
     # Index 0 is label, 1 is LOCAL_SET, 2 is LOCAL_GET
@@ -218,7 +219,7 @@ fn test_compile_fstring_concat {
     List::new(List[Op]) = ops
     3 OpValue::FstringConcat test_make_op ops.push
 
-    ops TEST_STORE make_compiler = compiler
+    ops TEST_STORE BytecodeCompiler::new = compiler
     List::new(List[InstValue]) = bytecode
     bytecode compiler compile_ops
 
@@ -235,7 +236,7 @@ fn test_compile_type_cast_no_output {
     List::new(List[Op]) = ops
     TYPE_UNKNOWN_T OpValue::TypeCast test_make_op ops.push
 
-    ops TEST_STORE make_compiler = compiler
+    ops TEST_STORE BytecodeCompiler::new = compiler
     List::new(List[InstValue]) = bytecode
     bytecode compiler compile_ops
 
@@ -249,7 +250,7 @@ fn test_compile_import_no_output {
     List::new(List[Op]) = ops
     "" OpValue::ImportFile test_make_op ops.push
 
-    ops TEST_STORE make_compiler = compiler
+    ops TEST_STORE BytecodeCompiler::new = compiler
     List::new(List[InstValue]) = bytecode
     bytecode compiler compile_ops
 
@@ -259,7 +260,7 @@ fn test_compile_import_no_output {
 fn test_op_to_label_identity {
     "op_to_label_identity" test_start
     List::new(List[Op]) = ops
-    ops TEST_STORE make_compiler = compiler
+    ops TEST_STORE BytecodeCompiler::new = compiler
     OpValue::Add test_make_op = op_a
     OpValue::Add test_make_op = op_b
     op_a compiler op_to_label = label_a_first
@@ -281,7 +282,7 @@ fn test_compile_if_block {
     "op 0 is if_start" 0 ops.get.value OpValue::IfStart is assert_true
     "op 2 is if_end" 2 ops.get.value OpValue::IfEnd is assert_true
 
-    ops TEST_STORE make_compiler = compiler
+    ops TEST_STORE BytecodeCompiler::new = compiler
     List::new(List[InstValue]) = bytecode
     bytecode compiler compile_ops
 
@@ -300,7 +301,7 @@ fn test_compile_while_block {
     OpValue::WhileCondition test_make_op ops.push
     OpValue::WhileEnd test_make_op ops.push
 
-    ops TEST_STORE make_compiler = compiler
+    ops TEST_STORE BytecodeCompiler::new = compiler
     List::new(List[InstValue]) = bytecode
     bytecode compiler compile_ops
 
@@ -319,7 +320,7 @@ fn test_compile_string_eq {
     List::new(List[Op]) = ops
     TYPE_STR_T OpValue::Eq test_make_op_with_type_hint ops.push
 
-    ops TEST_STORE make_compiler = compiler
+    ops TEST_STORE BytecodeCompiler::new = compiler
     List::new(List[InstValue]) = bytecode
     bytecode compiler compile_ops
 
@@ -332,7 +333,7 @@ fn test_compile_string_ne {
     List::new(List[Op]) = ops
     TYPE_STR_T OpValue::Ne test_make_op_with_type_hint ops.push
 
-    ops TEST_STORE make_compiler = compiler
+    ops TEST_STORE BytecodeCompiler::new = compiler
     List::new(List[InstValue]) = bytecode
     bytecode compiler compile_ops
 
@@ -344,12 +345,12 @@ fn test_compile_string_ne {
 fn test_compile_assign_increment {
     "compile_assign_increment" test_start
 
-    "" make_variable "counter" TEST_STORE.variables.set drop
+    "" Variable::new "counter" TEST_STORE.variables.set drop
 
     List::new(List[Op]) = ops
     "counter" OpValue::AssignInc test_make_op ops.push
 
-    ops TEST_STORE make_compiler = compiler
+    ops TEST_STORE BytecodeCompiler::new = compiler
     List::new(List[InstValue]) = bytecode
     bytecode compiler compile_ops
 
@@ -365,12 +366,12 @@ fn test_compile_assign_increment {
 fn test_compile_assign_decrement {
     "compile_assign_decrement" test_start
 
-    "" make_variable "counter" TEST_STORE.variables.set drop
+    "" Variable::new "counter" TEST_STORE.variables.set drop
 
     List::new(List[Op]) = ops
     "counter" OpValue::AssignDec test_make_op ops.push
 
-    ops TEST_STORE make_compiler = compiler
+    ops TEST_STORE BytecodeCompiler::new = compiler
     List::new(List[InstValue]) = bytecode
     bytecode compiler compile_ops
 
@@ -390,7 +391,7 @@ fn test_compile_push_bool_false {
     List::new(List[Op]) = ops
     0 OpValue::PushBool test_make_op ops.push
 
-    ops TEST_STORE make_compiler = compiler
+    ops TEST_STORE BytecodeCompiler::new = compiler
     List::new(List[InstValue]) = bytecode
     bytecode compiler compile_ops
 
@@ -423,7 +424,7 @@ fn test_compile_more_direct_ops {
     OpValue::Over test_make_op ops.push
     OpValue::Rot test_make_op ops.push
 
-    ops TEST_STORE make_compiler = compiler
+    ops TEST_STORE BytecodeCompiler::new = compiler
     List::new(List[InstValue]) = bytecode
     bytecode compiler compile_ops
 
@@ -456,7 +457,7 @@ fn test_compile_direct_ops_bitwise {
     OpValue::BitXor test_make_op ops.push
     OpValue::BitNot test_make_op ops.push
 
-    ops TEST_STORE make_compiler = compiler
+    ops TEST_STORE BytecodeCompiler::new = compiler
     List::new(List[InstValue]) = bytecode
     bytecode compiler compile_ops
 
@@ -480,7 +481,7 @@ fn test_compile_direct_ops_memory {
     OpValue::Store32 test_make_op ops.push
     OpValue::Store64 test_make_op ops.push
 
-    ops TEST_STORE make_compiler = compiler
+    ops TEST_STORE BytecodeCompiler::new = compiler
     List::new(List[InstValue]) = bytecode
     bytecode compiler compile_ops
 
@@ -507,7 +508,7 @@ fn test_compile_direct_ops_syscall {
     OpValue::Syscall5 test_make_op ops.push
     OpValue::Syscall6 test_make_op ops.push
 
-    ops TEST_STORE make_compiler = compiler
+    ops TEST_STORE BytecodeCompiler::new = compiler
     List::new(List[InstValue]) = bytecode
     bytecode compiler compile_ops
 
@@ -530,7 +531,7 @@ fn test_compile_direct_ops_print {
     OpValue::PrintCstr test_make_op ops.push
     OpValue::PrintBool test_make_op ops.push
 
-    ops TEST_STORE make_compiler = compiler
+    ops TEST_STORE BytecodeCompiler::new = compiler
     List::new(List[InstValue]) = bytecode
     bytecode compiler compile_ops
 
@@ -548,7 +549,7 @@ fn test_compile_direct_ops_fn {
     OpValue::FnExec test_make_op ops.push
     OpValue::FnReturn test_make_op ops.push
 
-    ops TEST_STORE make_compiler = compiler
+    ops TEST_STORE BytecodeCompiler::new = compiler
     List::new(List[InstValue]) = bytecode
     bytecode compiler compile_ops
 
@@ -567,9 +568,9 @@ fn test_compile_push_array {
 
     # Create a PushArray op with the items list as value
     List::new(List[Op]) = ops
-    make_test_location items OpValue::PushArray make_op ops.push
+    make_test_location items OpValue::PushArray Op::new ops.push
 
-    ops TEST_STORE make_compiler = compiler
+    ops TEST_STORE BytecodeCompiler::new = compiler
     List::new(List[InstValue]) = bytecode
     bytecode compiler compile_ops
 
@@ -601,7 +602,7 @@ fn test_compile_if_elif_else {
     OpValue::IfElse test_make_op ops.push
     OpValue::IfEnd test_make_op ops.push
 
-    ops TEST_STORE make_compiler = compiler
+    ops TEST_STORE BytecodeCompiler::new = compiler
     List::new(List[InstValue]) = bytecode
     bytecode compiler compile_ops
 
@@ -630,13 +631,13 @@ fn test_compile_fn_call {
 
     # Register a function in TEST_STORE.functions
     List::new(List[Op]) = fn_ops
-    make_test_location fn_ops "greet" make_function = func
+    make_test_location fn_ops "greet" Function::new = func
     func "greet" TEST_STORE.functions.set drop
 
     List::new(List[Op]) = ops
     "greet" OpValue::FnCall test_make_op ops.push
 
-    ops TEST_STORE make_compiler = compiler
+    ops TEST_STORE BytecodeCompiler::new = compiler
     List::new(List[InstValue]) = bytecode
     bytecode compiler compile_ops
 
@@ -654,13 +655,13 @@ fn test_compile_fn_push {
     # Register a function in TEST_STORE.functions with has_deferred_methods = 0
     List::new(List[Op]) = fn_ops
     1 OpValue::PushInt test_make_op fn_ops.push
-    make_test_location fn_ops "adder" make_function = func
+    make_test_location fn_ops "adder" Function::new = func
     func "adder" TEST_STORE.functions.set drop
 
     List::new(List[Op]) = ops
     "adder" OpValue::FnPush test_make_op ops.push
 
-    ops TEST_STORE make_compiler = compiler
+    ops TEST_STORE BytecodeCompiler::new = compiler
     List::new(List[InstValue]) = bytecode
     bytecode compiler compile_ops
 

--- a/tests/compiler/test_common.casa
+++ b/tests/compiler/test_common.casa
@@ -6,10 +6,10 @@ import "../../lib/test.casa"
 
 fn make_test_stack_effect param_type:str return_type:str -> StackEffect {
     List::new(List[Parameter]) = params
-    param_type make_param params.push
+    param_type Parameter::new params.push
     List::new(List[Type]) = returns
     return_type parse_type_str returns.push
-    returns params make_stack_effect
+    returns params StackEffect::new
 }
 
 fn test_type_base {
@@ -105,11 +105,11 @@ fn test_delimiter_lookup {
 fn test_stack_effect_to_str {
     "stack_effect_to_str" test_start
     List::new(List[Parameter]) = params
-    "int" make_param params.push
-    "str" make_param params.push
+    "int" Parameter::new params.push
+    "str" Parameter::new params.push
     List::new(List[Type]) = rets
     "bool" parse_type_str rets.push
-    rets params make_stack_effect = sig
+    rets params StackEffect::new = sig
     "effect to str" "int str -> bool" sig stack_effect_to_str assert_str_eq
     "empty effect to str" "None -> None" empty_stack_effect stack_effect_to_str assert_str_eq
 }
@@ -139,8 +139,8 @@ fn test_type_is_builtin {
 fn test_variable_list_helpers {
     "variable_list_helpers" test_start
     List::new(List[Variable]) = vars
-    "x" make_variable vars.push
-    "y" make_variable vars.push
+    "x" Variable::new vars.push
+    "y" Variable::new vars.push
     "contains x" "x" vars variable_list_contains assert_true
     "not contains z" "z" vars variable_list_contains ! assert_true
     "index of y" 1 "y" vars variable_list_index assert_eq

--- a/tests/compiler/test_common.casa
+++ b/tests/compiler/test_common.casa
@@ -150,30 +150,38 @@ fn test_variable_list_helpers {
 fn test_build_parameterized_type {
     "build_parameterized_type" test_start
     List::new(List[str]) = params
-    "int" params.push
-    "simple" "List[int]" params "List" build_parameterized_type assert_str_eq
+    "T" params.push
+    params "List" build_parameterized_type = simple_type
+    "List[T]" parse_type_str = expected_simple
+    "simple" expected_simple simple_type.eq assert_true
 
     List::new(List[str]) = multi_params
-    "str" multi_params.push
-    "int" multi_params.push
-    "multi" "Map[str int]" multi_params "Map" build_parameterized_type assert_str_eq
+    "K" multi_params.push
+    "V" multi_params.push
+    multi_params "Map" build_parameterized_type = multi_type
+    "Map[K V]" parse_type_str = expected_multi
+    "multi" expected_multi multi_type.eq assert_true
 }
 
 fn test_build_resolved_type {
     "build_resolved_type" test_start
     List::new(List[str]) = type_vars
     "T" type_vars.push
-    Map::new(Map[str str]) = bindings
-    "int" "T" bindings.set = bindings
-    "resolved" "Option[int]" bindings type_vars "Option" build_resolved_type assert_str_eq
+    Map::new(Map[str Type]) = bindings
+    TYPE_INT_T "T" bindings.set = bindings
+    bindings type_vars "Option" build_resolved_type = resolved_type
+    "Option[int]" parse_type_str = expected_resolved
+    "resolved" expected_resolved resolved_type.eq assert_true
 
     # Unresolved type var stays as-is
     List::new(List[str]) = type_vars2
     "K" type_vars2.push
     "V" type_vars2.push
-    Map::new(Map[str str]) = bindings2
-    "str" "K" bindings2.set = bindings2
-    "partial" "Map[str V]" bindings2 type_vars2 "Map" build_resolved_type assert_str_eq
+    Map::new(Map[str Type]) = bindings2
+    TYPE_STR_T "K" bindings2.set = bindings2
+    bindings2 type_vars2 "Map" build_resolved_type = partial_type
+    "Map[str V]" parse_type_str = expected_partial
+    "partial" expected_partial partial_type.eq assert_true
 }
 test_type_base
 test_type_params

--- a/tests/compiler/test_common.casa
+++ b/tests/compiler/test_common.casa
@@ -4,6 +4,14 @@ import "../../compiler/lexer.casa"
 import "../../compiler/syntax.casa"
 import "../../lib/test.casa"
 
+fn make_test_stack_effect param_type:str return_type:str -> StackEffect {
+    List::new(List[Parameter]) = params
+    param_type make_param params.push
+    List::new(List[Type]) = returns
+    return_type parse_type_str returns.push
+    returns params make_stack_effect
+}
+
 fn test_type_base {
     "type_base" test_start
     "array[int] has base" "array[int]" parse_type_str.base.is_some assert_true
@@ -106,28 +114,18 @@ fn test_stack_effect_to_str {
     "empty effect to str" "None -> None" empty_stack_effect stack_effect_to_str assert_str_eq
 }
 
-fn test_stack_effect_from_str {
-    "stack_effect_from_str" test_start
-    "int str -> bool" stack_effect_from_str = sig
-    "two params" 2 sig StackEffect::parameters.length assert_eq
-    "first param" "int" 0 sig StackEffect::parameters.get Parameter::typ.format assert_str_eq
-    "second param" "str" 1 sig StackEffect::parameters.get Parameter::typ.format assert_str_eq
-    "one return" 1 sig StackEffect::return_types.length assert_eq
-    "return type" "bool" 0 sig StackEffect::return_types.get.format assert_str_eq
-}
-
 fn test_stack_effect_matches {
     "stack_effect_matches" test_start
-    "int -> bool" stack_effect_from_str = effect1
-    "int -> bool" stack_effect_from_str = effect2
+    "bool" "int" make_test_stack_effect = effect1
+    "bool" "int" make_test_stack_effect = effect2
     "same sigs match" effect2 effect1 stack_effect_matches assert_true
 
-    "int -> bool" stack_effect_from_str = effect3
-    "str -> bool" stack_effect_from_str = effect4
+    "bool" "int" make_test_stack_effect = effect3
+    "bool" "str" make_test_stack_effect = effect4
     "different params don't match" effect4 effect3 stack_effect_matches ! assert_true
 
-    f"{TYPE_UNKNOWN} -> bool" stack_effect_from_str = effect5
-    "int -> bool" stack_effect_from_str = effect6
+    "bool" TYPE_UNKNOWN make_test_stack_effect = effect5
+    "bool" "int" make_test_stack_effect = effect6
     "TYPE_UNKNOWN matches int" effect6 effect5 stack_effect_matches assert_true
 }
 
@@ -187,7 +185,6 @@ test_operator_lookup
 test_intrinsic_lookup
 test_delimiter_lookup
 test_stack_effect_to_str
-test_stack_effect_from_str
 test_stack_effect_matches
 test_type_is_builtin
 test_variable_list_helpers

--- a/tests/compiler/test_emitter.casa
+++ b/tests/compiler/test_emitter.casa
@@ -73,9 +73,9 @@ fn test_emit_bss {
     List::new(List[InstValue])
     Program = program
 
-    StringBuilder::new = asm_builder
-    program asm_builder emit_bss
-    asm_builder.build = result
+    program Emitter::new = emitter
+    emitter.emit_bss
+    emitter.asm.build = result
 
     "has bss section" result ".section .bss" assert_contains
     "has globals" result "globals: .skip 24" assert_contains
@@ -102,9 +102,9 @@ fn test_emit_data {
     List::new(List[InstValue])
     Program = program
 
-    StringBuilder::new = asm_builder
-    program asm_builder emit_data
-    asm_builder.build = result
+    program Emitter::new = emitter
+    emitter.emit_data
+    emitter.asm.build = result
 
     "has data section" result ".section .data" assert_contains
     "has str_0 label" result "str_0:" assert_contains
@@ -1267,9 +1267,9 @@ fn test_emit_data_escape_sequences {
     List::new(List[InstValue])
     Program = program
 
-    StringBuilder::new = asm_builder
-    program asm_builder emit_data
-    asm_builder.build = result
+    program Emitter::new = emitter
+    emitter.emit_data
+    emitter.asm.build = result
 
     "has escaped newline" result "hello\\nworld" assert_contains
     "has escaped tab" result "col1\\tcol2" assert_contains

--- a/tests/compiler/test_error.casa
+++ b/tests/compiler/test_error.casa
@@ -62,14 +62,14 @@ fn test_error_kind_name {
 
 fn test_format_error_no_location {
     "format_error_no_location" test_start
-    empty_location "bad token" ErrorKind::Syntax make_error = err
+    empty_location "bad token" ErrorKind::Syntax CasaError::new = err
     err format_error = formatted
     "exact format" "error[SYNTAX]: bad token" formatted assert_str_eq
 }
 
 fn test_format_error_with_location_no_source {
     "format_error_with_location_no_source" test_start
-    3 0 "test.casa" make_location "not found" ErrorKind::UndefinedName make_error = err
+    3 0 "test.casa" Location::new "not found" ErrorKind::UndefinedName CasaError::new = err
     err format_error = formatted
     "has error kind" formatted "error[UNDEFINED_NAME]" str::find 0 1 - swap > assert_true
 }
@@ -78,7 +78,7 @@ fn test_format_error_with_source {
     global SOURCE_CACHE
     "format_error_with_source" test_start
     "foo bar baz" "test_src.casa" SOURCE_CACHE.set = SOURCE_CACHE
-    3 4 "test_src.casa" make_location "`bar` is not defined" ErrorKind::UndefinedName make_error = err
+    3 4 "test_src.casa" Location::new "`bar` is not defined" ErrorKind::UndefinedName CasaError::new = err
     err format_error = formatted
     "has error kind" formatted "error[UNDEFINED_NAME]" str::find 0 1 - swap > assert_true
     "has location" formatted "test_src.casa:1:5" str::find 0 1 - swap > assert_true
@@ -90,7 +90,7 @@ fn test_format_error_multiline_source {
     global SOURCE_CACHE
     "format_error_multiline_source" test_start
     "10 = x\nfoo\n20 = y" "test_multi.casa" SOURCE_CACHE.set = SOURCE_CACHE
-    3 7 "test_multi.casa" make_location "`foo` is not defined" ErrorKind::UndefinedName make_error = err
+    3 7 "test_multi.casa" Location::new "`foo` is not defined" ErrorKind::UndefinedName CasaError::new = err
     err format_error = formatted
     "has location" formatted "test_multi.casa:2:1" str::find 0 1 - swap > assert_true
     "has foo" formatted "foo" str::find 0 1 - swap > assert_true
@@ -99,7 +99,7 @@ fn test_format_error_multiline_source {
 
 fn test_format_error_with_expected_got {
     "format_error_with_expected_got" test_start
-    "`str`" "`int`" empty_location "Type mismatch" ErrorKind::TypeMismatch make_error_expected = err
+    "`str`" "`int`" empty_location "Type mismatch" ErrorKind::TypeMismatch CasaError::with_expected = err
     err format_error = formatted
     "has expected" formatted "Expected: `int`" str::find 0 1 - swap > assert_true
     "has got" formatted "Got: `str`" str::find 0 1 - swap > assert_true
@@ -109,8 +109,8 @@ fn test_format_error_with_note {
     global SOURCE_CACHE
     "format_error_with_note" test_start
     "\"hello\" 42 +" "test_note.casa" SOURCE_CACHE.set = SOURCE_CACHE
-    2 8 "test_note.casa" make_location "Type mismatch" ErrorKind::TypeMismatch make_error = err
-    7 0 "test_note.casa" make_location "value of type `str` pushed here" CasaNote = note
+    2 8 "test_note.casa" Location::new "Type mismatch" ErrorKind::TypeMismatch CasaError::new = err
+    7 0 "test_note.casa" Location::new "value of type `str` pushed here" CasaNote = note
     note err CasaError::notes.push
     err format_error = formatted
     "has Note prefix" formatted "Note: value of type `str` pushed here" str::find 0 1 - swap > assert_true
@@ -121,9 +121,9 @@ fn test_format_error_with_multiple_notes {
     global SOURCE_CACHE
     "format_error_with_multiple_notes" test_start
     "if true then\n    1 2\nelse\n    3\nfi" "test_notes.casa" SOURCE_CACHE.set = SOURCE_CACHE
-    2 30 "test_notes.casa" make_location "Branches have incompatible stack effects" ErrorKind::StackMismatch make_error = err
-    2 0 "test_notes.casa" make_location "`if` branch has stack effect `None -> int int`" CasaNote = note1
-    4 21 "test_notes.casa" make_location "`else` branch has stack effect `None -> int`" CasaNote = note2
+    2 30 "test_notes.casa" Location::new "Branches have incompatible stack effects" ErrorKind::StackMismatch CasaError::new = err
+    2 0 "test_notes.casa" Location::new "`if` branch has stack effect `None -> int int`" CasaNote = note1
+    4 21 "test_notes.casa" Location::new "`else` branch has stack effect `None -> int`" CasaNote = note2
     note1 err CasaError::notes.push
     note2 err CasaError::notes.push
     err format_error = formatted
@@ -141,8 +141,8 @@ fn test_format_error_note_without_source {
     global SOURCE_CACHE
     "format_error_note_without_source" test_start
     "foo" "present.casa" SOURCE_CACHE.set = SOURCE_CACHE
-    3 0 "present.casa" make_location "Type mismatch" ErrorKind::TypeMismatch make_error = err
-    5 0 "missing.casa" make_location "value pushed here" CasaNote = note
+    3 0 "present.casa" Location::new "Type mismatch" ErrorKind::TypeMismatch CasaError::new = err
+    5 0 "missing.casa" Location::new "value pushed here" CasaNote = note
     note err CasaError::notes.push
     err format_error = formatted
     "has Note prefix" formatted "Note: value pushed here" str::find 0 1 - swap > assert_true

--- a/tests/compiler/test_lsp.casa
+++ b/tests/compiler/test_lsp.casa
@@ -978,19 +978,19 @@ fn test_compute_hover_enum_variant_separator_returns_none {
 
 fn lsp_make_synthetic_method name:str self_type:str ret_type:str -> Function {
     List::new(List[Parameter]) = params
-    self_type make_param params.push
+    self_type Parameter::new params.push
     List::new(List[Type]) = returns
     ret_type parse_type_str returns.push
-    returns params make_stack_effect = sig
-    sig empty_location List::new(List[Op]) name make_function_with_stack_effect
+    returns params StackEffect::new = sig
+    sig empty_location List::new(List[Op]) name Function::with_stack_effect
 }
 
 fn lsp_make_synthetic_void name:str self_type:str -> Function {
     List::new(List[Parameter]) = params
-    self_type make_param params.push
+    self_type Parameter::new params.push
     List::new(List[Type]) = returns
-    returns params make_stack_effect = sig
-    sig empty_location List::new(List[Op]) name make_function_with_stack_effect
+    returns params StackEffect::new = sig
+    sig empty_location List::new(List[Op]) name Function::with_stack_effect
 }
 # Inject int:: synthetic methods into a DocumentState's functions map.
 # Returns a new DocumentState with the updated functions map.

--- a/tests/compiler/test_parser.casa
+++ b/tests/compiler/test_parser.casa
@@ -8,7 +8,7 @@ symbol_store_new = PARSER_TEST_STORE
 
 fn parser_test_parse tokens:List[Token] -> List[Op] {
     global PARSER_TEST_STORE
-    symbol_store_new make_parser = parser
+    symbol_store_new Parser::new = parser
     tokens parser parse_ops = ops
     parser.store = PARSER_TEST_STORE
     ops
@@ -600,7 +600,7 @@ fn test_dir_of_path_root {
 
 fn test_resolve_import_path_absolute {
     "resolve_import_path_absolute" test_start
-    symbol_store_new make_parser = parser
+    symbol_store_new Parser::new = parser
     "resolved"
     "/abs/foo.casa"
     empty_location "/abs/foo.casa" "casa.casa" parser resolve_import
@@ -609,7 +609,7 @@ fn test_resolve_import_path_absolute {
 
 fn test_resolve_import_path_relative {
     "resolve_import_path_relative" test_start
-    symbol_store_new make_parser = parser
+    symbol_store_new Parser::new = parser
     "resolved"
     "lib/std.casa"
     empty_location "lib/std.casa" "casa.casa" parser resolve_import
@@ -618,7 +618,7 @@ fn test_resolve_import_path_relative {
 
 fn test_resolve_import_module_in_source_dir {
     "resolve_import_module_in_source_dir" test_start
-    symbol_store_new make_parser = parser
+    symbol_store_new Parser::new = parser
     # Importing "std" from a sibling lib file resolves to lib/std.casa.
     "resolved"
     "lib/std.casa"
@@ -632,7 +632,7 @@ fn test_resolve_import_module_skips_self_match {
     # self-match and resolve via the lib/ search path instead.
     List::new(List[str]) = paths
     "lib" paths.push
-    symbol_store_new make_parser = parser
+    symbol_store_new Parser::new = parser
     paths parser->search_paths
     "resolved"
     "lib/argparse.casa"
@@ -645,7 +645,7 @@ fn test_resolve_import_module_via_search_path {
     # No std.casa in tests/compiler/, so resolver falls through to "lib".
     List::new(List[str]) = paths
     "lib" paths.push
-    symbol_store_new make_parser = parser
+    symbol_store_new Parser::new = parser
     paths parser->search_paths
     "resolved"
     "lib/std.casa"
@@ -658,7 +658,7 @@ fn test_resolve_import_search_paths_skips_missing {
     List::new(List[str]) = paths
     "no_such_dir" paths.push
     "lib" paths.push
-    symbol_store_new make_parser = parser
+    symbol_store_new Parser::new = parser
     paths parser->search_paths
     "resolved"
     "lib/std.casa"

--- a/tests/compiler/test_pattern.casa
+++ b/tests/compiler/test_pattern.casa
@@ -8,22 +8,22 @@ import "helpers.casa"
 # ============================================================================
 
 fn make_enum_arm enum_name:str variant_name:str -> Op {
-    Option::None variant_name enum_name make_enum_variant = variant
-    List::new(List[Op]) variant PatternValue::EnumVariant make_match_arm = arm
-    empty_location arm OpValue::MatchArm make_op
+    Option::None variant_name enum_name EnumVariant::new = variant
+    List::new(List[Op]) variant PatternValue::EnumVariant MatchArm::new = arm
+    empty_location arm OpValue::MatchArm Op::new
 }
 
 fn make_struct_arm struct_name:str -> Op {
     Map::new(Map[str str]) = bindings
     bindings struct_name StructPattern = struct_pat
-    List::new(List[Op]) struct_pat PatternValue::Struct make_match_arm = arm
-    empty_location arm OpValue::MatchArm make_op
+    List::new(List[Op]) struct_pat PatternValue::Struct MatchArm::new = arm
+    empty_location arm OpValue::MatchArm Op::new
 }
 
 fn make_literal_arm raw:str -> Op {
     raw 0 LiteralValue::Int LiteralPattern = literal_pat
-    List::new(List[Op]) literal_pat PatternValue::Literal make_match_arm = arm
-    empty_location arm OpValue::MatchArm make_op
+    List::new(List[Op]) literal_pat PatternValue::Literal MatchArm::new = arm
+    empty_location arm OpValue::MatchArm Op::new
 }
 
 # ============================================================================
@@ -94,12 +94,12 @@ fn test_pattern_bindings_enum_empty {
 
 fn test_pattern_bindings_enum_with_payload {
     "pattern_bindings_enum_with_payload" test_start
-    Option::None "Some" "Option" make_enum_variant = variant
+    Option::None "Some" "Option" EnumVariant::new = variant
     List::new(List[str]) = binds
     "x" binds.push
     binds variant EnumVariant::set_bindings
-    List::new(List[Op]) variant PatternValue::EnumVariant make_match_arm = arm
-    empty_location arm OpValue::MatchArm make_op = op
+    List::new(List[Op]) variant PatternValue::EnumVariant MatchArm::new = arm
+    empty_location arm OpValue::MatchArm Op::new = op
     op pattern_bindings = out
     "count" 1 out.length assert_eq
     "name" "x" 0 out.get assert_str_eq
@@ -111,8 +111,8 @@ fn test_pattern_bindings_struct_fields {
     "y" "row" bindings.set drop
     "x" "col" bindings.set drop
     bindings "Point" StructPattern = struct_pat
-    List::new(List[Op]) struct_pat PatternValue::Struct make_match_arm = arm
-    empty_location arm OpValue::MatchArm make_op = op
+    List::new(List[Op]) struct_pat PatternValue::Struct MatchArm::new = arm
+    empty_location arm OpValue::MatchArm Op::new = op
     op pattern_bindings = out
     "count" 2 out.length assert_eq
 }
@@ -184,9 +184,9 @@ fn test_guard_excluded_from_covered_key {
     "covered when unguarded" "__covered:42" unguarded pattern_covered_key assert_str_eq
     "42" 0 LiteralValue::Int LiteralPattern = literal_pat
     List::new(List[Op]) = guard_ops
-    empty_location 1 OpValue::PushBool make_op guard_ops.push
-    guard_ops literal_pat PatternValue::Literal make_match_arm = arm
-    empty_location arm OpValue::MatchArm make_op = guarded
+    empty_location 1 OpValue::PushBool Op::new guard_ops.push
+    guard_ops literal_pat PatternValue::Literal MatchArm::new = arm
+    empty_location arm OpValue::MatchArm Op::new = guarded
     "is guarded" guarded pattern_is_guarded assert_true
     "empty key when guarded" "" guarded pattern_covered_key assert_str_eq
 }

--- a/tests/compiler/test_traits.casa
+++ b/tests/compiler/test_traits.casa
@@ -597,7 +597,7 @@ fn test_type_var_with_matching_bound_satisfies {
     HASHABLE_TRAIT trait_test_parse drop
     # Build a StackEffect with K bounded by Hashable
     Map::new(Map[str TraitBound]) = bounds
-    "Hashable" make_simple_trait_bound "K" bounds.set = bounds
+    List::new(List[str]) "Hashable" TraitBound "K" bounds.set = bounds
     Set::new(Set[str]) = type_vars
     "K" type_vars.add = type_vars
     # Construct StackEffect: parameters, return_types, type_vars, trait_bounds
@@ -624,7 +624,7 @@ fn test_type_var_with_wrong_bound_does_not_satisfy {
     "trait Hashable { fn hash self:self -> int }\ntrait Printable { fn to_str self:self -> str }\n" trait_test_parse drop
     # Build a StackEffect with K bounded by Printable, check against Hashable
     Map::new(Map[str TraitBound]) = bounds
-    "Printable" make_simple_trait_bound "K" bounds.set = bounds
+    List::new(List[str]) "Printable" TraitBound "K" bounds.set = bounds
     Set::new(Set[str]) = type_vars
     "K" type_vars.add = type_vars
     bounds type_vars List::new(List[Type]) List::new(List[Parameter]) StackEffect = sig
@@ -646,7 +646,7 @@ fn test_trait_bounds_default_empty {
 fn test_trait_bounds_preserved_in_stack_effect {
     "trait_bounds_preserved_in_stack_effect" test_start
     Map::new(Map[str TraitBound]) = bounds
-    "Hashable" make_simple_trait_bound "K" bounds.set = bounds
+    List::new(List[str]) "Hashable" TraitBound "K" bounds.set = bounds
     Set::new(Set[str]) = type_vars
     "K" type_vars.add = type_vars
     bounds type_vars List::new(List[Type]) List::new(List[Parameter]) StackEffect = sig

--- a/tests/compiler/test_traits.casa
+++ b/tests/compiler/test_traits.casa
@@ -602,7 +602,7 @@ fn test_type_var_with_matching_bound_satisfies {
     "K" type_vars.add = type_vars
     # Construct StackEffect: parameters, return_types, type_vars, trait_bounds
     bounds type_vars List::new(List[Type]) List::new(List[Parameter]) StackEffect = sig
-    sig empty_location List::new(List[Op]) "test_fn" make_function_with_stack_effect = func
+    sig empty_location List::new(List[Op]) "test_fn" Function::with_stack_effect = func
     func Option::Some = func_opt
     "satisfies" TRAIT_TEST_STORE func_opt "Hashable" "K" parse_type_str type_satisfies_trait assert_true
 }
@@ -614,7 +614,7 @@ fn test_type_var_without_bound_does_not_satisfy {
     Set::new(Set[str]) = type_vars
     "K" type_vars.add = type_vars
     Map::new(Map[str TraitBound]) type_vars List::new(List[Type]) List::new(List[Parameter]) StackEffect = sig
-    sig empty_location List::new(List[Op]) "test_fn" make_function_with_stack_effect = func
+    sig empty_location List::new(List[Op]) "test_fn" Function::with_stack_effect = func
     func Option::Some = func_opt
     "does not satisfy" TRAIT_TEST_STORE func_opt "Hashable" "K" parse_type_str type_satisfies_trait ! assert_true
 }
@@ -628,7 +628,7 @@ fn test_type_var_with_wrong_bound_does_not_satisfy {
     Set::new(Set[str]) = type_vars
     "K" type_vars.add = type_vars
     bounds type_vars List::new(List[Type]) List::new(List[Parameter]) StackEffect = sig
-    sig empty_location List::new(List[Op]) "test_fn" make_function_with_stack_effect = func
+    sig empty_location List::new(List[Op]) "test_fn" Function::with_stack_effect = func
     func Option::Some = func_opt
     "does not satisfy" TRAIT_TEST_STORE func_opt "Hashable" "K" parse_type_str type_satisfies_trait ! assert_true
 }

--- a/tests/compiler/test_typechecker.casa
+++ b/tests/compiler/test_typechecker.casa
@@ -6,7 +6,7 @@ import "helpers.casa"
 # ============================================================================
 
 fn tc_check ops:List[Op] -> TypeChecker {
-    symbol_store_new make_typechecker = helper_tc
+    symbol_store_new TypeChecker::new = helper_tc
     0 = helper_i
     while helper_i ops.length > do
         helper_i ops.get = helper_op
@@ -136,10 +136,10 @@ fn tc_check ops:List[Op] -> TypeChecker {
 
 fn make_test_stack_effect param_type:str return_type:str -> StackEffect {
     List::new(List[Parameter]) = params
-    param_type make_param params.push
+    param_type Parameter::new params.push
     List::new(List[Type]) = returns
     return_type parse_type_str returns.push
-    returns params make_stack_effect
+    returns params StackEffect::new
 }
 
 # ============================================================================
@@ -149,7 +149,7 @@ fn make_test_stack_effect param_type:str return_type:str -> StackEffect {
 fn test_push_int_stack {
     "push_int_stack" test_start
     List::new(List[Op]) = ops
-    empty_location 42 OpValue::PushInt make_op ops.push
+    empty_location 42 OpValue::PushInt Op::new ops.push
     ops tc_check = result_tc
     "stack has one item" 1 result_tc.stack.types.length assert_eq
     "type is int" "int" 0 result_tc.stack.types.get.format assert_str_eq
@@ -162,9 +162,9 @@ fn test_push_int_stack {
 fn test_add_stack_effect {
     "add_stack_effect" test_start
     List::new(List[Op]) = ops
-    empty_location 10 OpValue::PushInt make_op ops.push
-    empty_location 20 OpValue::PushInt make_op ops.push
-    empty_location OpValue::Add make_op ops.push
+    empty_location 10 OpValue::PushInt Op::new ops.push
+    empty_location 20 OpValue::PushInt Op::new ops.push
+    empty_location OpValue::Add Op::new ops.push
     ops tc_check = result_tc
     "stack has one item after add" 1 result_tc.stack.types.length assert_eq
     "result type is int" "int" 0 result_tc.stack.types.get.format assert_str_eq
@@ -179,34 +179,34 @@ fn test_arithmetic_ops {
 
     # Sub
     List::new(List[Op]) = ops_sub
-    empty_location 5 OpValue::PushInt make_op ops_sub.push
-    empty_location 3 OpValue::PushInt make_op ops_sub.push
-    empty_location OpValue::Sub make_op ops_sub.push
+    empty_location 5 OpValue::PushInt Op::new ops_sub.push
+    empty_location 3 OpValue::PushInt Op::new ops_sub.push
+    empty_location OpValue::Sub Op::new ops_sub.push
     ops_sub tc_check = tc_sub
     "sub result" 1 tc_sub.stack.types.length assert_eq
     "sub type" "int" 0 tc_sub.stack.types.get.format assert_str_eq
 
     # Mul
     List::new(List[Op]) = ops_mul
-    empty_location 2 OpValue::PushInt make_op ops_mul.push
-    empty_location 3 OpValue::PushInt make_op ops_mul.push
-    empty_location OpValue::Mul make_op ops_mul.push
+    empty_location 2 OpValue::PushInt Op::new ops_mul.push
+    empty_location 3 OpValue::PushInt Op::new ops_mul.push
+    empty_location OpValue::Mul Op::new ops_mul.push
     ops_mul tc_check = tc_mul
     "mul type" "int" 0 tc_mul.stack.types.get.format assert_str_eq
 
     # Div
     List::new(List[Op]) = ops_div
-    empty_location 10 OpValue::PushInt make_op ops_div.push
-    empty_location 2 OpValue::PushInt make_op ops_div.push
-    empty_location OpValue::Div make_op ops_div.push
+    empty_location 10 OpValue::PushInt Op::new ops_div.push
+    empty_location 2 OpValue::PushInt Op::new ops_div.push
+    empty_location OpValue::Div Op::new ops_div.push
     ops_div tc_check = tc_div
     "div type" "int" 0 tc_div.stack.types.get.format assert_str_eq
 
     # Mod
     List::new(List[Op]) = ops_mod
-    empty_location 10 OpValue::PushInt make_op ops_mod.push
-    empty_location 3 OpValue::PushInt make_op ops_mod.push
-    empty_location OpValue::Mod make_op ops_mod.push
+    empty_location 10 OpValue::PushInt Op::new ops_mod.push
+    empty_location 3 OpValue::PushInt Op::new ops_mod.push
+    empty_location OpValue::Mod Op::new ops_mod.push
     ops_mod tc_check = tc_mod
     "mod type" "int" 0 tc_mod.stack.types.get.format assert_str_eq
 }
@@ -218,9 +218,9 @@ fn test_arithmetic_ops {
 fn test_comparison_produces_bool {
     "comparison_produces_bool" test_start
     List::new(List[Op]) = ops
-    empty_location 1 OpValue::PushInt make_op ops.push
-    empty_location 2 OpValue::PushInt make_op ops.push
-    empty_location OpValue::Lt make_op ops.push
+    empty_location 1 OpValue::PushInt Op::new ops.push
+    empty_location 2 OpValue::PushInt Op::new ops.push
+    empty_location OpValue::Lt Op::new ops.push
     ops tc_check = result_tc
     "stack after lt" 1 result_tc.stack.types.length assert_eq
     "lt result is bool" "bool" 0 result_tc.stack.types.get.format assert_str_eq
@@ -234,24 +234,24 @@ fn test_boolean_ops {
     "boolean_ops" test_start
     # AND
     List::new(List[Op]) = ops_and
-    empty_location 1 OpValue::PushBool make_op ops_and.push
-    empty_location 0 OpValue::PushBool make_op ops_and.push
-    empty_location OpValue::And make_op ops_and.push
+    empty_location 1 OpValue::PushBool Op::new ops_and.push
+    empty_location 0 OpValue::PushBool Op::new ops_and.push
+    empty_location OpValue::And Op::new ops_and.push
     ops_and tc_check = tc_and
     "and result" "bool" 0 tc_and.stack.types.get.format assert_str_eq
 
     # OR
     List::new(List[Op]) = ops_or
-    empty_location 1 OpValue::PushBool make_op ops_or.push
-    empty_location 0 OpValue::PushBool make_op ops_or.push
-    empty_location OpValue::Or make_op ops_or.push
+    empty_location 1 OpValue::PushBool Op::new ops_or.push
+    empty_location 0 OpValue::PushBool Op::new ops_or.push
+    empty_location OpValue::Or Op::new ops_or.push
     ops_or tc_check = tc_or
     "or result" "bool" 0 tc_or.stack.types.get.format assert_str_eq
 
     # NOT
     List::new(List[Op]) = ops_not
-    empty_location 1 OpValue::PushBool make_op ops_not.push
-    empty_location OpValue::Not make_op ops_not.push
+    empty_location 1 OpValue::PushBool Op::new ops_not.push
+    empty_location OpValue::Not Op::new ops_not.push
     ops_not tc_check = tc_not
     "not result" "bool" 0 tc_not.stack.types.get.format assert_str_eq
 }
@@ -263,8 +263,8 @@ fn test_boolean_ops {
 fn test_dup_stack_effect {
     "dup_stack_effect" test_start
     List::new(List[Op]) = ops
-    empty_location 42 OpValue::PushInt make_op ops.push
-    empty_location OpValue::Dup make_op ops.push
+    empty_location 42 OpValue::PushInt Op::new ops.push
+    empty_location OpValue::Dup Op::new ops.push
     ops tc_check = result_tc
     "stack after dup" 2 result_tc.stack.types.length assert_eq
     "first is int" "int" 0 result_tc.stack.types.get.format assert_str_eq
@@ -278,9 +278,9 @@ fn test_dup_stack_effect {
 fn test_swap_stack_effect {
     "swap_stack_effect" test_start
     List::new(List[Op]) = ops
-    empty_location 42 OpValue::PushInt make_op ops.push
-    empty_location "hello" OpValue::PushStr make_op ops.push
-    empty_location OpValue::Swap make_op ops.push
+    empty_location 42 OpValue::PushInt Op::new ops.push
+    empty_location "hello" OpValue::PushStr Op::new ops.push
+    empty_location OpValue::Swap Op::new ops.push
     ops tc_check = result_tc
     "stack after swap" 2 result_tc.stack.types.length assert_eq
     "bottom is str" "str" 0 result_tc.stack.types.get.format assert_str_eq
@@ -294,9 +294,9 @@ fn test_swap_stack_effect {
 fn test_over_stack_effect {
     "over_stack_effect" test_start
     List::new(List[Op]) = ops
-    empty_location 42 OpValue::PushInt make_op ops.push
-    empty_location "hello" OpValue::PushStr make_op ops.push
-    empty_location OpValue::Over make_op ops.push
+    empty_location 42 OpValue::PushInt Op::new ops.push
+    empty_location "hello" OpValue::PushStr Op::new ops.push
+    empty_location OpValue::Over Op::new ops.push
     ops tc_check = result_tc
     "stack after over" 3 result_tc.stack.types.length assert_eq
     "bottom is int" "int" 0 result_tc.stack.types.get.format assert_str_eq
@@ -311,9 +311,9 @@ fn test_over_stack_effect {
 fn test_drop_stack_effect {
     "drop_stack_effect" test_start
     List::new(List[Op]) = ops
-    empty_location 42 OpValue::PushInt make_op ops.push
-    empty_location "hello" OpValue::PushStr make_op ops.push
-    empty_location OpValue::Drop make_op ops.push
+    empty_location 42 OpValue::PushInt Op::new ops.push
+    empty_location "hello" OpValue::PushStr Op::new ops.push
+    empty_location OpValue::Drop Op::new ops.push
     ops tc_check = result_tc
     "stack after drop" 1 result_tc.stack.types.length assert_eq
     "remaining is int" "int" 0 result_tc.stack.types.get.format assert_str_eq
@@ -326,10 +326,10 @@ fn test_drop_stack_effect {
 fn test_rot_stack_effect {
     "rot_stack_effect" test_start
     List::new(List[Op]) = ops
-    empty_location 42 OpValue::PushInt make_op ops.push
-    empty_location "hello" OpValue::PushStr make_op ops.push
-    empty_location 1 OpValue::PushBool make_op ops.push
-    empty_location OpValue::Rot make_op ops.push
+    empty_location 42 OpValue::PushInt Op::new ops.push
+    empty_location "hello" OpValue::PushStr Op::new ops.push
+    empty_location 1 OpValue::PushBool Op::new ops.push
+    empty_location OpValue::Rot Op::new ops.push
     ops tc_check = result_tc
     "stack after rot" 3 result_tc.stack.types.length assert_eq
     # ROT: pop t1(bool), t2(str), t3(int) -> push t2(str), t1(bool), t3(int)
@@ -345,8 +345,8 @@ fn test_rot_stack_effect {
 fn test_type_cast {
     "type_cast" test_start
     List::new(List[Op]) = ops
-    empty_location 42 OpValue::PushInt make_op ops.push
-    empty_location TYPE_STR_T OpValue::TypeCast make_op ops.push
+    empty_location 42 OpValue::PushInt Op::new ops.push
+    empty_location TYPE_STR_T OpValue::TypeCast Op::new ops.push
     ops tc_check = result_tc
     "stack after cast" 1 result_tc.stack.types.length assert_eq
     "cast to str" "str" 0 result_tc.stack.types.get.format assert_str_eq
@@ -359,10 +359,10 @@ fn test_type_cast {
 fn test_push_literals {
     "push_literals" test_start
     List::new(List[Op]) = ops
-    empty_location 42 OpValue::PushInt make_op ops.push
-    empty_location "hi" OpValue::PushStr make_op ops.push
-    empty_location 1 OpValue::PushBool make_op ops.push
-    empty_location 65 OpValue::PushChar make_op ops.push
+    empty_location 42 OpValue::PushInt Op::new ops.push
+    empty_location "hi" OpValue::PushStr Op::new ops.push
+    empty_location 1 OpValue::PushBool Op::new ops.push
+    empty_location 65 OpValue::PushChar Op::new ops.push
     ops tc_check = result_tc
     "four items on stack" 4 result_tc.stack.types.length assert_eq
     "int" "int" 0 result_tc.stack.types.get.format assert_str_eq
@@ -380,22 +380,22 @@ fn test_print_dispatch {
 
     # print str -> OpPrintStr
     List::new(List[Op]) = ops_str
-    empty_location "hello" OpValue::PushStr make_op ops_str.push
-    empty_location OpValue::Print make_op ops_str.push
+    empty_location "hello" OpValue::PushStr Op::new ops_str.push
+    empty_location OpValue::Print Op::new ops_str.push
     ops_str tc_check drop
     "print str resolved" 1 ops_str.get.value OpValue::PrintStr is assert_true
 
     # print int -> OpPrintInt
     List::new(List[Op]) = ops_int
-    empty_location 42 OpValue::PushInt make_op ops_int.push
-    empty_location OpValue::Print make_op ops_int.push
+    empty_location 42 OpValue::PushInt Op::new ops_int.push
+    empty_location OpValue::Print Op::new ops_int.push
     ops_int tc_check drop
     "print int resolved" 1 ops_int.get.value OpValue::PrintInt is assert_true
 
     # print bool -> OpPrintBool
     List::new(List[Op]) = ops_bool
-    empty_location 1 OpValue::PushBool make_op ops_bool.push
-    empty_location OpValue::Print make_op ops_bool.push
+    empty_location 1 OpValue::PushBool Op::new ops_bool.push
+    empty_location OpValue::Print Op::new ops_bool.push
     ops_bool tc_check drop
     "print bool resolved" 1 ops_bool.get.value OpValue::PrintBool is assert_true
 }
@@ -407,8 +407,8 @@ fn test_print_dispatch {
 fn test_typeof_effect {
     "typeof_effect" test_start
     List::new(List[Op]) = ops
-    empty_location 42 OpValue::PushInt make_op ops.push
-    empty_location OpValue::Typeof make_op ops.push
+    empty_location 42 OpValue::PushInt Op::new ops.push
+    empty_location OpValue::Typeof Op::new ops.push
     ops tc_check = result_tc
     "stack after typeof" 1 result_tc.stack.types.length assert_eq
     "typeof result is str" "str" 0 result_tc.stack.types.get.format assert_str_eq
@@ -423,24 +423,24 @@ fn test_bitwise_ops {
 
     # BIT_NOT
     List::new(List[Op]) = ops_bnot
-    empty_location 42 OpValue::PushInt make_op ops_bnot.push
-    empty_location OpValue::BitNot make_op ops_bnot.push
+    empty_location 42 OpValue::PushInt Op::new ops_bnot.push
+    empty_location OpValue::BitNot Op::new ops_bnot.push
     ops_bnot tc_check = tc_bnot
     "bitnot result" "int" 0 tc_bnot.stack.types.get.format assert_str_eq
 
     # SHL
     List::new(List[Op]) = ops_shl
-    empty_location 1 OpValue::PushInt make_op ops_shl.push
-    empty_location 3 OpValue::PushInt make_op ops_shl.push
-    empty_location OpValue::Shl make_op ops_shl.push
+    empty_location 1 OpValue::PushInt Op::new ops_shl.push
+    empty_location 3 OpValue::PushInt Op::new ops_shl.push
+    empty_location OpValue::Shl Op::new ops_shl.push
     ops_shl tc_check = tc_shl
     "shl result" "int" 0 tc_shl.stack.types.get.format assert_str_eq
 
     # BIT_AND
     List::new(List[Op]) = ops_band
-    empty_location 0 OpValue::PushInt make_op ops_band.push
-    empty_location 1 OpValue::PushInt make_op ops_band.push
-    empty_location OpValue::BitAnd make_op ops_band.push
+    empty_location 0 OpValue::PushInt Op::new ops_band.push
+    empty_location 1 OpValue::PushInt Op::new ops_band.push
+    empty_location OpValue::BitAnd Op::new ops_band.push
     ops_band tc_check = tc_band
     "bitand result" "int" 0 tc_band.stack.types.get.format assert_str_eq
 }
@@ -454,8 +454,8 @@ fn test_memory_ops {
 
     # heap_alloc: int -> ptr
     List::new(List[Op]) = ops_alloc
-    empty_location 100 OpValue::PushInt make_op ops_alloc.push
-    empty_location OpValue::HeapAlloc make_op ops_alloc.push
+    empty_location 100 OpValue::PushInt Op::new ops_alloc.push
+    empty_location OpValue::HeapAlloc Op::new ops_alloc.push
     ops_alloc tc_check = tc_alloc
     "alloc result is ptr" "ptr" 0 tc_alloc.stack.types.get.format assert_str_eq
 }
@@ -467,8 +467,8 @@ fn test_memory_ops {
 fn test_argc_argv {
     "argc_argv" test_start
     List::new(List[Op]) = ops
-    empty_location OpValue::Argc make_op ops.push
-    empty_location OpValue::Argv make_op ops.push
+    empty_location OpValue::Argc Op::new ops.push
+    empty_location OpValue::Argv Op::new ops.push
     ops tc_check = result_tc
     "stack count" 2 result_tc.stack.types.length assert_eq
     "argc is int" "int" 0 result_tc.stack.types.get.format assert_str_eq
@@ -629,8 +629,8 @@ fn test_tc_pipeline_memory {
 fn test_print_dispatch_char {
     "print_dispatch_char" test_start
     List::new(List[Op]) = ops
-    empty_location 65 OpValue::PushChar make_op ops.push
-    empty_location OpValue::Print make_op ops.push
+    empty_location 65 OpValue::PushChar Op::new ops.push
+    empty_location OpValue::Print Op::new ops.push
     ops tc_check drop
     "print char resolved" 1 ops.get.value OpValue::PrintChar is assert_true
 }
@@ -638,9 +638,9 @@ fn test_print_dispatch_char {
 fn test_print_dispatch_cstr {
     "print_dispatch_cstr" test_start
     List::new(List[Op]) = ops
-    empty_location 42 OpValue::PushInt make_op ops.push
-    empty_location TYPE_CSTR_T OpValue::TypeCast make_op ops.push
-    empty_location OpValue::Print make_op ops.push
+    empty_location 42 OpValue::PushInt Op::new ops.push
+    empty_location TYPE_CSTR_T OpValue::TypeCast Op::new ops.push
+    empty_location OpValue::Print Op::new ops.push
     ops tc_check drop
     "print cstr resolved" 2 ops.get.value OpValue::PrintCstr is assert_true
 }
@@ -652,8 +652,8 @@ fn test_print_dispatch_cstr {
 fn test_print_pops_stack {
     "print_pops_stack" test_start
     List::new(List[Op]) = ops
-    empty_location 42 OpValue::PushInt make_op ops.push
-    empty_location OpValue::Print make_op ops.push
+    empty_location 42 OpValue::PushInt Op::new ops.push
+    empty_location OpValue::Print Op::new ops.push
     ops tc_check = result_tc
     "stack empty after print" 0 result_tc.stack.types.length assert_eq
 }
@@ -665,8 +665,8 @@ fn test_print_pops_stack {
 fn test_typeof_str {
     "typeof_str" test_start
     List::new(List[Op]) = ops
-    empty_location "hi" OpValue::PushStr make_op ops.push
-    empty_location OpValue::Typeof make_op ops.push
+    empty_location "hi" OpValue::PushStr Op::new ops.push
+    empty_location OpValue::Typeof Op::new ops.push
     ops tc_check = result_tc
     "typeof str result" "str" 0 result_tc.stack.types.get.format assert_str_eq
 }
@@ -674,8 +674,8 @@ fn test_typeof_str {
 fn test_typeof_bool {
     "typeof_bool" test_start
     List::new(List[Op]) = ops
-    empty_location 1 OpValue::PushBool make_op ops.push
-    empty_location OpValue::Typeof make_op ops.push
+    empty_location 1 OpValue::PushBool Op::new ops.push
+    empty_location OpValue::Typeof Op::new ops.push
     ops tc_check = result_tc
     "typeof bool result" "str" 0 result_tc.stack.types.get.format assert_str_eq
 }
@@ -689,41 +689,41 @@ fn test_all_comparison_ops {
 
     # Eq
     List::new(List[Op]) = ops_eq
-    empty_location 1 OpValue::PushInt make_op ops_eq.push
-    empty_location 1 OpValue::PushInt make_op ops_eq.push
-    empty_location OpValue::Eq make_op ops_eq.push
+    empty_location 1 OpValue::PushInt Op::new ops_eq.push
+    empty_location 1 OpValue::PushInt Op::new ops_eq.push
+    empty_location OpValue::Eq Op::new ops_eq.push
     ops_eq tc_check = tc_eq
     "eq is bool" "bool" 0 tc_eq.stack.types.get.format assert_str_eq
 
     # Ne
     List::new(List[Op]) = ops_ne
-    empty_location 1 OpValue::PushInt make_op ops_ne.push
-    empty_location 2 OpValue::PushInt make_op ops_ne.push
-    empty_location OpValue::Ne make_op ops_ne.push
+    empty_location 1 OpValue::PushInt Op::new ops_ne.push
+    empty_location 2 OpValue::PushInt Op::new ops_ne.push
+    empty_location OpValue::Ne Op::new ops_ne.push
     ops_ne tc_check = tc_ne
     "ne is bool" "bool" 0 tc_ne.stack.types.get.format assert_str_eq
 
     # Le
     List::new(List[Op]) = ops_le
-    empty_location 1 OpValue::PushInt make_op ops_le.push
-    empty_location 2 OpValue::PushInt make_op ops_le.push
-    empty_location OpValue::Le make_op ops_le.push
+    empty_location 1 OpValue::PushInt Op::new ops_le.push
+    empty_location 2 OpValue::PushInt Op::new ops_le.push
+    empty_location OpValue::Le Op::new ops_le.push
     ops_le tc_check = tc_le
     "le is bool" "bool" 0 tc_le.stack.types.get.format assert_str_eq
 
     # Ge
     List::new(List[Op]) = ops_ge
-    empty_location 1 OpValue::PushInt make_op ops_ge.push
-    empty_location 2 OpValue::PushInt make_op ops_ge.push
-    empty_location OpValue::Ge make_op ops_ge.push
+    empty_location 1 OpValue::PushInt Op::new ops_ge.push
+    empty_location 2 OpValue::PushInt Op::new ops_ge.push
+    empty_location OpValue::Ge Op::new ops_ge.push
     ops_ge tc_check = tc_ge
     "ge is bool" "bool" 0 tc_ge.stack.types.get.format assert_str_eq
 
     # Gt
     List::new(List[Op]) = ops_gt
-    empty_location 5 OpValue::PushInt make_op ops_gt.push
-    empty_location 2 OpValue::PushInt make_op ops_gt.push
-    empty_location OpValue::Gt make_op ops_gt.push
+    empty_location 5 OpValue::PushInt Op::new ops_gt.push
+    empty_location 2 OpValue::PushInt Op::new ops_gt.push
+    empty_location OpValue::Gt Op::new ops_gt.push
     ops_gt tc_check = tc_gt
     "gt is bool" "bool" 0 tc_gt.stack.types.get.format assert_str_eq
 }
@@ -735,9 +735,9 @@ fn test_all_comparison_ops {
 fn test_string_comparison_annotation {
     "string_comparison_annotation" test_start
     List::new(List[Op]) = ops
-    empty_location "a" OpValue::PushStr make_op ops.push
-    empty_location "b" OpValue::PushStr make_op ops.push
-    empty_location OpValue::Eq make_op ops.push
+    empty_location "a" OpValue::PushStr Op::new ops.push
+    empty_location "b" OpValue::PushStr Op::new ops.push
+    empty_location OpValue::Eq Op::new ops.push
     ops tc_check = result_tc
     "str cmp is bool" "bool" 0 result_tc.stack.types.get.format assert_str_eq
     "hint is str" TYPE_STR_T 2 ops.get Op::type_hint.unwrap.eq assert_true
@@ -750,9 +750,9 @@ fn test_string_comparison_annotation {
 fn test_bitwise_shr {
     "bitwise_shr" test_start
     List::new(List[Op]) = ops
-    empty_location 8 OpValue::PushInt make_op ops.push
-    empty_location 2 OpValue::PushInt make_op ops.push
-    empty_location OpValue::Shr make_op ops.push
+    empty_location 8 OpValue::PushInt Op::new ops.push
+    empty_location 2 OpValue::PushInt Op::new ops.push
+    empty_location OpValue::Shr Op::new ops.push
     ops tc_check = result_tc
     "shr result" "int" 0 result_tc.stack.types.get.format assert_str_eq
 }
@@ -760,9 +760,9 @@ fn test_bitwise_shr {
 fn test_bitwise_or {
     "bitwise_or" test_start
     List::new(List[Op]) = ops
-    empty_location 5 OpValue::PushInt make_op ops.push
-    empty_location 3 OpValue::PushInt make_op ops.push
-    empty_location OpValue::BitOr make_op ops.push
+    empty_location 5 OpValue::PushInt Op::new ops.push
+    empty_location 3 OpValue::PushInt Op::new ops.push
+    empty_location OpValue::BitOr Op::new ops.push
     ops tc_check = result_tc
     "bitor result" "int" 0 result_tc.stack.types.get.format assert_str_eq
 }
@@ -770,9 +770,9 @@ fn test_bitwise_or {
 fn test_bitwise_xor {
     "bitwise_xor" test_start
     List::new(List[Op]) = ops
-    empty_location 5 OpValue::PushInt make_op ops.push
-    empty_location 3 OpValue::PushInt make_op ops.push
-    empty_location OpValue::BitXor make_op ops.push
+    empty_location 5 OpValue::PushInt Op::new ops.push
+    empty_location 3 OpValue::PushInt Op::new ops.push
+    empty_location OpValue::BitXor Op::new ops.push
     ops tc_check = result_tc
     "bitxor result" "int" 0 result_tc.stack.types.get.format assert_str_eq
 }
@@ -786,25 +786,25 @@ fn test_memory_load_sizes {
 
     # load8
     List::new(List[Op]) = ops8
-    empty_location 8 OpValue::PushInt make_op ops8.push
-    empty_location OpValue::HeapAlloc make_op ops8.push
-    empty_location OpValue::Load8 make_op ops8.push
+    empty_location 8 OpValue::PushInt Op::new ops8.push
+    empty_location OpValue::HeapAlloc Op::new ops8.push
+    empty_location OpValue::Load8 Op::new ops8.push
     ops8 tc_check = tc8
     "load8 result" "int" 0 tc8.stack.types.get.format assert_str_eq
 
     # load16
     List::new(List[Op]) = ops16
-    empty_location 8 OpValue::PushInt make_op ops16.push
-    empty_location OpValue::HeapAlloc make_op ops16.push
-    empty_location OpValue::Load16 make_op ops16.push
+    empty_location 8 OpValue::PushInt Op::new ops16.push
+    empty_location OpValue::HeapAlloc Op::new ops16.push
+    empty_location OpValue::Load16 Op::new ops16.push
     ops16 tc_check = tc16
     "load16 result" "int" 0 tc16.stack.types.get.format assert_str_eq
 
     # load32
     List::new(List[Op]) = ops32
-    empty_location 8 OpValue::PushInt make_op ops32.push
-    empty_location OpValue::HeapAlloc make_op ops32.push
-    empty_location OpValue::Load32 make_op ops32.push
+    empty_location 8 OpValue::PushInt Op::new ops32.push
+    empty_location OpValue::HeapAlloc Op::new ops32.push
+    empty_location OpValue::Load32 Op::new ops32.push
     ops32 tc_check = tc32
     "load32 result" "int" 0 tc32.stack.types.get.format assert_str_eq
 }
@@ -814,28 +814,28 @@ fn test_memory_store_sizes {
 
     # store8: value ptr -> (empty)
     List::new(List[Op]) = ops8
-    empty_location 42 OpValue::PushInt make_op ops8.push
-    empty_location 8 OpValue::PushInt make_op ops8.push
-    empty_location OpValue::HeapAlloc make_op ops8.push
-    empty_location OpValue::Store8 make_op ops8.push
+    empty_location 42 OpValue::PushInt Op::new ops8.push
+    empty_location 8 OpValue::PushInt Op::new ops8.push
+    empty_location OpValue::HeapAlloc Op::new ops8.push
+    empty_location OpValue::Store8 Op::new ops8.push
     ops8 tc_check = tc8
     "store8 empty" 0 tc8.stack.types.length assert_eq
 
     # store16
     List::new(List[Op]) = ops16
-    empty_location 42 OpValue::PushInt make_op ops16.push
-    empty_location 8 OpValue::PushInt make_op ops16.push
-    empty_location OpValue::HeapAlloc make_op ops16.push
-    empty_location OpValue::Store16 make_op ops16.push
+    empty_location 42 OpValue::PushInt Op::new ops16.push
+    empty_location 8 OpValue::PushInt Op::new ops16.push
+    empty_location OpValue::HeapAlloc Op::new ops16.push
+    empty_location OpValue::Store16 Op::new ops16.push
     ops16 tc_check = tc16
     "store16 empty" 0 tc16.stack.types.length assert_eq
 
     # store32
     List::new(List[Op]) = ops32
-    empty_location 42 OpValue::PushInt make_op ops32.push
-    empty_location 8 OpValue::PushInt make_op ops32.push
-    empty_location OpValue::HeapAlloc make_op ops32.push
-    empty_location OpValue::Store32 make_op ops32.push
+    empty_location 42 OpValue::PushInt Op::new ops32.push
+    empty_location 8 OpValue::PushInt Op::new ops32.push
+    empty_location OpValue::HeapAlloc Op::new ops32.push
+    empty_location OpValue::Store32 Op::new ops32.push
     ops32 tc_check = tc32
     "store32 empty" 0 tc32.stack.types.length assert_eq
 }
@@ -1168,10 +1168,10 @@ fn test_store_accepts_any_value_type {
 fn test_memory_store64 {
     "memory_store64" test_start
     List::new(List[Op]) = ops
-    empty_location 42 OpValue::PushInt make_op ops.push
-    empty_location 8 OpValue::PushInt make_op ops.push
-    empty_location OpValue::HeapAlloc make_op ops.push
-    empty_location OpValue::Store64 make_op ops.push
+    empty_location 42 OpValue::PushInt Op::new ops.push
+    empty_location 8 OpValue::PushInt Op::new ops.push
+    empty_location OpValue::HeapAlloc Op::new ops.push
+    empty_location OpValue::Store64 Op::new ops.push
     ops tc_check = result_tc
     "store64 empty" 0 result_tc.stack.types.length assert_eq
 }
@@ -1299,28 +1299,28 @@ fn test_syscall_op_level {
 
     # syscall0: pops 1 (syscall number), pushes int
     List::new(List[Op]) = ops0
-    empty_location 60 OpValue::PushInt make_op ops0.push
-    empty_location OpValue::Syscall0 make_op ops0.push
+    empty_location 60 OpValue::PushInt Op::new ops0.push
+    empty_location OpValue::Syscall0 Op::new ops0.push
     ops0 tc_check = tc0
     "syscall0 result" 1 tc0.stack.types.length assert_eq
     "syscall0 type" "int" 0 tc0.stack.types.get.format assert_str_eq
 
     # syscall1: pops 2 (1 arg + syscall number), pushes int
     List::new(List[Op]) = ops1
-    empty_location 0 OpValue::PushInt make_op ops1.push
-    empty_location 60 OpValue::PushInt make_op ops1.push
-    empty_location OpValue::Syscall1 make_op ops1.push
+    empty_location 0 OpValue::PushInt Op::new ops1.push
+    empty_location 60 OpValue::PushInt Op::new ops1.push
+    empty_location OpValue::Syscall1 Op::new ops1.push
     ops1 tc_check = tc1
     "syscall1 result" 1 tc1.stack.types.length assert_eq
     "syscall1 type" "int" 0 tc1.stack.types.get.format assert_str_eq
 
     # syscall3: pops 4 (3 args + syscall number), pushes int
     List::new(List[Op]) = ops3
-    empty_location 0 OpValue::PushInt make_op ops3.push
-    empty_location 0 OpValue::PushInt make_op ops3.push
-    empty_location 0 OpValue::PushInt make_op ops3.push
-    empty_location 1 OpValue::PushInt make_op ops3.push
-    empty_location OpValue::Syscall3 make_op ops3.push
+    empty_location 0 OpValue::PushInt Op::new ops3.push
+    empty_location 0 OpValue::PushInt Op::new ops3.push
+    empty_location 0 OpValue::PushInt Op::new ops3.push
+    empty_location 1 OpValue::PushInt Op::new ops3.push
+    empty_location OpValue::Syscall3 Op::new ops3.push
     ops3 tc_check = tc3
     "syscall3 result" 1 tc3.stack.types.length assert_eq
     "syscall3 type" "int" 0 tc3.stack.types.get.format assert_str_eq
@@ -1333,8 +1333,8 @@ fn test_syscall_op_level {
 fn test_typeof_char {
     "typeof_char" test_start
     List::new(List[Op]) = ops
-    empty_location 65 OpValue::PushChar make_op ops.push
-    empty_location OpValue::Typeof make_op ops.push
+    empty_location 65 OpValue::PushChar Op::new ops.push
+    empty_location OpValue::Typeof Op::new ops.push
     ops tc_check = result_tc
     "typeof char result" "str" 0 result_tc.stack.types.get.format assert_str_eq
 }
@@ -1342,9 +1342,9 @@ fn test_typeof_char {
 fn test_typeof_ptr {
     "typeof_ptr" test_start
     List::new(List[Op]) = ops
-    empty_location 10 OpValue::PushInt make_op ops.push
-    empty_location OpValue::HeapAlloc make_op ops.push
-    empty_location OpValue::Typeof make_op ops.push
+    empty_location 10 OpValue::PushInt Op::new ops.push
+    empty_location OpValue::HeapAlloc Op::new ops.push
+    empty_location OpValue::Typeof Op::new ops.push
     ops tc_check = result_tc
     "typeof ptr result" "str" 0 result_tc.stack.types.get.format assert_str_eq
 }
@@ -1356,8 +1356,8 @@ fn test_typeof_ptr {
 fn test_dup_preserves_str {
     "dup_preserves_str" test_start
     List::new(List[Op]) = ops
-    empty_location "hello" OpValue::PushStr make_op ops.push
-    empty_location OpValue::Dup make_op ops.push
+    empty_location "hello" OpValue::PushStr Op::new ops.push
+    empty_location OpValue::Dup Op::new ops.push
     ops tc_check = result_tc
     "dup str count" 2 result_tc.stack.types.length assert_eq
     "dup str first" "str" 0 result_tc.stack.types.get.format assert_str_eq
@@ -1367,8 +1367,8 @@ fn test_dup_preserves_str {
 fn test_dup_preserves_bool {
     "dup_preserves_bool" test_start
     List::new(List[Op]) = ops
-    empty_location 1 OpValue::PushBool make_op ops.push
-    empty_location OpValue::Dup make_op ops.push
+    empty_location 1 OpValue::PushBool Op::new ops.push
+    empty_location OpValue::Dup Op::new ops.push
     ops tc_check = result_tc
     "dup bool count" 2 result_tc.stack.types.length assert_eq
     "dup bool first" "bool" 0 result_tc.stack.types.get.format assert_str_eq
@@ -1453,9 +1453,9 @@ fn test_error_fn_stack_effect_mismatch {
     # Build a function with declared stack effect "int -> str" but body returns int
     "str" "int" make_test_stack_effect = bad_stack_effect
     List::new(List[Op]) = bad_ops
-    empty_location 42 OpValue::PushInt make_op bad_ops.push
-    # RPN: stack effect, location, ops, name, make_function_with_stack_effect
-    bad_stack_effect empty_location bad_ops "bad_fn" make_function_with_stack_effect = bad_fn
+    empty_location 42 OpValue::PushInt Op::new bad_ops.push
+    # RPN: stack effect, location, ops, name, Function::with_stack_effect
+    bad_stack_effect empty_location bad_ops "bad_fn" Function::with_stack_effect = bad_fn
     symbol_store_new bad_fn Option::Some bad_ops type_check_ops drop
     "has errors" assert_has_errors
     "stack effect mismatch" ErrorKind::SignatureMismatch assert_error_kind
@@ -1474,7 +1474,7 @@ fn test_error_unused_fn_type_error {
     # Declared: int -> str, but body is empty (returns nothing)
     "str" "int" make_test_stack_effect = bad_stack_effect
     List::new(List[Op]) = empty_ops
-    bad_stack_effect empty_location empty_ops "bad_unused" make_function_with_stack_effect = bad_fn
+    bad_stack_effect empty_location empty_ops "bad_unused" Function::with_stack_effect = bad_fn
     symbol_store_new bad_fn Option::Some empty_ops type_check_ops drop
     "has errors" assert_has_errors
     "stack effect mismatch" ErrorKind::SignatureMismatch assert_error_kind
@@ -1604,9 +1604,9 @@ fn test_print_dispatch_no_display {
     enable_test_mode
     clear_errors
     List::new(List[Op]) = ops
-    empty_location 10 OpValue::PushInt make_op ops.push
-    empty_location OpValue::HeapAlloc make_op ops.push
-    empty_location OpValue::Print make_op ops.push
+    empty_location 10 OpValue::PushInt Op::new ops.push
+    empty_location OpValue::HeapAlloc Op::new ops.push
+    empty_location OpValue::Print Op::new ops.push
     ops tc_check drop
     "ptr without Display impl raises an error" assert_has_errors
     "error mentions Display trait" "Display" assert_error_contains
@@ -1621,8 +1621,8 @@ fn test_print_dispatch_no_display {
 fn test_typeof_annotation {
     "typeof_annotation" test_start
     List::new(List[Op]) = ops
-    empty_location 42 OpValue::PushInt make_op ops.push
-    empty_location OpValue::Typeof make_op ops.push
+    empty_location 42 OpValue::PushInt Op::new ops.push
+    empty_location OpValue::Typeof Op::new ops.push
     ops tc_check drop
     "typeof hint" TYPE_INT_T 1 ops.get Op::type_hint.unwrap.eq assert_true
 }
@@ -1634,8 +1634,8 @@ fn test_typeof_annotation {
 fn test_type_cast_str_to_int {
     "type_cast_str_to_int" test_start
     List::new(List[Op]) = ops
-    empty_location "hello" OpValue::PushStr make_op ops.push
-    empty_location TYPE_INT_T OpValue::TypeCast make_op ops.push
+    empty_location "hello" OpValue::PushStr Op::new ops.push
+    empty_location TYPE_INT_T OpValue::TypeCast Op::new ops.push
     ops tc_check = result_tc
     "cast str to int" 1 result_tc.stack.types.length assert_eq
     "cast result" "int" 0 result_tc.stack.types.get.format assert_str_eq
@@ -1644,8 +1644,8 @@ fn test_type_cast_str_to_int {
 fn test_type_cast_bool_to_int {
     "type_cast_bool_to_int" test_start
     List::new(List[Op]) = ops
-    empty_location 1 OpValue::PushBool make_op ops.push
-    empty_location TYPE_INT_T OpValue::TypeCast make_op ops.push
+    empty_location 1 OpValue::PushBool Op::new ops.push
+    empty_location TYPE_INT_T OpValue::TypeCast Op::new ops.push
     ops tc_check = result_tc
     "cast bool to int" "int" 0 result_tc.stack.types.get.format assert_str_eq
 }
@@ -1694,10 +1694,10 @@ fn test_error_str_lt_comparison {
 fn test_branch_if_empty_body {
     "branch_if_empty_body" test_start
     List::new(List[Op]) = ops
-    empty_location OpValue::IfStart make_op ops.push
-    empty_location 1 OpValue::PushBool make_op ops.push
-    empty_location OpValue::IfCondition make_op ops.push
-    empty_location OpValue::IfEnd make_op ops.push
+    empty_location OpValue::IfStart Op::new ops.push
+    empty_location 1 OpValue::PushBool Op::new ops.push
+    empty_location OpValue::IfCondition Op::new ops.push
+    empty_location OpValue::IfEnd Op::new ops.push
     ops tc_check = result_tc
     "stack empty after empty if" 0 result_tc.stack.types.length assert_eq
     "frame stack empty" 0 result_tc.branched_stacks.length assert_eq
@@ -1707,13 +1707,13 @@ fn test_branch_if_empty_body {
 fn test_branch_if_else_agree_int {
     "branch_if_else_agree_int" test_start
     List::new(List[Op]) = ops
-    empty_location OpValue::IfStart make_op ops.push
-    empty_location 1 OpValue::PushBool make_op ops.push
-    empty_location OpValue::IfCondition make_op ops.push
-    empty_location 10 OpValue::PushInt make_op ops.push
-    empty_location OpValue::IfElse make_op ops.push
-    empty_location 20 OpValue::PushInt make_op ops.push
-    empty_location OpValue::IfEnd make_op ops.push
+    empty_location OpValue::IfStart Op::new ops.push
+    empty_location 1 OpValue::PushBool Op::new ops.push
+    empty_location OpValue::IfCondition Op::new ops.push
+    empty_location 10 OpValue::PushInt Op::new ops.push
+    empty_location OpValue::IfElse Op::new ops.push
+    empty_location 20 OpValue::PushInt Op::new ops.push
+    empty_location OpValue::IfEnd Op::new ops.push
     ops tc_check = result_tc
     "stack has one item" 1 result_tc.stack.types.length assert_eq
     "unified type is int" "int" 0 result_tc.stack.types.get.format assert_str_eq
@@ -1724,14 +1724,14 @@ fn test_branch_if_else_agree_int {
 fn test_branch_if_end_pops_frame {
     "branch_if_end_pops_frame" test_start
     List::new(List[Op]) = ops
-    empty_location OpValue::IfStart make_op ops.push
-    empty_location 1 OpValue::PushBool make_op ops.push
-    empty_location OpValue::IfCondition make_op ops.push
+    empty_location OpValue::IfStart Op::new ops.push
+    empty_location 1 OpValue::PushBool Op::new ops.push
+    empty_location OpValue::IfCondition Op::new ops.push
     ops tc_check = result_tc
     "frame pushed on OpIfStart" 1 result_tc.branched_stacks.length assert_eq
     # Close the block
     List::new(List[Op]) = close_ops
-    empty_location OpValue::IfEnd make_op close_ops.push
+    empty_location OpValue::IfEnd Op::new close_ops.push
     0 = ci
     while ci close_ops.length > do
         ci close_ops.get result_tc check_if_block
@@ -1744,10 +1744,10 @@ fn test_branch_if_end_pops_frame {
 fn test_branch_while_empty_body {
     "branch_while_empty_body" test_start
     List::new(List[Op]) = ops
-    empty_location OpValue::WhileStart make_op ops.push
-    empty_location 0 OpValue::PushBool make_op ops.push
-    empty_location OpValue::WhileCondition make_op ops.push
-    empty_location OpValue::WhileEnd make_op ops.push
+    empty_location OpValue::WhileStart Op::new ops.push
+    empty_location 0 OpValue::PushBool Op::new ops.push
+    empty_location OpValue::WhileCondition Op::new ops.push
+    empty_location OpValue::WhileEnd Op::new ops.push
     ops tc_check = result_tc
     "stack empty" 0 result_tc.stack.types.length assert_eq
     "frame stack empty" 0 result_tc.branched_stacks.length assert_eq
@@ -1758,9 +1758,9 @@ fn test_branch_while_empty_body {
 
 fn test_branch_frame_kind_dispatch {
     "branch_frame_kind_dispatch" test_start
-    symbol_store_new make_typechecker = tc
+    symbol_store_new TypeChecker::new = tc
     List::new(List[Op]) = ops
-    empty_location OpValue::IfStart make_op ops.push
+    empty_location OpValue::IfStart Op::new ops.push
     0 = bd_i
     while bd_i ops.length > do
         bd_i ops.get tc check_if_block
@@ -1856,14 +1856,14 @@ fn test_error_array_literal_unresolved_assignment {
 
 fn test_branch_return_inside_if_restores_stack {
     "branch_return_inside_if_restores_stack" test_start
-    symbol_store_new make_typechecker = tc
+    symbol_store_new TypeChecker::new = tc
     # Seed the stack with a single `int`.
     "int" tc stack_push
     # Begin an `if true then` block.
     List::new(List[Op]) = begin_ops
-    empty_location OpValue::IfStart make_op begin_ops.push
-    empty_location 1 OpValue::PushBool make_op begin_ops.push
-    empty_location OpValue::IfCondition make_op begin_ops.push
+    empty_location OpValue::IfStart Op::new begin_ops.push
+    empty_location 1 OpValue::PushBool Op::new begin_ops.push
+    empty_location OpValue::IfCondition Op::new begin_ops.push
     0 = br_i
     while br_i begin_ops.length > do
         br_i begin_ops.get = br_op

--- a/tests/compiler/test_typechecker.casa
+++ b/tests/compiler/test_typechecker.casa
@@ -14,13 +14,13 @@ fn tc_check ops:List[Op] -> TypeChecker {
 
         # Literals
         if helper_kind OpValue::PushInt is then
-            "int" helper_tc stack_push
+            "int" helper_tc.stack_push
         elif helper_kind OpValue::PushStr is then
-            "str" helper_tc stack_push
+            "str" helper_tc.stack_push
         elif helper_kind OpValue::PushBool is then
-            "bool" helper_tc stack_push
+            "bool" helper_tc.stack_push
         elif helper_kind OpValue::PushChar is then
-            "char" helper_tc stack_push
+            "char" helper_tc.stack_push
             # Arithmetic
         elif
         helper_kind OpValue::Add is
@@ -29,7 +29,7 @@ fn tc_check ops:List[Op] -> TypeChecker {
         helper_kind OpValue::Div is ||
         helper_kind OpValue::Mod is ||
         then
-            helper_op helper_tc check_arithmetic
+            helper_op helper_tc.check_arithmetic
             # Comparison
         elif
         helper_kind OpValue::Eq is
@@ -40,7 +40,7 @@ fn tc_check ops:List[Op] -> TypeChecker {
         helper_kind OpValue::Ge is ||
         then
             1 += helper_i
-            Option::None(Option[Function]) helper_i ops helper_op helper_tc check_comparison = helper_i
+            Option::None(Option[Function]) helper_i ops helper_op helper_tc.check_comparison = helper_i
             continue
             # Boolean
         elif
@@ -48,7 +48,7 @@ fn tc_check ops:List[Op] -> TypeChecker {
         helper_kind OpValue::Or is ||
         helper_kind OpValue::Not is ||
         then
-            helper_op helper_tc check_boolean
+            helper_op helper_tc.check_boolean
             # Bitwise
         elif
         helper_kind OpValue::BitAnd is
@@ -58,7 +58,7 @@ fn tc_check ops:List[Op] -> TypeChecker {
         helper_kind OpValue::Shl is ||
         helper_kind OpValue::Shr is ||
         then
-            helper_op helper_tc check_bitwise
+            helper_op helper_tc.check_bitwise
             # Stack ops
         elif
         helper_kind OpValue::Drop is
@@ -67,7 +67,7 @@ fn tc_check ops:List[Op] -> TypeChecker {
         helper_kind OpValue::Over is ||
         helper_kind OpValue::Rot is ||
         then
-            helper_op helper_tc check_stack_ops
+            helper_op helper_tc.check_stack_ops
             # Memory
         elif
         helper_kind OpValue::Load8 is
@@ -80,19 +80,19 @@ fn tc_check ops:List[Op] -> TypeChecker {
         helper_kind OpValue::Store64 is ||
         helper_kind OpValue::HeapAlloc is ||
         then
-            Option::None(Option[Function]) helper_op helper_tc check_memory
+            Option::None(Option[Function]) helper_op helper_tc.check_memory
             # Print
         elif helper_kind OpValue::Print is then
             1 += helper_i
-            Option::None(Option[Function]) helper_i ops helper_op helper_tc check_io = helper_i
+            Option::None(Option[Function]) helper_i ops helper_op helper_tc.check_io = helper_i
             continue
             # Typeof
         elif helper_kind OpValue::Typeof is then
-            helper_op helper_tc check_typeof
+            helper_op helper_tc.check_typeof
             # Type cast
         elif helper_kind OpValue::TypeCast(cast_type) is then
-            helper_tc stack_pop drop
-            cast_type helper_tc stack_push_type
+            helper_tc.stack_pop drop
+            cast_type helper_tc.stack_push_type
             # Syscalls
         elif
         helper_kind OpValue::Syscall0 is
@@ -103,12 +103,12 @@ fn tc_check ops:List[Op] -> TypeChecker {
         helper_kind OpValue::Syscall5 is ||
         helper_kind OpValue::Syscall6 is ||
         then
-            Option::None(Option[Function]) helper_op helper_tc check_syscalls
+            Option::None(Option[Function]) helper_op helper_tc.check_syscalls
             # Argc / Argv
         elif helper_kind OpValue::Argc is then
-            "int" helper_tc stack_push
+            "int" helper_tc.stack_push
         elif helper_kind OpValue::Argv is then
-            "ptr" helper_tc stack_push
+            "ptr" helper_tc.stack_push
             # Branch ops — routed to real handlers so tests can exercise the
             # BranchFrame sum type and the if/while/match branch algebra.
         elif
@@ -118,7 +118,7 @@ fn tc_check ops:List[Op] -> TypeChecker {
         helper_kind OpValue::IfElse is ||
         helper_kind OpValue::IfEnd is ||
         then
-            helper_op helper_tc check_if_block
+            helper_op helper_tc.check_if_block
         elif
         helper_kind OpValue::WhileStart is
         helper_kind OpValue::WhileCondition is ||
@@ -126,7 +126,7 @@ fn tc_check ops:List[Op] -> TypeChecker {
         helper_kind OpValue::WhileContinue is ||
         helper_kind OpValue::WhileEnd is ||
         then
-            helper_op helper_tc check_while_block
+            helper_op helper_tc.check_while_block
         fi
 
         1 += helper_i
@@ -1734,7 +1734,7 @@ fn test_branch_if_end_pops_frame {
     empty_location OpValue::IfEnd Op::new close_ops.push
     0 = ci
     while ci close_ops.length > do
-        ci close_ops.get result_tc check_if_block
+        ci close_ops.get result_tc.check_if_block
         1 += ci
     done
     "frame popped on OpIfEnd" 0 result_tc.branched_stacks.length assert_eq
@@ -1763,7 +1763,7 @@ fn test_branch_frame_kind_dispatch {
     empty_location OpValue::IfStart Op::new ops.push
     0 = bd_i
     while bd_i ops.length > do
-        bd_i ops.get tc check_if_block
+        bd_i ops.get tc.check_if_block
         1 += bd_i
     done
     "pushed BranchIf frame" 1 tc.branched_stacks.length assert_eq
@@ -1858,7 +1858,7 @@ fn test_branch_return_inside_if_restores_stack {
     "branch_return_inside_if_restores_stack" test_start
     symbol_store_new TypeChecker::new = tc
     # Seed the stack with a single `int`.
-    "int" tc stack_push
+    "int" tc.stack_push
     # Begin an `if true then` block.
     List::new(List[Op]) = begin_ops
     empty_location OpValue::IfStart Op::new begin_ops.push
@@ -1872,14 +1872,14 @@ fn test_branch_return_inside_if_restores_stack {
         OpValue::IfStart br_kind ==
         OpValue::IfCondition br_kind == ||
         then
-            br_op tc check_if_block
+            br_op tc.check_if_block
         elif 0 OpValue::PushBool br_kind == then
-            "bool" tc stack_push
+            "bool" tc.stack_push
         fi
         1 += br_i
     done
     # Body modifies the stack by pushing an extra `str`.
-    "str" tc stack_push
+    "str" tc.stack_push
     "stack grew inside branch" 2 tc.stack.types.length assert_eq
     # Simulate OpFnReturn: first visit snapshots stack into return_types, then
     # restores stack from the top frame's before snapshot.

--- a/tests/compiler/test_typechecker.casa
+++ b/tests/compiler/test_typechecker.casa
@@ -134,6 +134,14 @@ fn tc_check ops:List[Op] -> TypeChecker {
     helper_tc
 }
 
+fn make_test_stack_effect param_type:str return_type:str -> StackEffect {
+    List::new(List[Parameter]) = params
+    param_type make_param params.push
+    List::new(List[Type]) = returns
+    return_type parse_type_str returns.push
+    returns params make_stack_effect
+}
+
 # ============================================================================
 # Tests: Push int effects
 # ============================================================================
@@ -143,8 +151,8 @@ fn test_push_int_stack {
     List::new(List[Op]) = ops
     empty_location 42 OpValue::PushInt make_op ops.push
     ops tc_check = result_tc
-    "stack has one item" 1 result_tc TypeChecker::live TypedStack::types.length assert_eq
-    "type is int" "int" 0 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "stack has one item" 1 result_tc.stack.types.length assert_eq
+    "type is int" "int" 0 result_tc.stack.types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -158,8 +166,8 @@ fn test_add_stack_effect {
     empty_location 20 OpValue::PushInt make_op ops.push
     empty_location OpValue::Add make_op ops.push
     ops tc_check = result_tc
-    "stack has one item after add" 1 result_tc TypeChecker::live TypedStack::types.length assert_eq
-    "result type is int" "int" 0 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "stack has one item after add" 1 result_tc.stack.types.length assert_eq
+    "result type is int" "int" 0 result_tc.stack.types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -175,8 +183,8 @@ fn test_arithmetic_ops {
     empty_location 3 OpValue::PushInt make_op ops_sub.push
     empty_location OpValue::Sub make_op ops_sub.push
     ops_sub tc_check = tc_sub
-    "sub result" 1 tc_sub TypeChecker::live TypedStack::types.length assert_eq
-    "sub type" "int" 0 tc_sub TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "sub result" 1 tc_sub.stack.types.length assert_eq
+    "sub type" "int" 0 tc_sub.stack.types.get.format assert_str_eq
 
     # Mul
     List::new(List[Op]) = ops_mul
@@ -184,7 +192,7 @@ fn test_arithmetic_ops {
     empty_location 3 OpValue::PushInt make_op ops_mul.push
     empty_location OpValue::Mul make_op ops_mul.push
     ops_mul tc_check = tc_mul
-    "mul type" "int" 0 tc_mul TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "mul type" "int" 0 tc_mul.stack.types.get.format assert_str_eq
 
     # Div
     List::new(List[Op]) = ops_div
@@ -192,7 +200,7 @@ fn test_arithmetic_ops {
     empty_location 2 OpValue::PushInt make_op ops_div.push
     empty_location OpValue::Div make_op ops_div.push
     ops_div tc_check = tc_div
-    "div type" "int" 0 tc_div TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "div type" "int" 0 tc_div.stack.types.get.format assert_str_eq
 
     # Mod
     List::new(List[Op]) = ops_mod
@@ -200,7 +208,7 @@ fn test_arithmetic_ops {
     empty_location 3 OpValue::PushInt make_op ops_mod.push
     empty_location OpValue::Mod make_op ops_mod.push
     ops_mod tc_check = tc_mod
-    "mod type" "int" 0 tc_mod TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "mod type" "int" 0 tc_mod.stack.types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -214,8 +222,8 @@ fn test_comparison_produces_bool {
     empty_location 2 OpValue::PushInt make_op ops.push
     empty_location OpValue::Lt make_op ops.push
     ops tc_check = result_tc
-    "stack after lt" 1 result_tc TypeChecker::live TypedStack::types.length assert_eq
-    "lt result is bool" "bool" 0 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "stack after lt" 1 result_tc.stack.types.length assert_eq
+    "lt result is bool" "bool" 0 result_tc.stack.types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -230,7 +238,7 @@ fn test_boolean_ops {
     empty_location 0 OpValue::PushBool make_op ops_and.push
     empty_location OpValue::And make_op ops_and.push
     ops_and tc_check = tc_and
-    "and result" "bool" 0 tc_and TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "and result" "bool" 0 tc_and.stack.types.get.format assert_str_eq
 
     # OR
     List::new(List[Op]) = ops_or
@@ -238,14 +246,14 @@ fn test_boolean_ops {
     empty_location 0 OpValue::PushBool make_op ops_or.push
     empty_location OpValue::Or make_op ops_or.push
     ops_or tc_check = tc_or
-    "or result" "bool" 0 tc_or TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "or result" "bool" 0 tc_or.stack.types.get.format assert_str_eq
 
     # NOT
     List::new(List[Op]) = ops_not
     empty_location 1 OpValue::PushBool make_op ops_not.push
     empty_location OpValue::Not make_op ops_not.push
     ops_not tc_check = tc_not
-    "not result" "bool" 0 tc_not TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "not result" "bool" 0 tc_not.stack.types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -258,9 +266,9 @@ fn test_dup_stack_effect {
     empty_location 42 OpValue::PushInt make_op ops.push
     empty_location OpValue::Dup make_op ops.push
     ops tc_check = result_tc
-    "stack after dup" 2 result_tc TypeChecker::live TypedStack::types.length assert_eq
-    "first is int" "int" 0 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
-    "second is int" "int" 1 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "stack after dup" 2 result_tc.stack.types.length assert_eq
+    "first is int" "int" 0 result_tc.stack.types.get.format assert_str_eq
+    "second is int" "int" 1 result_tc.stack.types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -274,9 +282,9 @@ fn test_swap_stack_effect {
     empty_location "hello" OpValue::PushStr make_op ops.push
     empty_location OpValue::Swap make_op ops.push
     ops tc_check = result_tc
-    "stack after swap" 2 result_tc TypeChecker::live TypedStack::types.length assert_eq
-    "bottom is str" "str" 0 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
-    "top is int" "int" 1 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "stack after swap" 2 result_tc.stack.types.length assert_eq
+    "bottom is str" "str" 0 result_tc.stack.types.get.format assert_str_eq
+    "top is int" "int" 1 result_tc.stack.types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -290,10 +298,10 @@ fn test_over_stack_effect {
     empty_location "hello" OpValue::PushStr make_op ops.push
     empty_location OpValue::Over make_op ops.push
     ops tc_check = result_tc
-    "stack after over" 3 result_tc TypeChecker::live TypedStack::types.length assert_eq
-    "bottom is int" "int" 0 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
-    "middle is str" "str" 1 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
-    "top is int" "int" 2 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "stack after over" 3 result_tc.stack.types.length assert_eq
+    "bottom is int" "int" 0 result_tc.stack.types.get.format assert_str_eq
+    "middle is str" "str" 1 result_tc.stack.types.get.format assert_str_eq
+    "top is int" "int" 2 result_tc.stack.types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -307,8 +315,8 @@ fn test_drop_stack_effect {
     empty_location "hello" OpValue::PushStr make_op ops.push
     empty_location OpValue::Drop make_op ops.push
     ops tc_check = result_tc
-    "stack after drop" 1 result_tc TypeChecker::live TypedStack::types.length assert_eq
-    "remaining is int" "int" 0 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "stack after drop" 1 result_tc.stack.types.length assert_eq
+    "remaining is int" "int" 0 result_tc.stack.types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -323,11 +331,11 @@ fn test_rot_stack_effect {
     empty_location 1 OpValue::PushBool make_op ops.push
     empty_location OpValue::Rot make_op ops.push
     ops tc_check = result_tc
-    "stack after rot" 3 result_tc TypeChecker::live TypedStack::types.length assert_eq
+    "stack after rot" 3 result_tc.stack.types.length assert_eq
     # ROT: pop t1(bool), t2(str), t3(int) -> push t2(str), t1(bool), t3(int)
-    "bottom is str" "str" 0 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
-    "middle is bool" "bool" 1 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
-    "top is int" "int" 2 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "bottom is str" "str" 0 result_tc.stack.types.get.format assert_str_eq
+    "middle is bool" "bool" 1 result_tc.stack.types.get.format assert_str_eq
+    "top is int" "int" 2 result_tc.stack.types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -340,8 +348,8 @@ fn test_type_cast {
     empty_location 42 OpValue::PushInt make_op ops.push
     empty_location TYPE_STR_T OpValue::TypeCast make_op ops.push
     ops tc_check = result_tc
-    "stack after cast" 1 result_tc TypeChecker::live TypedStack::types.length assert_eq
-    "cast to str" "str" 0 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "stack after cast" 1 result_tc.stack.types.length assert_eq
+    "cast to str" "str" 0 result_tc.stack.types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -356,11 +364,11 @@ fn test_push_literals {
     empty_location 1 OpValue::PushBool make_op ops.push
     empty_location 65 OpValue::PushChar make_op ops.push
     ops tc_check = result_tc
-    "four items on stack" 4 result_tc TypeChecker::live TypedStack::types.length assert_eq
-    "int" "int" 0 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
-    "str" "str" 1 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
-    "bool" "bool" 2 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
-    "char" "char" 3 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "four items on stack" 4 result_tc.stack.types.length assert_eq
+    "int" "int" 0 result_tc.stack.types.get.format assert_str_eq
+    "str" "str" 1 result_tc.stack.types.get.format assert_str_eq
+    "bool" "bool" 2 result_tc.stack.types.get.format assert_str_eq
+    "char" "char" 3 result_tc.stack.types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -402,8 +410,8 @@ fn test_typeof_effect {
     empty_location 42 OpValue::PushInt make_op ops.push
     empty_location OpValue::Typeof make_op ops.push
     ops tc_check = result_tc
-    "stack after typeof" 1 result_tc TypeChecker::live TypedStack::types.length assert_eq
-    "typeof result is str" "str" 0 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "stack after typeof" 1 result_tc.stack.types.length assert_eq
+    "typeof result is str" "str" 0 result_tc.stack.types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -418,7 +426,7 @@ fn test_bitwise_ops {
     empty_location 42 OpValue::PushInt make_op ops_bnot.push
     empty_location OpValue::BitNot make_op ops_bnot.push
     ops_bnot tc_check = tc_bnot
-    "bitnot result" "int" 0 tc_bnot TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "bitnot result" "int" 0 tc_bnot.stack.types.get.format assert_str_eq
 
     # SHL
     List::new(List[Op]) = ops_shl
@@ -426,7 +434,7 @@ fn test_bitwise_ops {
     empty_location 3 OpValue::PushInt make_op ops_shl.push
     empty_location OpValue::Shl make_op ops_shl.push
     ops_shl tc_check = tc_shl
-    "shl result" "int" 0 tc_shl TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "shl result" "int" 0 tc_shl.stack.types.get.format assert_str_eq
 
     # BIT_AND
     List::new(List[Op]) = ops_band
@@ -434,7 +442,7 @@ fn test_bitwise_ops {
     empty_location 1 OpValue::PushInt make_op ops_band.push
     empty_location OpValue::BitAnd make_op ops_band.push
     ops_band tc_check = tc_band
-    "bitand result" "int" 0 tc_band TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "bitand result" "int" 0 tc_band.stack.types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -449,7 +457,7 @@ fn test_memory_ops {
     empty_location 100 OpValue::PushInt make_op ops_alloc.push
     empty_location OpValue::HeapAlloc make_op ops_alloc.push
     ops_alloc tc_check = tc_alloc
-    "alloc result is ptr" "ptr" 0 tc_alloc TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "alloc result is ptr" "ptr" 0 tc_alloc.stack.types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -462,9 +470,9 @@ fn test_argc_argv {
     empty_location OpValue::Argc make_op ops.push
     empty_location OpValue::Argv make_op ops.push
     ops tc_check = result_tc
-    "stack count" 2 result_tc TypeChecker::live TypedStack::types.length assert_eq
-    "argc is int" "int" 0 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
-    "argv is ptr" "ptr" 1 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "stack count" 2 result_tc.stack.types.length assert_eq
+    "argc is int" "int" 0 result_tc.stack.types.get.format assert_str_eq
+    "argv is ptr" "ptr" 1 result_tc.stack.types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -647,7 +655,7 @@ fn test_print_pops_stack {
     empty_location 42 OpValue::PushInt make_op ops.push
     empty_location OpValue::Print make_op ops.push
     ops tc_check = result_tc
-    "stack empty after print" 0 result_tc TypeChecker::live TypedStack::types.length assert_eq
+    "stack empty after print" 0 result_tc.stack.types.length assert_eq
 }
 
 # ============================================================================
@@ -660,7 +668,7 @@ fn test_typeof_str {
     empty_location "hi" OpValue::PushStr make_op ops.push
     empty_location OpValue::Typeof make_op ops.push
     ops tc_check = result_tc
-    "typeof str result" "str" 0 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "typeof str result" "str" 0 result_tc.stack.types.get.format assert_str_eq
 }
 
 fn test_typeof_bool {
@@ -669,7 +677,7 @@ fn test_typeof_bool {
     empty_location 1 OpValue::PushBool make_op ops.push
     empty_location OpValue::Typeof make_op ops.push
     ops tc_check = result_tc
-    "typeof bool result" "str" 0 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "typeof bool result" "str" 0 result_tc.stack.types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -685,7 +693,7 @@ fn test_all_comparison_ops {
     empty_location 1 OpValue::PushInt make_op ops_eq.push
     empty_location OpValue::Eq make_op ops_eq.push
     ops_eq tc_check = tc_eq
-    "eq is bool" "bool" 0 tc_eq TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "eq is bool" "bool" 0 tc_eq.stack.types.get.format assert_str_eq
 
     # Ne
     List::new(List[Op]) = ops_ne
@@ -693,7 +701,7 @@ fn test_all_comparison_ops {
     empty_location 2 OpValue::PushInt make_op ops_ne.push
     empty_location OpValue::Ne make_op ops_ne.push
     ops_ne tc_check = tc_ne
-    "ne is bool" "bool" 0 tc_ne TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "ne is bool" "bool" 0 tc_ne.stack.types.get.format assert_str_eq
 
     # Le
     List::new(List[Op]) = ops_le
@@ -701,7 +709,7 @@ fn test_all_comparison_ops {
     empty_location 2 OpValue::PushInt make_op ops_le.push
     empty_location OpValue::Le make_op ops_le.push
     ops_le tc_check = tc_le
-    "le is bool" "bool" 0 tc_le TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "le is bool" "bool" 0 tc_le.stack.types.get.format assert_str_eq
 
     # Ge
     List::new(List[Op]) = ops_ge
@@ -709,7 +717,7 @@ fn test_all_comparison_ops {
     empty_location 2 OpValue::PushInt make_op ops_ge.push
     empty_location OpValue::Ge make_op ops_ge.push
     ops_ge tc_check = tc_ge
-    "ge is bool" "bool" 0 tc_ge TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "ge is bool" "bool" 0 tc_ge.stack.types.get.format assert_str_eq
 
     # Gt
     List::new(List[Op]) = ops_gt
@@ -717,7 +725,7 @@ fn test_all_comparison_ops {
     empty_location 2 OpValue::PushInt make_op ops_gt.push
     empty_location OpValue::Gt make_op ops_gt.push
     ops_gt tc_check = tc_gt
-    "gt is bool" "bool" 0 tc_gt TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "gt is bool" "bool" 0 tc_gt.stack.types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -731,7 +739,7 @@ fn test_string_comparison_annotation {
     empty_location "b" OpValue::PushStr make_op ops.push
     empty_location OpValue::Eq make_op ops.push
     ops tc_check = result_tc
-    "str cmp is bool" "bool" 0 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "str cmp is bool" "bool" 0 result_tc.stack.types.get.format assert_str_eq
     "hint is str" TYPE_STR_T 2 ops.get Op::type_hint.unwrap.eq assert_true
 }
 
@@ -746,7 +754,7 @@ fn test_bitwise_shr {
     empty_location 2 OpValue::PushInt make_op ops.push
     empty_location OpValue::Shr make_op ops.push
     ops tc_check = result_tc
-    "shr result" "int" 0 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "shr result" "int" 0 result_tc.stack.types.get.format assert_str_eq
 }
 
 fn test_bitwise_or {
@@ -756,7 +764,7 @@ fn test_bitwise_or {
     empty_location 3 OpValue::PushInt make_op ops.push
     empty_location OpValue::BitOr make_op ops.push
     ops tc_check = result_tc
-    "bitor result" "int" 0 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "bitor result" "int" 0 result_tc.stack.types.get.format assert_str_eq
 }
 
 fn test_bitwise_xor {
@@ -766,7 +774,7 @@ fn test_bitwise_xor {
     empty_location 3 OpValue::PushInt make_op ops.push
     empty_location OpValue::BitXor make_op ops.push
     ops tc_check = result_tc
-    "bitxor result" "int" 0 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "bitxor result" "int" 0 result_tc.stack.types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -782,7 +790,7 @@ fn test_memory_load_sizes {
     empty_location OpValue::HeapAlloc make_op ops8.push
     empty_location OpValue::Load8 make_op ops8.push
     ops8 tc_check = tc8
-    "load8 result" "int" 0 tc8 TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "load8 result" "int" 0 tc8.stack.types.get.format assert_str_eq
 
     # load16
     List::new(List[Op]) = ops16
@@ -790,7 +798,7 @@ fn test_memory_load_sizes {
     empty_location OpValue::HeapAlloc make_op ops16.push
     empty_location OpValue::Load16 make_op ops16.push
     ops16 tc_check = tc16
-    "load16 result" "int" 0 tc16 TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "load16 result" "int" 0 tc16.stack.types.get.format assert_str_eq
 
     # load32
     List::new(List[Op]) = ops32
@@ -798,7 +806,7 @@ fn test_memory_load_sizes {
     empty_location OpValue::HeapAlloc make_op ops32.push
     empty_location OpValue::Load32 make_op ops32.push
     ops32 tc_check = tc32
-    "load32 result" "int" 0 tc32 TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "load32 result" "int" 0 tc32.stack.types.get.format assert_str_eq
 }
 
 fn test_memory_store_sizes {
@@ -811,7 +819,7 @@ fn test_memory_store_sizes {
     empty_location OpValue::HeapAlloc make_op ops8.push
     empty_location OpValue::Store8 make_op ops8.push
     ops8 tc_check = tc8
-    "store8 empty" 0 tc8 TypeChecker::live TypedStack::types.length assert_eq
+    "store8 empty" 0 tc8.stack.types.length assert_eq
 
     # store16
     List::new(List[Op]) = ops16
@@ -820,7 +828,7 @@ fn test_memory_store_sizes {
     empty_location OpValue::HeapAlloc make_op ops16.push
     empty_location OpValue::Store16 make_op ops16.push
     ops16 tc_check = tc16
-    "store16 empty" 0 tc16 TypeChecker::live TypedStack::types.length assert_eq
+    "store16 empty" 0 tc16.stack.types.length assert_eq
 
     # store32
     List::new(List[Op]) = ops32
@@ -829,7 +837,7 @@ fn test_memory_store_sizes {
     empty_location OpValue::HeapAlloc make_op ops32.push
     empty_location OpValue::Store32 make_op ops32.push
     ops32 tc_check = tc32
-    "store32 empty" 0 tc32 TypeChecker::live TypedStack::types.length assert_eq
+    "store32 empty" 0 tc32.stack.types.length assert_eq
 }
 
 # ============================================================================
@@ -1165,7 +1173,7 @@ fn test_memory_store64 {
     empty_location OpValue::HeapAlloc make_op ops.push
     empty_location OpValue::Store64 make_op ops.push
     ops tc_check = result_tc
-    "store64 empty" 0 result_tc TypeChecker::live TypedStack::types.length assert_eq
+    "store64 empty" 0 result_tc.stack.types.length assert_eq
 }
 
 # ============================================================================
@@ -1294,8 +1302,8 @@ fn test_syscall_op_level {
     empty_location 60 OpValue::PushInt make_op ops0.push
     empty_location OpValue::Syscall0 make_op ops0.push
     ops0 tc_check = tc0
-    "syscall0 result" 1 tc0 TypeChecker::live TypedStack::types.length assert_eq
-    "syscall0 type" "int" 0 tc0 TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "syscall0 result" 1 tc0.stack.types.length assert_eq
+    "syscall0 type" "int" 0 tc0.stack.types.get.format assert_str_eq
 
     # syscall1: pops 2 (1 arg + syscall number), pushes int
     List::new(List[Op]) = ops1
@@ -1303,8 +1311,8 @@ fn test_syscall_op_level {
     empty_location 60 OpValue::PushInt make_op ops1.push
     empty_location OpValue::Syscall1 make_op ops1.push
     ops1 tc_check = tc1
-    "syscall1 result" 1 tc1 TypeChecker::live TypedStack::types.length assert_eq
-    "syscall1 type" "int" 0 tc1 TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "syscall1 result" 1 tc1.stack.types.length assert_eq
+    "syscall1 type" "int" 0 tc1.stack.types.get.format assert_str_eq
 
     # syscall3: pops 4 (3 args + syscall number), pushes int
     List::new(List[Op]) = ops3
@@ -1314,8 +1322,8 @@ fn test_syscall_op_level {
     empty_location 1 OpValue::PushInt make_op ops3.push
     empty_location OpValue::Syscall3 make_op ops3.push
     ops3 tc_check = tc3
-    "syscall3 result" 1 tc3 TypeChecker::live TypedStack::types.length assert_eq
-    "syscall3 type" "int" 0 tc3 TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "syscall3 result" 1 tc3.stack.types.length assert_eq
+    "syscall3 type" "int" 0 tc3.stack.types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -1328,7 +1336,7 @@ fn test_typeof_char {
     empty_location 65 OpValue::PushChar make_op ops.push
     empty_location OpValue::Typeof make_op ops.push
     ops tc_check = result_tc
-    "typeof char result" "str" 0 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "typeof char result" "str" 0 result_tc.stack.types.get.format assert_str_eq
 }
 
 fn test_typeof_ptr {
@@ -1338,7 +1346,7 @@ fn test_typeof_ptr {
     empty_location OpValue::HeapAlloc make_op ops.push
     empty_location OpValue::Typeof make_op ops.push
     ops tc_check = result_tc
-    "typeof ptr result" "str" 0 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "typeof ptr result" "str" 0 result_tc.stack.types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -1351,9 +1359,9 @@ fn test_dup_preserves_str {
     empty_location "hello" OpValue::PushStr make_op ops.push
     empty_location OpValue::Dup make_op ops.push
     ops tc_check = result_tc
-    "dup str count" 2 result_tc TypeChecker::live TypedStack::types.length assert_eq
-    "dup str first" "str" 0 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
-    "dup str second" "str" 1 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "dup str count" 2 result_tc.stack.types.length assert_eq
+    "dup str first" "str" 0 result_tc.stack.types.get.format assert_str_eq
+    "dup str second" "str" 1 result_tc.stack.types.get.format assert_str_eq
 }
 
 fn test_dup_preserves_bool {
@@ -1362,9 +1370,9 @@ fn test_dup_preserves_bool {
     empty_location 1 OpValue::PushBool make_op ops.push
     empty_location OpValue::Dup make_op ops.push
     ops tc_check = result_tc
-    "dup bool count" 2 result_tc TypeChecker::live TypedStack::types.length assert_eq
-    "dup bool first" "bool" 0 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
-    "dup bool second" "bool" 1 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "dup bool count" 2 result_tc.stack.types.length assert_eq
+    "dup bool first" "bool" 0 result_tc.stack.types.get.format assert_str_eq
+    "dup bool second" "bool" 1 result_tc.stack.types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -1443,7 +1451,7 @@ fn test_error_fn_stack_effect_mismatch {
     enable_test_mode
     clear_errors
     # Build a function with declared stack effect "int -> str" but body returns int
-    "int -> str" stack_effect_from_str = bad_stack_effect
+    "str" "int" make_test_stack_effect = bad_stack_effect
     List::new(List[Op]) = bad_ops
     empty_location 42 OpValue::PushInt make_op bad_ops.push
     # RPN: stack effect, location, ops, name, make_function_with_stack_effect
@@ -1464,7 +1472,7 @@ fn test_error_unused_fn_type_error {
     enable_test_mode
     clear_errors
     # Declared: int -> str, but body is empty (returns nothing)
-    "int -> str" stack_effect_from_str = bad_stack_effect
+    "str" "int" make_test_stack_effect = bad_stack_effect
     List::new(List[Op]) = empty_ops
     bad_stack_effect empty_location empty_ops "bad_unused" make_function_with_stack_effect = bad_fn
     symbol_store_new bad_fn Option::Some empty_ops type_check_ops drop
@@ -1629,8 +1637,8 @@ fn test_type_cast_str_to_int {
     empty_location "hello" OpValue::PushStr make_op ops.push
     empty_location TYPE_INT_T OpValue::TypeCast make_op ops.push
     ops tc_check = result_tc
-    "cast str to int" 1 result_tc TypeChecker::live TypedStack::types.length assert_eq
-    "cast result" "int" 0 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "cast str to int" 1 result_tc.stack.types.length assert_eq
+    "cast result" "int" 0 result_tc.stack.types.get.format assert_str_eq
 }
 
 fn test_type_cast_bool_to_int {
@@ -1639,7 +1647,7 @@ fn test_type_cast_bool_to_int {
     empty_location 1 OpValue::PushBool make_op ops.push
     empty_location TYPE_INT_T OpValue::TypeCast make_op ops.push
     ops tc_check = result_tc
-    "cast bool to int" "int" 0 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
+    "cast bool to int" "int" 0 result_tc.stack.types.get.format assert_str_eq
 }
 
 # ============================================================================
@@ -1680,7 +1688,7 @@ fn test_error_str_lt_comparison {
 # ============================================================================
 # Tests: Branch frame machinery (RFC #81)
 # ============================================================================
-# An `if true then fi` block with an empty body leaves the live stack unchanged
+# An `if true then fi` block with an empty body leaves the stack unchanged
 # and pops the BranchIf frame cleanly.
 
 fn test_branch_if_empty_body {
@@ -1691,10 +1699,10 @@ fn test_branch_if_empty_body {
     empty_location OpValue::IfCondition make_op ops.push
     empty_location OpValue::IfEnd make_op ops.push
     ops tc_check = result_tc
-    "live empty after empty if" 0 result_tc TypeChecker::live TypedStack::types.length assert_eq
-    "frame stack empty" 0 result_tc TypeChecker::branched_stacks.length assert_eq
+    "stack empty after empty if" 0 result_tc.stack.types.length assert_eq
+    "frame stack empty" 0 result_tc.branched_stacks.length assert_eq
 }
-# `if cond then push_int else push_int fi` unifies to a single `int` on the live stack.
+# `if cond then push_int else push_int fi` unifies to a single `int` on the stack.
 
 fn test_branch_if_else_agree_int {
     "branch_if_else_agree_int" test_start
@@ -1707,9 +1715,9 @@ fn test_branch_if_else_agree_int {
     empty_location 20 OpValue::PushInt make_op ops.push
     empty_location OpValue::IfEnd make_op ops.push
     ops tc_check = result_tc
-    "live has one item" 1 result_tc TypeChecker::live TypedStack::types.length assert_eq
-    "unified type is int" "int" 0 result_tc TypeChecker::live TypedStack::types.get.format assert_str_eq
-    "frame stack empty" 0 result_tc TypeChecker::branched_stacks.length assert_eq
+    "stack has one item" 1 result_tc.stack.types.length assert_eq
+    "unified type is int" "int" 0 result_tc.stack.types.get.format assert_str_eq
+    "frame stack empty" 0 result_tc.branched_stacks.length assert_eq
 }
 # OpIfEnd must pop the BranchFrame from branched_stacks.
 
@@ -1720,7 +1728,7 @@ fn test_branch_if_end_pops_frame {
     empty_location 1 OpValue::PushBool make_op ops.push
     empty_location OpValue::IfCondition make_op ops.push
     ops tc_check = result_tc
-    "frame pushed on OpIfStart" 1 result_tc TypeChecker::branched_stacks.length assert_eq
+    "frame pushed on OpIfStart" 1 result_tc.branched_stacks.length assert_eq
     # Close the block
     List::new(List[Op]) = close_ops
     empty_location OpValue::IfEnd make_op close_ops.push
@@ -1729,7 +1737,7 @@ fn test_branch_if_end_pops_frame {
         ci close_ops.get result_tc check_if_block
         1 += ci
     done
-    "frame popped on OpIfEnd" 0 result_tc TypeChecker::branched_stacks.length assert_eq
+    "frame popped on OpIfEnd" 0 result_tc.branched_stacks.length assert_eq
 }
 # A `while cond do done` with an empty body pushes and pops a BranchWhile frame.
 
@@ -1741,8 +1749,8 @@ fn test_branch_while_empty_body {
     empty_location OpValue::WhileCondition make_op ops.push
     empty_location OpValue::WhileEnd make_op ops.push
     ops tc_check = result_tc
-    "live empty" 0 result_tc TypeChecker::live TypedStack::types.length assert_eq
-    "frame stack empty" 0 result_tc TypeChecker::branched_stacks.length assert_eq
+    "stack empty" 0 result_tc.stack.types.length assert_eq
+    "frame stack empty" 0 result_tc.branched_stacks.length assert_eq
 }
 # Direct exercise of the BranchFrame sum type: confirm that the top frame
 # destructures to the right variant and that mutation through the binding
@@ -1758,8 +1766,8 @@ fn test_branch_frame_kind_dispatch {
         bd_i ops.get tc check_if_block
         1 += bd_i
     done
-    "pushed BranchIf frame" 1 tc TypeChecker::branched_stacks.length assert_eq
-    tc TypeChecker::branched_stacks.length 1 - tc TypeChecker::branched_stacks.get = top_frame
+    "pushed BranchIf frame" 1 tc.branched_stacks.length assert_eq
+    tc.branched_stacks.length 1 - tc.branched_stacks.get = top_frame
     false = is_if
     false = is_while
     false = is_match
@@ -1778,7 +1786,7 @@ fn test_branch_frame_kind_dispatch {
     "top frame is not BranchWhile" is_while assert_false
     "top frame is not BranchMatch" is_match assert_false
     # Re-destructure to verify mutation persisted.
-    tc TypeChecker::branched_stacks.length 1 - tc TypeChecker::branched_stacks.get = top_frame2
+    tc.branched_stacks.length 1 - tc.branched_stacks.get = top_frame2
     false = default_present_after
     if top_frame2 BranchFrame::BranchIf(bd_if_ctx2) is then
         bd_if_ctx2 IfContext::default_present = default_present_after
@@ -1844,12 +1852,12 @@ fn test_error_array_literal_unresolved_assignment {
     clear_errors
     disable_test_mode
 }
-# OpFnReturn inside a branch restores live from the frame's `before` snapshot.
+# OpFnReturn inside a branch restores stack from the frame's `before` snapshot.
 
-fn test_branch_return_inside_if_restores_live {
-    "branch_return_inside_if_restores_live" test_start
+fn test_branch_return_inside_if_restores_stack {
+    "branch_return_inside_if_restores_stack" test_start
     symbol_store_new make_typechecker = tc
-    # Seed the live stack with a single `int`.
+    # Seed the stack with a single `int`.
     "int" tc stack_push
     # Begin an `if true then` block.
     List::new(List[Op]) = begin_ops
@@ -1872,19 +1880,19 @@ fn test_branch_return_inside_if_restores_live {
     done
     # Body modifies the stack by pushing an extra `str`.
     "str" tc stack_push
-    "stack grew inside branch" 2 tc TypeChecker::live TypedStack::types.length assert_eq
-    # Simulate OpFnReturn: first visit snapshots live into return_types, then
-    # restores live from the top frame's before snapshot.
-    "has_return_types starts false" tc TypeChecker::has_return_types assert_false
-    tc TypeChecker::live tc TypeChecker::return_types.restore
-    true tc TypeChecker::set_has_return_types
-    tc TypeChecker::branched_stacks.length 1 - tc TypeChecker::branched_stacks.get = ret_frame
+    "stack grew inside branch" 2 tc.stack.types.length assert_eq
+    # Simulate OpFnReturn: first visit snapshots stack into return_types, then
+    # restores stack from the top frame's before snapshot.
+    "has_return_types starts false" tc.has_return_types assert_false
+    tc.stack tc.return_types.restore
+    true tc->has_return_types
+    tc.branched_stacks.length 1 - tc.branched_stacks.get = ret_frame
     if ret_frame BranchFrame::BranchIf(ret_if_ctx) is then
-        ret_if_ctx IfContext::before tc TypeChecker::live.restore
+        ret_if_ctx IfContext::before tc.stack.restore
     fi
-    "live restored to pre-branch state" 1 tc TypeChecker::live TypedStack::types.length assert_eq
-    "restored type is int" "int" 0 tc TypeChecker::live TypedStack::types.get.format assert_str_eq
-    "return_types snapshot captured full state" 2 tc TypeChecker::return_types TypedStack::types.length assert_eq
+    "stack restored to pre-branch state" 1 tc.stack.types.length assert_eq
+    "restored type is int" "int" 0 tc.stack.types.get.format assert_str_eq
+    "return_types snapshot captured full state" 2 tc.return_types.types.length assert_eq
 }
 
 # ============================================================================
@@ -2008,7 +2016,7 @@ test_branch_if_else_agree_int
 test_branch_if_end_pops_frame
 test_branch_while_empty_body
 test_branch_frame_kind_dispatch
-test_branch_return_inside_if_restores_live
+test_branch_return_inside_if_restores_stack
 test_array_literal_int_inference
 test_array_literal_str_inference
 test_array_literal_bool_inference


### PR DESCRIPTION
## Summary
- rename constructor helpers and clean up typechecker naming/dead helpers
- move emitter, formatter, typechecker, bytecode, and LSP JSON behavior behind struct impls
- replace selected absent int sentinels with Option[int]

## Tests
- ./casac -L lib casa.casa -o casac
- tests/test_compiler.sh < /dev/null
- tests/test_examples.sh
- tests/test_formatter.sh
- tests/test_bootstrap.sh