### PR TITLE
feat: add block scoping for while/do/done

### DIFF
--- a/compiler/bytecode.casa
+++ b/compiler/bytecode.casa
@@ -23,10 +23,12 @@ struct BytecodeCompiler {
     label_counter:      int
     op_label_map:       Map[Op int]
     compiled_functions: Set[str]
+    scope_stack:        List[List[str]]
 }
 
 impl BytecodeCompiler {
     fn new store:SymbolStore ops:List[Op] -> BytecodeCompiler {
+        List::new(List[List[str]])
         Set::new(Set[str])
         Map::new(Map[Op int])
         0
@@ -42,6 +44,7 @@ impl BytecodeCompiler {
     }
 
     fn child self:BytecodeCompiler function:Function ops:List[Op] -> BytecodeCompiler {
+        List::new(List[List[str]])
         self.compiled_functions
         self.op_label_map
         self.label_counter
@@ -377,10 +380,14 @@ impl BytecodeCompiler {
                 true "`done` without parent `while`" loc start_targets OpValue::WhileStart op_index ops compiler.require_matching = loop_start
                 loop_start InstValue::Jump bytecode.push
                 while_label InstValue::Label bytecode.push
+                if 0 compiler.scope_stack.length != then
+                    compiler.scope_stack.pop drop
+                fi
             }
             OpValue::WhileStart => {
                 op_index compiler.ops.get compiler.op_to_label = start_label
                 start_label InstValue::Label bytecode.push
+                List::new(List[str]) compiler.scope_stack.push
             }
             _ => {
                 "Internal error: compile_while_block called with non-while OpValue\n" eprint

--- a/compiler/bytecode.casa
+++ b/compiler/bytecode.casa
@@ -23,12 +23,10 @@ struct BytecodeCompiler {
     label_counter:      int
     op_label_map:       Map[Op int]
     compiled_functions: Set[str]
-    scope_stack:        List[List[str]]
 }
 
 impl BytecodeCompiler {
     fn new store:SymbolStore ops:List[Op] -> BytecodeCompiler {
-        List::new(List[List[str]])
         Set::new(Set[str])
         Map::new(Map[Op int])
         0
@@ -44,7 +42,6 @@ impl BytecodeCompiler {
     }
 
     fn child self:BytecodeCompiler function:Function ops:List[Op] -> BytecodeCompiler {
-        List::new(List[List[str]])
         self.compiled_functions
         self.op_label_map
         self.label_counter
@@ -380,14 +377,10 @@ impl BytecodeCompiler {
                 true "`done` without parent `while`" loc start_targets OpValue::WhileStart op_index ops compiler.require_matching = loop_start
                 loop_start InstValue::Jump bytecode.push
                 while_label InstValue::Label bytecode.push
-                if 0 compiler.scope_stack.length != then
-                    compiler.scope_stack.pop drop
-                fi
             }
             OpValue::WhileStart => {
                 op_index compiler.ops.get compiler.op_to_label = start_label
                 start_label InstValue::Label bytecode.push
-                List::new(List[str]) compiler.scope_stack.push
             }
             _ => {
                 "Internal error: compile_while_block called with non-while OpValue\n" eprint

--- a/compiler/typechecker.casa
+++ b/compiler/typechecker.casa
@@ -1051,6 +1051,59 @@ fn unify_variable_assignment
 }
 
 impl TypeChecker {
+    # Record a variable assignment relative to the active while-block scopes.
+    # Outside any while block the name is a pre-scope (function-level) variable,
+    # and any stale out-of-scope marking is cleared. Inside a while block, a name
+    # that is not already active, pre-scope, or global becomes local to the
+    # innermost frame (reactivating it if it was previously out of scope).
+    fn record_var_scope tc:TypeChecker var_name:str {
+        if 0 tc.scope_stack.length == then
+            if var_name tc.pre_scope_vars.has ! then
+                var_name tc.pre_scope_vars.add = updated_pre
+                updated_pre tc->pre_scope_vars
+            fi
+            # A fresh outer-scope assignment is always accessible — clear any
+            # stale out-of-scope marking left by an earlier while block.
+            if var_name tc.out_of_scope.has then
+                var_name tc.out_of_scope.remove = cleared_pre
+                cleared_pre tc->out_of_scope
+            fi
+        else
+            false = in_active_scope
+            0 = scope_idx
+            while scope_idx tc.scope_stack.length > do
+                scope_idx tc.scope_stack.get = active_frame
+                if var_name active_frame string_list_contains then
+                    true = in_active_scope
+                fi
+                1 += scope_idx
+            done
+
+            false = is_pre_scope_global
+            if var_name tc.store.variables.has then
+                true = is_pre_scope_global
+            fi
+
+            var_name tc.pre_scope_vars.has = is_pre_scope_local
+
+            # If not active, not pre-scope, not global: it is block-local.
+            if
+            in_active_scope !
+            is_pre_scope_local ! &&
+            is_pre_scope_global ! &&
+            then
+                if var_name tc.out_of_scope.has then
+                    var_name tc.out_of_scope.remove = cleared_oos
+                    cleared_oos tc->out_of_scope
+                fi
+                tc.scope_stack.length 1 - tc.scope_stack.get = cur_frame
+                if var_name cur_frame string_list_contains ! then
+                    var_name cur_frame.push
+                fi
+            fi
+        fi
+    }
+
     fn check_assignment tc:TypeChecker op:Op function_opt:Option[Function] {
         if
         op.value OpValue::AssignDec is
@@ -1074,51 +1127,8 @@ impl TypeChecker {
             op Op::location f"Cannot infer element type of empty array literal assigned to `{var_name}`; add a type annotation (e.g. `= {var_name}:array[int]`) or an explicit cast (e.g. `[] (array[int])`)." ErrorKind::TypeMismatch raise_error
         fi
 
-        # Scope tracking: record variable assignments relative to while blocks.
-        if 0 tc.scope_stack.length == then
-            # Outside any while block: record as pre-scope (will not be block-local).
-            if var_name tc.pre_scope_vars.has ! then
-                var_name tc.pre_scope_vars.add = updated_pre
-                updated_pre tc->pre_scope_vars
-            fi
-        else
-            # Inside a while block: check if var is pre-scope (outer) or block-local.
-            false = in_active_scope
-            0 = scope_idx
-            while scope_idx tc.scope_stack.length > do
-                scope_idx tc.scope_stack.get = active_frame
-                if var_name active_frame string_list_contains then
-                    true = in_active_scope
-                fi
-                1 += scope_idx
-            done
-
-            false = is_pre_scope_global
-            if var_name tc.store.variables.has then
-                true = is_pre_scope_global
-            fi
-
-            # A variable is pre-scope if it was assigned before the while block.
-            var_name tc.pre_scope_vars.has = is_pre_scope_local
-
-            # If not in any active scope, not pre-scope, not global: block-local.
-            if
-            in_active_scope !
-            is_pre_scope_local ! &&
-            is_pre_scope_global ! &&
-            then
-                if var_name tc.out_of_scope.has then
-                    # Remove from out_of_scope — now active again in new sibling scope
-                    var_name tc.out_of_scope.remove = cleared_oos
-                    cleared_oos tc->out_of_scope
-                fi
-                # Add to innermost scope frame (last element)
-                tc.scope_stack.length 1 - tc.scope_stack.get = cur_frame
-                if var_name cur_frame string_list_contains ! then
-                    var_name cur_frame.push
-                fi
-            fi
-        fi
+        # Scope tracking: record variable assignment relative to while blocks.
+        var_name tc.record_var_scope
 
         # Try local variables first
         if function_opt.is_some then
@@ -2209,43 +2219,9 @@ impl TypeChecker {
             fi
         fi
         typ.format variant function_opt tc register_enum_pattern_bindings
-        # Track bindings in scope (same logic as AssignVar)
+        # Track bindings in scope (same rules as AssignVar)
         for binding_var in variant EnumVariant::bindings.iter do
-            if 0 tc.scope_stack.length == then
-                if binding_var tc.pre_scope_vars.has ! then
-                    binding_var tc.pre_scope_vars.add = updated_pre2
-                    updated_pre2 tc->pre_scope_vars
-                fi
-            else
-                false = binding_in_active_scope
-                0 = binding_scope_idx
-                while binding_scope_idx tc.scope_stack.length > do
-                    binding_scope_idx tc.scope_stack.get = binding_frame
-                    if binding_var binding_frame string_list_contains then
-                        true = binding_in_active_scope
-                    fi
-                    1 += binding_scope_idx
-                done
-                false = binding_is_pre_scope_global
-                if binding_var tc.store.variables.has then
-                    true = binding_is_pre_scope_global
-                fi
-                binding_var tc.pre_scope_vars.has = binding_is_pre_scope_local
-                if
-                binding_in_active_scope !
-                binding_is_pre_scope_local ! &&
-                binding_is_pre_scope_global ! &&
-                then
-                    if binding_var tc.out_of_scope.has then
-                        binding_var tc.out_of_scope.remove = cleared2
-                        cleared2 tc->out_of_scope
-                    fi
-                    tc.scope_stack.length 1 - tc.scope_stack.get = cur_frame2
-                    if binding_var cur_frame2 string_list_contains ! then
-                        binding_var cur_frame2.push
-                    fi
-                fi
-            fi
+            binding_var tc.record_var_scope
         done
         TYPE_BOOL_T tc.stack_push_type
     }

--- a/compiler/typechecker.casa
+++ b/compiler/typechecker.casa
@@ -130,10 +130,16 @@ struct TypeChecker {
     store:                      SymbolStore
     param_cap:                  Option[int]
     underflow_reported_this_op: bool
+    scope_stack:                List[List[str]]
+    out_of_scope:               Set[str]
+    pre_scope_vars:             Set[str]
 }
 
 impl TypeChecker {
     fn new store:SymbolStore -> TypeChecker {
+        Set::new(Set[str]) # pre_scope_vars
+        Set::new(Set[str]) # out_of_scope
+        List::new(List[List[str]]) # scope_stack
         false # underflow_reported_this_op
         Option::None(Option[int]) # param_cap
         store # store
@@ -1068,6 +1074,52 @@ impl TypeChecker {
             op Op::location f"Cannot infer element type of empty array literal assigned to `{var_name}`; add a type annotation (e.g. `= {var_name}:array[int]`) or an explicit cast (e.g. `[] (array[int])`)." ErrorKind::TypeMismatch raise_error
         fi
 
+        # Scope tracking: record variable assignments relative to while blocks.
+        if 0 tc.scope_stack.length == then
+            # Outside any while block: record as pre-scope (will not be block-local).
+            if var_name tc.pre_scope_vars.has ! then
+                var_name tc.pre_scope_vars.add = updated_pre
+                updated_pre tc->pre_scope_vars
+            fi
+        else
+            # Inside a while block: check if var is pre-scope (outer) or block-local.
+            false = in_active_scope
+            0 = scope_idx
+            while scope_idx tc.scope_stack.length > do
+                scope_idx tc.scope_stack.get = active_frame
+                if var_name active_frame string_list_contains then
+                    true = in_active_scope
+                fi
+                1 += scope_idx
+            done
+
+            false = is_pre_scope_global
+            if var_name tc.store.variables.has then
+                true = is_pre_scope_global
+            fi
+
+            # A variable is pre-scope if it was assigned before the while block.
+            var_name tc.pre_scope_vars.has = is_pre_scope_local
+
+            # If not in any active scope, not pre-scope, not global: block-local.
+            if
+            in_active_scope !
+            is_pre_scope_local ! &&
+            is_pre_scope_global ! &&
+            then
+                if var_name tc.out_of_scope.has then
+                    # Remove from out_of_scope — now active again in new sibling scope
+                    var_name tc.out_of_scope.remove = cleared_oos
+                    cleared_oos tc->out_of_scope
+                fi
+                # Add to innermost scope frame (last element)
+                tc.scope_stack.length 1 - tc.scope_stack.get = cur_frame
+                if var_name cur_frame string_list_contains ! then
+                    var_name cur_frame.push
+                fi
+            fi
+        fi
+
         # Try local variables first
         if function_opt.is_some then
             if function_opt Option::Some(function) is then
@@ -1180,6 +1232,13 @@ impl TypeChecker {
 
         # PUSH_VARIABLE
         if op.value OpValue::PushVar(var_name) is ! then return fi
+
+        # Check if variable has gone out of scope (was only in a popped while scope)
+        if var_name tc.out_of_scope.has then
+            op Op::location f"Variable `{var_name}` is not accessible outside its while block scope" ErrorKind::UndefinedName add_error
+            TYPE_UNKNOWN_T tc.stack_push_type
+            return
+        fi
 
         # Check local variables first
         if function_opt.is_some then
@@ -1313,6 +1372,7 @@ impl TypeChecker {
             op Op::location while_ctx WhileContext::set_current_branch_location
             while_ctx BranchFrame::BranchWhile = while_frame
             while_frame tc.branched_stacks.push
+            List::new(List[str]) tc.scope_stack.push
         elif while_value OpValue::WhileCondition is then
             TYPE_BOOL_T tc.expect_type_t
             if 0 tc.branched_stacks.length == then return fi
@@ -1327,6 +1387,25 @@ impl TypeChecker {
             if 0 tc.branched_stacks.length == then return fi
         elif while_value OpValue::WhileEnd is then
             tc.branched_stacks.pop drop
+            if 0 tc.scope_stack.length != then
+                tc.scope_stack.pop = popped_frame
+                for exiting_name in popped_frame.iter do
+                    # Only move to out_of_scope if not still active in an outer frame
+                    false = still_active
+                    0 = outer_idx
+                    while outer_idx tc.scope_stack.length > do
+                        outer_idx tc.scope_stack.get = outer_frame
+                        if exiting_name outer_frame string_list_contains then
+                            true = still_active
+                        fi
+                        1 += outer_idx
+                    done
+                    if still_active ! then
+                        exiting_name tc.out_of_scope.add = new_oos
+                        new_oos tc->out_of_scope
+                    fi
+                done
+            fi
         fi
     }
 }
@@ -2130,6 +2209,44 @@ impl TypeChecker {
             fi
         fi
         typ.format variant function_opt tc register_enum_pattern_bindings
+        # Track bindings in scope (same logic as AssignVar)
+        for binding_var in variant EnumVariant::bindings.iter do
+            if 0 tc.scope_stack.length == then
+                if binding_var tc.pre_scope_vars.has ! then
+                    binding_var tc.pre_scope_vars.add = updated_pre2
+                    updated_pre2 tc->pre_scope_vars
+                fi
+            else
+                false = binding_in_active_scope
+                0 = binding_scope_idx
+                while binding_scope_idx tc.scope_stack.length > do
+                    binding_scope_idx tc.scope_stack.get = binding_frame
+                    if binding_var binding_frame string_list_contains then
+                        true = binding_in_active_scope
+                    fi
+                    1 += binding_scope_idx
+                done
+                false = binding_is_pre_scope_global
+                if binding_var tc.store.variables.has then
+                    true = binding_is_pre_scope_global
+                fi
+                binding_var tc.pre_scope_vars.has = binding_is_pre_scope_local
+                if
+                binding_in_active_scope !
+                binding_is_pre_scope_local ! &&
+                binding_is_pre_scope_global ! &&
+                then
+                    if binding_var tc.out_of_scope.has then
+                        binding_var tc.out_of_scope.remove = cleared2
+                        cleared2 tc->out_of_scope
+                    fi
+                    tc.scope_stack.length 1 - tc.scope_stack.get = cur_frame2
+                    if binding_var cur_frame2 string_list_contains ! then
+                        binding_var cur_frame2.push
+                    fi
+                fi
+            fi
+        done
         TYPE_BOOL_T tc.stack_push_type
     }
 }

--- a/tests/compiler/test_scope.casa
+++ b/tests/compiler/test_scope.casa
@@ -1,0 +1,96 @@
+import "../../compiler/typechecker.casa"
+import "helpers.casa"
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+fn parse_typecheck code:str {
+    enable_test_mode
+    clear_errors
+    code parse_resolve_test_source = result
+    result ParseResolveResult::ops = ops
+    result ParseResolveResult::store = store
+    store Option::None(Option[Function]) ops type_check_ops drop
+}
+
+# ============================================================================
+# While scoping: variable declared inside while is not visible after done
+# ============================================================================
+
+fn test_while_scope_var_not_visible_after_done {
+    "while_scope_var_not_visible_after_done" test_start
+    "fn f {\n    while false do\n        1 = x\n    done\n    x\n}\nf\n" parse_typecheck
+    "has scope error" assert_has_errors
+    "undefined name kind" ErrorKind::UndefinedName assert_error_kind
+    clear_errors
+    disable_test_mode
+}
+
+# ============================================================================
+# While scoping: variable declared inside while is visible within the block
+# ============================================================================
+
+fn test_while_scope_var_visible_inside {
+    "while_scope_var_visible_inside" test_start
+    "fn f {\n    while false do\n        1 = x\n        x drop\n    done\n}\nf\n" parse_typecheck
+    "no errors inside while" assert_no_errors
+    disable_test_mode
+}
+
+# ============================================================================
+# For scoping: iteration variable not visible after done
+# ============================================================================
+
+fn test_for_scope_iter_var_not_visible_after_done {
+    "for_scope_iter_var_not_visible_after_done" test_start
+    "[1 2 3] = items\n    for item in items.iter do\n        item drop\n    done\n    item\n" parse_typecheck
+    "has scope error for iter var" assert_has_errors
+    "undefined name kind" ErrorKind::UndefinedName assert_error_kind
+    clear_errors
+    disable_test_mode
+}
+
+# ============================================================================
+# Mutation: outer variable can be mutated inside while block
+# ============================================================================
+
+fn test_while_outer_var_mutation {
+    "while_outer_var_mutation" test_start
+    "fn f -> int {\n    0 = counter\n    while false do\n        1 += counter\n    done\n    counter\n}\nf drop\n" parse_typecheck
+    "no errors mutating outer var" assert_no_errors
+    disable_test_mode
+}
+
+# ============================================================================
+# Sibling scopes: same var name reused in successive while blocks
+# ============================================================================
+
+fn test_while_sibling_scope_reuse {
+    "while_sibling_scope_reuse" test_start
+    "fn f {\n    while false do\n        1 = tmp\n        tmp drop\n    done\n    while false do\n        2 = tmp\n        tmp drop\n    done\n}\nf\n" parse_typecheck
+    "no errors with sibling while reuse" assert_no_errors
+    disable_test_mode
+}
+
+# ============================================================================
+# Global bypass: global variable inside while is accessible after done
+# ============================================================================
+
+fn test_while_global_accessible_after_done {
+    "while_global_accessible_after_done" test_start
+    "0 = COUNTER\nfn f {\n    global COUNTER\n    while false do\n        1 = COUNTER\n    done\n    COUNTER drop\n}\nf\n" parse_typecheck
+    "no errors for global after while" assert_no_errors
+    disable_test_mode
+}
+
+# ============================================================================
+# Run tests
+# ============================================================================
+test_while_scope_var_not_visible_after_done
+test_while_scope_var_visible_inside
+test_for_scope_iter_var_not_visible_after_done
+test_while_outer_var_mutation
+test_while_sibling_scope_reuse
+test_while_global_accessible_after_done
+test_summary

--- a/tests/compiler/test_scope.casa
+++ b/tests/compiler/test_scope.casa
@@ -74,6 +74,17 @@ fn test_while_sibling_scope_reuse {
 }
 
 # ============================================================================
+# Reassignment: name reused at outer scope after a while block stays visible
+# ============================================================================
+
+fn test_while_outer_var_reassigned_after_done {
+    "while_outer_var_reassigned_after_done" test_start
+    "fn f {\n    while false do\n        1 = x\n        x drop\n    done\n    2 = x\n    x drop\n}\nf\n" parse_typecheck
+    "no errors reassigning name after while block" assert_no_errors
+    disable_test_mode
+}
+
+# ============================================================================
 # Global bypass: global variable inside while is accessible after done
 # ============================================================================
 
@@ -92,5 +103,6 @@ test_while_scope_var_visible_inside
 test_for_scope_iter_var_not_visible_after_done
 test_while_outer_var_mutation
 test_while_sibling_scope_reuse
+test_while_outer_var_reassigned_after_done
 test_while_global_accessible_after_done
 test_summary


### PR DESCRIPTION
## Summary

- Add `scope_stack: List[List[str]]` to `TypeChecker` and `BytecodeCompiler`
- Push new frame on `WhileStart`, pop on `WhileEnd`; variables first assigned inside a while block are block-local and inaccessible after `done`
- Variables already in scope before the block (`pre_scope_vars`) and `global` declarations are unaffected
- Pattern bindings from `is` checks follow the same rules; `for` loop variables covered automatically via desugar-to-while

## Test plan

- [x] `test_scope`: while scoping, for scoping, outer mutation, sibling reuse, global bypass
- [x] Full compiler test suite: 56 passed, 0 failed
- [x] Examples: 47 passed, 0 failed
- [x] Bootstrap: self-compilation + fixed-point verified

Closes #246