### PR TITLE
refactor: restructure if-block is-bindings to avoid leaks

### DIFF
--- a/compiler/bytecode.casa
+++ b/compiler/bytecode.casa
@@ -403,11 +403,12 @@ impl BytecodeCompiler {
         struct_pattern:StructPattern
         bytecode:List[InstValue]
     {
-        if struct_pattern StructPattern::struct_name compiler.store.structs.get Option::Some(casa_struct) is then
-        else
+        struct_pattern StructPattern::struct_name compiler.store.structs.get = casa_struct_opt
+        if casa_struct_opt.is_none then
             empty_location "Expected option value while unwrapping struct_pattern StructPattern::struct_name compiler.store.structs.get" ErrorKind::Syntax raise_error
             1 exit
         fi
+        casa_struct_opt.unwrap = casa_struct
         0 = index
         while index casa_struct CasaStruct::members.length > do
             index casa_struct CasaStruct::members.get Member::name = field_name
@@ -482,11 +483,7 @@ impl BytecodeCompiler {
         if is_wildcard then return fi
         variant EnumVariant::enum_name = enum_name
         if "" enum_name != enum_name compiler.store.enums.has && then
-            if enum_name compiler.store.enums.get Option::Some(casa_enum) is then
-            else
-                empty_location "Expected option value while unwrapping enum_name compiler.store.enums.get" ErrorKind::Syntax raise_error
-                1 exit
-            fi
+            enum_name compiler.store.enums.get.unwrap = casa_enum
             if casa_enum has_inner_values then
                 if is_last ! then
                     InstValue::Dup bytecode.push
@@ -714,11 +711,12 @@ impl BytecodeCompiler {
     fn compile_is_check compiler:BytecodeCompiler op:Op bytecode:List[InstValue] {
         if op.value OpValue::IsCheck(variant) is ! then return fi
         variant EnumVariant::enum_name = enum_name
-        if enum_name compiler.store.enums.get Option::Some(casa_enum) is then
-        else
+        enum_name compiler.store.enums.get = casa_enum_opt
+        if casa_enum_opt.is_none then
             empty_location "Expected option value while unwrapping enum_name compiler.store.enums.get" ErrorKind::Syntax raise_error
             1 exit
         fi
+        casa_enum_opt.unwrap = casa_enum
 
         if casa_enum has_inner_values ! then
             # Plain enum: compare ordinal directly
@@ -779,11 +777,12 @@ impl BytecodeCompiler {
 impl BytecodeCompiler {
     fn compile_struct_literal compiler:BytecodeCompiler op:Op bytecode:List[InstValue] {
         if op.value OpValue::StructLiteral(literal) is ! then return fi
-        if literal StructLiteral::struct_name compiler.store.structs.get Option::Some(casa_struct) is then
-        else
+        literal StructLiteral::struct_name compiler.store.structs.get = casa_struct_opt
+        if casa_struct_opt.is_none then
             empty_location "Expected option value while unwrapping literal StructLiteral::struct_name compiler.store.structs.get" ErrorKind::Syntax raise_error
             1 exit
         fi
+        casa_struct_opt.unwrap = casa_struct
         casa_struct CasaStruct::members.length = count
 
         # Store all field values into temp locals (top of stack = last in field_order)
@@ -896,11 +895,12 @@ impl BytecodeCompiler {
         fi
         literal StructLiteral::struct_name = struct_name
         literal StructLiteral::field_order = field_order
-        if struct_name compiler.store.structs.get Option::Some(casa_struct) is then
-        else
+        struct_name compiler.store.structs.get = casa_struct_opt
+        if casa_struct_opt.is_none then
             empty_location "Expected option value while unwrapping struct_name compiler.store.structs.get" ErrorKind::Syntax raise_error
             1 exit
         fi
+        casa_struct_opt.unwrap = casa_struct
 
         List::new(List[StaticArrayElement]) = ordered_elems
         0 = i
@@ -1080,12 +1080,12 @@ impl BytecodeCompiler {
         op.value match
             OpValue::FnCall => {
                 if name compiler.store.functions.get Option::Some(function) is then
+                    op function compiler.compile_function
+                    name InstValue::FnCall bytecode.push
                 else
                     empty_location "Expected option value while unwrapping name compiler.store.functions.get" ErrorKind::Syntax raise_error
                     1 exit
                 fi
-                op function compiler.compile_function
-                name InstValue::FnCall bytecode.push
             }
             OpValue::FnPush => {
                 name compiler.store.functions.get = function_opt
@@ -1093,11 +1093,7 @@ impl BytecodeCompiler {
                     op Op::location f"Function `{name}` is not defined" ErrorKind::UndefinedName CasaError::new ERRORS.push
                     return
                 fi
-                if function_opt Option::Some(lambda) is then
-                else
-                    empty_location "Expected option value while unwrapping function_opt" ErrorKind::Syntax raise_error
-                    1 exit
-                fi
+                function_opt.unwrap = lambda
                 op lambda compiler.compile_function
 
                 # Zero-capture closures share a single static record so trait
@@ -1212,11 +1208,7 @@ impl BytecodeCompiler {
             if op_value OpValue::FnPush(fn_push_name) is then
                 fn_push_name compiler.store.functions.get = function_opt
                 if function_opt.is_some then
-                    if function_opt Option::Some(function_check) is then
-                    else
-                        empty_location "Expected option value while unwrapping function_opt" ErrorKind::Syntax raise_error
-                        1 exit
-                    fi
+                    function_opt.unwrap = function_check
                     if function_check Function::has_deferred_methods then
                         0 InstValue::Push bytecode.push
                         return
@@ -1239,14 +1231,14 @@ impl BytecodeCompiler {
             # No instruction emitted
         elif op_value OpValue::PushEnumVariant(variant) is then
             if variant EnumVariant::enum_name compiler.store.enums.get Option::Some(casa_enum) is then
+                if casa_enum has_inner_values then
+                    bytecode casa_enum variant compiler.compile_enum_variant
+                else
+                    variant enum_variant_ordinal InstValue::Push bytecode.push
+                fi
             else
                 empty_location "Expected option value while unwrapping variant EnumVariant::enum_name compiler.store.enums.get" ErrorKind::Syntax raise_error
                 1 exit
-            fi
-            if casa_enum has_inner_values then
-                bytecode casa_enum variant compiler.compile_enum_variant
-            else
-                variant enum_variant_ordinal InstValue::Push bytecode.push
             fi
         elif op_value OpValue::IsCheck is then
             bytecode op compiler.compile_is_check

--- a/compiler/lexer.casa
+++ b/compiler/lexer.casa
@@ -51,11 +51,7 @@ impl Lexer {
         while self Lexer::cursor.is_eof ! do
             self Lexer::cursor.peek = char_opt
             if char_opt.is_none then break fi
-            if char_opt Option::Some(ch) is then
-            else
-                empty_location "Expected option value while unwrapping char_opt" ErrorKind::Syntax raise_error
-                1 exit
-            fi
+            char_opt.unwrap = ch
             if FMT_LEXER_MODE then
                 if ch ' ' == ch '\t' == || ! then break fi
             else
@@ -163,11 +159,7 @@ impl Lexer {
         while self Lexer::cursor.is_eof ! do
             self Lexer::cursor.advance = char_opt
             if char_opt.is_none then break fi
-            if char_opt Option::Some(character) is then
-            else
-                empty_location "Expected option value while unwrapping char_opt" ErrorKind::Syntax raise_error
-                1 exit
-            fi
+            char_opt.unwrap = character
             if '\\' character == then
                 self.parse_escape = escape
                 if escape.is_none then break fi
@@ -200,11 +192,7 @@ impl Lexer {
             error_loc "Unclosed char literal" ErrorKind::Syntax self.add_error
             error_loc TokenKind::Literal "'\0'" Token::new return
         fi
-        if next_opt Option::Some(next_char) is then
-        else
-            empty_location "Expected option value while unwrapping next_opt" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        next_opt.unwrap = next_char
         "" = char_value
 
         if '\\' next_char == then
@@ -213,11 +201,7 @@ impl Lexer {
                 self Lexer::cursor Cursor::pos start - start self.loc = error_loc2
                 error_loc2 TokenKind::Literal "'\0'" Token::new return
             fi
-            if escape Option::Some(char_value) is then
-            else
-                empty_location "Expected option value while unwrapping escape" ErrorKind::Syntax raise_error
-                1 exit
-            fi
+            escape.unwrap = char_value
         elif '\'' next_char == then
             self Lexer::cursor Cursor::pos start - start self.loc = error_loc3
             error_loc3 "Empty char literal" ErrorKind::Syntax self.add_error
@@ -351,11 +335,12 @@ impl Lexer {
         while self Lexer::cursor.is_eof ! do
             self.skip_whitespace
             if self Lexer::cursor.is_eof then break fi
-            if self Lexer::cursor.peek Option::Some(character) is then
-            else
+            self Lexer::cursor.peek = char_opt
+            if char_opt.is_none then
                 empty_location "Expected option value while unwrapping self Lexer::cursor.peek" ErrorKind::Syntax raise_error
                 1 exit
             fi
+            char_opt.unwrap = character
             # Nested f-string
             if "f\"" self.startswith then
                 tokens self.lex_fstring
@@ -392,11 +377,12 @@ impl Lexer {
         self Lexer::cursor Cursor::pos = text_start
 
         while self Lexer::cursor.is_eof ! do
-            if self Lexer::cursor.peek Option::Some(character) is then
-            else
+            self Lexer::cursor.peek = char_opt
+            if char_opt.is_none then
                 empty_location "Expected option value while unwrapping self Lexer::cursor.peek" ErrorKind::Syntax raise_error
                 1 exit
             fi
+            char_opt.unwrap = character
             # Escape
             if '\\' character == then
                 self Lexer::cursor.advance drop
@@ -581,11 +567,7 @@ fn lex_file path:str -> List[Token] {
         f"error: cannot read {path}: {read_err.to_str}" eprintln
         1 exit
     fi
-    if read_result Result::Ok(code) is then
-    else
-        empty_location "Expected option value while unwrapping read_result" ErrorKind::Syntax raise_error
-        1 exit
-    fi
+    read_result.unwrap = code
     code path SOURCE_CACHE.set = SOURCE_CACHE
     path code Lexer::new.lex
 }

--- a/compiler/pattern.casa
+++ b/compiler/pattern.casa
@@ -61,11 +61,11 @@ fn pattern_bindings op:Op -> List[str] {
             struct_pat.bindings.keys = field_names
             for field_name in field_names.iter do
                 if field_name struct_pat.bindings.get Option::Some(bound_name) is then
+                    bound_name out.push
                 else
                     empty_location "Expected option value while unwrapping field_name struct_pat.bindings.get" ErrorKind::Syntax raise_error
                     1 exit
                 fi
-                bound_name out.push
             done
         }
         PatternValue::EnumVariant(variant) => {
@@ -162,19 +162,20 @@ fn register_struct_pattern_bindings
     function_opt:Option[Function]
     struct_pattern:StructPattern
 {
-    if struct_pattern StructPattern::struct_name tc.store.structs.get Option::Some(matched_struct) is then
-    else
+    struct_pattern StructPattern::struct_name tc.store.structs.get = matched_struct_opt
+    if matched_struct_opt.is_none then
         empty_location "Expected option value while unwrapping struct_pattern StructPattern::struct_name tc.store.structs.get" ErrorKind::Syntax raise_error
         1 exit
     fi
+    matched_struct_opt.unwrap = matched_struct
     struct_pattern StructPattern::bindings.keys = binding_keys
     for field_name in binding_keys.iter do
         if field_name struct_pattern StructPattern::bindings.get Option::Some(bound_var) is then
+            tc.store function_opt bound_var field_name matched_struct assign_struct_binding_type
         else
             empty_location "Expected option value while unwrapping field_name struct_pattern StructPattern::bindings.get" ErrorKind::Syntax raise_error
             1 exit
         fi
-        tc.store function_opt bound_var field_name matched_struct assign_struct_binding_type
     done
 }
 

--- a/compiler/syntax.casa
+++ b/compiler/syntax.casa
@@ -174,11 +174,7 @@ fn expect_token cursor:TokenCursor -> Token {
         # Return dummy token for resilient/test mode
         empty_location TokenKind::Eof "" Token::new return
     fi
-    if result_opt Option::Some(token) is then
-    else
-        empty_location "Expected option value while unwrapping result_opt" ErrorKind::Syntax raise_error
-        1 exit
-    fi
+    result_opt.unwrap = token
     if TokenKind::Eof token Token::kind == then
         token Token::location "Unexpected end of input" ErrorKind::UnexpectedToken raise_error
     fi
@@ -213,11 +209,7 @@ fn expect_token_kind cursor:TokenCursor expected_kind:TokenKind -> Token {
 fn expect_delimiter cursor:TokenCursor expected_value:str -> bool {
     cursor.peek = peek_opt
     if peek_opt.is_none then false return fi
-    if peek_opt Option::Some(token) is then
-    else
-        empty_location "Expected option value while unwrapping peek_opt" ErrorKind::Syntax raise_error
-        1 exit
-    fi
+    peek_opt.unwrap = token
     if expected_value token Token::value != then false return fi
     cursor.advance
     true
@@ -233,11 +225,7 @@ fn parse_type_ast cursor:TokenCursor -> Type {
         empty_location "Expected type" ErrorKind::UnexpectedToken raise_error
         Type::Unknown return
     fi
-    if peek_opt Option::Some(peek) is then
-    else
-        empty_location "Expected option value while unwrapping peek_opt" ErrorKind::Syntax raise_error
-        1 exit
-    fi
+    peek_opt.unwrap = peek
 
     if "fn" peek Token::value == then
         cursor.pop drop
@@ -371,11 +359,7 @@ fn get_op_intrinsic token:Token -> Op {
     if kind_opt.is_none then
         token Token::location f"Token `{token Token::value}` is not an intrinsic" ErrorKind::Syntax raise_error
     fi
-    if kind_opt Option::Some(intrinsic_kind) is then
-    else
-        empty_location "Expected option value while unwrapping kind_opt" ErrorKind::Syntax raise_error
-        1 exit
-    fi
+    kind_opt.unwrap = intrinsic_kind
     intrinsic_kind intrinsic_to_op_value = op_value_opt
     if op_value_opt.is_none then
         token Token::location f"No OpValue for intrinsic `{token Token::value}`" ErrorKind::Syntax raise_error
@@ -395,11 +379,7 @@ fn get_op_operator token:Token cursor:TokenCursor function_name:str -> Op {
     if kind_opt.is_none then
         token Token::location f"Token `{token Token::value}` is not an operator" ErrorKind::Syntax raise_error
     fi
-    if kind_opt Option::Some(operator_kind) is then
-    else
-        empty_location "Expected option value while unwrapping kind_opt" ErrorKind::Syntax raise_error
-        1 exit
-    fi
+    kind_opt.unwrap = operator_kind
 
     # Assignment: = varname
     if OperatorKind::Assign operator_kind == then
@@ -497,11 +477,7 @@ fn get_op_array parser:Parser function_name:str cursor:TokenCursor -> Op {
         if value_opt.is_none then
             open_token Token::location "Unexpected end of input in array literal" ErrorKind::UnexpectedToken raise_error
         fi
-        if value_opt Option::Some(value_token) is then
-        else
-            empty_location "Expected option value while unwrapping value_opt" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        value_opt.unwrap = value_token
         if "{" value_token Token::value == then
             items value_token cursor function_name parser parse_array_lambda
         elif TokenKind::Literal value_token Token::kind == then
@@ -537,11 +513,7 @@ fn parse_block_ops parser:Parser cursor:TokenCursor function_name:str -> List[Op
         if token_opt.is_none then
             open_token Token::location "Unclosed block" ErrorKind::UnmatchedBlock raise_error
         fi
-        if token_opt Option::Some(token) is then
-        else
-            empty_location "Expected option value while unwrapping token_opt" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        token_opt.unwrap = token
         if TokenKind::Comment token Token::kind == then continue fi
         if TokenKind::Newline token Token::kind == then continue fi
         if "}" token Token::value == then
@@ -565,11 +537,7 @@ fn parse_fstring_expr parser:Parser cursor:TokenCursor function_name:str -> List
     while true do
         cursor.pop = token_opt
         if token_opt.is_none then break fi
-        if token_opt Option::Some(token) is then
-        else
-            empty_location "Expected option value while unwrapping token_opt" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        token_opt.unwrap = token
         if TokenKind::FstringExprEnd token Token::kind == then
             break
         fi
@@ -593,11 +561,7 @@ fn handle_fstring
     while true do
         cursor.pop = token_opt
         if token_opt.is_none then break fi
-        if token_opt Option::Some(token) is then
-        else
-            empty_location "Expected option value while unwrapping token_opt" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        token_opt.unwrap = token
         if TokenKind::FstringText token Token::kind == then
             token Token::location token Token::value OpValue::PushStr Op::new ops.push
             1 += part_count
@@ -693,11 +657,7 @@ fn try_parse_is_check token:Token cursor:TokenCursor -> Option[Op] {
                 saved_pos cursor.restore
                 Option::None return
             fi
-            if inner_opt Option::Some(inner) is then
-            else
-                saved_pos cursor.restore
-                Option::None return
-            fi
+            inner_opt.unwrap = inner
             if ")" inner Token::value == then
                 cursor.pop drop # consume )
                 if 0 bindings.length == then
@@ -840,11 +800,7 @@ fn parse_type_vars parser:Parser cursor:TokenCursor -> List[str] {
         if token_opt.is_none then
             empty_location "Expected `]` to close type parameters" ErrorKind::Syntax raise_error
         fi
-        if token_opt Option::Some(token) is then
-        else
-            empty_location "Expected option value while unwrapping token_opt" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        token_opt.unwrap = token
         if "]" token Token::value == then
             if 0 vars.length == then
                 token Token::location "Empty type parameter list `[]` is not allowed" ErrorKind::Syntax raise_error
@@ -916,11 +872,7 @@ fn parse_parameters cursor:TokenCursor -> List[Parameter] {
         if token_opt.is_none then
             empty_location "Unexpected end of input" ErrorKind::UnexpectedToken raise_error
         fi
-        if token_opt Option::Some(token) is then
-        else
-            empty_location "Expected option value while unwrapping token_opt" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        token_opt.unwrap = token
 
         # Stop at -> or {
         if "->" token Token::value == "{" token Token::value == || then
@@ -1034,18 +986,10 @@ fn build_hidden_trait_methods
     List::new(List[HiddenTraitMethod]) = result
     trait_bounds.keys = bound_keys
     for bound_type_var in bound_keys.iter do
-        if bound_type_var trait_bounds.get Option::Some(bound) is then
-        else
-            empty_location "Expected option value while unwrapping bound_type_var trait_bounds.get" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        bound_type_var trait_bounds.get.unwrap = bound
         bound TraitBound::name parser.store.traits.get = bound_trait_opt
         if bound_trait_opt.is_some then
-            if bound_trait_opt Option::Some(bound_trait) is then
-            else
-                empty_location "Expected option value while unwrapping bound_trait_opt" ErrorKind::Syntax raise_error
-                1 exit
-            fi
+            bound_trait_opt.unwrap = bound_trait
             # Build substitution map from trait's declared type_params to the
             # concrete type_args carried on the bound.
             Map::new(Map[str Type]) = bound_subs
@@ -1103,10 +1047,7 @@ fn try_fold_const_fn_call
 -> int {
     fn_name store.functions.get = fold_fn_opt
     if fold_fn_opt.is_none then op_index return fi
-    if fold_fn_opt Option::Some(fold_fn) is then
-    else
-        op_index return
-    fi
+    fold_fn_opt.unwrap = fold_fn
     if fold_fn Function::is_const_fn ! then op_index return fi
     fold_fn Function::stack_effect StackEffect::parameters.length = fold_param_count
     op_index 1 - = call_idx
@@ -1305,11 +1246,7 @@ fn eval_const_fn
     if fn_opt.is_none then
         location f"`{fn_name}` is not a const fn" ErrorKind::Syntax raise_error
     fi
-    if fn_opt Option::Some(function) is then
-    else
-        empty_location "Expected option value while unwrapping fn_opt" ErrorKind::Syntax raise_error
-        1 exit
-    fi
+    fn_opt.unwrap = function
     if function Function::is_const_fn ! then
         location f"`{fn_name}` is not a const fn" ErrorKind::Syntax raise_error
     fi
@@ -1416,11 +1353,7 @@ fn eval_const_block parser:Parser cursor:TokenCursor location:Location -> Consta
         if tok_opt.is_none then
             location "Unclosed const block expression" ErrorKind::Syntax raise_error
         fi
-        if tok_opt Option::Some(tok) is then
-        else
-            empty_location "Expected option value while unwrapping tok_opt" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        tok_opt.unwrap = tok
         if "}" tok Token::value == then break fi
         if TokenKind::Comment tok Token::kind == then continue fi
         if TokenKind::Newline tok Token::kind == then continue fi
@@ -1604,11 +1537,7 @@ fn parse_enum parser:Parser cursor:TokenCursor -> CasaEnum {
         for variant_name in variants.iter do
             variant_name variant_types.get = vt_opt
             if vt_opt.is_some then
-                if vt_opt Option::Some(vt_inner) is then
-                else
-                    empty_location "Expected option value while unwrapping vt_opt" ErrorKind::Syntax raise_error
-                    1 exit
-                fi
+                vt_opt.unwrap = vt_inner
                 0 = vt_index
                 while vt_index vt_inner.length > do
                     tv_set vt_index vt_inner.get canonicalize_type_var vt_index vt_inner.set
@@ -1791,11 +1720,7 @@ fn parse_trait_method_stack_effect cursor:TokenCursor -> StackEffect {
     while true do
         cursor.peek = peek_opt
         if peek_opt.is_none then break fi
-        if peek_opt Option::Some(peek) is then
-        else
-            empty_location "Expected option value while unwrapping peek_opt" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        peek_opt.unwrap = peek
         if
         "->" peek Token::value ==
         "{" peek Token::value == ||
@@ -1824,10 +1749,7 @@ fn parse_trait_method_stack_effect cursor:TokenCursor -> StackEffect {
             while true do
                 cursor.peek = return_opt
                 if return_opt.is_none then break fi
-                if return_opt Option::Some(return_token) is then
-                else
-                    break
-                fi
+                return_opt.unwrap = return_token
                 if
                 "fn" return_token Token::value ==
                 "}" return_token Token::value == ||
@@ -1857,11 +1779,7 @@ fn parse_simple_type_vars cursor:TokenCursor context:str -> List[str] {
             empty_location f"Unclosed {context} type parameter list" ErrorKind::UnmatchedBlock raise_error
             false = loop_flag
         else
-            if token_opt Option::Some(token) is then
-            else
-                empty_location "Expected option value while unwrapping token_opt" ErrorKind::Syntax raise_error
-                1 exit
-            fi
+            token_opt.unwrap = token
             if "]" token Token::value == then
                 cursor.pop drop
                 false = loop_flag
@@ -2173,11 +2091,7 @@ fn parse_pattern_terminator parser:Parser cursor:TokenCursor function_name:str -
             if "=>" next_value == 0 match_depth == && then break fi
             cursor.pop = guard_token_opt
             if guard_token_opt.is_none then break fi
-            if guard_token_opt Option::Some(guard_token) is then
-            else
-                empty_location "Expected option value while unwrapping guard_token_opt" ErrorKind::Syntax raise_error
-                1 exit
-            fi
+            guard_token_opt.unwrap = guard_token
             if "match" guard_token Token::value == then
                 1 += match_depth
             elif "end" guard_token Token::value == 0 match_depth != && then
@@ -2302,11 +2216,7 @@ fn parse_match_arm_body parser:Parser cursor:TokenCursor function_name:str ops:L
         fi
         cursor.pop = body_token_opt
         if body_token_opt.is_none then break fi
-        if body_token_opt Option::Some(body_token) is then
-        else
-            empty_location "Expected option value while unwrapping body_token_opt" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        body_token_opt.unwrap = body_token
         if TokenKind::FstringStart body_token Token::kind == then
             ops function_name cursor body_token parser handle_fstring
             continue
@@ -2447,11 +2357,7 @@ fn parse_selective_import_symbols cursor:TokenCursor location:Location -> List[s
         if symbol_opt.is_none then
             location "Unclosed selective import list" ErrorKind::UnmatchedBlock raise_error
         fi
-        if symbol_opt Option::Some(symbol_token) is then
-        else
-            empty_location "Expected option value while unwrapping symbol_opt" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        symbol_opt.unwrap = symbol_token
         if TokenKind::Comment symbol_token Token::kind == then continue fi
         if TokenKind::Newline symbol_token Token::kind == then continue fi
         if "}" symbol_token Token::value == then
@@ -2603,11 +2509,7 @@ fn selective_import_symbol
 
     symbol import_parser.store.functions.get = fn_opt
     if fn_opt.is_some then
-        if fn_opt Option::Some(imported_fn) is then
-        else
-            empty_location "Expected option value while unwrapping fn_opt" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        fn_opt.unwrap = imported_fn
         if symbol parser.store.functions.has then
             location f"Imported symbol `{symbol}` conflicts with an existing function" ErrorKind::DuplicateName raise_error
         fi
@@ -2780,11 +2682,7 @@ fn handle_keyword_for parser:Parser token:Token cursor:TokenCursor function_name
             for_loc "Unclosed `for` loop" ErrorKind::UnmatchedBlock raise_error
             return
         fi
-        if peek_opt Option::Some(peeked_token) is then
-        else
-            empty_location "Expected option value while unwrapping peek_opt" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        peek_opt.unwrap = peeked_token
         if "do" peeked_token Token::value == 0 nesting_depth == && then
             cursor.pop drop
             break
@@ -2825,11 +2723,7 @@ fn handle_keyword_for parser:Parser token:Token cursor:TokenCursor function_name
             for_loc "Unclosed `for` loop body" ErrorKind::UnmatchedBlock raise_error
             return
         fi
-        if body_peek_opt Option::Some(body_token) is then
-        else
-            empty_location "Expected option value while unwrapping body_peek_opt" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        body_peek_opt.unwrap = body_token
         if "done" body_token Token::value == 0 body_nesting_depth == && then
             cursor.pop drop
             body_token Token::location OpValue::WhileEnd Op::new ops.push
@@ -2859,11 +2753,7 @@ fn get_op_keyword parser:Parser token:Token cursor:TokenCursor function_name:str
     if keyword_opt.is_none then
         token Token::location f"Token `{token Token::value}` is not a keyword" ErrorKind::Syntax raise_error
     fi
-    if keyword_opt Option::Some(keyword) is then
-    else
-        empty_location "Expected option value while unwrapping keyword_opt" ErrorKind::Syntax raise_error
-        1 exit
-    fi
+    keyword_opt.unwrap = keyword
 
     # Simple keyword -> OpValue lookup
     keyword keyword_to_op_value = simple_opt
@@ -3010,11 +2900,7 @@ fn get_op_keyword parser:Parser token:Token cursor:TokenCursor function_name:str
         if const_value_token_opt.is_none then
             token Token::location "Expected a literal value, block expression, or constant name after constant name" ErrorKind::Syntax raise_error
         fi
-        if const_value_token_opt Option::Some(const_value_token) is then
-        else
-            empty_location "Expected option value while unwrapping const_value_token_opt" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        const_value_token_opt.unwrap = const_value_token
         if "{" const_value_token Token::value == then
             cursor.retreat
             token Token::location cursor parser eval_const_block = const_block_val
@@ -3089,11 +2975,7 @@ fn parse_struct_field_value
         if member_names cursor is_struct_field_boundary then break fi
         cursor.pop = value_opt
         if value_opt.is_none then break fi
-        if value_opt Option::Some(value_token) is then
-        else
-            empty_location "Expected option value while unwrapping value_opt" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        value_opt.unwrap = value_token
         if TokenKind::FstringStart value_token Token::kind == then
             all_ops function_name cursor value_token parser handle_fstring
             continue
@@ -3109,11 +2991,12 @@ fn parse_struct_literal
     function_name:str
 -> List[Op] {
     "{" cursor expect_token_value drop
-    if name_token Token::value parser.store.structs.get Option::Some(casa_struct) is then
-    else
+    name_token Token::value parser.store.structs.get = casa_struct_opt
+    if casa_struct_opt.is_none then
         empty_location "Expected option value while unwrapping name_token Token::value parser.store.structs.get" ErrorKind::Syntax raise_error
         1 exit
     fi
+    casa_struct_opt.unwrap = casa_struct
     List::new(List[str]) = member_names
     for member in casa_struct CasaStruct::members.iter do
         member Member::name member_names.push
@@ -3250,11 +3133,7 @@ fn parse_ops parser:Parser tokens:List[Token] -> List[Op] {
     while cursor.is_finished ! do
         cursor.pop = token_opt
         if token_opt.is_none then break fi
-        if token_opt Option::Some(token) is then
-        else
-            empty_location "Expected option value while unwrapping token_opt" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        token_opt.unwrap = token
         if TokenKind::Comment token Token::kind == then continue fi
         if TokenKind::Newline token Token::kind == then continue fi
         if TokenKind::FstringStart token Token::kind == then
@@ -3353,11 +3232,7 @@ fn resolve_enum_variant
         if rev_enum_opt.is_none then
             op Op::location f"Enum `{variant EnumVariant::enum_name}` is not defined" ErrorKind::UndefinedName CasaError::new errors.push
         else
-            if rev_enum_opt Option::Some(rev_enum) is then
-            else
-                empty_location "Expected option value while unwrapping rev_enum_opt" ErrorKind::Syntax raise_error
-                1 exit
-            fi
+            rev_enum_opt.unwrap = rev_enum
             variant EnumVariant::variant_name rev_enum CasaEnum::variants string_list_index = rev_ordinal
             if 0 rev_ordinal < then
                 op Op::location f"Variant `{variant EnumVariant::variant_name}` is not defined in enum `{variant EnumVariant::enum_name}`" ErrorKind::UndefinedName CasaError::new errors.push
@@ -3477,11 +3352,7 @@ fn resolve_identifiers store:SymbolStore ops:List[Op] function:Function -> List[
         if current_op.value OpValue::FnPush(fn_name) is then
             fn_name store.functions.get = lambda_opt
             if lambda_opt.is_some then
-                if lambda_opt Option::Some(lambda) is then
-                else
-                    empty_location "Expected option value while unwrapping lambda_opt" ErrorKind::Syntax raise_error
-                    1 exit
-                fi
+                lambda_opt.unwrap = lambda
                 true lambda Function::set_is_used
                 function lambda store gather_captures
                 lambda lambda Function::ops store resolve_identifiers = lambda_resolved
@@ -3556,11 +3427,7 @@ fn resolve_match_op store:SymbolStore function:Function op:Op errors:List[CasaEr
         PatternValue::Struct(struct_pattern) => {
             struct_pattern.bindings.keys = pattern_keys
             for pattern_key in pattern_keys.iter do
-                if pattern_key struct_pattern.bindings.get Option::Some(binding_name) is then
-                else
-                    empty_location "Expected option value while unwrapping pattern_key struct_pattern.bindings.get" ErrorKind::Syntax raise_error
-                    1 exit
-                fi
+                pattern_key struct_pattern.bindings.get.unwrap = binding_name
                 binding_name function store register_struct_pattern_binding
             done
         }
@@ -3626,10 +3493,7 @@ fn try_resolve_enum_variant_ident
     enum_name store.enums.get = enum_opt
     if enum_opt.is_none then false return fi
     ident separator 2 + ident.length separator - 2 - str::substring = binding_name
-    if enum_opt Option::Some(casa_enum) is then
-    else
-        false return
-    fi
+    enum_opt.unwrap = casa_enum
     binding_name casa_enum CasaEnum::variants string_list_index = ordinal
     if 0 ordinal < then
         op Op::location f"Variant `{binding_name}` is not defined in enum `{enum_name}`" ErrorKind::UndefinedName CasaError::new resolve_errors.push

--- a/compiler/typechecker.casa
+++ b/compiler/typechecker.casa
@@ -347,26 +347,19 @@ fn unify_generic_params_t type_a:Type type_b:Type store:SymbolStore -> Option[Ty
     type_b.type_params = params_b_opt
     if params_a_opt.is_none then type_b Option::Some return fi
     if params_b_opt.is_none then type_a Option::Some return fi
-    if params_a_opt Option::Some(params_a) is then
-    else
-        empty_location "Expected option value while unwrapping params_a_opt" ErrorKind::Syntax raise_error
-        1 exit
-    fi
-    if params_b_opt Option::Some(params_b) is then
-    else
-        empty_location "Expected option value while unwrapping params_b_opt" ErrorKind::Syntax raise_error
-        1 exit
-    fi
+    params_a_opt.unwrap = params_a
+    params_b_opt.unwrap = params_b
     if params_a.length params_b.length != then Option::None(Option[Type]) return fi
     List::new(List[Type]) = unified
     for pair in params_b.iter params_a.iter.zip do
         store pair.second pair.first unify_type_t ? unified.push
     done
-    if type_a.base Option::Some(base) is then
-    else
+    type_a.base = base_opt
+    if base_opt.is_none then
         empty_location "Expected option value while unwrapping type_a.base" ErrorKind::Syntax raise_error
         1 exit
     fi
+    base_opt.unwrap = base
     unified base GenericType Type::Generic Option::Some
 }
 
@@ -486,11 +479,7 @@ impl TypeChecker {
         if existing.is_none then
             actual type_var bindings.set return
         fi
-        if existing Option::Some(bound) is then
-        else
-            empty_location "Expected option value while unwrapping existing" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        existing.unwrap = bound
         actual.is_unknown_placeholder = actual_unknown
         bound.is_unknown_placeholder = bound_unknown
         if
@@ -524,11 +513,7 @@ impl TypeChecker {
         if base_opt.is_none then false return fi
         expected Parameter::typ.type_params = expected_params_opt
         if expected_params_opt.is_none then false return fi
-        if expected_params_opt Option::Some(expected_params) is then
-        else
-            empty_location "Expected option value while unwrapping expected_params_opt" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        expected_params_opt.unwrap = expected_params
         # Check if any param is a type variable
         false = has_type_var
         for expected_param in expected_params.iter do
@@ -540,11 +525,7 @@ impl TypeChecker {
         done
         if has_type_var ! then false return fi
 
-        if base_opt Option::Some(base) is then
-        else
-            empty_location "Expected option value while unwrapping base_opt" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        base_opt.unwrap = base
         tc.stack_pop_type match
             Type::Generic(actual_g) => {
                 if 0 actual_g.params.length == then
@@ -821,11 +802,7 @@ impl TypeChecker {
         # Enums: tag comparison via bytecode; data-carrying variants need annotation.
         if is_enum1 is_enum2 || then
             if is_enum1 then
-                if base1 tc.store.enums.get Option::Some(casa_enum) is then
-                else
-                    empty_location "Expected option value while unwrapping base1 tc.store.enums.get" ErrorKind::Syntax raise_error
-                    1 exit
-                fi
+                base1 tc.store.enums.get.unwrap = casa_enum
                 if casa_enum has_inner_values then
                     base1 GenericType::new Type::Generic Option::Some op Op::set_type_hint
                 fi
@@ -1058,11 +1035,12 @@ impl TypeChecker {
         op Op::type_hint.is_some = has_annotation
         stack_type_t = effective_type_t
         if has_annotation then
-            if op Op::type_hint Option::Some(effective_type_t) is then
-            else
+            op Op::type_hint = hint_opt
+            if hint_opt.is_none then
                 empty_location "Expected option value while unwrapping op Op::type_hint" ErrorKind::Syntax raise_error
                 1 exit
             fi
+            hint_opt.unwrap = effective_type_t
         fi
         if has_annotation ! stack_type_t.has_unresolved && then
             op Op::location f"Cannot infer element type of empty array literal assigned to `{var_name}`; add a type annotation (e.g. `= {var_name}:array[int]`) or an explicit cast (e.g. `[] (array[int])`)." ErrorKind::TypeMismatch raise_error
@@ -1070,11 +1048,7 @@ impl TypeChecker {
 
         # Try local variables first
         if function_opt.is_some then
-            if function_opt Option::Some(function) is then
-            else
-                empty_location "Expected option value while unwrapping function_opt" ErrorKind::Syntax raise_error
-                1 exit
-            fi
+            function_opt.unwrap = function
             var_name function Function::variables variable_list_index = local_index
             if 0 local_index >= then
                 local_index function Function::variables.get = local_var
@@ -1087,11 +1061,7 @@ impl TypeChecker {
         # Try global variables
         var_name tc.store.variables.get = global_opt
         if global_opt.is_some then
-            if global_opt Option::Some(global_var) is then
-            else
-                empty_location "Expected option value while unwrapping global_opt" ErrorKind::Syntax raise_error
-                1 exit
-            fi
+            global_opt.unwrap = global_var
             tc.store "global" effective_type_t global_var op unify_variable_assignment
             effective_type_t tc.expect_type_t
             return
@@ -1124,11 +1094,7 @@ impl TypeChecker {
             return
         fi
         if trait_def_opt.is_none then return fi
-        if trait_def_opt Option::Some(trait_def) is then
-        else
-            empty_location "Expected option value while unwrapping trait_def_opt" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        trait_def_opt.unwrap = trait_def
         for trait_method_entry in trait_def tc.store collect_trait_methods.iter do
             if trait_method_name trait_method_entry TraitMethod::name == then
                 tc.stack_pop_drop
@@ -1144,11 +1110,7 @@ impl TypeChecker {
     fn check_push_var tc:TypeChecker op:Op function_opt:Option[Function] {
         if op.value OpValue::PushCapture(capture_name) is then
             if function_opt.is_some then
-                if function_opt Option::Some(function) is then
-                else
-                    empty_location "Expected option value while unwrapping function_opt" ErrorKind::Syntax raise_error
-                    1 exit
-                fi
+                function_opt.unwrap = function
                 capture_name function Function::captures variable_list_index = capture_index
                 if 0 capture_index >= then
                     if capture_index function Function::captures.get Variable::typ.is_unknown ! then
@@ -1183,11 +1145,7 @@ impl TypeChecker {
 
         # Check local variables first
         if function_opt.is_some then
-            if function_opt Option::Some(function) is then
-            else
-                empty_location "Expected option value while unwrapping function_opt" ErrorKind::Syntax raise_error
-                1 exit
-            fi
+            function_opt.unwrap = function
             var_name function Function::variables variable_list_index = local_index
             if 0 local_index >= then
                 if local_index function Function::variables.get Variable::typ.is_unknown ! then
@@ -1378,21 +1336,13 @@ fn type_satisfies_trait
     fi
     trait_lookup_name store.traits.get = trait_opt
     if trait_opt.is_none then false return fi
-    if trait_opt Option::Some(trait_def) is then
-    else
-        empty_location "Expected option value while unwrapping trait_opt" ErrorKind::Syntax raise_error
-        1 exit
-    fi
+    trait_opt.unwrap = trait_def
     # Build substitution map from trait's type_params to concrete args from trait_name.
     Map::new(Map[str Type]) = trait_subs
     if trait_base_opt.is_some then
         trait_type.type_params = trait_args_opt
         if trait_args_opt.is_some then
-            if trait_args_opt Option::Some(trait_args) is then
-            else
-                empty_location "Expected option value while unwrapping trait_args_opt" ErrorKind::Syntax raise_error
-                1 exit
-            fi
+            trait_args_opt.unwrap = trait_args
             trait_def CasaTrait::type_params = tparams
             if trait_args.length tparams.length == then
                 for sub_pair in trait_args.iter tparams.iter.zip do
@@ -1429,11 +1379,7 @@ fn type_satisfies_trait
             fi
             false return
         fi
-        if fn_opt Option::Some(function) is then
-        else
-            empty_location "Expected option value while unwrapping fn_opt" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        fn_opt.unwrap = function
         store function ensure_typechecked
         if "None -> None" function Function::stack_effect stack_effect_to_str == then false return fi
         # When satisfying via the generic base, skip strict stack-effect comparison:
@@ -1564,11 +1510,7 @@ fn method_diff_bind_for_bound
 -> Map[str Type] {
     bound TraitBound::name store.traits.get = trait_opt
     if trait_opt.is_none then bindings return fi
-    if trait_opt Option::Some(trait_def) is then
-    else
-        empty_location "Expected option value while unwrapping trait_opt" ErrorKind::Syntax raise_error
-        1 exit
-    fi
+    trait_opt.unwrap = trait_def
     trait_def CasaTrait::type_params = trait_params
     bound TraitBound::type_args = bound_args
     if bound_args.length trait_params.length != then bindings return fi
@@ -1591,13 +1533,13 @@ fn method_diff_bind_all
     effect StackEffect::trait_bounds.keys = bound_keys
     for bound_type_var in bound_keys.iter do
         if bound_type_var effect StackEffect::trait_bounds.get Option::Some(bound_constraint) is then
+            bound_type_var bindings.get = concrete_opt
+            if concrete_opt Option::Some(concrete) is then
+                store concrete.format bound_constraint effect bindings method_diff_bind_for_bound = bindings
+            fi
         else
             empty_location "Expected option value while unwrapping bound_type_var effect StackEffect::trait_bounds.get" ErrorKind::Syntax raise_error
             1 exit
-        fi
-        bound_type_var bindings.get = concrete_opt
-        if concrete_opt Option::Some(concrete) is then
-            store concrete.format bound_constraint effect bindings method_diff_bind_for_bound = bindings
         fi
     done
     bindings
@@ -1637,11 +1579,7 @@ impl TypeChecker {
                         if existing_binding_opt.is_none then
                             actual binding_type_var bindings.set = bindings
                         else
-                            if existing_binding_opt Option::Some(existing_binding) is then
-                            else
-                                empty_location "Expected option value while unwrapping existing_binding_opt" ErrorKind::Syntax raise_error
-                                1 exit
-                            fi
+                            existing_binding_opt.unwrap = existing_binding
                             if existing_binding actual.eq ! then
                                 location f"Type variable `{binding_type_var}` bound to `{existing_binding.format}` but got `{actual.format}`" ErrorKind::TypeMismatch raise_error
                             fi
@@ -1683,11 +1621,12 @@ impl TypeChecker {
         type_var_keys.length 1 - = type_index
         while 0 type_index >= do
             type_index type_var_keys.get = type_var
-            if type_var effect StackEffect::trait_bounds.get Option::Some(trait_bound) is then
-            else
+            type_var effect StackEffect::trait_bounds.get = trait_bound_opt
+            if trait_bound_opt.is_none then
                 empty_location "Expected option value while unwrapping type_var effect StackEffect::trait_bounds.get" ErrorKind::Syntax raise_error
                 1 exit
             fi
+            trait_bound_opt.unwrap = trait_bound
             # Resolve trait type args against current bindings so that
             # `Carrier[T]` becomes `Carrier[int]` once T has been bound.
             trait_bound trait_bound_to_type = trait_bound_type
@@ -1698,28 +1637,21 @@ impl TypeChecker {
                 type_index 1 - = type_index
                 continue
             fi
-            if concrete_opt Option::Some(concrete_t) is then
-            else
-                empty_location "Expected option value while unwrapping concrete_opt" ErrorKind::Syntax raise_error
-                1 exit
-            fi
+            concrete_opt.unwrap = concrete_t
             concrete_t.format = concrete
-            if trait_bound TraitBound::name tc.store.traits.get Option::Some(trait_def) is then
-            else
+            trait_bound TraitBound::name tc.store.traits.get = trait_def_opt
+            if trait_def_opt.is_none then
                 empty_location "Expected option value while unwrapping trait_bound TraitBound::name tc.store.traits.get" ErrorKind::Syntax raise_error
                 1 exit
             fi
+            trait_def_opt.unwrap = trait_def
 
             # Check if forwarding (type var has same trait bound in calling function)
             false = is_forwarding
             if function_opt Option::Some(function) is then
                 concrete function Function::stack_effect StackEffect::trait_bounds.get = caller_bound_opt
                 if caller_bound_opt.is_some then
-                    if caller_bound_opt Option::Some(caller_bound_val) is then
-                    else
-                        empty_location "Expected option value while unwrapping caller_bound_opt" ErrorKind::Syntax raise_error
-                        1 exit
-                    fi
+                    caller_bound_opt.unwrap = caller_bound_val
                     if trait_bound caller_bound_val trait_bound_eq then
                         true = is_forwarding
                     fi
@@ -1757,11 +1689,7 @@ impl TypeChecker {
                         f"{concrete}::{method TraitMethod::name}" = fn_name
                         fn_name tc.store.functions.get = global_fn_opt
                         if global_fn_opt.is_some then
-                            if global_fn_opt Option::Some(global_fn) is then
-                            else
-                                empty_location "Expected option value while unwrapping global_fn_opt" ErrorKind::Syntax raise_error
-                                1 exit
-                            fi
+                            global_fn_opt.unwrap = global_fn
                             if global_fn Function::is_used ! then
                                 true global_fn Function::set_is_used
                                 global_fn global_fn Function::ops tc.store resolve_identifiers global_fn Function::set_ops
@@ -1801,11 +1729,7 @@ impl TypeChecker {
         if fn_value OpValue::FnCall(fn_name) is then
             fn_name tc.store.functions.get = fn_opt
             if fn_opt.is_some then
-                if fn_opt Option::Some(function) is then
-                else
-                    empty_location "Expected option value while unwrapping fn_opt" ErrorKind::Syntax raise_error
-                    1 exit
-                fi
+                fn_opt.unwrap = function
                 tc.store function ensure_typechecked
                 function Function::stack_effect = effect
                 if 0 effect StackEffect::trait_bounds.keys.length != then
@@ -1829,11 +1753,7 @@ impl TypeChecker {
         elif fn_value OpValue::FnPush(push_name) is then
             push_name tc.store.functions.get = push_fn_opt
             if push_fn_opt.is_some then
-                if push_fn_opt Option::Some(push_fn) is then
-                else
-                    empty_location "Expected option value while unwrapping push_fn_opt" ErrorKind::Syntax raise_error
-                    1 exit
-                fi
+                push_fn_opt.unwrap = push_fn
                 tc.store push_fn ensure_typechecked
                 push_fn Function::stack_effect stack_effect_to_function_type tc.stack_push_type
             else
@@ -1889,11 +1809,7 @@ impl TypeChecker {
                     if unified_opt.is_none then
                         op Op::location f"Heterogeneous array literal: cannot unify `{elem_type_t.format}` and `{item_type_t.format}`" ErrorKind::TypeMismatch raise_error
                     else
-                        if unified_opt Option::Some(elem_type_t) is then
-                        else
-                            empty_location "Expected option value while unwrapping unified_opt" ErrorKind::Syntax raise_error
-                            1 exit
-                        fi
+                        unified_opt.unwrap = elem_type_t
                     fi
                     1 += items_idx
                 done
@@ -2000,11 +1916,7 @@ impl TypeChecker {
             _ => Option::None(Option[int])
         end = arg_count_opt
         if arg_count_opt.is_none then return fi
-        if arg_count_opt Option::Some(arg_count) is then
-        else
-            empty_location "Expected option value while unwrapping arg_count_opt" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        arg_count_opt.unwrap = arg_count
         TYPE_INT_T tc.expect_type_t
         0 = index
         while index arg_count > do
@@ -2029,11 +1941,7 @@ impl TypeChecker {
             enum_name GenericType::new Type::Generic tc.stack_push_type
             return
         fi
-        if enum_opt Option::Some(casa_enum) is then
-        else
-            empty_location "Expected option value while unwrapping enum_opt" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        enum_opt.unwrap = casa_enum
         variant EnumVariant::variant_name casa_enum CasaEnum::variant_types.get = inner_opt
         if inner_opt.is_none then
             # No inner values - push the enum type
@@ -2044,11 +1952,7 @@ impl TypeChecker {
             fi
             return
         fi
-        if inner_opt Option::Some(inner_types) is then
-        else
-            empty_location "Expected option value while unwrapping inner_opt" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        inner_opt.unwrap = inner_types
         if 0 inner_types.length == then
             if 0 casa_enum CasaEnum::type_vars.length != then
                 casa_enum CasaEnum::type_vars enum_name build_parameterized_type tc.stack_push_type
@@ -2100,11 +2004,7 @@ impl TypeChecker {
             TYPE_BOOL_T tc.stack_push_type
             return
         fi
-        if base tc.store.enums.get Option::Some(casa_enum) is then
-        else
-            empty_location "Expected option value while unwrapping base tc.store.enums.get" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        base tc.store.enums.get.unwrap = casa_enum
         if op.value OpValue::IsCheck(variant) is ! then
             TYPE_BOOL_T tc.stack_push_type
             return
@@ -2119,11 +2019,7 @@ impl TypeChecker {
         if 0 variant EnumVariant::bindings.length != then
             variant EnumVariant::variant_name casa_enum CasaEnum::variant_types.get = inner_opt
             if inner_opt.is_some then
-                if inner_opt Option::Some(inner_types) is then
-                else
-                    empty_location "Expected option value while unwrapping inner_opt" ErrorKind::Syntax raise_error
-                    1 exit
-                fi
+                inner_opt.unwrap = inner_types
                 if variant EnumVariant::bindings.length inner_types.length != then
                     f"Variant `{variant EnumVariant::enum_name}::{variant EnumVariant::variant_name}` has {inner_types.length} inner value(s), but {variant EnumVariant::bindings.length} binding(s) provided" tc.raise_type_mismatch
                 fi
@@ -2140,11 +2036,7 @@ impl TypeChecker {
 
 fn set_binding_type var_name:str field_type:Type function_opt:Option[Function] store:SymbolStore {
     if function_opt.is_some then
-        if function_opt Option::Some(function) is then
-        else
-            empty_location "Expected option value while unwrapping function_opt" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        function_opt.unwrap = function
         for variable in function Function::variables.iter do
             if var_name variable Variable::name == then
                 field_type variable Variable::set_typ
@@ -2229,11 +2121,7 @@ impl TypeChecker {
 
                 # Check exhaustiveness
                 if end_base tc.store.enums.get.is_some has_wildcard ! && then
-                    if end_base tc.store.enums.get Option::Some(end_enum) is then
-                    else
-                        empty_location "Expected option value while unwrapping end_base tc.store.enums.get" ErrorKind::Syntax raise_error
-                        1 exit
-                    fi
+                    end_base tc.store.enums.get.unwrap = end_enum
                     List::new(List[str]) = missing
                     for variant_name in end_enum CasaEnum::variants.iter do
                         if variant_name covered_set.has ! then
@@ -2347,11 +2235,7 @@ impl TypeChecker {
             name GenericType::new Type::Generic tc.stack_push_type
             return
         fi
-        if struct_opt Option::Some(casa_struct) is then
-        else
-            empty_location "Expected option value while unwrapping struct_opt" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        struct_opt.unwrap = casa_struct
         # Pop field values in reverse order
         literal StructLiteral::field_order.length 1 - = index
         while 0 index >= do
@@ -2376,11 +2260,7 @@ impl TypeChecker {
 fn find_default_trait_method method_name:str store:SymbolStore -> Option[TraitMethod] {
     store.traits.keys = find_trait_keys
     for find_trait_key in find_trait_keys.iter do
-        if find_trait_key store.traits.get Option::Some(find_trait_def) is then
-        else
-            empty_location "Expected option value while unwrapping find_trait_key store.traits.get" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        find_trait_key store.traits.get.unwrap = find_trait_def
         for find_method in find_trait_def CasaTrait::methods.iter do
             if method_name find_method TraitMethod::name == 0 find_method TraitMethod::default_ops.length != && then
                 find_method Option::Some return
@@ -2393,11 +2273,7 @@ fn find_default_trait_method method_name:str store:SymbolStore -> Option[TraitMe
 fn find_trait_for_method method_name:str store:SymbolStore -> Option[CasaTrait] {
     store.traits.keys = ftm_trait_keys
     for ftm_trait_key in ftm_trait_keys.iter do
-        if ftm_trait_key store.traits.get Option::Some(ftm_trait_def) is then
-        else
-            empty_location "Expected option value while unwrapping ftm_trait_key store.traits.get" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        ftm_trait_key store.traits.get.unwrap = ftm_trait_def
         for ftm_method in ftm_trait_def CasaTrait::methods.iter do
             if method_name ftm_method TraitMethod::name == 0 ftm_method TraitMethod::default_ops.length != && then
                 ftm_trait_def Option::Some return
@@ -2454,22 +2330,14 @@ fn instantiate_default_trait_method
         false = DEFAULT_METHOD_INSTANTIATING
         Option::None(Option[str]) return
     fi
-    if default_method_opt Option::Some(default_method) is then
-    else
-        empty_location "Expected option value while unwrapping default_method_opt" ErrorKind::Syntax raise_error
-        1 exit
-    fi
+    default_method_opt.unwrap = default_method
 
     store method_name find_trait_for_method = trait_opt
     if trait_opt.is_none then
         false = DEFAULT_METHOD_INSTANTIATING
         Option::None(Option[str]) return
     fi
-    if trait_opt Option::Some(trait_def) is then
-    else
-        empty_location "Expected option value while unwrapping trait_opt" ErrorKind::Syntax raise_error
-        1 exit
-    fi
+    trait_opt.unwrap = trait_def
 
     # Check that receiver implements all abstract methods
     if store trait_def receiver check_abstract_methods_present ! then
@@ -2492,11 +2360,7 @@ fn instantiate_default_trait_method
     Map::new(Map[str Type]) = trait_subs
     receiver = default_self_type
     if fn_base_opt.is_some then
-        if fn_base_opt Option::Some(base_name) is then
-        else
-            empty_location "Expected option value while unwrapping fn_base_opt" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        fn_base_opt.unwrap = base_name
         if 0 type_params.length != then
             " " type_params.join = tparams_str
             f"{base_name}[{tparams_str}]" = default_self_type
@@ -2514,11 +2378,7 @@ fn instantiate_default_trait_method
             if 0 infer_method TraitMethod::default_ops.length == then
                 f"{receiver}::{infer_method TraitMethod::name}" store.functions.get = infer_fn_opt
                 if infer_fn_opt.is_some then
-                    if infer_fn_opt Option::Some(infer_fn) is then
-                    else
-                        empty_location "Expected option value while unwrapping infer_fn_opt" ErrorKind::Syntax raise_error
-                        1 exit
-                    fi
+                    infer_fn_opt.unwrap = infer_fn
                     store infer_fn ensure_typechecked
                     receiver infer_method TraitMethod::stack_effect resolve_trait_stack_effect = infer_trait_resolved
                     0 = ret_index
@@ -2568,11 +2428,7 @@ fn instantiate_default_trait_method
         if lambda_name "lambda__" str::starts_with ! then continue fi
         lambda_name store.functions.get = lambda_opt
         if lambda_opt.is_none then continue fi
-        if lambda_opt Option::Some(lambda) is then
-        else
-            empty_location "Expected lambda function during default method instantiation" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        lambda_opt.unwrap = lambda
 
         f"{lambda_name}__{synth_fn_name}_{cloned_lambda_index}" = cloned_lambda_name
         lambda Function::ops clone_ops = lambda_ops
@@ -2626,19 +2482,11 @@ impl TypeChecker {
             function Function::stack_effect StackEffect::trait_bounds = bounds
             receiver bounds.get = trait_opt
             if trait_opt.is_some then
-                if trait_opt Option::Some(bound) is then
-                else
-                    empty_location "Expected option value while unwrapping trait_opt" ErrorKind::Syntax raise_error
-                    1 exit
-                fi
+                trait_opt.unwrap = bound
                 bound TraitBound::name = trait_name
                 trait_name tc.store.traits.get = trait_def_opt
                 if trait_def_opt.is_some then
-                    if trait_def_opt Option::Some(trait_def) is then
-                    else
-                        empty_location "Expected option value while unwrapping trait_def_opt" ErrorKind::Syntax raise_error
-                        1 exit
-                    fi
+                    trait_def_opt.unwrap = trait_def
                     # Build substitution map from trait's type_params to the
                     # bound's concrete type_args, so that a trait method like
                     # `next self:self -> Option[T]` with bound `I: Iterable[int]`
@@ -2686,21 +2534,13 @@ impl TypeChecker {
         if fn_opt.is_none then
             tc.store receiver method_name function_opt instantiate_default_trait_method = default_inst_opt
             if default_inst_opt.is_some then
-                if default_inst_opt Option::Some(fn_name) is then
-                else
-                    empty_location "Expected option value while unwrapping default_inst_opt" ErrorKind::Syntax raise_error
-                    1 exit
-                fi
+                default_inst_opt.unwrap = fn_name
                 fn_name tc.store.functions.get = fn_opt
             fi
         fi
 
         if fn_opt.is_some then
-            if fn_opt Option::Some(function) is then
-            else
-                empty_location "Expected option value while unwrapping fn_opt" ErrorKind::Syntax raise_error
-                1 exit
-            fi
+            fn_opt.unwrap = function
             if function Function::is_typechecked ! then
                 function function Function::ops tc.store resolve_identifiers function Function::set_ops
                 true function Function::set_is_used
@@ -3058,11 +2898,7 @@ fn type_check_ops ops:List[Op] function_opt:Option[Function] store:SymbolStore -
     store TypeChecker::new = checker
     Option::None(Option[int]) = budget
     if function_opt.is_some then
-        if function_opt Option::Some(the_function) is then
-        else
-            empty_location "Expected option value while unwrapping function_opt" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        function_opt.unwrap = the_function
         if the_function Function::name "lambda__" str::starts_with ! then
             the_function Function::stack_effect StackEffect::parameters.length Option::Some = budget
         fi
@@ -3081,11 +2917,7 @@ fn type_check_ops ops:List[Op] function_opt:Option[Function] store:SymbolStore -
     # Verify against declared stack effect if function has one
     ERRORS.length errors_before_ops < = had_type_errors
     if function_opt.is_some had_type_errors ! && then
-        if function_opt Option::Some(declared_function) is then
-        else
-            empty_location "Expected option value while unwrapping function_opt" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        function_opt.unwrap = declared_function
         declared_function Function::stack_effect = declared
         if
         declared stack_effect_to_str "None -> None" !=

--- a/lsp.casa
+++ b/lsp.casa
@@ -265,10 +265,7 @@ fn read_message reader:StdinReader -> Option[JsonValue] {
         Option::None(Option[JsonValue])
         return
     fi
-    if content_length Option::Some(length) is then
-    else
-        Option::None(Option[JsonValue]) return
-    fi
+    content_length.unwrap = length
     length reader stdin_read_exact = body
     body Cursor::new = cursor
     cursor json_parse = parse_result
@@ -320,11 +317,7 @@ fn compile_document file_path:str source:str open_docs:Map[str DocumentState] ->
     # Seed SOURCE_CACHE from peer open documents
     open_docs.keys = uris
     for uri in uris.iter do
-        if uri open_docs.get Option::Some(cached_state) is then
-        else
-            empty_location "Expected option value while unwrapping uri open_docs.get" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        uri open_docs.get.unwrap = cached_state
         if cached_state DocumentState::file_path file_path != then
             cached_state DocumentState::source cached_state DocumentState::file_path SOURCE_CACHE.set = SOURCE_CACHE
         fi
@@ -360,11 +353,7 @@ fn compile_document file_path:str source:str open_docs:Map[str DocumentState] ->
     Map::new(Map[str Variable]) = vars_copy
     store.variables.keys = var_keys
     for var_name in var_keys.iter do
-        if var_name store.variables.get Option::Some(var_value) is then
-        else
-            empty_location "Expected option value while unwrapping var_name store.variables.get" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        var_name store.variables.get.unwrap = var_value
         var_value var_name vars_copy.set = vars_copy
     done
     vars_copy
@@ -372,11 +361,7 @@ fn compile_document file_path:str source:str open_docs:Map[str DocumentState] ->
     Map::new(Map[str CasaEnum]) = enums_copy
     store.enums.keys = enum_keys
     for enum_name in enum_keys.iter do
-        if enum_name store.enums.get Option::Some(enum_value) is then
-        else
-            empty_location "Expected option value while unwrapping enum_name store.enums.get" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        enum_name store.enums.get.unwrap = enum_value
         enum_value enum_name enums_copy.set = enums_copy
     done
     enums_copy
@@ -384,11 +369,7 @@ fn compile_document file_path:str source:str open_docs:Map[str DocumentState] ->
     Map::new(Map[str CasaStruct]) = structs_copy
     store.structs.keys = struct_keys
     for struct_name in struct_keys.iter do
-        if struct_name store.structs.get Option::Some(struct_value) is then
-        else
-            empty_location "Expected option value while unwrapping struct_name store.structs.get" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        struct_name store.structs.get.unwrap = struct_value
         struct_value struct_name structs_copy.set = structs_copy
     done
     structs_copy
@@ -396,11 +377,7 @@ fn compile_document file_path:str source:str open_docs:Map[str DocumentState] ->
     Map::new(Map[str Function]) = fns_copy
     store.functions.keys = fn_keys
     for fn_name in fn_keys.iter do
-        if fn_name store.functions.get Option::Some(fn_value) is then
-        else
-            empty_location "Expected option value while unwrapping fn_name store.functions.get" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        fn_name store.functions.get.unwrap = fn_value
         fn_value fn_name fns_copy.set = fns_copy
     done
     fns_copy
@@ -453,11 +430,7 @@ fn diagnostics_from result:CompileResult path:str -> List[LspDiagnostic] {
         fi
         error CasaError::location Location::file source_cache.get = source_opt
         if source_opt.is_some then
-            if source_opt Option::Some(error_source) is then
-            else
-                empty_location "Expected option value while unwrapping source_opt" ErrorKind::Syntax raise_error
-                1 exit
-            fi
+            source_opt.unwrap = error_source
         else
             fallback_source = error_source
         fi
@@ -494,11 +467,7 @@ fn diagnostics_from result:CompileResult path:str -> List[LspDiagnostic] {
         fi
         warning CasaWarning::location Location::file source_cache.get = warn_source_opt
         if warn_source_opt.is_some then
-            if warn_source_opt Option::Some(warn_source) is then
-            else
-                empty_location "Expected option value while unwrapping warn_source_opt" ErrorKind::Syntax raise_error
-                1 exit
-            fi
+            warn_source_opt.unwrap = warn_source
         else
             fallback_source = warn_source
         fi
@@ -564,11 +533,7 @@ fn find_op_at_position state:DocumentState line:int col:int -> Option[FindResult
     # Search function ops
     state DocumentState::functions.keys = func_keys
     for func_name in func_keys.iter do
-        if func_name state DocumentState::functions.get Option::Some(func) is then
-        else
-            empty_location "Expected option value while unwrapping func_name state DocumentState::functions.get" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        func_name state DocumentState::functions.get.unwrap = func
         if
         "" func Function::location Location::file ==
         func Function::location Location::file state DocumentState::file_path != ||
@@ -585,11 +550,7 @@ fn find_function_at_position state:DocumentState line:int col:int -> Option[Func
     col line state DocumentState::source position_to_offset = target_offset
     state DocumentState::functions.keys = func_keys
     for func_name in func_keys.iter do
-        if func_name state DocumentState::functions.get Option::Some(func) is then
-        else
-            empty_location "Expected option value while unwrapping func_name state DocumentState::functions.get" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        func_name state DocumentState::functions.get.unwrap = func
         if
         "" func Function::location Location::file ==
         func Function::location Location::file state DocumentState::file_path != ||
@@ -626,11 +587,7 @@ fn function_short_name name:str -> str {
 fn find_containing_function state:DocumentState offset:int -> Option[Function] {
     state DocumentState::functions.keys = func_keys
     for func_name in func_keys.iter do
-        if func_name state DocumentState::functions.get Option::Some(func) is then
-        else
-            empty_location "Expected option value while unwrapping func_name state DocumentState::functions.get" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        func_name state DocumentState::functions.get.unwrap = func
         if "" func Function::location Location::file == then
             continue
         fi
@@ -654,11 +611,7 @@ fn find_containing_function state:DocumentState offset:int -> Option[Function] {
 fn casa_location_to_lsp location:Location -> LspLocation {
     location Location::file SOURCE_CACHE.get = source_opt
     if source_opt.is_some then
-        if source_opt Option::Some(location_source) is then
-        else
-            empty_location "Expected option value while unwrapping source_opt" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        source_opt.unwrap = location_source
     else
         "" = location_source
     fi
@@ -719,16 +672,18 @@ fn split_qualified name:str -> List[str] {
 # ============================================================================
 
 fn extract_uri message:JsonValue -> str {
-    if "params" message json_get_object Option::Some(params) is then
-    else
+    "params" message json_get_object = params_opt
+    if params_opt.is_none then
         empty_location "Expected option value while unwrapping params message json_get_object" ErrorKind::Syntax raise_error
         1 exit
     fi
-    if "textDocument" params json_get_object Option::Some(text_document) is then
-    else
+    params_opt.unwrap = params
+    "textDocument" params json_get_object = text_document_opt
+    if text_document_opt.is_none then
         empty_location "Expected option value while unwrapping textDocument params json_get_object" ErrorKind::Syntax raise_error
         1 exit
     fi
+    text_document_opt.unwrap = text_document
     if "uri" text_document json_get_str Option::Some(uri) is then
         uri return
     fi
@@ -738,81 +693,94 @@ fn extract_uri message:JsonValue -> str {
 }
 
 fn extract_position message:JsonValue -> LspRange {
-    if "params" message json_get_object Option::Some(params) is then
-    else
+    "params" message json_get_object = params_opt
+    if params_opt.is_none then
         empty_location "Expected option value while unwrapping params message json_get_object" ErrorKind::Syntax raise_error
         1 exit
     fi
-    if "position" params json_get_object Option::Some(position) is then
-    else
+    params_opt.unwrap = params
+    "position" params json_get_object = position_opt
+    if position_opt.is_none then
         empty_location "Expected option value while unwrapping position params json_get_object" ErrorKind::Syntax raise_error
         1 exit
     fi
-    if "line" position json_get_int Option::Some(line) is then
-    else
+    position_opt.unwrap = position
+    "line" position json_get_int = line_opt
+    if line_opt.is_none then
         empty_location "Expected option value while unwrapping line position json_get_int" ErrorKind::Syntax raise_error
         1 exit
     fi
-    if "character" position json_get_int Option::Some(character) is then
-    else
+    line_opt.unwrap = line
+    "character" position json_get_int = character_opt
+    if character_opt.is_none then
         empty_location "Expected option value while unwrapping character position json_get_int" ErrorKind::Syntax raise_error
         1 exit
     fi
+    character_opt.unwrap = character
     0 0 character line LspRange
 }
 
 fn handle_did_open message:JsonValue {
-    if "params" message json_get_object Option::Some(params) is then
-    else
+    "params" message json_get_object = params_opt
+    if params_opt.is_none then
         empty_location "Expected option value while unwrapping params message json_get_object" ErrorKind::Syntax raise_error
         1 exit
     fi
-    if "textDocument" params json_get_object Option::Some(text_document) is then
-    else
+    params_opt.unwrap = params
+    "textDocument" params json_get_object = text_document_opt
+    if text_document_opt.is_none then
         empty_location "Expected option value while unwrapping textDocument params json_get_object" ErrorKind::Syntax raise_error
         1 exit
     fi
-    if "uri" text_document json_get_str Option::Some(uri) is then
-    else
+    text_document_opt.unwrap = text_document
+    "uri" text_document json_get_str = uri_opt
+    if uri_opt.is_none then
         empty_location "Expected option value while unwrapping uri text_document json_get_str" ErrorKind::Syntax raise_error
         1 exit
     fi
-    if "text" text_document json_get_str Option::Some(text) is then
-    else
+    uri_opt.unwrap = uri
+    "text" text_document json_get_str = text_opt
+    if text_opt.is_none then
         empty_location "Expected option value while unwrapping text text_document json_get_str" ErrorKind::Syntax raise_error
         1 exit
     fi
+    text_opt.unwrap = text
     text uri ingest_document = diagnostics
     diagnostics uri publish_diagnostics
 }
 
 fn handle_did_change message:JsonValue {
-    if "params" message json_get_object Option::Some(params) is then
-    else
+    "params" message json_get_object = params_opt
+    if params_opt.is_none then
         empty_location "Expected option value while unwrapping params message json_get_object" ErrorKind::Syntax raise_error
         1 exit
     fi
-    if "textDocument" params json_get_object Option::Some(text_document) is then
-    else
+    params_opt.unwrap = params
+    "textDocument" params json_get_object = text_document_opt
+    if text_document_opt.is_none then
         empty_location "Expected option value while unwrapping textDocument params json_get_object" ErrorKind::Syntax raise_error
         1 exit
     fi
-    if "uri" text_document json_get_str Option::Some(uri) is then
-    else
+    text_document_opt.unwrap = text_document
+    "uri" text_document json_get_str = uri_opt
+    if uri_opt.is_none then
         empty_location "Expected option value while unwrapping uri text_document json_get_str" ErrorKind::Syntax raise_error
         1 exit
     fi
-    if "contentChanges" params json_get_array Option::Some(changes) is then
-    else
+    uri_opt.unwrap = uri
+    "contentChanges" params json_get_array = changes_opt
+    if changes_opt.is_none then
         empty_location "Expected option value while unwrapping contentChanges params json_get_array" ErrorKind::Syntax raise_error
         1 exit
     fi
+    changes_opt.unwrap = changes
     0 changes.get = change
-    if "text" change json_get_str Option::Some(text) is then
-    else
+    "text" change json_get_str = text_opt
+    if text_opt.is_none then
         empty_location "Expected option value while unwrapping text change json_get_str" ErrorKind::Syntax raise_error
         1 exit
     fi
+    text_opt.unwrap = text
     text uri ingest_document = diagnostics
     diagnostics uri publish_diagnostics
 }
@@ -824,11 +792,7 @@ fn handle_did_save message:JsonValue {
         f"error: handle_did_save read failed for {uri}: {read_err.to_str}" eprintln
         return
     fi
-    if read_result Result::Ok(saved_source) is then
-    else
-        empty_location "Expected option value while unwrapping read_result" ErrorKind::Syntax raise_error
-        1 exit
-    fi
+    read_result.unwrap = saved_source
     saved_source uri ingest_document = diagnostics
     diagnostics uri publish_diagnostics
 }
@@ -880,11 +844,7 @@ fn compute_definition state:DocumentState line:int col:int -> Option[LspLocation
         Option::None(Option[LspLocation])
         return
     fi
-    if result Option::Some(find) is then
-    else
-        empty_location "Expected option value while unwrapping result" ErrorKind::Syntax raise_error
-        1 exit
-    fi
+    result.unwrap = find
     find FindResult::op = op
     find FindResult::function = func
     col line state DocumentState::source position_to_offset = cursor_offset
@@ -922,11 +882,7 @@ fn compute_definition state:DocumentState line:int col:int -> Option[LspLocation
         fi
         op op_str_value state DocumentState::functions.get = fn_opt
         if fn_opt.is_some then
-            if fn_opt Option::Some(fn_def) is then
-            else
-                empty_location "Expected option value while unwrapping fn_opt" ErrorKind::Syntax raise_error
-                1 exit
-            fi
+            fn_opt.unwrap = fn_def
             if "" fn_def Function::location Location::file != then
                 fn_def Function::location casa_location_to_lsp Option::Some
                 return
@@ -955,11 +911,7 @@ fn compute_definition state:DocumentState line:int col:int -> Option[LspLocation
             Option::None(Option[LspLocation])
             return
         fi
-        if enum_name state DocumentState::enums.get Option::Some(casa_enum) is then
-        else
-            empty_location "Expected option value while unwrapping enum_name state DocumentState::enums.get" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        enum_name state DocumentState::enums.get.unwrap = casa_enum
         enum_variant EnumVariant::variant_name casa_enum CasaEnum::variant_locations.get = variant_loc_opt
         if qpart_is_member then
             if variant_loc_opt Option::Some(variant_loc) is then
@@ -989,22 +941,19 @@ fn compute_definition state:DocumentState line:int col:int -> Option[LspLocation
 
 fn handle_definition message:JsonValue {
     message extract_uri = uri
-    if "id" message json_get_value Option::Some(request_id) is then
-    else
+    "id" message json_get_value = request_id_opt
+    if request_id_opt.is_none then
         empty_location "Expected option value while unwrapping id message json_get_value" ErrorKind::Syntax raise_error
         1 exit
     fi
+    request_id_opt.unwrap = request_id
 
     uri DOCUMENT_STATES.get = state_opt
     if state_opt.is_none then
         JsonValue::JsonNull request_id send_response
         return
     fi
-    if state_opt Option::Some(state) is then
-    else
-        empty_location "Expected option value while unwrapping state_opt" ErrorKind::Syntax raise_error
-        1 exit
-    fi
+    state_opt.unwrap = state
 
     message extract_position = position
     position LspRange::start_col position LspRange::start_line state compute_definition = loc_opt
@@ -1021,11 +970,7 @@ fn handle_definition message:JsonValue {
 
 fn resolve_variable_type name:str func:Option[Function] state:DocumentState -> Option[str] {
     if func.is_some then
-        if func Option::Some(resolved_func) is then
-        else
-            empty_location "Expected option value while unwrapping func" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        func.unwrap = resolved_func
         for variable in resolved_func Function::variables.iter do
             if variable Variable::name name == then
                 if "" variable Variable::typ.format != then
@@ -1061,11 +1006,7 @@ fn format_hover op:Op state:DocumentState func:Option[Function] -> Option[str] {
     if op_value OpValue::FnCall is op_value OpValue::FnPush is || then
         op op_str_value state DocumentState::functions.get = fn_opt
         if fn_opt.is_some then
-            if fn_opt Option::Some(hover_func) is then
-            else
-                empty_location "Expected option value while unwrapping fn_opt" ErrorKind::Syntax raise_error
-                1 exit
-            fi
+            fn_opt.unwrap = hover_func
             StringBuilder::new = builder
             "fn " builder.append
             hover_func Function::name builder.append
@@ -1249,11 +1190,7 @@ fn compute_hover state:DocumentState line:int col:int -> Option[HoverContent] {
         Option::None(Option[HoverContent])
         return
     fi
-    if result Option::Some(find) is then
-    else
-        empty_location "Expected option value while unwrapping result" ErrorKind::Syntax raise_error
-        1 exit
-    fi
+    result.unwrap = find
     find FindResult::op = op
     find FindResult::function = func
     col line state DocumentState::source position_to_offset = cursor_offset
@@ -1335,22 +1272,19 @@ fn compute_hover state:DocumentState line:int col:int -> Option[HoverContent] {
 
 fn handle_hover message:JsonValue {
     message extract_uri = uri
-    if "id" message json_get_value Option::Some(request_id) is then
-    else
+    "id" message json_get_value = request_id_opt
+    if request_id_opt.is_none then
         empty_location "Expected option value while unwrapping id message json_get_value" ErrorKind::Syntax raise_error
         1 exit
     fi
+    request_id_opt.unwrap = request_id
 
     uri DOCUMENT_STATES.get = state_opt
     if state_opt.is_none then
         JsonValue::JsonNull request_id send_response
         return
     fi
-    if state_opt Option::Some(state) is then
-    else
-        empty_location "Expected option value while unwrapping state_opt" ErrorKind::Syntax raise_error
-        1 exit
-    fi
+    state_opt.unwrap = state
 
     message extract_position = position
     position LspRange::start_col position LspRange::start_line state compute_hover = hover_opt
@@ -1358,11 +1292,7 @@ fn handle_hover message:JsonValue {
         JsonValue::JsonNull request_id send_response
         return
     fi
-    if hover_opt Option::Some(hover) is then
-    else
-        empty_location "Expected option value while unwrapping hover_opt" ErrorKind::Syntax raise_error
-        1 exit
-    fi
+    hover_opt.unwrap = hover
     json_object
     "contents" json_object
     "kind" "markdown" JsonValue::JsonString json_set
@@ -1401,11 +1331,7 @@ fn members_for_qualified type_name:str state:DocumentState -> List[CompletionIte
     # Enum variants
     type_name state DocumentState::enums.get = enum_opt
     if enum_opt.is_some then
-        if enum_opt Option::Some(casa_enum) is then
-        else
-            empty_location "Expected option value while unwrapping enum_opt" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        enum_opt.unwrap = casa_enum
         for variant_name in casa_enum CasaEnum::variants.iter do
             "" COMPLETION_ENUM_MEMBER variant_name CompletionItem items.push
         done
@@ -1495,11 +1421,7 @@ fn resolve_chain_type parts:List[str] state:DocumentState offset:int -> Option[s
         Option::None(Option[str])
         return
     fi
-    if current_type Option::Some(resolved_type) is then
-    else
-        empty_location "Expected option value while unwrapping current_type" ErrorKind::Syntax raise_error
-        1 exit
-    fi
+    current_type.unwrap = resolved_type
     1 = part_index
     while part_index parts.length > do
         resolved_type parse_type_str.base = base_opt
@@ -1510,11 +1432,7 @@ fn resolve_chain_type parts:List[str] state:DocumentState offset:int -> Option[s
             Option::None(Option[str])
             return
         fi
-        if fn_opt Option::Some(func) is then
-        else
-            empty_location "Expected option value while unwrapping fn_opt" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        fn_opt.unwrap = func
         if 0 func Function::stack_effect StackEffect::return_types.length == then
             Option::None(Option[str])
             return
@@ -1583,11 +1501,7 @@ fn compute_completion state:DocumentState line:int col:int trigger:str -> List[C
     # Structs
     state DocumentState::structs.keys = struct_keys
     for struct_name in struct_keys.iter do
-        if struct_name state DocumentState::structs.get Option::Some(struct_val) is then
-        else
-            empty_location "Expected option value while unwrapping struct_name state DocumentState::structs.get" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        struct_name state DocumentState::structs.get.unwrap = struct_val
         StringBuilder::new = member_builder
         0 = member_index
         while member_index struct_val CasaStruct::members.length > do
@@ -1610,11 +1524,7 @@ fn compute_completion state:DocumentState line:int col:int trigger:str -> List[C
     # Local variables
     cursor_offset state find_containing_function = containing_func_opt
     if containing_func_opt.is_some then
-        if containing_func_opt Option::Some(containing_func) is then
-        else
-            empty_location "Expected option value while unwrapping containing_func_opt" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        containing_func_opt.unwrap = containing_func
         for local_var in containing_func Function::variables.iter do
             local_var Variable::typ.format COMPLETION_VARIABLE local_var Variable::name CompletionItem items.push
         done
@@ -1651,11 +1561,12 @@ fn compute_completion state:DocumentState line:int col:int trigger:str -> List[C
 
 fn handle_completion message:JsonValue {
     message extract_uri = uri
-    if "id" message json_get_value Option::Some(request_id) is then
-    else
+    "id" message json_get_value = request_id_opt
+    if request_id_opt.is_none then
         empty_location "Expected option value while unwrapping id message json_get_value" ErrorKind::Syntax raise_error
         1 exit
     fi
+    request_id_opt.unwrap = request_id
 
     uri DOCUMENT_STATES.get = state_opt
     if state_opt.is_none then
@@ -1665,28 +1576,21 @@ fn handle_completion message:JsonValue {
         JsonValue::JsonObject request_id send_response
         return
     fi
-    if state_opt Option::Some(state) is then
-    else
-        empty_location "Expected option value while unwrapping state_opt" ErrorKind::Syntax raise_error
-        1 exit
-    fi
+    state_opt.unwrap = state
 
     # Check trigger character
-    if "params" message json_get_object Option::Some(params) is then
-    else
+    "params" message json_get_object = params_opt
+    if params_opt.is_none then
         empty_location "Expected option value while unwrapping params message json_get_object" ErrorKind::Syntax raise_error
         1 exit
     fi
+    params_opt.unwrap = params
     "context" params json_get_object = context_opt
     "" = trigger
     if context_opt Option::Some(context) is then
         "triggerCharacter" context json_get_str = trigger_opt
         if trigger_opt.is_some then
-            if trigger_opt Option::Some(trigger) is then
-            else
-                empty_location "Expected option value while unwrapping trigger_opt" ErrorKind::Syntax raise_error
-                1 exit
-            fi
+            trigger_opt.unwrap = trigger
         fi
     fi
 
@@ -1773,11 +1677,7 @@ fn collect_refs_in_all_functions
 {
     state DocumentState::functions.keys = fn_keys
     for fn_name in fn_keys.iter do
-        if fn_name state DocumentState::functions.get Option::Some(func) is then
-        else
-            empty_location "Expected option value while unwrapping fn_name state DocumentState::functions.get" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        fn_name state DocumentState::functions.get.unwrap = func
         if COLLECTOR_FN collector_kind == then
             results name func Function::ops collect_fn_refs
         elif COLLECTOR_VAR collector_kind == then
@@ -1792,11 +1692,7 @@ fn collect_refs_in_all_functions
 
 fn is_local_variable name:str func:Option[Function] -> bool {
     if func.is_none then false return fi
-    if func Option::Some(resolved_func) is then
-    else
-        empty_location "Expected option value while unwrapping func" ErrorKind::Syntax raise_error
-        1 exit
-    fi
+    func.unwrap = resolved_func
     for variable in resolved_func Function::variables.iter do
         if variable Variable::name name == then
             true return
@@ -1896,11 +1792,7 @@ fn compute_references
             Option::None(Option[List[LspLocation]])
             return
         fi
-        if result Option::Some(find) is then
-        else
-            empty_location "Expected option value while unwrapping result" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        result.unwrap = find
         find FindResult::op = op
         find FindResult::function = func
     fi
@@ -1915,22 +1807,19 @@ fn compute_references
 
 fn handle_references message:JsonValue {
     message extract_uri = uri
-    if "id" message json_get_value Option::Some(request_id) is then
-    else
+    "id" message json_get_value = request_id_opt
+    if request_id_opt.is_none then
         empty_location "Expected option value while unwrapping id message json_get_value" ErrorKind::Syntax raise_error
         1 exit
     fi
+    request_id_opt.unwrap = request_id
 
     uri DOCUMENT_STATES.get = state_opt
     if state_opt.is_none then
         JsonValue::JsonNull request_id send_response
         return
     fi
-    if state_opt Option::Some(state) is then
-    else
-        empty_location "Expected option value while unwrapping state_opt" ErrorKind::Syntax raise_error
-        1 exit
-    fi
+    state_opt.unwrap = state
 
     # includeDeclaration
     Option::None(Option[JsonValue]) = context_opt
@@ -1941,11 +1830,7 @@ fn handle_references message:JsonValue {
     if context_opt Option::Some(context) is then
         "includeDeclaration" context json_get_bool = include_decl_opt
         if include_decl_opt.is_some then
-            if include_decl_opt Option::Some(include_decl) is then
-            else
-                empty_location "Expected option value while unwrapping include_decl_opt" ErrorKind::Syntax raise_error
-                1 exit
-            fi
+            include_decl_opt.unwrap = include_decl
         fi
     fi
 
@@ -1955,11 +1840,7 @@ fn handle_references message:JsonValue {
         JsonValue::JsonNull request_id send_response
         return
     fi
-    if refs_opt Option::Some(refs) is then
-    else
-        empty_location "Expected option value while unwrapping refs_opt" ErrorKind::Syntax raise_error
-        1 exit
-    fi
+    refs_opt.unwrap = refs
     List::new(List[JsonValue]) = json_refs
     for ref_loc in refs.iter do
         ref_loc.to_json json_refs.push
@@ -1989,11 +1870,7 @@ fn compute_rename
             Option::None(Option[Map[str List[TextEdit]]])
             return
         fi
-        if result Option::Some(find) is then
-        else
-            empty_location "Expected option value while unwrapping result" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        result.unwrap = find
         find FindResult::op = op
         find FindResult::function = func
         op op_str_value = old_name
@@ -2038,33 +1915,32 @@ fn compute_rename
 
 fn handle_rename message:JsonValue {
     message extract_uri = uri
-    if "id" message json_get_value Option::Some(request_id) is then
-    else
+    "id" message json_get_value = request_id_opt
+    if request_id_opt.is_none then
         empty_location "Expected option value while unwrapping id message json_get_value" ErrorKind::Syntax raise_error
         1 exit
     fi
+    request_id_opt.unwrap = request_id
 
     uri DOCUMENT_STATES.get = state_opt
     if state_opt.is_none then
         JsonValue::JsonNull request_id send_response
         return
     fi
-    if state_opt Option::Some(state) is then
-    else
-        empty_location "Expected option value while unwrapping state_opt" ErrorKind::Syntax raise_error
-        1 exit
-    fi
+    state_opt.unwrap = state
 
-    if "params" message json_get_object Option::Some(params) is then
-    else
+    "params" message json_get_object = params_opt
+    if params_opt.is_none then
         empty_location "Expected option value while unwrapping params message json_get_object" ErrorKind::Syntax raise_error
         1 exit
     fi
-    if "newName" params json_get_str Option::Some(new_name) is then
-    else
+    params_opt.unwrap = params
+    "newName" params json_get_str = new_name_opt
+    if new_name_opt.is_none then
         empty_location "Expected option value while unwrapping newName params json_get_str" ErrorKind::Syntax raise_error
         1 exit
     fi
+    new_name_opt.unwrap = new_name
 
     message extract_position = position
     new_name position LspRange::start_col position LspRange::start_line state compute_rename = edits_opt
@@ -2072,21 +1948,13 @@ fn handle_rename message:JsonValue {
         JsonValue::JsonNull request_id send_response
         return
     fi
-    if edits_opt Option::Some(edits_map) is then
-    else
-        empty_location "Expected option value while unwrapping edits_opt" ErrorKind::Syntax raise_error
-        1 exit
-    fi
+    edits_opt.unwrap = edits_map
 
     # Convert to JSON changes object
     json_object = changes
     edits_map.keys = change_uris
     for change_uri in change_uris.iter do
-        if change_uri edits_map.get Option::Some(edit_list) is then
-        else
-            empty_location "Expected option value while unwrapping change_uri edits_map.get" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        change_uri edits_map.get.unwrap = edit_list
         List::new(List[JsonValue]) = edit_json_list
         for edit_item in edit_list.iter do
             edit_item.to_json edit_json_list.push
@@ -2209,11 +2077,7 @@ fn collect_semantic_tokens ops:List[Op] state:DocumentState tokens:List[Semantic
         if token_type_opt.is_none then
             continue
         fi
-        if token_type_opt Option::Some(token_type) is then
-        else
-            empty_location "Expected option value while unwrapping token_type_opt" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        token_type_opt.unwrap = token_type
 
         # Check for qualified names
         if
@@ -2278,21 +2142,13 @@ fn compute_semantic_tokens state:DocumentState -> List[SemanticToken] {
     # Collect from function ops
     state DocumentState::functions.keys = fn_keys
     for fn_name in fn_keys.iter do
-        if fn_name state DocumentState::functions.get Option::Some(func) is then
-        else
-            empty_location "Expected option value while unwrapping fn_name state DocumentState::functions.get" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        fn_name state DocumentState::functions.get.unwrap = func
         tokens state func Function::ops collect_semantic_tokens
     done
 
     # Add function definition names + fn keyword
     for fn_def_name in fn_keys.iter do
-        if fn_def_name state DocumentState::functions.get Option::Some(fn_def) is then
-        else
-            empty_location "Expected option value while unwrapping fn_def_name state DocumentState::functions.get" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        fn_def_name state DocumentState::functions.get.unwrap = fn_def
         if "" fn_def Function::location Location::file == then
             continue
         fi
@@ -2315,11 +2171,7 @@ fn compute_semantic_tokens state:DocumentState -> List[SemanticToken] {
     # Add enum definition names + enum keyword
     state DocumentState::enums.keys = enum_keys
     for enum_def_name in enum_keys.iter do
-        if enum_def_name state DocumentState::enums.get Option::Some(enum_def) is then
-        else
-            empty_location "Expected option value while unwrapping enum_def_name state DocumentState::enums.get" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        enum_def_name state DocumentState::enums.get.unwrap = enum_def
         if enum_def CasaEnum::location Location::file state DocumentState::file_path != then
             continue
         fi
@@ -2336,11 +2188,7 @@ fn compute_semantic_tokens state:DocumentState -> List[SemanticToken] {
     # Add struct definition names + struct keyword
     state DocumentState::structs.keys = struct_keys
     for struct_def_name in struct_keys.iter do
-        if struct_def_name state DocumentState::structs.get Option::Some(struct_def) is then
-        else
-            empty_location "Expected option value while unwrapping struct_def_name state DocumentState::structs.get" ErrorKind::Syntax raise_error
-            1 exit
-        fi
+        struct_def_name state DocumentState::structs.get.unwrap = struct_def
         if struct_def CasaStruct::location Location::file state DocumentState::file_path != then
             continue
         fi
@@ -2380,11 +2228,12 @@ fn compute_semantic_tokens state:DocumentState -> List[SemanticToken] {
 
 fn handle_semantic_tokens message:JsonValue {
     message extract_uri = uri
-    if "id" message json_get_value Option::Some(request_id) is then
-    else
+    "id" message json_get_value = request_id_opt
+    if request_id_opt.is_none then
         empty_location "Expected option value while unwrapping id message json_get_value" ErrorKind::Syntax raise_error
         1 exit
     fi
+    request_id_opt.unwrap = request_id
 
     uri DOCUMENT_STATES.get = state_opt
     if state_opt.is_none then
@@ -2393,11 +2242,7 @@ fn handle_semantic_tokens message:JsonValue {
         JsonValue::JsonObject request_id send_response
         return
     fi
-    if state_opt Option::Some(state) is then
-    else
-        empty_location "Expected option value while unwrapping state_opt" ErrorKind::Syntax raise_error
-        1 exit
-    fi
+    state_opt.unwrap = state
 
     state compute_semantic_tokens = tokens
 
@@ -2558,23 +2403,13 @@ fn extract_library_paths message:JsonValue -> List[str] {
     List::new(List[str]) = paths
     "params" message json_get_object = params_option
     if params_option.is_none then paths return fi
-    if params_option Option::Some(params) is then
-    else
-        paths return
-    fi
+    params_option.unwrap = params
     "initializationOptions" params json_get_object = init_options_option
     if init_options_option.is_none then paths return fi
-    if init_options_option Option::Some(init_options) is then
-    else
-        paths return
-    fi
+    init_options_option.unwrap = init_options
     "libraryPaths" init_options json_get_array = library_paths_option
     if library_paths_option.is_none then paths return fi
-    if library_paths_option Option::Some(library_paths_array) is then
-    else
-        empty_location "Expected option value while unwrapping library_paths_option" ErrorKind::Syntax raise_error
-        1 exit
-    fi
+    library_paths_option.unwrap = library_paths_array
     for path_value in library_paths_array.iter do
         if path_value JsonValue::JsonString(path_string) is then
             path_string paths.push
@@ -2585,11 +2420,12 @@ fn extract_library_paths message:JsonValue -> List[str] {
 
 fn handle_initialize message:JsonValue {
     global LSP_LIBRARY_PATHS
-    if "id" message json_get_value Option::Some(request_id) is then
-    else
+    "id" message json_get_value = request_id_opt
+    if request_id_opt.is_none then
         empty_location "Expected option value while unwrapping id message json_get_value" ErrorKind::Syntax raise_error
         1 exit
     fi
+    request_id_opt.unwrap = request_id
 
     message extract_library_paths = LSP_LIBRARY_PATHS
 
@@ -2638,11 +2474,11 @@ fn handle_initialize message:JsonValue {
 
 fn handle_shutdown message:JsonValue {
     if "id" message json_get_value Option::Some(request_id) is then
+        JsonValue::JsonNull request_id send_response
     else
         empty_location "Expected option value while unwrapping id message json_get_value" ErrorKind::Syntax raise_error
         1 exit
     fi
-    JsonValue::JsonNull request_id send_response
 }
 
 fn handle_exit message:JsonValue {
@@ -2652,11 +2488,7 @@ fn handle_exit message:JsonValue {
 fn dispatch_message message:JsonValue {
     "method" message json_get_str = method_opt
     if method_opt.is_none then return fi
-    if method_opt Option::Some(method) is then
-    else
-        empty_location "Expected option value while unwrapping method_opt" ErrorKind::Syntax raise_error
-        1 exit
-    fi
+    method_opt.unwrap = method
 
     if "initialize" method == then
         message handle_initialize


### PR DESCRIPTION
## Summary

Prep for `if`-block scoping (#247): variables bound by `is` inside `if`
conditions and used after `fi` no longer leak out of the branch. Once `if`
scoping is enforced, such bindings become inaccessible after `fi`, so every
occurrence across the compiler and language server is rewritten now.

All 177 occurrences across `compiler/{pattern,lexer,bytecode,syntax,typechecker}.casa`
and `lsp.casa` are eliminated. Each is rewritten by one of:

- **restructuring the usage into the `then` branch** (preferred), keeping the
  `else` error;
- **`.unwrap`** where a preceding guard (`is_none` early-exit, `.has` check,
  enclosing `is_some`, or a key drawn from `MAP.keys`) already makes the
  assertion unreachable — this removes dead error branches;
- **an `is_none`/`is_error` guard plus `.unwrap`** where restructuring is
  impractical (long body / nesting limit / sequential extractions), preserving
  the original error message verbatim.

127 redundant (unreachable) assertions are removed; 44 reachable error paths are
preserved unchanged. No custom error message on a reachable path is dropped, and
no observable behavior changes.

## Test plan

- [x] 0 `is`-bound-after-`fi` occurrences remain (all six files)
- [x] `./casafmt` clean — no reflow on any changed file
- [x] Compiler test suite: 55 passed, 0 failed
- [x] Examples: 47 passed, 0 failed
- [x] Bootstrap: self-compilation + fixed-point verified

Closes #247